### PR TITLE
Fix schema operator== comparing self with self and always returning true...

### DIFF
--- a/src/Schema.cpp
+++ b/src/Schema.cpp
@@ -105,7 +105,7 @@ bool Schema::operator==(const Schema& other) const
     if (m_index.size() != other.m_index.size()) return false;
 
     schema::index_by_index const& idx = m_index.get<schema::index>();
-    schema::index_by_index const& idx2 = m_index.get<schema::index>();
+    schema::index_by_index const& idx2 = other.m_index.get<schema::index>();
 
     schema::index_by_index::size_type i(0);
     for (i = 0; i < idx.size(); ++i)


### PR DESCRIPTION
This was causing the pgpointcloud to always select the first schema returned from the database instead of selecting a matching schema or creating a matching schema if one didn't already exist.
