### PR TITLE
Allow point dump with sequential iterators.

### DIFF
--- a/include/pdal/StageIterator.hpp
+++ b/include/pdal/StageIterator.hpp
@@ -84,6 +84,17 @@ public:
     void readBufferEnd(PointBuffer&);
     void readEnd();
 
+    // advance N points ahead in the file
+    //
+    // In some cases, this might be a very slow, painful function to call
+    // because it might entail physically reading the N points (and dropping
+    // the data on the floor)
+    //
+    // Returns the number actually skipped (which might be less than count,
+    // if the end of the stage was reached first).
+    //
+    virtual boost::uint64_t skip(boost::uint64_t count);
+
     // Returns the current point number.  The first point is 0.
     // If this number if > getNumPoints(), then no more points
     // may be read (and atEnd() should be true).
@@ -108,6 +119,7 @@ protected:
     virtual boost::uint32_t readBufferImpl(PointBuffer&) = 0;
     virtual void readBufferEndImpl(PointBuffer&) {}
     virtual void readEndImpl() {}
+    virtual boost::uint64_t skipImpl(boost::uint64_t pointNum) = 0;
 
     // This is provided as a sample implementation that some stages could use
     // to implement their own skip or seek functions. It uses the read() call
@@ -134,24 +146,12 @@ public:
     StageSequentialIterator(PointBuffer& buffer);
     virtual ~StageSequentialIterator();
 
-    // advance N points ahead in the file
-    //
-    // In some cases, this might be a very slow, painful function to call
-    // because it might entail physically reading the N points (and dropping
-    // the data on the floor)
-    //
-    // Returns the number actually skipped (which might be less than count,
-    // if the end of the stage was reached first).
-    //
-    boost::uint64_t skip(boost::uint64_t count);
-
     // returns true after we've read all the points available to this stage
     bool atEnd() const;
 
 protected:
     // from Iterator
     virtual boost::uint32_t readBufferImpl(PointBuffer&) = 0;
-    virtual boost::uint64_t skipImpl(boost::uint64_t pointNum) = 0;
     virtual bool atEndImpl() const = 0;
 };
 
@@ -175,6 +175,7 @@ public:
 protected:
     // from Iterator
     virtual boost::uint64_t seekImpl(boost::uint64_t position) = 0;
+    virtual boost::uint64_t skipImpl(boost::uint64_t position);
 };
 
 } // namespace pdal

--- a/include/pdal/kernel/Info.hpp
+++ b/include/pdal/kernel/Info.hpp
@@ -71,7 +71,13 @@ private:
     void validateSwitches(); // overrride
 
     void dumpPoints(const Stage& stage, std::string const& points) const;
-    void dumpStats(pdal::filters::Stats& filter, PipelineManager* manager) const;
+    void dumpPointsRandom(const std::vector<uint32_t>& points,
+        StageRandomIterator *iter) const;
+    void dumpPointsSequential(const std::vector<uint32_t>& points,
+        StageSequentialIterator *iter) const;
+    void dumpPointData(PointBuffer& outputData) const;
+    void dumpStats(pdal::filters::Stats& filter,
+    PipelineManager* manager) const;
     void dumpSchema(const Stage&, pdal::PipelineManager* manager) const;
     void dumpStage(const Stage&) const;
     void dumpQuery(Stage const&, IndexedPointBuffer&) const;

--- a/src/StageIterator.cpp
+++ b/src/StageIterator.cpp
@@ -164,6 +164,15 @@ void StageIterator::readEnd()
 }
 
 
+boost::uint64_t StageIterator::skip(boost::uint64_t count)
+{
+    uint32_t pos = m_index;
+    boost::uint64_t numSkipped = skipImpl(count);
+    m_index = pos + numSkipped;
+    return numSkipped;
+}
+
+
 boost::uint64_t StageIterator::naiveSkipImpl(boost::uint64_t count)
 {
     boost::uint64_t totalNumRead = 0;
@@ -206,14 +215,6 @@ StageSequentialIterator::~StageSequentialIterator()
 {}
 
 
-boost::uint64_t StageSequentialIterator::skip(boost::uint64_t count)
-{
-    boost::uint64_t numSkipped = skipImpl(count);
-    m_index += numSkipped;
-    return numSkipped;
-}
-
-
 bool StageSequentialIterator::atEnd() const
 {
     return atEndImpl();
@@ -238,6 +239,14 @@ boost::uint64_t StageRandomIterator::seek(boost::uint64_t position)
 {
     m_index = seekImpl(position);
     return m_index;
+}
+
+
+boost::uint64_t StageRandomIterator::skipImpl(boost::uint64_t numPts)
+{
+    uint64_t pos = m_index;
+    pos = seekImpl(pos + numPts);
+    return (pos - numPts);
 }
 
 } // namespace pdal


### PR DESCRIPTION
Allow pdal info to work with a sequential iterator as long as the requested points are in order (monotonically increasing).
