### PR TITLE
CMake doesn't die when USE_PYTHON=ON and NumPy is not found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -581,7 +581,7 @@ if(WITH_PYTHON)
     add_definitions(-DHAVE_PYTHON=1)    
     set(PDAL_HAVE_PYTHON 1)
     
-    find_package(NumPy 1.5)
+    find_package(NumPy 1.5 REQUIRED)
     include_directories(SYSTEM ${NUMPY_INCLUDE_DIR})
     message(STATUS "Found Python: ${PYTHON_LIBRARY}")
   endif()


### PR DESCRIPTION
Is python support useful w/o Numpy? The actual build fails with a missing numpy header, even though CMake both (a) raises a warning about the missing numpy and (b) completes successfully.
