### PR TITLE
Delete temporary test file after use

### DIFF
--- a/test/unit/drivers/buffer/BufferReaderTest.cpp
+++ b/test/unit/drivers/buffer/BufferReaderTest.cpp
@@ -306,7 +306,7 @@ BOOST_AUTO_TEST_CASE(test_iterator_write)
     boost::uint64_t numWritten = writer.write(100);
 
     BOOST_CHECK_EQUAL(numWritten, 100u);
-    FileUtils::deleteFile(Support::temppath(out_filename.getValue<std::string>()));    
+    FileUtils::deleteFile(out_filename.getValue<std::string>());
 
     return;
 }


### PR DESCRIPTION
Fix an incorrect call to FileUtils::deleteFile that meant that a test
wasn't cleaning up after itself.
