### PR TITLE
Allow SRS to be ignored in Mosaic filter

### DIFF
--- a/src/filters/Mosaic.cpp
+++ b/src/filters/Mosaic.cpp
@@ -59,6 +59,7 @@ void Mosaic::initialize()
 
     const Stage& stage0 = *stages[0];
     const SpatialReference& srs0 = stage0.getSpatialReference();
+    const bool ignoreSrs = getOptions().getValueOrDefault<bool>("ignore_srs", false);
     const Schema& schema0 = stage0.getSchema();
     PointCountType pointCountType0 = stage0.getPointCountType();
     boost::uint64_t totalPoints = stage0.getNumPoints();
@@ -68,7 +69,7 @@ void Mosaic::initialize()
     for (boost::uint32_t i=1; i<stages.size(); i++)
     {
         Stage& stage = *(stages[i]);
-        if (stage.getSpatialReference() != srs0)
+        if (!ignoreSrs && stage.getSpatialReference() != srs0)
             throw impedance_invalid("mosaicked stages must have same srs");
         if (stage.getSchema() != schema0)
             throw impedance_invalid("mosaicked stages must have same schema");


### PR DESCRIPTION
Ignoring the SRS is useful when pdal has been compiled without gdal support, and the user knows the inputs have a shared spatial reference system.  (Attempting SRS comparison in this case would otherwise result in an exception.)

I'm not so sure about this patch, but the mosaic filter is useless without it unless you accept gdal as a dependency.  Alternative suggestions welcome!
