### PR TITLE
No way to tell if embedded boost was used at runtime

### DIFF
--- a/apps/Application.cpp
+++ b/apps/Application.cpp
@@ -303,8 +303,8 @@ void Application::addPositionalSwitch(const char* name, int max_count)
 
 void Application::outputDrivers()
 {
-    pdal::StageFactory* factory = new pdal::StageFactory;
-    std::map<std::string, pdal::StageInfo> const& drivers = factory->getStageInfos();
+    pdal::StageFactory factory;
+    std::map<std::string, pdal::StageInfo> const& drivers = factory.getStageInfos();
     typedef std::map<std::string, pdal::StageInfo>::const_iterator Iterator;
     
     for (Iterator i = drivers.begin(); i != drivers.end(); ++i)

--- a/include/pdal/pdal_config.hpp
+++ b/include/pdal/pdal_config.hpp
@@ -55,6 +55,7 @@ PDAL_DLL bool IsLibLASEnabled();
 PDAL_DLL bool IsGDALEnabled();
 PDAL_DLL bool IsLibGeoTIFFEnabled();
 PDAL_DLL bool IsLasZipEnabled();
+PDAL_DLL bool IsEmbeddedBoost();
 
 PDAL_DLL std::string GetFullVersionString();
 PDAL_DLL std::string GetVersionString();
@@ -62,6 +63,8 @@ PDAL_DLL int GetVersionInteger();
 PDAL_DLL int GetVersionMajor();
 PDAL_DLL int GetVersionMinor();
 PDAL_DLL int GetVersionPatch();
+
+
 
 } // namespace pdal
 

--- a/src/pdal_config.cpp
+++ b/src/pdal_config.cpp
@@ -92,6 +92,14 @@ bool IsLasZipEnabled()
 #endif
 }
 
+bool IsEmbeddedBoost()
+{
+#ifdef PDAL_EMBED_BOOST
+    return true;
+#else
+    return false;
+#endif
+}
 
 int GetVersionMajor()
 {
@@ -143,7 +151,12 @@ std::string GetFullVersionString()
        << LASZIP_VERSION_MINOR << "."
        << LASZIP_VERSION_REVISION;
 #endif
-
+    
+    if (IsEmbeddedBoost())
+        os << " Embed ";
+    else
+        os << " System "; 
+    
     std::string info(os.str());
     os.str("");
     os << "PDAL " << PDAL_VERSION_STRING;


### PR DESCRIPTION
Add a IsEmbeddedBoost method for configuration, report that when --version strings are generated.
