### PR TITLE
Provide switch to turn on Vagrant's ssh forwarding

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,6 +12,25 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.hostname = "pdal-vagrant"
   config.vm.box_url = "http://files.vagrantup.com/precise64.box"
   config.vm.host_name = "pdal-vagrant"
+
+  # Set the bash environment variable PDAL_VAGRANT_SSH_FORWARD_AGENT to any
+  # value to turn on ssh forwarding. This allows you to use your host machine's
+  # ssh credentials inside your guest box, for example when interacting with
+  # private github repositories.
+  #
+  # To confirm that ssh fowarding is working, run the following from inside the
+  # guest machine:
+  #
+  #   ssh -T git@github.com
+  #
+  # You should see something like "Hi <your name here>! You've successfully
+  # authenticated, but GitHub does not provide shell access."
+  #
+  # You may need to run `ssh-add` on your host machine to add your private key
+  # identities to the authentication agent.
+  if ENV['PDAL_VAGRANT_SSH_FORWARD_AGENT']
+    config.ssh.forward_agent = true
+  end
   
   config.vm.network :forwarded_port, guest: 80, host: 8080
 


### PR DESCRIPTION
The switch is an environment variable, PDAL_VAGRANT_SSH_FOWARD_AGENT, which, when set to any value, turns on ssh.forward_agent in the Vagrantfile. More information about ssh configuration options can be found in the [Vagrant docs](http://docs.vagrantup.com/v2/vagrantfile/ssh_settings.html).

To turn on ssh forwading automatically when you boot your PDAL Vagrant VM, put the following in your bash profile:

``` bash
export PDAL_VAGRANT_SSH_FORWARD_AGENT=true
```

It seems to me as if environment variables (with a PDAL_VAGRANT_ prefix) might be the cleanest way to provide per-developer configuration for the Vagrantfile. Other suggestions for these customizations are welcome.
