### PR TITLE
drivers.las.writer uses metadata instead of option when 'format' is set

### DIFF
--- a/include/pdal/drivers/las/Writer.hpp
+++ b/include/pdal/drivers/las/Writer.hpp
@@ -127,7 +127,7 @@ private:
         boost::optional<std::string> candidate = options.getMetadataOption<std::string>(name);
         if (!candidate)
         {
-            return default_value;
+            return options.getValueOrDefault<T>(name, default_value);
         }
             
         if (boost::algorithm::iequals(*candidate, "FORWARD"))

--- a/src/drivers/las/Writer.cpp
+++ b/src/drivers/las/Writer.cpp
@@ -421,11 +421,16 @@ void Writer::writeBufferBegin(PointBuffer const& data)
         // or given in a metadata option
         boost::uint32_t v = getMetadataOption<boost::uint32_t>(getOptions(),
             m, "dataformat_id", 3);
+        boost::uint32_t v2 = getMetadataOption<boost::uint32_t>(getOptions(),
+            m, "format", 3);
+            
+        // Use the 'format' option specified by the options instead of the metadata one that was set passively
+        if (v2 != v) v = v2; 
         setPointFormat(static_cast<PointFormat>(v));
         log()->get(logDEBUG) << "Setting point format to "
                              << v
                              << " from metadata " << std::endl;
-
+        
         boost::uint32_t minor = getMetadataOption<boost::uint32_t>(getOptions(),
             m, "minor_version", 2);
 

--- a/test/data/pipeline/pipeline_write.xml
+++ b/test/data/pipeline/pipeline_write.xml
@@ -1,12 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Pipeline version="1.0">
     <Writer type="drivers.las.writer">
+        <Option name="metadata">
+            <Options/>
+          </Option>
         <Option name="filename">
             pdal-compressed.laz
         </Option>
         <Option name="compression">
             true
         </Option>
+        <Option name="format">
+            2
+        </Option>        
         <Filter type="filters.stats">
             <Option name="exact_dimensions">Classification</Option>
             <Option name="dimensions">drivers.las.reader.X, drivers.las.reader.Y, drivers.las.reader.Z, Classification</Option>


### PR DESCRIPTION
If the user actually set a format option, it should be used no matter what.
