### PR TITLE
If using external Boost, link libs to utility

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -42,6 +42,10 @@ if(PDAL_UTILITY)
     target_link_libraries(${PDAL_UTILITY} ${PDAL_LINKAGE} ${PDAL_LIB_NAME})
 endif()
 
+if(NOT PDAL_EMBED_BOOST)
+    target_link_libraries(${PDAL_UTILITY} ${BOOST_LINKAGE} ${Boost_LIBRARIES})
+endif()
+
 #------------------------------------------------------------------------------
 # Targets installation
 #------------------------------------------------------------------------------


### PR DESCRIPTION
I added the PDAL_EMBED_BOOST conditional, because it seemed to compile fine when using the internal Boost libs. However, the pdal lib adds the same Boost libs target link without any conditional. Not sure which is preferred, so I avoided any possible unnecessary linking.
