### PR TITLE
Allow a FauxReader to have an unknown point count

### DIFF
--- a/include/pdal/drivers/faux/Reader.hpp
+++ b/include/pdal/drivers/faux/Reader.hpp
@@ -87,7 +87,7 @@ public:
     Reader(const Options& options);
     Reader(const Bounds<double>&, boost::uint64_t numPoints, Mode mode);
     Reader(const Bounds<double>&, boost::uint64_t numPoints, Mode mode,
-        const std::vector<Dimension>& dimensions);
+        const std::vector<Dimension>& dimensions, bool forceZeroNumPoints = false);
 
     virtual void initialize();
     static Options getDefaultOptions();

--- a/src/drivers/faux/Reader.cpp
+++ b/src/drivers/faux/Reader.cpp
@@ -63,6 +63,7 @@ Reader::Reader(const Options& options)
     , m_mode(string2mode(options.getValueOrThrow<std::string>("mode")))
 {
     m_schema = Schema(getDefaultDimensions());
+    setNumPoints(m_numPoints);
 }
 
 
@@ -73,15 +74,18 @@ Reader::Reader(const Bounds<double>& bounds, boost::uint64_t numPoints, Mode mod
     , m_mode(mode)
 {
     m_schema = Schema(getDefaultDimensions());
+    setNumPoints(m_numPoints);
 }
 
-Reader::Reader(const Bounds<double>& bounds, boost::uint64_t numPoints, Mode mode, const std::vector<Dimension>& dimensions)
+Reader::Reader(const Bounds<double>& bounds, boost::uint64_t numPoints, Mode mode, const std::vector<Dimension>& dimensions,
+               bool forceZeroNumPoints)
     : pdal::Reader(Options::none())
     , m_bounds(bounds)
     , m_numPoints(numPoints)
     , m_mode(mode)
 {
     m_schema = Schema(dimensions);
+    setNumPoints(forceZeroNumPoints ? 0 : m_numPoints);
 }
 
 std::vector<Dimension> Reader::getDefaultDimensions()
@@ -114,8 +118,6 @@ void Reader::initialize()
 {
     pdal::Reader::initialize();
 
-    setNumPoints(m_numPoints);
-
     setBounds(m_bounds);
 }
 
@@ -137,7 +139,7 @@ pdal::StageSequentialIterator*
 Reader::createSequentialIterator(PointBuffer& buffer) const
 {
     return new pdal::drivers::faux::iterators::sequential::Reader(*this,
-        buffer, getNumPoints(), log());
+        buffer, m_numPoints, log());
 }
 
 
@@ -158,7 +160,7 @@ boost::uint32_t Reader::processBuffer(PointBuffer& data, boost::uint64_t index) 
     boost::uint64_t numPointsWanted = data.getCapacity();
 
     // we can only give them as many as we have left
-    boost::uint64_t numPointsAvailable = getNumPoints() - index;
+    boost::uint64_t numPointsAvailable = m_numPoints - index;
     if (numPointsAvailable < numPointsWanted)
         numPointsWanted = numPointsAvailable;
 
@@ -171,7 +173,7 @@ boost::uint32_t Reader::processBuffer(PointBuffer& data, boost::uint64_t index) 
     const double minZ = dims[2].getMinimum();
     const double maxZ = dims[2].getMaximum();
 
-    const double numDeltas = (double)getNumPoints() - 1.0;
+    const double numDeltas = (double)m_numPoints - 1.0;
     const double delX = (maxX - minX) / numDeltas;
     const double delY = (maxY - minY) / numDeltas;
     const double delZ = (maxZ - minZ) / numDeltas;

--- a/test/unit/drivers/faux/FauxReaderTest.cpp
+++ b/test/unit/drivers/faux/FauxReaderTest.cpp
@@ -415,4 +415,24 @@ BOOST_AUTO_TEST_CASE(test_custom_fields)
 }
 
 
+BOOST_AUTO_TEST_CASE(testUnknownPointCountType)
+{
+    Bounds<double> bounds(1.0, 2.0, 3.0, 101.0, 102.0, 103.0);
+    std::vector<Dimension> dims = pdal::drivers::faux::Reader::getDefaultDimensions();
+    pdal::drivers::faux::Reader reader(bounds, 1000, pdal::drivers::faux::Reader::Constant,
+                                       dims, true);
+    reader.initialize();
+    BOOST_CHECK_EQUAL(reader.getNumPoints(), 0);
+
+    PointBuffer data(reader.getSchema(), 1250);
+    StageSequentialIterator* iter = reader.createSequentialIterator(data);
+    boost::uint32_t numRead = iter->read(data);
+    BOOST_CHECK_EQUAL(numRead, 1000);
+
+    delete iter;
+
+    return;
+}
+
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This will be used for simulating readers that also have unknown point counts.

The point count type argument is added as an optional parameter to the longest faux::Reader constructor. There's a couple of ways to skin that cat but this one seemed like the one with the lowest friction.
