### PR TITLE
Build system option for static PDAL build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,8 @@ set(ENABLE_CTEST FALSE CACHE BOOL
 # General build settings
 #------------------------------------------------------------------------------
 
+option(PDAL_BUILD_STATIC "Build PDAL as a static library" OFF)
+
 if(WIN32)
   if(MSVC)
     option(PDAL_USE_STATIC_RUNTIME "Use the static runtime" OFF)
@@ -196,7 +198,7 @@ else()
   # Recommended C++ compilation flags
   # -Weffc++
   set(PDAL_COMMON_CXX_FLAGS
-	  "-Wextra -Wall -Wno-unused-parameter -Wno-unused-variable -Wpointer-arith -Wcast-align -Wcast-qual -Wfloat-equal -Wredundant-decls -Wno-long-long -fPIC")
+      "-Wextra -Wall -Wno-unused-parameter -Wno-unused-variable -Wpointer-arith -Wcast-align -Wcast-qual -Wfloat-equal -Wredundant-decls -Wno-long-long")
 
   if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX)
 
@@ -589,6 +591,12 @@ set (USE_PDAL_PLUGIN_MRSID FALSE CACHE BOOL "Build the MrSID driver as a plugin 
 set (USE_PDAL_PLUGIN_CARIS FALSE CACHE BOOL "Build the Caris driver as a plugin rather than embedding")
 set (USE_PDAL_PLUGIN_NITRO FALSE CACHE BOOL "Build the NITF writer as a plugin rather than embedding")
 
+if (USE_PDAL_PLUGIN_TEXT OR USE_PDAL_PLUGIN_SOCI OR USE_PDAL_PLUGIN_OCI OR
+    USE_PDAL_PLUGIN_MRSID OR USE_PDAL_PLUGIN_CARIS OR USE_PDAL_PLUGIN_NITRO)
+  if (PDAL_BUILD_STATIC)
+    message(SEND_ERROR "Cannot build separate plugins with statically compiled PDAL")
+  endif()
+endif()
 
 #------------------------------------------------------------------------------
 # installation commands

--- a/boost/CMakeLists.txt
+++ b/boost/CMakeLists.txt
@@ -141,3 +141,7 @@ endif(WIN32)
 
 add_library(${PDALBOOST_LIB_NAME} STATIC ${PDALBOOST_SOURCES})
 
+if (UNIX AND NOT PDAL_BUILD_STATIC)
+     # Must use position independent code to link static libs into dynamic ones
+     set_target_properties(${PDALBOOST_LIB_NAME} PROPERTIES COMPILE_FLAGS "-fPIC")
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -629,7 +629,12 @@ if (NOT WITH_STATIC_LASZIP)
 endif()
 endif()
 
-add_library(${PDAL_LIB_NAME} SHARED ${PDAL_SOURCES})
+if (PDAL_BUILD_STATIC)
+  set(PDAL_LIB_TYPE STATIC)
+else()
+  set(PDAL_LIB_TYPE SHARED)
+endif()
+add_library(${PDAL_LIB_NAME} ${PDAL_LIB_TYPE} ${PDAL_SOURCES})
 
 set (SOCI_LIBRARIES ${SOCI_LIBRARY} ${SOCI_postgresql_PLUGIN})
 


### PR DESCRIPTION
Add an option (off by default) to build pdal as a static library.  I don't know how useful this really is because it requires plugins to be builtin, but it will get me unstuck for now.

Note that I've **removed** -fPIC from the generic common options, because that's counter productive for a static build.  However, it's required when linking the static embedded boost into a dynamic pdal lib, so I made a change to put it in there.  @hobu I hope that works for you - I see that you added -fPIC in 9855c9a0c ?
