### PR TITLE
Exclude PCLBlockFilterTest when building w/o PCL

### DIFF
--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -37,7 +37,6 @@ SET(PDAL_UNITTEST_TEST_SRC
     MetadataTest.cpp
     filters/MosaicFilterTest.cpp
     OptionsTest.cpp
-    filters/PCLBlockFilterTest.cpp
     PipelineManagerTest.cpp
     drivers/pipeline/PipelineReaderTest.cpp
     drivers/pipeline/PipelineWriterTest.cpp
@@ -142,6 +141,17 @@ if (WITH_NITRO)
             CACHE INTERNAL "source files for test")
     ENDFOREACH(file)
 endif (WITH_NITRO)
+
+if (WITH_PCL)
+    set(PDAL_PCL_TEST_CPP
+        filters/PCLBlockFilterTest.cpp
+        )
+
+    FOREACH(file ${PDAL_PCL_TEST_CPP})
+        SET(PDAL_UNITTEST_TEST_SRC "${PDAL_UNITTEST_TEST_SRC};${file}"
+            CACHE INTERNAL "source files for test")
+    ENDFOREACH(file)
+endif (WITH_PCL)
 
 set(PDAL_UNITTEST_SOURCES "")
 FOREACH(file ${PDAL_UNITTEST_TEST_SRC})


### PR DESCRIPTION
This patch puts `filters/PCLBlockFilterTest.cpp` inside a WITH_PCL check,
so we build with it only when we have PCL available.
