### PR TITLE
Fix segfault when reading from las into multiple buffers

### DIFF
--- a/include/pdal/drivers/las/Reader.hpp
+++ b/include/pdal/drivers/las/Reader.hpp
@@ -144,10 +144,6 @@ protected:
     const pdal::drivers::las::Reader& m_reader;
     std::istream& m_istream;
 
-    PointDimensions* m_pointDimensions;
-    Schema const* m_schema;
-
-    void setPointDimensions(PointBuffer& buffer);
     inline pdal::drivers::las::Reader const& getReader()
     {
         return m_reader;


### PR DESCRIPTION
In the presence of multiple buffers (such as the temporary buffers used
by the Mosaic stage) caching the dimensions when reading las doesn't
work: dimensions may be in different locations in different buffers.
The previously used buffers may even be deallocated, in which case the
cached dimensions will be stale pointers, leading to segfaults.

The fix here simply removes dimension caching entirely.  With any
reasonable chunk size this shouldn't lead to performance degradation.

I also took the liberty of removing las::iterator::Base::m_schema which appears to be entirely unused.

A crash arising from this bug may be demonstrated by executing the following pipeline using

```
pcpipeline las_crash.xml --chunk_size 100
```

las_crash.xml:

```
<?xml version="1.0" encoding="utf-8"?>
<Pipeline version="1.0">
    <Writer type="drivers.faux.writer">
        <MultiFilter type="filters.mosaic">
            <Reader type="drivers.las.reader">
                <Option name="filename">
                    autzen-thin.las
                </Option>
            </Reader>
        </MultiFilter>
    </Writer>
</Pipeline>
```
