### PR TITLE
#define CPL_SERV_H_INCLUDED to prevent conflict messages

### DIFF
--- a/src/drivers/las/GeotiffSupport.hpp
+++ b/src/drivers/las/GeotiffSupport.hpp
@@ -37,6 +37,9 @@
 
 #include <pdal/pdal_internal.hpp>
 
+// See http://lists.osgeo.org/pipermail/gdal-dev/2013-November/037429.html
+#define CPL_SERV_H_INCLUDED
+
 #ifdef PDAL_HAVE_LIBGEOTIFF
 #include <geo_simpletags.h>
 #include <cpl_conv.h>


### PR DESCRIPTION
libgeotiff and GDAL conflict due to cpl_serv.h. Doing this define before the libgeotiff headers should quiet the error.
