### PR TITLE
Add default statement to fix busted GCC implementation.

### DIFF
--- a/src/drivers/bpf/BpfSeqIterator.cpp
+++ b/src/drivers/bpf/BpfSeqIterator.cpp
@@ -82,6 +82,8 @@ BpfSeqIterator::Charbuf::seekoff(off_type off, std::ios_base::seekdir dir,
         case std::ios::end:
             cpos = egptr() - off;
             break;
+        default:
+            break;
     }
     if (cpos < eback() || cpos > egptr())
         return -1;


### PR DESCRIPTION
The standard only lists three value of std::seekdir, but GCC 4.8 complains anyway.
