### PR TITLE
drivers.oci.reader autoscales incongruent dimensions

### DIFF
--- a/src/drivers/oci/Reader.cpp
+++ b/src/drivers/oci/Reader.cpp
@@ -736,7 +736,7 @@ void IteratorBase::copyOracleData(  PointBuffer& source,
                                     boost::uint32_t howMany)
 {
     
-    boost::optional<Dimension const&> source_dim = source.getSchema().getDimensionOptional(dest_dim.getName());
+    boost::optional<Dimension const&> source_dim = source.getSchema().getDimensionOptional(dest_dim.getName(), dest_dim.getNamespace());
     
     if (!source_dim)
     {


### PR DESCRIPTION
drivers.oci.reader autoscales dimensions that have the same name, for example, `X`, but have differening namespaces. The oracle driver is simply attempting to do a buffer copy of _exact_ dimensions here, and shouldn't be doing magical stuff.
