### PR TITLE
Remove m_pointCountType and references

### DIFF
--- a/include/pdal/Stage.hpp
+++ b/include/pdal/Stage.hpp
@@ -71,7 +71,6 @@ public:
     }
     
     virtual boost::uint64_t getNumPoints() const;
-    PointCountType getPointCountType() const;
     const Bounds<double>& getBounds() const;
     const SpatialReference& getSpatialReference() const;
 
@@ -86,7 +85,6 @@ protected:
 
     void setSchema(Schema const&);
     void setNumPoints(boost::uint64_t);
-    void setPointCountType(PointCountType);
     void setBounds(Bounds<double> const&);
     void setSpatialReference(SpatialReference const&);
 
@@ -96,7 +94,6 @@ protected:
 
 private:
     mutable boost::uint64_t m_numPoints;
-    PointCountType m_pointCountType;
     Bounds<double> m_bounds;
     SpatialReference m_spatialReference;
 

--- a/include/pdal/pdal_types.hpp
+++ b/include/pdal/pdal_types.hpp
@@ -47,11 +47,6 @@ enum EndianType
     Endian_Unknown = 128
 };
 
-enum PointCountType
-{
-    PointCount_Fixed,       // getNumPoints will return value (which might be zero, though)
-    PointCount_Unknown      // the stage has an unknown count, and getNumPoints will return 0
-};
 
 enum StageIteratorType
 {

--- a/src/Stage.cpp
+++ b/src/Stage.cpp
@@ -44,7 +44,6 @@ namespace pdal
 Stage::Stage(const std::vector<StageBase*>& prevs, const Options& options)
     : StageBase(prevs, options)
     , m_numPoints(0)
-    , m_pointCountType(PointCount_Fixed)
 {}
 
 
@@ -121,18 +120,6 @@ void Stage::setNumPoints(boost::uint64_t numPoints)
 }
 
 
-PointCountType Stage::getPointCountType() const
-{
-    return m_pointCountType;
-}
-
-
-void Stage::setPointCountType(PointCountType pointCountType)
-{
-    m_pointCountType = pointCountType;
-}
-
-
 const SpatialReference& Stage::getSpatialReference() const
 {
     return m_spatialReference;
@@ -159,7 +146,6 @@ void Stage::setCoreProperties(const Stage& stage)
 {
     this->setSchema(stage.getSchema());
     this->setNumPoints(stage.getNumPoints());
-    this->setPointCountType(stage.getPointCountType());
     this->setBounds(stage.getBounds());
     this->setSpatialReference(stage.getSpatialReference());
 }

--- a/src/drivers/buffer/Reader.cpp
+++ b/src/drivers/buffer/Reader.cpp
@@ -52,7 +52,6 @@ Reader::Reader(const Options& options, const PointBuffer& buffer)
     setNumPoints(buffer.getNumPoints());
     setBounds(buffer.getSpatialBounds());
     setSchema(buffer.getSchema());
-    setPointCountType(PointCount_Fixed);
 
     return;
 }

--- a/src/drivers/faux/Reader.cpp
+++ b/src/drivers/faux/Reader.cpp
@@ -115,7 +115,6 @@ void Reader::initialize()
     pdal::Reader::initialize();
 
     setNumPoints(m_numPoints);
-    setPointCountType(PointCount_Fixed);
 
     setBounds(m_bounds);
 }

--- a/src/drivers/mrsid/Reader.cpp
+++ b/src/drivers/mrsid/Reader.cpp
@@ -102,7 +102,6 @@ void Reader::initialize()
     }
 
     setNumPoints(m_PS->getNumPoints());
-    setPointCountType(PointCount_Fixed);
     pdal::Bounds<double> b(m_PS->getBounds().x.min, m_PS->getBounds().x.max, m_PS->getBounds().y.min, m_PS->getBounds().y.max, m_PS->getBounds().z.min,m_PS->getBounds().z.max);
     setBounds(b);
     m_iter = m_PS->createIterator(m_PS->getBounds(), 1.0, m_PS->getPointInfo(), NULL);

--- a/src/drivers/pipeline/Reader.cpp
+++ b/src/drivers/pipeline/Reader.cpp
@@ -80,7 +80,6 @@ void Reader::initialize()
     setSchema(m_stage->getSchema());
 
     setNumPoints(m_stage->getNumPoints());
-    setPointCountType(m_stage->getPointCountType());
     setBounds(m_stage->getBounds());
     setSpatialReference(m_stage->getSpatialReference());
 

--- a/src/drivers/qfit/Reader.cpp
+++ b/src/drivers/qfit/Reader.cpp
@@ -388,7 +388,6 @@ Reader::Reader(const Options& options)
         throw qfit_error(msg.str());
 
     }
-    setPointCountType(PointCount_Fixed);
     setNumPoints(count);
 
     if (str != 0)

--- a/src/filters/ByteSwap.cpp
+++ b/src/filters/ByteSwap.cpp
@@ -69,7 +69,6 @@ void ByteSwap::initialize()
 
     const Stage& stage = getPrevStage();
     this->setNumPoints(stage.getNumPoints());
-    this->setPointCountType(stage.getPointCountType());
 
     schema::index_by_index const& dimensions =
         m_schema.getDimensions().get<schema::index>();

--- a/src/filters/Chipper.cpp
+++ b/src/filters/Chipper.cpp
@@ -107,7 +107,6 @@ void Chipper::initialize()
 
     m_schema = alterSchema(m_schema);
 
-    setPointCountType(PointCount_Fixed);
     setNumPoints(0);
 
     if (m_threshold == 0)

--- a/src/filters/Crop.cpp
+++ b/src/filters/Crop.cpp
@@ -169,7 +169,6 @@ void Crop::initialize()
 
     setBounds(m_bounds);
     setNumPoints(0);
-    setPointCountType(PointCount_Unknown);
 }
 
 

--- a/src/filters/Mosaic.cpp
+++ b/src/filters/Mosaic.cpp
@@ -61,7 +61,6 @@ void Mosaic::initialize()
     const SpatialReference& srs0 = stage0.getSpatialReference();
     bool respectSrs = getOptions().getValueOrDefault<bool>("require_matching_srs", false);
     const Schema& schema0 = stage0.getSchema();
-    PointCountType pointCountType0 = stage0.getPointCountType();
     boost::uint64_t totalPoints = stage0.getNumPoints();
     Bounds<double> bigbox(stage0.getBounds());
 
@@ -73,19 +72,13 @@ void Mosaic::initialize()
             throw impedance_invalid("mosaicked stages must have same srs");
         if (stage.getSchema() != schema0)
             throw impedance_invalid("mosaicked stages must have same schema");
-        if (stage.getPointCountType() == PointCount_Unknown)
-            pointCountType0 = PointCount_Unknown;
 
         totalPoints += stage.getNumPoints();
 
         bigbox.grow(stage.getBounds());
     }
 
-    if (pointCountType0 == PointCount_Unknown)
-        totalPoints = 0;
-
     setCoreProperties(stage0);
-    setPointCountType(pointCountType0);
     setNumPoints(totalPoints);
 
     return;

--- a/test/data/apps/pdalinfo_stage.txt
+++ b/test/data/apps/pdalinfo_stage.txt
@@ -21,7 +21,6 @@
         }
     },
     "NumPoints": "1065",
-    "PointCountType": "0",
     "Bounds": "([635620, 638983], [848900, 853535], [406.59, 586.38])",
     "SRS": "",
     "Compression": "false"

--- a/test/data/apps/pdalinfo_stage_nosrs.txt
+++ b/test/data/apps/pdalinfo_stage_nosrs.txt
@@ -21,7 +21,6 @@
         }
     },
     "NumPoints": "1065",
-    "PointCountType": "0",
     "Bounds": "([635620, 638983], [848900, 853535], [406.59, 586.38])",
     "SRS": "SpatialReference data is not available without GDAL+libgeotiff support",
     "Compression": "false"

--- a/test/unit/drivers/sbet/SbetReaderTest.cpp
+++ b/test/unit/drivers/sbet/SbetReaderTest.cpp
@@ -97,7 +97,6 @@ BOOST_AUTO_TEST_CASE(testConstructor)
 
     reader.initialize();
 
-    BOOST_CHECK_EQUAL(reader.getPointCountType(), pdal::PointCount_Fixed);
     BOOST_CHECK_EQUAL(reader.getNumPoints(), 2);
 
 }


### PR DESCRIPTION
Per discussion in #328, `m_pointCountType` is not and will mostly likely not be used. This patch removes the member variable from `Stage` and all references to that variable and its associated methods.

Closes #329.
