### PR TITLE
#194 and #195 broke the case when the user explicitly sets the offset

### DIFF
--- a/src/filters/InPlaceReprojection.cpp
+++ b/src/filters/InPlaceReprojection.cpp
@@ -253,25 +253,32 @@ Schema InPlaceReprojection::alterSchema(Schema& schema)
     double offset_x = dimX.getNumericOffset();
     double offset_y = dimY.getNumericOffset();
     double offset_z = dimZ.getNumericOffset();
-
+    
+    offset_x = getOptions().getValueOrDefault<double>("offset_x", offset_x);
+    offset_y = getOptions().getValueOrDefault<double>("offset_y", offset_y);
+    offset_z = getOptions().getValueOrDefault<double>("offset_z", offset_z);    
+    
     /* Reproject incoming offsets to new coordinate system */
     log()->floatPrecision(8);
     log()->get(logDEBUG2) << "original offset x,y: " << offset_x <<"," << offset_y << std::endl;
 
     try
     {
-        reprojectOffsets(offset_x, offset_y, offset_z);        
+        double x(offset_x);
+        double y(offset_y);
+        double z(offset_z);
+        reprojectOffsets(x, y, z);        
         log()->get(logDEBUG2) << "reprojected offset x,y: " 
-                              << offset_x <<"," 
-                              << offset_y << std::endl;
+                              << x <<"," 
+                              << y << std::endl;
+        offset_x = x;
+        offset_y = y;
+        offset_z = z;
     } catch (pdal::pdal_error&)
     {
         // If we failed to reproject the offsets, we're going to just use
         // what we have
         /* If user-specified offsets exist, use those instead of the reprojected offsets */
-        offset_x = getOptions().getValueOrDefault<double>("offset_x", offset_x);
-        offset_y = getOptions().getValueOrDefault<double>("offset_y", offset_y);
-        offset_z = getOptions().getValueOrDefault<double>("offset_z", offset_z);
         log()->get(logDEBUG2) << "Default offset used due to inability to reproject original offset x,y: " 
                               << offset_x <<"," 
                               << offset_y << std::endl;


### PR DESCRIPTION
For InPlaceReprojection, if the user explicitly sets the offsets to override them (because of scaling issues, most likely), we need to use those.
#194 and #195 kind of broke this scenario, and it is what is causing #213.
