### PR TITLE
Fix incorrect comparison when shrinking buffer

### DIFF
--- a/src/Writer.cpp
+++ b/src/Writer.cpp
@@ -216,7 +216,7 @@ boost::uint64_t Writer::write(  boost::uint64_t targetNumPointsToWrite,
             const boost::uint32_t numPointsToReadThisChunk = static_cast<boost::uint32_t>(numPointsToReadThisChunk64);
 
             // we are reusing the buffer, so we may need to adjust the capacity for the last (and likely undersized) chunk
-            if (m_writer_buffer->getCapacity() < numPointsToReadThisChunk)
+            if (m_writer_buffer->getCapacity() > numPointsToReadThisChunk)
             {
                 m_writer_buffer->resize(numPointsToReadThisChunk);
             }

--- a/test/unit/drivers/faux/FauxWriterTest.cpp
+++ b/test/unit/drivers/faux/FauxWriterTest.cpp
@@ -209,4 +209,16 @@ BOOST_AUTO_TEST_CASE(test_callbacks)
 }
 
 
+BOOST_AUTO_TEST_CASE(test_buffer_resize)
+{
+    Bounds<double> bounds(1.0, 2.0, 3.0, 101.0, 102.0, 103.0);
+    pdal::drivers::faux::Reader reader(bounds, 1000, pdal::drivers::faux::Reader::Random);
+    pdal::drivers::faux::Writer writer(reader, Options::none());
+    writer.initialize();
+    writer.setChunkSize(101);
+
+    BOOST_CHECK_EQUAL(writer.write(750), 750);
+}
+
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
During a write operation, the same buffer gets re-used for each chunk of
writing. If the number of points left to write is smaller than the
capacity of the buffer, we want to shrink the buffer down to size.
Unfortunately, there was a typo in that comparison (lt instead of gt) so
the buffer would never get shrunk.

This patch adds a test case to confirm the bug and provides a fix.
