### PR TITLE
Require Boost 1.41, not 1.44

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,7 +188,7 @@ if(WIN32)
 endif(WIN32)
 
 # BUG: are there other Boost components we're using?
-find_package(Boost 1.44 COMPONENTS program_options thread iostreams filesystem system unit_test_framework REQUIRED)
+find_package(Boost 1.41 COMPONENTS program_options thread iostreams filesystem system unit_test_framework REQUIRED)
 
 if(Boost_FOUND AND Boost_PROGRAM_OPTIONS_FOUND)
   include_directories(${Boost_INCLUDE_DIRS})


### PR DESCRIPTION
Hey, I here's the CMakeLists.txt change to required 1.41 instead of 1.44 by default.
