### PR TITLE
add option to build PDAL using static runtime libraries on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,24 @@ set(ENABLE_CTEST FALSE CACHE BOOL
 # General build settings
 #------------------------------------------------------------------------------
 
+if(WIN32)
+  if(MSVC)
+    option(PDAL_USE_STATIC_RUNTIME "Use the static runtime" OFF)
+
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MT")
+
+    # Note that the CMake cache will still show /MD
+    # http://www.cmake.org/Wiki/CMake_FAQ#Dynamic_Replace
+    foreach(flag_var
+      CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
+      CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
+      if(${flag_var} MATCHES "/MD")
+        string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
+      endif(${flag_var} MATCHES "/MD")
+    endforeach(flag_var)
+  endif(MSVC)
+endif(WIN32)
+
 # note we default to debug mode
 if(NOT MSVC_IDE)
   if(NOT CMAKE_BUILD_TYPE)
@@ -198,6 +216,21 @@ endif(APPLE)
 
 find_package(Threads)
 
+# Default to using static, multithreaded libraries for 
+# linking under MSVC.  This is because we show users how to 
+# use boostpro.com installer and install those options when linking 
+# on windows in the compilation documentation.
+if(WIN32)
+  if (MSVC)
+    set(Boost_USE_STATIC_LIBS   ON)
+    set(Boost_USE_MULTITHREADED ON)
+
+    if (PDAL_USE_STATIC_RUNTIME)
+      set(Boost_USE_STATIC_RUNTIME ON)
+    endif(PDAL_USE_STATIC_RUNTIME)
+  endif(MSVC)
+endif(WIN32)
+
 if (NOT PDAL_EMBED_BOOST)
   find_package(Boost 1.48 COMPONENTS program_options thread iostreams filesystem system unit_test_framework random)
 endif()
@@ -209,18 +242,7 @@ if(Boost_FOUND)
   mark_as_advanced(CLEAR Boost_INCLUDE_DIR) 
   mark_as_advanced(CLEAR Boost_LIBRARY_DIRS) 
   link_directories(${Boost_LIBRARY_DIRS})
-
-  # Default to using static, multithreaded libraries for 
-  # linking under MSVC.  This is because we show users how to 
-  # use boostpro.com installer and install those options when linking 
-  # on windows in the compilation documentation.
-  if(WIN32)
-    if (MSVC)
-      set(Boost_USE_STATIC_LIBS   ON)
-      set(Boost_USE_MULTITHREADED ON)
-    endif(MSVC)
-  endif(WIN32)
-  
+ 
 else()
   set(BOOST_ROOT ${PROJECT_SOURCE_DIR}/boost)
 


### PR DESCRIPTION
This amounts to specifying /MT rather than the default /MD. Also,
Boost can be found more easily (for non-embedded users) by specifying
options up front.
