### PR TITLE
Bounds update in Reprojection should min/max crossover

### DIFF
--- a/src/filters/InPlaceReprojection.cpp
+++ b/src/filters/InPlaceReprojection.cpp
@@ -559,20 +559,24 @@ void IteratorBase::updateBounds(PointBuffer& buffer)
         return;
     }
 
-	try
-	{
-	    Bounds<double> newBounds(minx, miny, minz, maxx, maxy, maxz);
-
-	    buffer.setSpatialBounds(newBounds);
-		
-	}
-	catch (pdal::bounds_error&)
-	{
-	    Bounds<double> newBounds(minx, miny, oldBounds.getMinimum(2), maxx, maxy, oldBounds.getMaximum(2));
-
-	    buffer.setSpatialBounds(newBounds);
-		
-	}
+    try
+    {
+        Bounds<double> newBounds(minx, miny, minz, maxx, maxy, maxz);
+        buffer.setSpatialBounds(newBounds);
+    }
+    catch (pdal::bounds_error&)
+    {
+        try
+        {
+            Bounds<double> newBounds(minx, miny, oldBounds.getMinimum(2), maxx, maxy, oldBounds.getMaximum(2));
+            buffer.setSpatialBounds(newBounds);
+        }
+        catch (pdal::bounds_error&)
+        {
+            Bounds<double> newBounds = buffer.calculateBounds(true);
+            buffer.setSpatialBounds(newBounds);
+        }
+    }
 
     return;
 }


### PR DESCRIPTION
When doing a transform, the InPlaceRprojection filter tries to just reproject the corner ticks directly and expects them to continue to confirm to min<max rules. They won't always. I've put in a more extreme bounds handling as a fall-back, but it might be better closer to the top of the block. Also, it might be better just to _always_ recalculate the bounds, since otherwise almost certainly there will be points in the buffer that are not in the bounds, with moderate frequency when doing reprojections (particularly ones from geographic to projected or vice versa).
