### PR TITLE
string_ref and external boost 1.53 is no good

### DIFF
--- a/include/pdal/Schema.hpp
+++ b/include/pdal/Schema.hpp
@@ -52,10 +52,11 @@
 #include <boost/cstdint.hpp>
 #include <boost/any.hpp>
 #include <boost/shared_ptr.hpp>
-#include <boost/utility/string_ref.hpp>
 #include <boost/foreach.hpp>
 #include <boost/array.hpp>
 #include <boost/optional.hpp>
+
+#include <pdal/third/string_ref.hpp>
 
 
 #include <boost/multi_index_container.hpp>
@@ -158,8 +159,8 @@ public:
     /// @param name name to use when searching
     /// @param ns namespace to use when searching. If none is given, the first
     /// matching Dimension instance with name \b name is returned.
-    const Dimension& getDimension(boost::string_ref name,
-                                  boost::string_ref ns = boost::string_ref()) const;
+    const Dimension& getDimension(pdal::string_ref name,
+                                  pdal::string_ref ns = string_ref()) const;
 
     /// @return a const& to a Dimension with the given dimension::id. If
     /// no matching dimension is found, pdal::dimension_not_found is thrown.
@@ -179,8 +180,8 @@ public:
     /// @param ns namespace to use when searching. If none is given, the first
     /// matching Dimension instance with name \b name is returned.
     /// @param errorMsg optional location for storing error messages
-    const Dimension* getDimensionPtr(boost::string_ref name,
-                                     boost::string_ref ns = boost::string_ref(),
+    const Dimension* getDimensionPtr(string_ref name,
+                                     string_ref ns = string_ref(),
                                      std::string* errorMsg = 0) const;
 
     /// @return a boost::optional-wrapped const& to a Dimension with the given name
@@ -188,8 +189,8 @@ public:
     /// @param name name to use when searching
     /// @param ns namespace to use when searching. If none is given, the first
     /// matching Dimension instance with name \b name is returned.
-    boost::optional<Dimension const&> getDimensionOptional(boost::string_ref name,
-                                                           boost::string_ref ns=boost::string_ref()) const;
+    boost::optional<Dimension const&> getDimensionOptional(string_ref name,
+                                                           string_ref ns=string_ref()) const;
 
     /// @return a boost::optional-wrapped const& to a Dimension with the given dimension::id.
     /// If no matching dimension is found, the optional will be empty.

--- a/include/pdal/third/string_ref.hpp
+++ b/include/pdal/third/string_ref.hpp
@@ -1,0 +1,536 @@
+/*
+   Copyright (c) Marshall Clow 2012-2012.
+
+   Distributed under the Boost Software License, Version 1.0. (See accompanying
+   file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+    For more information, see http://www.boost.org
+
+    Based on the StringRef implementation in LLVM (http://llvm.org) and
+    N3422 by Jeffrey Yasskin
+        http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2012/n3442.html
+
+*/
+
+#ifndef PDAL_BOOST_STRING_REF_HPP
+#define PDAL_BOOST_STRING_REF_HPP
+
+#include <boost/config.hpp>
+#include <boost/detail/workaround.hpp>
+#include "string_ref_fwd.hpp"
+#include <boost/throw_exception.hpp>
+
+#include <cstddef>
+#include <stdexcept>
+#include <algorithm>
+#include <iterator>
+#include <string>
+#include <iosfwd>
+
+namespace pdal {
+
+    namespace detail {
+    //  A helper functor because sometimes we don't have lambdas
+        template <typename charT, typename traits>
+        class string_ref_traits_eq {
+        public:
+            string_ref_traits_eq ( charT ch ) : ch_(ch) {}
+            bool operator () ( charT val ) const { return traits::eq ( ch_, val ); }
+            charT ch_;
+            };
+        }
+
+    template<typename charT, typename traits>
+    class basic_string_ref {
+    public:
+        // types
+        typedef charT value_type;
+        typedef const charT* pointer;
+        typedef const charT& reference;
+        typedef const charT& const_reference;
+        typedef pointer const_iterator; // impl-defined
+        typedef const_iterator iterator;
+        typedef std::reverse_iterator<const_iterator> const_reverse_iterator;
+        typedef const_reverse_iterator reverse_iterator;
+        typedef std::size_t size_type;
+        typedef std::ptrdiff_t difference_type;
+        static BOOST_CONSTEXPR_OR_CONST size_type npos = size_type(-1);
+
+        // construct/copy
+        BOOST_CONSTEXPR basic_string_ref ()
+            : ptr_(NULL), len_(0) {}
+
+        BOOST_CONSTEXPR basic_string_ref (const basic_string_ref &rhs)
+            : ptr_(rhs.ptr_), len_(rhs.len_) {}
+
+        basic_string_ref& operator=(const basic_string_ref &rhs) {
+            ptr_ = rhs.ptr_;
+            len_ = rhs.len_;
+            return *this;
+            }
+
+        basic_string_ref(const charT* str)
+            : ptr_(str), len_(traits::length(str)) {}
+
+        template<typename Allocator>
+        basic_string_ref(const std::basic_string<charT, traits, Allocator>& str)
+            : ptr_(str.data()), len_(str.length()) {}
+
+        BOOST_CONSTEXPR basic_string_ref(const charT* str, size_type len)
+            : ptr_(str), len_(len) {}
+
+#ifndef BOOST_NO_CXX11_EXPLICIT_CONVERSION_OPERATORS
+        template<typename Allocator>
+        explicit operator std::basic_string<charT, traits, Allocator>() const {
+            return std::basic_string<charT, traits, Allocator> ( ptr_, len_ );
+            }
+#endif
+
+        std::basic_string<charT, traits> to_string () const {
+            return std::basic_string<charT, traits> ( ptr_, len_ );
+            }
+
+        // iterators
+        BOOST_CONSTEXPR const_iterator   begin() const { return ptr_; }
+        BOOST_CONSTEXPR const_iterator  cbegin() const { return ptr_; }
+        BOOST_CONSTEXPR const_iterator     end() const { return ptr_ + len_; }
+        BOOST_CONSTEXPR const_iterator    cend() const { return ptr_ + len_; }
+                const_reverse_iterator  rbegin() const { return const_reverse_iterator (end()); }
+                const_reverse_iterator crbegin() const { return const_reverse_iterator (end()); }
+                const_reverse_iterator    rend() const { return const_reverse_iterator (begin()); }
+                const_reverse_iterator   crend() const { return const_reverse_iterator (begin()); }
+
+        // capacity
+        BOOST_CONSTEXPR size_type size()     const { return len_; }
+        BOOST_CONSTEXPR size_type length()   const { return len_; }
+        BOOST_CONSTEXPR size_type max_size() const { return len_; }
+        BOOST_CONSTEXPR bool empty()         const { return len_ == 0; }
+
+        // element access
+        BOOST_CONSTEXPR const charT& operator[](size_type pos) const { return ptr_[pos]; }
+
+        const charT& at(size_t pos) const {
+            if ( pos >= len_ )
+                BOOST_THROW_EXCEPTION( std::out_of_range ( "boost::string_ref::at" ) );
+            return ptr_[pos];
+            }
+
+        BOOST_CONSTEXPR const charT& front() const { return ptr_[0]; }
+        BOOST_CONSTEXPR const charT& back()  const { return ptr_[len_-1]; }
+        BOOST_CONSTEXPR const charT* data()  const { return ptr_; }
+
+        // modifiers
+        void clear() { len_ = 0; }
+        void remove_prefix(size_type n) {
+            if ( n > len_ )
+                n = len_;
+            ptr_ += n;
+            len_ -= n;
+            }
+
+        void remove_suffix(size_type n) {
+            if ( n > len_ )
+                n = len_;
+            len_ -= n;
+            }
+
+
+        // basic_string_ref string operations
+        basic_string_ref substr(size_type pos, size_type n=npos) const {
+            if ( pos > size())
+                BOOST_THROW_EXCEPTION( std::out_of_range ( "string_ref::substr" ) );
+            if ( n == npos || pos + n > size())
+                n = size () - pos;
+            return basic_string_ref ( data() + pos, n );
+            }
+
+        int compare(basic_string_ref x) const {
+            const int cmp = traits::compare ( ptr_, x.ptr_, (std::min)(len_, x.len_));
+            return cmp != 0 ? cmp : ( len_ == x.len_ ? 0 : len_ < x.len_ ? -1 : 1 );
+            }
+
+        bool starts_with(charT c) const { return !empty() && traits::eq ( c, front()); }
+        bool starts_with(basic_string_ref x) const {
+            return len_ >= x.len_ && traits::compare ( ptr_, x.ptr_, x.len_ ) == 0;
+            }
+
+        bool ends_with(charT c) const { return !empty() && traits::eq ( c, back()); }
+        bool ends_with(basic_string_ref x) const {
+            return len_ >= x.len_ && traits::compare ( ptr_ + len_ - x.len_, x.ptr_, x.len_ ) == 0;
+            }
+
+        size_type find(basic_string_ref s) const {
+            const_iterator iter = std::search ( this->cbegin (), this->cend (),
+                                                s.cbegin (), s.cend (), traits::eq );
+            return iter == this->cend () ? npos : std::distance ( this->cbegin (), iter );
+            }
+
+        size_type find(charT c) const {
+            const_iterator iter = std::find_if ( this->cbegin (), this->cend (),
+                                    detail::string_ref_traits_eq<charT, traits> ( c ));
+            return iter == this->cend () ? npos : std::distance ( this->cbegin (), iter );
+            }
+
+        size_type rfind(basic_string_ref s) const {
+            const_reverse_iterator iter = std::search ( this->crbegin (), this->crend (),
+                                                s.crbegin (), s.crend (), traits::eq );
+            return iter == this->crend () ? npos : reverse_distance ( this->crbegin (), iter );
+            }
+
+        size_type rfind(charT c) const {
+            const_reverse_iterator iter = std::find_if ( this->crbegin (), this->crend (),
+                                    detail::string_ref_traits_eq<charT, traits> ( c ));
+            return iter == this->crend () ? npos : reverse_distance ( this->crbegin (), iter );
+            }
+
+        size_type find_first_of(charT c) const { return  find (c); }
+        size_type find_last_of (charT c) const { return rfind (c); }
+
+        size_type find_first_of(basic_string_ref s) const {
+            const_iterator iter = std::find_first_of
+                ( this->cbegin (), this->cend (), s.cbegin (), s.cend (), traits::eq );
+            return iter == this->cend () ? npos : std::distance ( this->cbegin (), iter );
+            }
+
+        size_type find_last_of(basic_string_ref s) const {
+            const_reverse_iterator iter = std::find_first_of
+                ( this->crbegin (), this->crend (), s.cbegin (), s.cend (), traits::eq );
+            return iter == this->crend () ? npos : reverse_distance ( this->crbegin (), iter);
+            }
+
+        size_type find_first_not_of(basic_string_ref s) const {
+            const_iterator iter = find_not_of ( this->cbegin (), this->cend (), s );
+            return iter == this->cend () ? npos : std::distance ( this->cbegin (), iter );
+            }
+
+        size_type find_first_not_of(charT c) const {
+            for ( const_iterator iter = this->cbegin (); iter != this->cend (); ++iter )
+                if ( !traits::eq ( c, *iter ))
+                    return std::distance ( this->cbegin (), iter );
+            return npos;
+            }
+
+        size_type find_last_not_of(basic_string_ref s) const {
+            const_reverse_iterator iter = find_not_of ( this->crbegin (), this->crend (), s );
+            return iter == this->crend () ? npos : reverse_distance ( this->crbegin (), iter );
+            }
+
+        size_type find_last_not_of(charT c) const {
+            for ( const_reverse_iterator iter = this->crbegin (); iter != this->crend (); ++iter )
+                if ( !traits::eq ( c, *iter ))
+                    return reverse_distance ( this->crbegin (), iter );
+            return npos;
+            }
+
+    private:
+        template <typename r_iter>
+        size_type reverse_distance ( r_iter first, r_iter last ) const {
+            return len_ - 1 - std::distance ( first, last );
+            }
+
+        template <typename Iterator>
+        Iterator find_not_of ( Iterator first, Iterator last, basic_string_ref s ) const {
+            for ( ; first != last ; ++first )
+                if ( 0 == traits::find ( s.ptr_, s.len_, *first ))
+                    return first;
+            return last;
+            }
+
+
+
+        const charT *ptr_;
+        std::size_t len_;
+        };
+
+
+//  Comparison operators
+//  Equality
+    template<typename charT, typename traits>
+    inline bool operator==(basic_string_ref<charT, traits> x, basic_string_ref<charT, traits> y) {
+        if ( x.size () != y.size ()) return false;
+        return x.compare(y) == 0;
+        }
+
+    template<typename charT, typename traits, typename Allocator>
+    inline bool operator==(basic_string_ref<charT, traits> x, const std::basic_string<charT, traits, Allocator> & y) {
+        return x == basic_string_ref<charT, traits>(y);
+        }
+
+    template<typename charT, typename traits, typename Allocator>
+    inline bool operator==(const std::basic_string<charT, traits, Allocator> & x, basic_string_ref<charT, traits> y) {
+        return basic_string_ref<charT, traits>(x) == y;
+        }
+
+    template<typename charT, typename traits>
+    inline bool operator==(basic_string_ref<charT, traits> x, const charT * y) {
+        return x == basic_string_ref<charT, traits>(y);
+        }
+
+    template<typename charT, typename traits>
+    inline bool operator==(const charT * x, basic_string_ref<charT, traits> y) {
+        return basic_string_ref<charT, traits>(x) == y;
+        }
+
+//  Inequality
+    template<typename charT, typename traits>
+    inline bool operator!=(basic_string_ref<charT, traits> x, basic_string_ref<charT, traits> y) {
+        if ( x.size () != y.size ()) return true;
+        return x.compare(y) != 0;
+        }
+
+    template<typename charT, typename traits, typename Allocator>
+    inline bool operator!=(basic_string_ref<charT, traits> x, const std::basic_string<charT, traits, Allocator> & y) {
+        return x != basic_string_ref<charT, traits>(y);
+        }
+
+    template<typename charT, typename traits, typename Allocator>
+    inline bool operator!=(const std::basic_string<charT, traits, Allocator> & x, basic_string_ref<charT, traits> y) {
+        return basic_string_ref<charT, traits>(x) != y;
+        }
+
+    template<typename charT, typename traits>
+    inline bool operator!=(basic_string_ref<charT, traits> x, const charT * y) {
+        return x != basic_string_ref<charT, traits>(y);
+        }
+
+    template<typename charT, typename traits>
+    inline bool operator!=(const charT * x, basic_string_ref<charT, traits> y) {
+        return basic_string_ref<charT, traits>(x) != y;
+        }
+
+//  Less than
+    template<typename charT, typename traits>
+    inline bool operator<(basic_string_ref<charT, traits> x, basic_string_ref<charT, traits> y) {
+        return x.compare(y) < 0;
+        }
+
+    template<typename charT, typename traits, typename Allocator>
+    inline bool operator<(basic_string_ref<charT, traits> x, const std::basic_string<charT, traits, Allocator> & y) {
+        return x < basic_string_ref<charT, traits>(y);
+        }
+
+    template<typename charT, typename traits, typename Allocator>
+    inline bool operator<(const std::basic_string<charT, traits, Allocator> & x, basic_string_ref<charT, traits> y) {
+        return basic_string_ref<charT, traits>(x) < y;
+        }
+
+    template<typename charT, typename traits>
+    inline bool operator<(basic_string_ref<charT, traits> x, const charT * y) {
+        return x < basic_string_ref<charT, traits>(y);
+        }
+
+    template<typename charT, typename traits>
+    inline bool operator<(const charT * x, basic_string_ref<charT, traits> y) {
+        return basic_string_ref<charT, traits>(x) < y;
+        }
+
+//  Greater than
+    template<typename charT, typename traits>
+    inline bool operator>(basic_string_ref<charT, traits> x, basic_string_ref<charT, traits> y) {
+        return x.compare(y) > 0;
+        }
+
+    template<typename charT, typename traits, typename Allocator>
+    inline bool operator>(basic_string_ref<charT, traits> x, const std::basic_string<charT, traits, Allocator> & y) {
+        return x > basic_string_ref<charT, traits>(y);
+        }
+
+    template<typename charT, typename traits, typename Allocator>
+    inline bool operator>(const std::basic_string<charT, traits, Allocator> & x, basic_string_ref<charT, traits> y) {
+        return basic_string_ref<charT, traits>(x) > y;
+        }
+
+    template<typename charT, typename traits>
+    inline bool operator>(basic_string_ref<charT, traits> x, const charT * y) {
+        return x > basic_string_ref<charT, traits>(y);
+        }
+
+    template<typename charT, typename traits>
+    inline bool operator>(const charT * x, basic_string_ref<charT, traits> y) {
+        return basic_string_ref<charT, traits>(x) > y;
+        }
+
+//  Less than or equal to
+    template<typename charT, typename traits>
+    inline bool operator<=(basic_string_ref<charT, traits> x, basic_string_ref<charT, traits> y) {
+        return x.compare(y) <= 0;
+        }
+
+    template<typename charT, typename traits, typename Allocator>
+    inline bool operator<=(basic_string_ref<charT, traits> x, const std::basic_string<charT, traits, Allocator> & y) {
+        return x <= basic_string_ref<charT, traits>(y);
+        }
+
+    template<typename charT, typename traits, typename Allocator>
+    inline bool operator<=(const std::basic_string<charT, traits, Allocator> & x, basic_string_ref<charT, traits> y) {
+        return basic_string_ref<charT, traits>(x) <= y;
+        }
+
+    template<typename charT, typename traits>
+    inline bool operator<=(basic_string_ref<charT, traits> x, const charT * y) {
+        return x <= basic_string_ref<charT, traits>(y);
+        }
+
+    template<typename charT, typename traits>
+    inline bool operator<=(const charT * x, basic_string_ref<charT, traits> y) {
+        return basic_string_ref<charT, traits>(x) <= y;
+        }
+
+//  Greater than or equal to
+    template<typename charT, typename traits>
+    inline bool operator>=(basic_string_ref<charT, traits> x, basic_string_ref<charT, traits> y) {
+        return x.compare(y) >= 0;
+        }
+
+    template<typename charT, typename traits, typename Allocator>
+    inline bool operator>=(basic_string_ref<charT, traits> x, const std::basic_string<charT, traits, Allocator> & y) {
+        return x >= basic_string_ref<charT, traits>(y);
+        }
+
+    template<typename charT, typename traits, typename Allocator>
+    inline bool operator>=(const std::basic_string<charT, traits, Allocator> & x, basic_string_ref<charT, traits> y) {
+        return basic_string_ref<charT, traits>(x) >= y;
+        }
+
+    template<typename charT, typename traits>
+    inline bool operator>=(basic_string_ref<charT, traits> x, const charT * y) {
+        return x >= basic_string_ref<charT, traits>(y);
+        }
+
+    template<typename charT, typename traits>
+    inline bool operator>=(const charT * x, basic_string_ref<charT, traits> y) {
+        return basic_string_ref<charT, traits>(x) >= y;
+        }
+
+    namespace detail {
+
+        template<class charT, class traits>
+        inline void insert_fill_chars(std::basic_ostream<charT, traits>& os, std::size_t n) {
+            enum { chunk_size = 8 };
+            charT fill_chars[chunk_size];
+            std::fill_n(fill_chars, static_cast< std::size_t >(chunk_size), os.fill());
+            for (; n >= chunk_size && os.good(); n -= chunk_size)
+                os.write(fill_chars, static_cast< std::size_t >(chunk_size));
+            if (n > 0 && os.good())
+                os.write(fill_chars, n);
+            }
+
+        template<class charT, class traits>
+        void insert_aligned(std::basic_ostream<charT, traits>& os, const basic_string_ref<charT,traits>& str) {
+            const std::size_t size = str.size();
+            const std::size_t alignment_size = static_cast< std::size_t >(os.width()) - size;
+            const bool align_left = (os.flags() & std::basic_ostream<charT, traits>::adjustfield) == std::basic_ostream<charT, traits>::left;
+            if (!align_left) {
+                detail::insert_fill_chars(os, alignment_size);
+                if (os.good())
+                    os.write(str.data(), size);
+                }
+            else {
+                os.write(str.data(), size);
+                if (os.good())
+                    detail::insert_fill_chars(os, alignment_size);
+                }
+            }
+
+        } // namespace detail
+
+    // Inserter
+    template<class charT, class traits>
+    inline std::basic_ostream<charT, traits>&
+    operator<<(std::basic_ostream<charT, traits>& os, const basic_string_ref<charT,traits>& str) {
+        if (os.good()) {
+            const std::size_t size = str.size();
+            const std::size_t w = static_cast< std::size_t >(os.width());
+            if (w <= size)
+                os.write(str.data(), size);
+            else
+                detail::insert_aligned(os, str);
+            os.width(0);
+            }
+        return os;
+        }
+
+#if 0
+    // numeric conversions
+    //
+    //  These are short-term implementations.
+    //  In a production environment, I would rather avoid the copying.
+    //
+    inline int stoi (string_ref str, size_t* idx=0, int base=10) {
+        return std::stoi ( std::string(str), idx, base );
+        }
+
+    inline long stol (string_ref str, size_t* idx=0, int base=10) {
+        return std::stol ( std::string(str), idx, base );
+        }
+
+    inline unsigned long stoul (string_ref str, size_t* idx=0, int base=10) {
+        return std::stoul ( std::string(str), idx, base );
+        }
+
+    inline long long stoll (string_ref str, size_t* idx=0, int base=10) {
+        return std::stoll ( std::string(str), idx, base );
+        }
+
+    inline unsigned long long stoull (string_ref str, size_t* idx=0, int base=10) {
+        return std::stoull ( std::string(str), idx, base );
+        }
+
+    inline float stof (string_ref str, size_t* idx=0) {
+        return std::stof ( std::string(str), idx );
+        }
+
+    inline double stod (string_ref str, size_t* idx=0) {
+        return std::stod ( std::string(str), idx );
+        }
+
+    inline long double stold (string_ref str, size_t* idx=0)  {
+        return std::stold ( std::string(str), idx );
+        }
+
+    inline int  stoi (wstring_ref str, size_t* idx=0, int base=10) {
+        return std::stoi ( std::wstring(str), idx, base );
+        }
+
+    inline long stol (wstring_ref str, size_t* idx=0, int base=10) {
+        return std::stol ( std::wstring(str), idx, base );
+        }
+
+    inline unsigned long stoul (wstring_ref str, size_t* idx=0, int base=10) {
+        return std::stoul ( std::wstring(str), idx, base );
+        }
+
+    inline long long stoll (wstring_ref str, size_t* idx=0, int base=10) {
+        return std::stoll ( std::wstring(str), idx, base );
+        }
+
+    inline unsigned long long stoull (wstring_ref str, size_t* idx=0, int base=10) {
+        return std::stoull ( std::wstring(str), idx, base );
+        }
+
+    inline float  stof (wstring_ref str, size_t* idx=0) {
+        return std::stof ( std::wstring(str), idx );
+        }
+
+    inline double stod (wstring_ref str, size_t* idx=0) {
+        return std::stod ( std::wstring(str), idx );
+        }
+
+    inline long double stold (wstring_ref str, size_t* idx=0) {
+        return std::stold ( std::wstring(str), idx );
+        }
+#endif
+
+}
+
+#if 0
+namespace std {
+    // Hashing
+    template<> struct hash<boost::string_ref>;
+    template<> struct hash<boost::u16string_ref>;
+    template<> struct hash<boost::u32string_ref>;
+    template<> struct hash<boost::wstring_ref>;
+}
+#endif
+
+#endif

--- a/include/pdal/third/string_ref_fwd.hpp
+++ b/include/pdal/third/string_ref_fwd.hpp
@@ -1,0 +1,37 @@
+/*
+   Copyright (c) Marshall Clow 2012-2012.
+
+   Distributed under the Boost Software License, Version 1.0. (See accompanying
+   file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+    For more information, see http://www.boost.org
+
+    Based on the StringRef implementation in LLVM (http://llvm.org) and
+    N3422 by Jeffrey Yasskin
+        http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2012/n3442.html
+
+*/
+
+#ifndef PDAL_BOOST_STRING_REF_FWD_HPP
+#define PDAL_BOOST_STRING_REF_FWD_HPP
+
+#include <boost/config.hpp>
+#include <string>
+
+namespace pdal {
+
+    template<typename charT, typename traits = std::char_traits<charT> > class basic_string_ref;
+    typedef basic_string_ref<char,     std::char_traits<char> >        string_ref;
+    typedef basic_string_ref<wchar_t,  std::char_traits<wchar_t> >    wstring_ref;
+
+#ifndef BOOST_NO_CXX11_CHAR16_T
+    typedef basic_string_ref<char16_t, std::char_traits<char16_t> > u16string_ref;
+#endif
+
+#ifndef BOOST_NO_CXX11_CHAR32_T
+    typedef basic_string_ref<char32_t, std::char_traits<char32_t> > u32string_ref;
+#endif
+
+}
+
+#endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -60,6 +60,9 @@ set(PDAL_BASE_HPP
   ${PDAL_HEADERS_DIR}/Vector.hpp  
   ${PDAL_HEADERS_DIR}/Writer.hpp
   ${PDAL_HEADERS_DIR}/XMLSchema.hpp
+  ${PDAL_HEADERS_DIR}/third/nanoflann.hpp
+  ${PDAL_HEADERS_DIR}/third/string_ref.hpp
+  ${PDAL_HEADERS_DIR}/third/string_ref_fwd.hpp
 )
 
 if (PDAL_HAVE_LIBXML2)

--- a/src/Schema.cpp
+++ b/src/Schema.cpp
@@ -200,7 +200,7 @@ boost::optional<Dimension const&> Schema::getDimensionOptional(schema::size_type
 }
 
 
-const Dimension& Schema::getDimension(boost::string_ref name, boost::string_ref namespc) const
+const Dimension& Schema::getDimension(string_ref name, string_ref namespc) const
 {
     std::string errorMsg;
     const Dimension* dim = getDimensionPtr(name, namespc, &errorMsg);
@@ -216,16 +216,16 @@ namespace
 {
 // Helpers for searching the dimension index without constructing a std::string
 
-// Hash for boost::string_ref
+// Hash for string_ref
 struct string_ref_hash
 {
-    std::size_t operator()(boost::string_ref str) const
+    std::size_t operator()(string_ref str) const
     {
         return boost::hash_range(str.begin(), str.end());
     }
 };
 
-// Compare boost::string_ref and std::string
+// Compare string_ref and std::string
 struct string_ref_equal
 {
     template<typename T1, typename T2>
@@ -238,17 +238,17 @@ struct string_ref_equal
 } // namespace
 
 
-const Dimension* Schema::getDimensionPtr(boost::string_ref nameIn, boost::string_ref namespc,
+const Dimension* Schema::getDimensionPtr(string_ref nameIn, string_ref namespc,
         std::string* errorMsg) const
 {
-    // getDimensionPtr is implemented in terms of boost::string_ref so that we
+    // getDimensionPtr is implemented in terms of string_ref so that we
     // can guarentee not to allocate memory unless we really need to.
-    boost::string_ref name = nameIn;
-    boost::string_ref ns = namespc;
+    string_ref name = nameIn;
+    string_ref ns = namespc;
     if (ns.empty())
     {
         size_t dotPos = nameIn.rfind('.');
-        if (dotPos != boost::string_ref::npos)
+        if (dotPos != string_ref::npos)
         {
             // dimension is named as namespace.name (eg, drivers.las.reader.X)
             // - split into name and namespace
@@ -370,8 +370,8 @@ const Dimension* Schema::getDimensionPtr(boost::string_ref nameIn, boost::string
 }
 
 
-boost::optional<Dimension const&> Schema::getDimensionOptional(boost::string_ref name,
-        boost::string_ref ns) const
+boost::optional<Dimension const&> Schema::getDimensionOptional(string_ref name,
+        string_ref ns) const
 {
     const Dimension* dim = getDimensionPtr(name, ns);
     if (dim)


### PR DESCRIPTION
@c42f For some reason @gadomski is getting an error when he compiles against an external boost 1.53.  Should we just include string_ref into PDAL for now and hide it behind the pdal:: namespace? It rather significantly increases our boost requirement, and doesn't seem so stable version-to-version as far as boost releases goes right now...

```
/home/gadomski/Code/PDAL-rivlib/test/unit/drivers/rxp/TestReader.cpp:33: undefined reference to `pdal::Schema::getDimension(boost::basic_string_ref<char, std::char_traits<char> >, boost::basic_string_ref<char, std::char_traits<char> >) const'
```

The offending code looks like this:

```
pdal::Dimension const& dimX = schema.getDimension("X");

```
