### PR TITLE
Minor fixes to app messages

### DIFF
--- a/apps/AppSupport.cpp
+++ b/apps/AppSupport.cpp
@@ -162,18 +162,22 @@ void PercentageCallback::callback()
     
     if (pdal::Utils::compare_distance<double>(currPerc, 100.0))
     {
-        std::cout << "100\n";
+        if(m_lastMajorPerc == m_lastMinorPerc)
+            std::cout << '.';
+        std::cout << "100" << std::endl;
         m_done = true;
     }
     else if (currPerc >= m_lastMajorPerc + 10.0)
     {
-        std::cout << (int)currPerc;
+        if(m_lastMajorPerc == m_lastMinorPerc)
+            std::cout << '.';
+        std::cout << (int)currPerc << std::flush;
         m_lastMajorPerc = currPerc;
         m_lastMinorPerc = currPerc;
     }
     else if (currPerc >= m_lastMinorPerc + 2.0)
     {
-        std::cout << '.';
+        std::cout << '.' << std::flush;
         m_lastMinorPerc = currPerc;
     }
 

--- a/apps/pcinfo.cpp
+++ b/apps/pcinfo.cpp
@@ -45,6 +45,7 @@
 
 #include <boost/property_tree/xml_parser.hpp>
 #include <boost/property_tree/json_parser.hpp>
+#include <boost/lexical_cast.hpp>
 
 #include "AppSupport.hpp"
 #include "Application.hpp"
@@ -167,7 +168,8 @@ void PcInfo::dumpOnePoint(const Stage& stage) const
     const boost::uint32_t numRead = iter->read(data);
     if (numRead != 1)
     {
-        throw app_runtime_error("problem reading point number " + m_pointNumber);
+        throw app_runtime_error("problem reading point number " 
+            + boost::lexical_cast<std::string>(m_pointNumber) );
     }
 
     boost::property_tree::ptree tree = data.toPTree();

--- a/src/Log.cpp
+++ b/src/Log.cpp
@@ -105,7 +105,7 @@ std::ostream& Log::get(LogLevel level)
     if (level <= m_level)
     {
         *m_log << "(" << m_leader << " "<< getLevelString(level) <<": " << level << "): ";
-        *m_log << std::string(level > logDEBUG ? 0 : level - logDEBUG, '\t');
+        *m_log << std::string(level < logDEBUG ? 0 : level - logDEBUG, '\t');
         return *m_log;
     }
     else


### PR DESCRIPTION
- Always print a '.' between numbers in PercentageCallback
- Fix pcinfo -p error message
- Fix log indent level
