### PR TITLE
Dimension caching change wrecks chipper performance

### DIFF
--- a/doc/development/conventions.txt
+++ b/doc/development/conventions.txt
@@ -106,14 +106,10 @@ Layout/Organization of Source Tree
   pdal headers may be further grouped by subdirectory, e.g. drivers/liblas,
   filters, etc.
 
-* First exception to the above: source files (.cpp) should #include their
+* Exception to the above: source files (.cpp) should #include their
   corresponding .hpp file first.  This assures that the header is including
   all the files it needs to.
   
-* Second exception to the above: header files (.hpp) should #include pdal.hpp
-  first.  This assures that we are consistent in including all "standard" stuff
-  we use everywhere.
-
 * Don't #include a file where a simple forward declaration will do.
   (Note: this only applies to pdal files; don't forward declare from system
   or 3rd party headers.)


### PR DESCRIPTION
After the commit at e3ab7125b993542e7e793a28e3e61ec04d7279d9 the chipper filter is running about 10x slower than previously.
