### PR TITLE
Allow out-of-source builds (include PROJECT_BINARY_DIR/include)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -556,6 +556,8 @@ configure_file(
   "${PROJECT_SOURCE_DIR}/pdal_defines.h.in"
   "${PDAL_INCLUDE_DIR}/pdal/pdal_defines.h")
 
+include_directories(${PROJECT_BINARY_DIR}/include})
+
 #------------------------------------------------------------------------------
 # subdirectory controls
 #------------------------------------------------------------------------------


### PR DESCRIPTION
I could not build out of source without adding this path. Curiously, adding PDAL_INCLUDE_DIR did not work.
