### PR TITLE
Remove all oci trigger code

### DIFF
--- a/include/pdal/drivers/oci/Writer.hpp
+++ b/include/pdal/drivers/oci/Writer.hpp
@@ -110,8 +110,6 @@ private:
     bool isSolid() const;
     boost::int32_t getPCID() const;
     void UpdatePCExtent();
-    std::string ShutOff_SDO_PC_Trigger();
-    void TurnOn_SDO_PC_Trigger(std::string trigger_name);
     pdal::Bounds<double> CalculateBounds(PointBuffer const& buffer);
     bool IsValidWKT(std::string const& wkt);
     
@@ -136,7 +134,6 @@ private:
     std::string m_base_table_boundary_column;
     std::string m_base_table_boundary_wkt;
     boost::shared_ptr<pdal::gdal::Debug> m_gdal_debug;
-    std::string m_trigger_name;
     
 };
 

--- a/src/drivers/oci/Writer.cpp
+++ b/src/drivers/oci/Writer.cpp
@@ -864,7 +864,6 @@ void Writer::writeBegin(boost::uint64_t targetNumPointsToWrite)
     }
         
     CreatePCEntry();
-    m_trigger_name = ShutOff_SDO_PC_Trigger();
     return;
 }
 
@@ -883,8 +882,6 @@ void Writer::writeEnd(boost::uint64_t actualNumPointsWritten)
     // Update extent of SDO_PC entry
     UpdatePCExtent();
     
-    if (getOptions().getValueOrDefault<bool>("reenable_cloud_trigger", true))
-        TurnOn_SDO_PC_Trigger(m_trigger_name);
     m_connection->Commit();   
 
     RunFileSQL("post_block_sql");
@@ -1114,68 +1111,6 @@ bool Writer::WriteBlock(PointBuffer const& buffer)
 
     
     return true;
-}
-
-std::string Writer::ShutOff_SDO_PC_Trigger()
-{
-    std::string base_table_name = boost::to_upper_copy(getOptions().getValueOrThrow<std::string>("base_table_name"));
-    std::string cloud_column_name = boost::to_upper_copy(getOptions().getValueOrThrow<std::string>("cloud_column_name"));
-
-    std::ostringstream oss;
-
-    char szTrigger[OWNAME] = "";
-    char szStatus[OWNAME] = "";
-
-    oss << "select trigger_name, status from all_triggers where table_name = '" << base_table_name << "' AND TRIGGER_NAME like upper('%%MDTNPC_%%') ";
-    Statement statement = Statement(m_connection->CreateStatement(oss.str().c_str()));
-    
-    statement->Define(szTrigger);
-    statement->Define(szStatus);
-    
-    statement->Execute();
-
-    // Yes, we're assuming there's only one trigger that met these criteria.
-    
-    if (!strlen(szStatus))
-    {
-        // No rows returned, no trigger exists
-        return std::string("");
-    }
-    
-    
-    if (boost::iequals(szStatus, "ENABLED"))
-    {
-        oss.str("");
-        oss << "ALTER TRIGGER " << szTrigger << " DISABLE ";
-    
-        statement = Statement(m_connection->CreateStatement(oss.str().c_str()));
-        statement->Execute();
-    
-        return std::string(szTrigger);
-    } else
-    {
-        return std::string("");
-    }
-
-
-    
-}
-
-void Writer::TurnOn_SDO_PC_Trigger(std::string trigger_name)
-{
-    
-    if (!trigger_name.size()) return;
-    
-    std::ostringstream oss;
-    
-    std::string base_table_name = boost::to_upper_copy(getOptions().getValueOrThrow<std::string>("base_table_name"));
-
-    oss << "ALTER TRIGGER " << trigger_name << " ENABLE ";
-    
-    Statement statement = Statement(m_connection->CreateStatement(oss.str().c_str()));
-    statement->Execute();
-
-        
 }
 
 void Writer::UpdatePCExtent()

--- a/test/data/pipeline/oracle-pipeline-write.xml
+++ b/test/data/pipeline/oracle-pipeline-write.xml
@@ -51,9 +51,6 @@
         <Option name="stream_output_precision">
             8
         </Option>
-        <Option name="reenable_cloud_trigger">
-            false
-        </Option>
             <Filter type="filters.inplacereprojection">
                 <Option name="out_srs">
                     EPSG:4326


### PR DESCRIPTION
A new patch to oracle prevents the trigger from being fired when
pc_extents is updated. We don't need to manipulate the trigger at all
anymore.
