### PR TITLE
Add word expansion (shell syntax handling) for filenames in pipelines on

### DIFF
--- a/include/pdal/Options.hpp
+++ b/include/pdal/Options.hpp
@@ -93,46 +93,16 @@ public:
 
     /// Empty constructor
     Option()
-        : m_name("")
-        , m_value("")
-        , m_description("")
-    {
-        return;
-    }
+    {}
 
     /// Primary constructor
     template <typename T>
-    Option(std::string const& name, const T& value, std::string const& description="")
-        : m_name(name)
-        , m_value("")
-        , m_description(description)
+    Option(std::string const& name, const T& value,
+            std::string const& description = "") :
+        m_name(name), m_description(description)
     {
         // FIXME: This shouldn't be able to throw -- hobu
         setValue<T>(value);
-        return;
-    }
-
-    /// Copy constructor
-    Option(const Option& rhs)
-        : m_name(rhs.m_name)
-        , m_value(rhs.m_value)
-        , m_description(rhs.m_description)
-        , m_options(rhs.m_options)
-    {
-        return;
-    }
-
-    /// Assignment constructor
-    Option& operator=(const Option& rhs)
-    {
-        if (&rhs != this)
-        {
-            m_name = rhs.m_name;
-            m_value = rhs.m_value;
-            m_description = rhs.m_description;
-            m_options = rhs.m_options;
-        }
-        return *this;
     }
 
     /// Construct from an existing boost::property_tree
@@ -142,13 +112,10 @@ public:
     /// Equality
     bool equals(const Option& rhs) const
     {
-        if (m_name == rhs.getName() &&
-                m_value == rhs.getValue<std::string>() &&
-                m_description == rhs.getDescription() && m_options == rhs.m_options)
-        {
-            return true;
-        }
-        return false;
+        return (m_name == rhs.getName() &&
+            m_value == rhs.getValue<std::string>() &&
+            m_description == rhs.getDescription() &&
+            m_options == rhs.m_options);
     }
 
     /// Equality operator
@@ -197,7 +164,8 @@ public:
         return boost::lexical_cast<T>(m_value);
     }
 
-    /// sets the value of the Option to T after boost::lexical_cast'ing it to a std::string
+    /// sets the value of the Option to T after boost::lexical_cast'ing
+    /// it to a std::string
     template<typename T> void setValue(const T& value)
     {
         m_value = boost::lexical_cast<std::string>(value);
@@ -229,12 +197,15 @@ public:
     /// the string value of the Option is "true" or "false"
     template<> bool getValue() const
     {
-        if (m_value=="true") return true;
-        if (m_value=="false") return false;
+        if (m_value == "true")
+            return true;
+        if (m_value=="false")
+            return false;
         return boost::lexical_cast<bool>(m_value);
     }
 
-    /// explicit specialization to return a (const ref) string so we don't need lexical_cast
+    /// explicit specialization to return a (const ref) string so we
+    /// don't need lexical_cast
     template<> const std::string& getValue() const
     {
         return m_value;
@@ -318,27 +289,16 @@ public:
     Options(const Options&);
 
     // assignment operator
-    Options& operator=(const Options& rhs)
-    {
-        if (&rhs != this)
-        {
-            m_options = rhs.m_options;
-        }
-        return *this;
-    }
-
-    // assignment operator
     Options& operator+=(const Options& rhs)
     {
-
         if (&rhs != this)
         {
             options::map_t::const_iterator i;
             for (i = rhs.m_options.begin(); i != rhs.m_options.end(); ++i)
             {
-                m_options.insert(std::pair<std::string, Option>(i->first, i->second));
+                m_options.insert(std::pair<std::string, Option>(
+                    i->first, i->second));
             }
-
         }
         return *this;
     }
@@ -350,11 +310,7 @@ public:
 
     bool equals(const Options& rhs) const
     {
-        if (m_options== rhs.m_options)
-        {
-            return true;
-        }
-        return false;
+        return m_options == rhs.m_options;
     }
 
     bool operator==(const Options& rhs) const
@@ -378,7 +334,8 @@ public:
     void remove(const std::string& name);
 
     // add an option (shortcut version, bypass need for an Option object)
-    template<typename T> void add(const std::string& name, T value, const std::string& description="")
+    template<typename T> void add(const std::string& name, T value,
+        const std::string& description="")
     {
         Option opt(name, value, description);
         add(opt);
@@ -397,7 +354,8 @@ public:
     }
 
     // get value of an option, or use given default if option not present
-    template<typename T> T getValueOrDefault(std::string const& name, T defaultValue) const
+    template<typename T> T getValueOrDefault(std::string const& name,
+        T defaultValue) const
     {
         T result;
 
@@ -422,7 +380,8 @@ public:
     boost::property_tree::ptree toPTree() const;
 
     // the empty options list
-    // BUG: this should be a member variable, not a function, but doing so causes vs2010 to fail to link
+    // BUG: this should be a member variable, not a function, but doing so
+    // causes vs2010 to fail to link
     static const Options& none();
 
     void dump() const;
@@ -476,14 +435,16 @@ public:
             try
             {
                 meta->getOption(name);
-                } catch (pdal::option_not_found&) { return boost::optional<T>(); }
+            }
+            catch (pdal::option_not_found&)
+            {
+                return boost::optional<T>();
+            }
 
             return boost::optional<T>(meta->getOption(name).getValue<T>());
         }
-
         return boost::optional<T>();
     }
-
 
 private:
     options::map_t m_options;

--- a/include/pdal/PipelineReader.hpp
+++ b/include/pdal/PipelineReader.hpp
@@ -54,8 +54,8 @@ private:
     class StageParserContext;
 
 public:
-    PipelineReader(PipelineManager&, bool debug=false, boost::uint32_t verbose=0);
-    ~PipelineReader();
+    PipelineReader(PipelineManager&, bool debug=false,
+        boost::uint32_t verbose = 0);
 
     // Use this to fill in a pipeline manager with an XML file that
     // contains a <Writer> as the last pipeline stage.
@@ -69,16 +69,18 @@ private:
     typedef std::map<std::string, std::string> map_t;
 
     bool parseElement_Pipeline(const boost::property_tree::ptree&);
-    Stage* parseElement_anystage(const std::string& name, const boost::property_tree::ptree& subtree);
+    Stage* parseElement_anystage(const std::string& name,
+        const boost::property_tree::ptree& subtree);
     Reader* parseElement_Reader(const boost::property_tree::ptree& tree);
     Filter* parseElement_Filter(const boost::property_tree::ptree& tree);
-    MultiFilter* parseElement_MultiFilter(const boost::property_tree::ptree& tree);
+    MultiFilter* parseElement_MultiFilter(
+        const boost::property_tree::ptree& tree);
     Writer* parseElement_Writer(const boost::property_tree::ptree& tree);
-
     Option parseElement_Option(const boost::property_tree::ptree& tree);
-
-    void collect_attributes(map_t& attrs, const boost::property_tree::ptree& tree);
-    void parse_attributes(map_t& attrs, const boost::property_tree::ptree& tree);
+    void collect_attributes(map_t& attrs,
+        const boost::property_tree::ptree& tree);
+    void parse_attributes(map_t& attrs,
+        const boost::property_tree::ptree& tree);
 
 private:
     PipelineManager& m_manager;

--- a/src/Options.cpp
+++ b/src/Options.cpp
@@ -50,9 +50,6 @@
 namespace pdal
 {
 
-//---------------------------------------------------------------------------
-
-
 Option::Option(const boost::property_tree::ptree& tree)
     : m_name("")
     , m_value("")
@@ -62,13 +59,13 @@ Option::Option(const boost::property_tree::ptree& tree)
 
     m_name = tree.get<std::string>("Name");
     m_value = tree.get<std::string>("Value");
-    m_description = tree.count("Description") ? tree.get<std::string>("Description") : "";
+    m_description =
+    tree.count("Description") ? tree.get<std::string>("Description") : "";
 
     boost::property_tree::ptree opts;
     ptree const& options = tree.get_child("Options", opts);
     if (options.size())
         m_options = options::OptionsPtr(new Options(options));
-    return;
 }
 
 
@@ -98,8 +95,7 @@ boost::optional<Options const&> Option::getOptions() const
 
 void Option::setOptions(Options const& options)
 {
-    options::OptionsPtr p = options::OptionsPtr(new Options(options));
-    m_options = p;
+    m_options = options::OptionsPtr(new Options(options));
 }
 
 #if !defined(PDAL_COMPILER_MSVC)
@@ -108,8 +104,10 @@ void Option::setOptions(Options const& options)
 //   so we handle those situations explicitly
 template<> bool Option::getValue() const
 {
-    if (m_value=="true") return true;
-    if (m_value=="false") return false;
+    if (m_value == "true")
+        return true;
+    if (m_value == "false")
+        return false;
     return boost::lexical_cast<bool>(m_value);
 }
 
@@ -144,37 +142,29 @@ template<> void Option::setValue(const std::string& value)
 
 Options::Options(const Options& rhs)
     : m_options(rhs.m_options)
-{
-    return;
-}
+{}
 
 
 Options::Options(const Option& opt)
 {
     add(opt);
-    return;
 }
 
 
 Options::Options(const boost::property_tree::ptree& tree)
 {
-    for (boost::property_tree::ptree::const_iterator iter = tree.begin();
-            iter != tree.end();
-            ++iter)
+    for (auto iter = tree.begin(); iter != tree.end(); ++iter)
     {
         assert(iter->first == "Option");
         Option opt(iter->second);
         add(opt);
     }
-
-    return;
 }
 
 
 void Options::add(const Option& option)
 {
     m_options.insert(std::pair<std::string, Option>(option.getName(), option));
-    // m_options[option.getName()] = option;
 }
 
 
@@ -184,11 +174,11 @@ Option& Options::getOptionByRef(const std::string& name)
     if (iter == m_options.end())
     {
         std::ostringstream oss;
-        oss << "Options::getOptionByRef: Required option '" << name << "' was not found on this stage";
+        oss << "Options::getOptionByRef: Required option '" << name <<
+            "' was not found on this stage";
         throw option_not_found(oss.str());
     }
-    Option& option = iter->second;
-    return option;
+    return iter->second;
 }
 
 
@@ -198,38 +188,34 @@ const Option& Options::getOption(const std::string& name) const
     if (iter == m_options.end())
     {
         std::ostringstream oss;
-        oss << "Options::getOption: Required option '" << name << "' was not found on this stage";
+        oss << "Options::getOption: Required option '" << name <<
+            "' was not found on this stage";
         throw option_not_found(oss.str());
     }
-    const Option& option = iter->second;
-    return option;
+    return iter->second;
 }
 
 std::vector<Option> Options::getOptions(std::string const& name) const
 {
-    std::pair<std::multimap<std::string,Option>::const_iterator,std::multimap<std::string,Option>::const_iterator> ret;
     std::vector<Option> output;
 
     // If we have an empty name, return them all
     if (boost::iequals(name, ""))
     {
-        std::multimap<std::string, Option>::const_iterator it;
-        for (it = m_options.begin(); it != m_options.end(); ++it)
+        for (auto it = m_options.begin(); it != m_options.end(); ++it)
         {
-            output.push_back((*it).second);
+            output.push_back(it->second);
         }
     }
     else
     {
-        ret = m_options.equal_range(name);
-        std::multimap<std::string, Option>::const_iterator it;
-        for (it = ret.first; it != ret.second; ++it)
+        auto ret = m_options.equal_range(name);
+        for (auto it = ret.first; it != ret.second; ++it)
         {
-            output.push_back((*it).second);
+            output.push_back(it->second);
         }
     }
     return output;
-
 }
 
 // the empty options set
@@ -242,20 +228,14 @@ const Options& Options::none()
 
 bool Options::hasOption(std::string const& name) const
 {
-    bool ok = false;
-
     try
     {
         (void)getOption(name);
-        ok = true;
+        return true;
     }
     catch (option_not_found&)
-    {
-        ok = false;
-    }
-    // any other exception will bubble up
-
-    return ok;
+    {}
+    return false;
 }
 
 
@@ -263,13 +243,12 @@ boost::property_tree::ptree Options::toPTree() const
 {
     boost::property_tree::ptree tree;
 
-    for (options::map_t::const_iterator citer = m_options.begin(); citer != m_options.end(); ++citer)
+    for (auto citer = m_options.begin(); citer != m_options.end(); ++citer)
     {
         const Option& option = citer->second;
         boost::property_tree::ptree subtree = option.toPTree();
         tree.add_child("Option", subtree);
     }
-
     return tree;
 }
 


### PR DESCRIPTION
non-Windows systems.
Use some C++11 and use the boost::property_tree namespace to simplify code
in Options.*
