### PR TITLE
Remove returns from BOOST_AUTO_TEST_CASEs

### DIFF
--- a/test/unit/BoundsTest.cpp
+++ b/test/unit/BoundsTest.cpp
@@ -218,8 +218,6 @@ BOOST_AUTO_TEST_CASE(test_grow)
     r4.grow(ptHi);
     Bounds<int> r5(-1,-2,20,201);
     BOOST_CHECK(r4 == r5);
-
-    return;
 }
 
 
@@ -257,8 +255,6 @@ BOOST_AUTO_TEST_CASE(test_output)
 
     BOOST_CHECK_EQUAL(out2, "([1, 101], [2, 102])");
     BOOST_CHECK_EQUAL(out3, "([1.1, 101.1], [2.2, 102.2], [3.3, 103.3])");
-
-    return;
 }
 
 
@@ -277,8 +273,6 @@ BOOST_AUTO_TEST_CASE(BoundsTest_ptree)
     const std::string ref = xml_header + "<0><minimum>1</minimum><maximum>101</maximum></0><1><minimum>2</minimum><maximum>102</maximum></1>";
 
     BOOST_CHECK_EQUAL(ref, out1);
-
-    return;
 }
 
 
@@ -297,8 +291,6 @@ BOOST_AUTO_TEST_CASE(test_input)
     Bounds<double> empty2;
     empty2_s >> empty2;
     BOOST_CHECK_EQUAL(true, empty2.empty());
-
-    return;
 }
 
 
@@ -308,16 +300,12 @@ BOOST_AUTO_TEST_CASE(test_lexicalcast_whitespace)
     const Bounds<double> b2 = boost::lexical_cast< Bounds<double> >("([1, 101], [2, 102], [3, 103])");
 
     BOOST_CHECK_EQUAL(b1, b2);
-
-    return;
 }
 
 BOOST_AUTO_TEST_CASE(test_wkt)
 {
     const Bounds<double> b(1.1,2.2,3.3,101.1,102.2,103.3);
     BOOST_CHECK_EQUAL(b.toWKT(1), "POLYGON ((1.1 2.2, 1.1 102.2, 101.1 102.2, 101.1 2.2, 1.1 2.2))");
-
-    return;
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/unit/ConfigTest.cpp
+++ b/test/unit/ConfigTest.cpp
@@ -65,8 +65,6 @@ BOOST_AUTO_TEST_CASE(test_3rdparty_libs)
 #else
     BOOST_CHECK(!laszip);
 #endif
-
-    return;
 }
 
 BOOST_AUTO_TEST_CASE(test_version)
@@ -87,8 +85,6 @@ BOOST_AUTO_TEST_CASE(test_version)
 
     int bignum = GetVersionInteger();
     BOOST_CHECK(bignum > 0);
-
-    return;
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/unit/DimensionTest.cpp
+++ b/test/unit/DimensionTest.cpp
@@ -151,9 +151,6 @@ BOOST_AUTO_TEST_CASE(DimensionTest_ptree)
     BOOST_CHECK_EQUAL(tree.get<std::string>("namespace"), "");
 
     BOOST_CHECK_EQUAL(tree.get<std::string>("uuid"), "9bf8d966-0c0d-4c94-a14e-bce97e860bde");
-
-
-    return;
 }
 
 
@@ -166,7 +163,6 @@ BOOST_AUTO_TEST_CASE(DimensionTest_Interpretation)
     dimension::Interpretation interp = Dimension::getInterpretation(x.getInterpretationName());
     
     BOOST_CHECK_EQUAL(interp, pdal::dimension::SignedInteger);
-    return;
 }
 
 

--- a/test/unit/EnvironmentTest.cpp
+++ b/test/unit/EnvironmentTest.cpp
@@ -54,8 +54,6 @@ BOOST_AUTO_TEST_CASE(EnvironmentTest_1)
 
     (void)python_env;
 #endif
-
-    return;
 }
 
 boost::test_tools::predicate_result
@@ -127,8 +125,6 @@ BOOST_AUTO_TEST_CASE(EnvironmentTest_rng)
     // }
     // 
     // BOOST_CHECK(compare_uuids(e, f));    
-    
-    return;
 }
 
 

--- a/test/unit/FileUtilsTest.cpp
+++ b/test/unit/FileUtilsTest.cpp
@@ -90,8 +90,6 @@ BOOST_AUTO_TEST_CASE(test_readFileIntoString)
     const std::string ref = "Redistribution and use in source and binary forms, with or without modification...";
 
     BOOST_CHECK(source == ref);
-
-    return;
 }
 
 
@@ -102,8 +100,6 @@ BOOST_AUTO_TEST_CASE(test_getcwd)
     const std::string cwd = FileUtils::getcwd();
     BOOST_CHECK(cwd == "D:/dev/pdal/test/unit/");
 #endif
-
-    return;
 }
 
 
@@ -149,8 +145,6 @@ BOOST_AUTO_TEST_CASE(test_toAbsolutePath)
     // check 1-arg version: make absolute when file is already absolute
     const string e = FileUtils::toAbsolutePath(drive+"/baz/foo.txt", drive+"/a/b/c/d");
     compare_paths(e, drive + "/baz/foo.txt");
-
-    return;
 }
 
 
@@ -163,8 +157,6 @@ BOOST_AUTO_TEST_CASE(test_getDirectory)
     // test relative case
     const std::string b = FileUtils::getDirectory("a/b/foo.txt");
     compare_paths(b, "a/b/");
-
-    return;
 }
 
 
@@ -177,8 +169,6 @@ BOOST_AUTO_TEST_CASE(test_isAbsolute)
     // test relative case
     const bool b = FileUtils::isAbsolutePath("a/b/foo.txt");
     BOOST_CHECK(!b);
-
-    return;
 }
 
 

--- a/test/unit/GDALUtilsTest.cpp
+++ b/test/unit/GDALUtilsTest.cpp
@@ -94,8 +94,6 @@ BOOST_AUTO_TEST_CASE(test_wrapped_vsifile_read)
     VSIFCloseL/*fclose*/(fp);
 
     pdal::FileUtils::deleteFile(tempfile);
-
-    return;
 }
 
 
@@ -146,8 +144,6 @@ BOOST_AUTO_TEST_CASE(GDALUtilsTest_test_vsifile_write)
 
     pdal::FileUtils::deleteFile(tempfile_a);
     pdal::FileUtils::deleteFile(tempfile_b);
-
-    return;
 }
 
 
@@ -208,8 +204,6 @@ BOOST_AUTO_TEST_CASE(test_wrapped_vsifile_subsequence)
     VSIFCloseL/*fclose*/(vsi_file);
 
     pdal::FileUtils::deleteFile(tempfile);
-
-    return;
 }
 
 

--- a/test/unit/LogTest.cpp
+++ b/test/unit/LogTest.cpp
@@ -85,9 +85,6 @@ BOOST_AUTO_TEST_CASE(test_one)
     {
         FileUtils::deleteFile(Support::temppath("mylog_one.txt"));
     }
-    
-
-    return;
 }
 
 #ifdef PDAL_HAVE_PYTHON
@@ -180,8 +177,6 @@ BOOST_AUTO_TEST_CASE(test_two_a)
     
     //FileUtils::deleteFile(Support::temppath("logtest_2.txt"));
     //FileUtils::deleteFile(Support::temppath("logtest_3.txt"));
-
-    return;
 }
 
 
@@ -286,8 +281,6 @@ BOOST_AUTO_TEST_CASE(test_two_b)
     {
         FileUtils::deleteFile(Support::temppath("logtest_test_two_b_3.txt"));
     }        
-
-    return;
 }
 
 
@@ -352,10 +345,6 @@ BOOST_AUTO_TEST_CASE(test_three)
     {
         FileUtils::deleteFile(Support::temppath("mylog_three.txt"));
     }
-    
-   
-    
-    return;
 }
 
 #endif

--- a/test/unit/MetadataTest.cpp
+++ b/test/unit/MetadataTest.cpp
@@ -136,8 +136,6 @@ BOOST_AUTO_TEST_CASE(test_construction)
     m.setValue<boost::uint64_t>(u64);
     BOOST_CHECK_EQUAL(m.getValue<boost::uint64_t>(), 64u);
     BOOST_CHECK_EQUAL(m.getType(), "nonNegativeInteger");
-
-    return;
 }
 
 BOOST_AUTO_TEST_CASE(test_metadata_copy)
@@ -170,8 +168,6 @@ BOOST_AUTO_TEST_CASE(test_metadata_copy)
     // pdal::Metadata m22 = b2.getEntry("m2");
     // BOOST_CHECK_EQUAL(m22.getValue<boost::uint32_t>(), 1u);
     //BOOST_CHECK_THROW(m22.getValue<boost::uint32_t>(), boost::bad_get);
-
-    return;
 }
 
 BOOST_AUTO_TEST_CASE(test_metadata_set)
@@ -195,8 +191,6 @@ BOOST_AUTO_TEST_CASE(test_metadata_set)
 
     
     b.addMetadata("uuid", boost::uuids::nil_uuid());
-    
-    return;
 }
 
 BOOST_AUTO_TEST_CASE(test_metadata_stage)
@@ -222,8 +216,6 @@ BOOST_AUTO_TEST_CASE(test_metadata_stage)
     // boost::property_tree::write_xml(std::cout, pipeline_metadata.toPTree());
 
     BOOST_CHECK_EQUAL(pipeline_metadata.toPTree().get_child("metadata").size(), 32u);
-
-    return;
 }
 
 BOOST_AUTO_TEST_CASE(test_metadata_constructor_no_throw)
@@ -231,8 +223,6 @@ BOOST_AUTO_TEST_CASE(test_metadata_constructor_no_throw)
 
     pdal::Bounds<double> b;
     pdal::Metadata entry("name", b);
-
-    return;
 }
 
 

--- a/test/unit/OptionsTest.cpp
+++ b/test/unit/OptionsTest.cpp
@@ -62,8 +62,6 @@ BOOST_AUTO_TEST_CASE(test_static_options)
     BOOST_CHECK(!opts.hasOption("metes"));
     const boost::property_tree::ptree& pt = opts.toPTree();
     BOOST_CHECK(pt.size() == 3);
-
-    return;
 }
 
 
@@ -95,8 +93,6 @@ BOOST_AUTO_TEST_CASE(test_option_writing)
     boost::property_tree::xml_parser::write_xml(ostr_s, tree_s);
     const std::string str_s = ostr_s.str();
     BOOST_CHECK(str_s == ref_s);
-
-    return;
 }
 
 
@@ -121,8 +117,6 @@ BOOST_AUTO_TEST_CASE(test_option_reading)
     BOOST_CHECK(opt_from_ptree.getDescription() == "This is my integral option.");
     BOOST_CHECK(opt_from_ptree.getValue<std::string>() == "17");
     BOOST_CHECK(opt_from_ptree.getValue<int>() == 17);
-
-    return;
 }
 
 
@@ -141,8 +135,6 @@ BOOST_AUTO_TEST_CASE(test_options_copy_ctor)
 
     BOOST_CHECK(copy.hasOption("my_int"));
     BOOST_CHECK(copy.hasOption("my_string"));
-
-    return;
 }
 
 BOOST_AUTO_TEST_CASE(test_options_multi)
@@ -164,8 +156,6 @@ BOOST_AUTO_TEST_CASE(test_options_multi)
 
     pdal::Option const& s = o->getOption("b");
     BOOST_CHECK_EQUAL(s.getValue<std::string>(), "2");
-
-    return;
 }
 
 BOOST_AUTO_TEST_CASE(test_options_writing)
@@ -193,8 +183,6 @@ BOOST_AUTO_TEST_CASE(test_options_writing)
     BOOST_CHECK(val_s == "Yow.");
     BOOST_CHECK(desc_i == "This is my integral option.");
     BOOST_CHECK(desc_s == "This is my stringy option.");
-
-    return;
 }
 
 
@@ -211,8 +199,6 @@ BOOST_AUTO_TEST_CASE(test_options_reading)
 
     BOOST_CHECK(opt.getValue<std::string>() == "17");
     BOOST_CHECK(opt.getValue<int>() == 17);
-
-    return;
 }
 
 
@@ -261,8 +247,6 @@ BOOST_AUTO_TEST_CASE(test_valid_options)
 
         BOOST_CHECK(options[1].getValue<std::string>() == "nineteen");
     }
-
-    return;
 }
 
 
@@ -298,8 +282,6 @@ BOOST_AUTO_TEST_CASE(Options_test_bool)
     BOOST_CHECK_EQUAL(bv, false);
     BOOST_CHECK_EQUAL(cv, true);
     BOOST_CHECK_EQUAL(dv, false);
-
-    return;
 }
 
 

--- a/test/unit/PipelineManagerTest.cpp
+++ b/test/unit/PipelineManagerTest.cpp
@@ -70,8 +70,6 @@ BOOST_AUTO_TEST_CASE(PipelineManagerTest_test1)
     }
 
     FileUtils::deleteFile("temp.las");
-
-    return;
 }
 
 
@@ -150,8 +148,6 @@ BOOST_AUTO_TEST_CASE(PipelineManagerTest_test2)
     }
 
     FileUtils::deleteFile("temp.las");
-
-    return;
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/unit/PointBufferCacheTest.cpp
+++ b/test/unit/PointBufferCacheTest.cpp
@@ -89,8 +89,6 @@ BOOST_AUTO_TEST_CASE(test1)
     BOOST_CHECK(lookupHits == 5);
     BOOST_CHECK(insertMisses == 4);
     BOOST_CHECK(insertHits == 0);
-
-    return;
 }
 
 

--- a/test/unit/PointBufferTest.cpp
+++ b/test/unit/PointBufferTest.cpp
@@ -56,8 +56,6 @@ BOOST_AUTO_TEST_CASE(test_ctor)
 
     BOOST_CHECK(data.getCapacity() == 10);
     BOOST_CHECK(data.getSchema() == schema);
-
-    return;
 }
 
 
@@ -305,8 +303,6 @@ BOOST_AUTO_TEST_CASE(PointBufferTest_ptree)
     const std::string ref = xml_header + "<0><Classification>1</Classification><X>0</X><Y>0</Y></0><1><Classification>2</Classification><X>10</X><Y>100</Y></1>";
 
     BOOST_CHECK_EQUAL(ref, out1.substr(0, ref.length()));
-
-    return;
 }
 
 
@@ -367,8 +363,6 @@ BOOST_AUTO_TEST_CASE(PointBufferTest_ptree)
 //     BOOST_CHECK_EQUAL(x1, x2);
 //     
 //     delete data;
-// 
-//     return;
 // }
 
 
@@ -404,9 +398,6 @@ BOOST_AUTO_TEST_CASE(PointBufferTest_resetting)
     BOOST_CHECK_EQUAL(data.getBufferByteCapacity(), 5200u);
     BOOST_CHECK_EQUAL(data.getBufferByteLength(), 5200u);
     BOOST_CHECK_EQUAL(data.getCapacity(), 400u);
-    
-
-    return;
 }
 
 
@@ -451,8 +442,6 @@ BOOST_AUTO_TEST_CASE(PointBufferTest_copy_like_Dimensions)
     BOOST_CHECK_EQUAL(150, data_b.getField<boost::int32_t>(x2, 150));
     
     delete dimensions;
-
-    return;
 }
 
 BOOST_AUTO_TEST_CASE(test_indexed)
@@ -513,8 +502,6 @@ BOOST_AUTO_TEST_CASE(test_indexed)
     BOOST_CHECK_EQUAL(rids.size(), 11u);    
     
     delete iter;
-    return;
-
 }
 
 
@@ -570,8 +557,6 @@ BOOST_AUTO_TEST_CASE(test_packing)
     // BOOST_CHECK_CLOSE(packed.getField<double>(y2,7), 7 + 100, 0.000001);    
     
     delete packed;
-    return;
-
 }
 
 
@@ -616,7 +601,6 @@ BOOST_AUTO_TEST_CASE(test_orientation)
         BOOST_CHECK_CLOSE(y, i + 100, 0.000001);
         BOOST_CHECK_EQUAL(c, 7u);
     }
-    return;
 }
 
 BOOST_AUTO_TEST_CASE(test_orientation_packing)
@@ -666,11 +650,6 @@ BOOST_AUTO_TEST_CASE(test_orientation_packing)
 
     delete dims;
     delete packed;
-
-
-
-    return;
-
 }
 
 
@@ -717,11 +696,6 @@ BOOST_AUTO_TEST_CASE(test_orientation_point_interleaved_flipping)
     BOOST_CHECK_EQUAL(flipped->getField<boost::int32_t>(x2,8),8);
     BOOST_CHECK_CLOSE(flipped->getField<double>(y2,7), 7 + 100, 0.000001);
     delete flipped;
-
-
-
-    return;
-
 }
 
 
@@ -799,11 +773,6 @@ BOOST_AUTO_TEST_CASE(test_orientation_dimension_interleaved_flipping)
     
     delete flipped;
     delete again;
-
-
-
-    return;
-
 }
 
 
@@ -893,8 +862,6 @@ BOOST_AUTO_TEST_CASE(test_copyLikeDimensions)
     }  
 
     delete dims_offset;
-    return;
-
 }
 
 BOOST_AUTO_TEST_CASE(test_copyLikeDimensions_All)
@@ -1046,10 +1013,5 @@ BOOST_AUTO_TEST_CASE(PointBufferTest_dataStriding)
     }
     
     // delete dims;
-
-
-
-    return;
-
 }
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/unit/RangeTest.cpp
+++ b/test/unit/RangeTest.cpp
@@ -211,8 +211,6 @@ BOOST_AUTO_TEST_CASE(test_output)
 
     BOOST_CHECK(out1 == "[1, 2]");
     BOOST_CHECK(out2 == "[1.1, 2.2]");
-
-    return;
 }
 
 
@@ -230,8 +228,6 @@ BOOST_AUTO_TEST_CASE(RangeTest_ptree)
     const std::string ref = xml_header + "<minimum>23</minimum><maximum>56</maximum>";
 
     BOOST_CHECK_EQUAL(ref, out1);
-
-    return;
 }
 
 
@@ -244,8 +240,6 @@ BOOST_AUTO_TEST_CASE(test_input)
 
     const Range<double> r(1.1,2.2);
     BOOST_CHECK(r == rr);
-
-    return;
 }
 
 BOOST_AUTO_TEST_CASE(test_lexicalcast_whitespace)
@@ -254,8 +248,6 @@ BOOST_AUTO_TEST_CASE(test_lexicalcast_whitespace)
     const Range<double> b2 = boost::lexical_cast< Range<double> >("[1, 101] ");
 
     BOOST_CHECK_EQUAL(b1, b2);
-
-    return;
 }
 
 

--- a/test/unit/SchemaLayoutTest.cpp
+++ b/test/unit/SchemaLayoutTest.cpp
@@ -111,8 +111,6 @@ BOOST_AUTO_TEST_CASE(SchemaLayoutTest_ptree)
     boost::algorithm::erase_all(out1, "\n");
     boost::algorithm::erase_all(ref, "\n");
     BOOST_CHECK_EQUAL(ref, out1);
-
-    return;
 }
 #endif
 

--- a/test/unit/SchemaTest.cpp
+++ b/test/unit/SchemaTest.cpp
@@ -96,8 +96,6 @@ BOOST_AUTO_TEST_CASE(SchemaTest_ptree)
 
     boost::algorithm::erase_all(ref, "\n");
     BOOST_CHECK_EQUAL(ref, out1);
-
-    return;
 }
 
 
@@ -154,9 +152,6 @@ BOOST_AUTO_TEST_CASE(SchemaTest_orientation)
     s.appendDimension(y);
     
     BOOST_CHECK_EQUAL(s.getOrientation(), pdal::schema::POINT_INTERLEAVED);
-
-
-    return;
 }
 
 
@@ -175,11 +170,6 @@ BOOST_AUTO_TEST_CASE(SchemaTest_pack)
     
     BOOST_CHECK_EQUAL(p.size(), 1);
     BOOST_CHECK_EQUAL(s.size(), 2);
-
-    
-
-
-    return;
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/unit/SpatialReferenceTest.cpp
+++ b/test/unit/SpatialReferenceTest.cpp
@@ -56,7 +56,6 @@ BOOST_AUTO_TEST_CASE(test_env_vars)
     BOOST_CHECK(pdal::FileUtils::fileExists(gdal_data));
     BOOST_CHECK(pdal::FileUtils::fileExists(proj_lib));
 #endif
-    return;
 }
 
 
@@ -67,8 +66,6 @@ BOOST_AUTO_TEST_CASE(test_ctor)
     BOOST_CHECK(srs.getProj4() == "");
     BOOST_CHECK(srs.getWKT() == "");
     BOOST_CHECK(srs.empty());
-
-    return;
 }
 
 
@@ -102,8 +99,6 @@ BOOST_AUTO_TEST_CASE(test_proj4_roundtrip)
         const std::string ret = ref.getProj4();
         BOOST_CHECK(ret == proj4_out);
     }
-
-    return;
 }
 
 
@@ -123,8 +118,6 @@ BOOST_AUTO_TEST_CASE(test_userstring_roundtrip)
 
     BOOST_CHECK(ret_proj == proj4);
     BOOST_CHECK(ret_wkt == wkt);
-
-    return;
 }
 
 
@@ -146,8 +139,6 @@ BOOST_AUTO_TEST_CASE(test_read_srs)
 
     const std::string proj4 = "+proj=utm +zone=17 +datum=WGS84 +units=m +no_defs";
     BOOST_CHECK(ret_proj4 == proj4);
-
-    return;
 }
 
 
@@ -163,8 +154,6 @@ BOOST_AUTO_TEST_CASE(test_vlr_sizes)
 
     BOOST_CHECK(vlrs.size() == boost::uint32_t(4));
     BOOST_CHECK(vlrs[0].getLength() == boost::uint32_t(64));
-
-    return;
 }
 
 
@@ -203,8 +192,6 @@ BOOST_AUTO_TEST_CASE(test_vertical_datum)
         // const std::string wkt2_ret = ref2.getWKT(pdal::SpatialReference::eCompoundOK);
         // BOOST_CHECK_EQUAL(wkt2_ret,wkt3);
     }
-
-    return;
 }
 
 
@@ -231,8 +218,6 @@ BOOST_AUTO_TEST_CASE(test_vertical_datum_notcompound)
     //BOOST_CHECK(vlrs_horizonly[1].getLength() == 16);
     //BOOST_CHECK(vlrs_horizonly[2].getLength() == 7);
     //BOOST_CHECK(vlrs_horizonly[3].getLength() == 511);
-
-    return;
 }
 
 // Try writing a compound coordinate system to file and ensure we get back
@@ -283,8 +268,6 @@ BOOST_AUTO_TEST_CASE(test_vertical_datums)
 
     // Cleanup
     pdal::FileUtils::deleteFile(tmpfile);
-
-    return;
 }
 
 
@@ -365,8 +348,6 @@ BOOST_AUTO_TEST_CASE(test_writing_vlr)
 
     // Cleanup
     pdal::FileUtils::deleteFile(tmpfile);
-
-    return;
 }
 
 
@@ -386,9 +367,6 @@ BOOST_AUTO_TEST_CASE(test_io)
     ss >> ref2;
 
     BOOST_CHECK(ref == ref2);
-
-
-    return;
 }
 
 #endif

--- a/test/unit/StageFactoryTest.cpp
+++ b/test/unit/StageFactoryTest.cpp
@@ -90,8 +90,6 @@ BOOST_AUTO_TEST_CASE(StageFactoryTest_test1)
     delete reader;
 
     FileUtils::deleteFile("temp.las");
-
-    return;
 }
 
 
@@ -190,8 +188,6 @@ BOOST_AUTO_TEST_CASE(StageFactoryTest_test2)
     delete reader;
 
     FileUtils::deleteFile("temp.las");
-
-    return;
 }
 
 

--- a/test/unit/StreamFactoryTest.cpp
+++ b/test/unit/StreamFactoryTest.cpp
@@ -84,8 +84,6 @@ BOOST_AUTO_TEST_CASE(test1)
         FileUtils::closeFile(ostreamname);
         FileUtils::deleteFile(wfilename);
     }
-
-    return;
 }
 
 
@@ -138,8 +136,6 @@ static void check_contents(std::istream& s)
     BOOST_CHECK(s.get() == -1);
 
     BOOST_CHECK(s.eof());
-
-    return;
 }
 
 
@@ -194,8 +190,6 @@ BOOST_AUTO_TEST_CASE(test2)
         f.deallocate(s3);
         // f.deallocate(s2);   // let the dtor do it for us
     }
-
-    return;
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/unit/Support.cpp
+++ b/test/unit/Support.cpp
@@ -394,8 +394,6 @@ void Support::check_pN(const pdal::PointBuffer& data,
         BOOST_CHECK_EQUAL(g0, gref);
         BOOST_CHECK_EQUAL(b0, bref);
     }
-
-    return;
 }
 
 

--- a/test/unit/SupportTest.cpp
+++ b/test/unit/SupportTest.cpp
@@ -120,8 +120,6 @@ BOOST_AUTO_TEST_CASE(test_diff_file)
     same = Support::compare_files(Support::datapath("misc/data3.dat"), Support::datapath("misc/data1.dat"));
     BOOST_CHECK(diffs == 2);
     BOOST_CHECK(same == false);
-
-    return;
 }
 
 
@@ -167,8 +165,6 @@ BOOST_AUTO_TEST_CASE(test_diff_file_ignorable)
         diffs = Support::diff_files(Support::datapath("misc/data4a.dat"), Support::datapath("misc/data4b.dat"), start, len, 2);
         BOOST_CHECK(diffs == 1);
     }
-
-    return;
 }
 
 
@@ -211,8 +207,6 @@ BOOST_AUTO_TEST_CASE(test_diff_text_file)
     same = Support::compare_text_files(Support::datapath("misc/data3.txt"), Support::datapath("misc/data1.txt"));
     BOOST_CHECK(diffs == 2);
     BOOST_CHECK(same == false);
-
-    return;
 }
 
 
@@ -226,8 +220,6 @@ BOOST_AUTO_TEST_CASE(test_run_command)
 
     BOOST_CHECK_EQUAL(output.substr(0, 3), "foo");
     BOOST_CHECK_EQUAL(stat, 0);
-
-    return;
 }
 
 

--- a/test/unit/ThreadTest.cpp
+++ b/test/unit/ThreadTest.cpp
@@ -118,8 +118,6 @@ Options makeReaderOptions()
 
 BOOST_AUTO_TEST_CASE(test_parallel)
 {
-    //return;
-
 #define TEN 10
     Options opts[TEN][TEN];
     Stage* stages[TEN][TEN];
@@ -180,8 +178,6 @@ BOOST_AUTO_TEST_CASE(test_parallel)
     FileUtils::deleteFile(Support::temppath("logtest_1.txt"));
     FileUtils::deleteFile(Support::temppath("logtest_2.txt"));
     FileUtils::deleteFile(Support::temppath("logtest_3.txt"));
-    
-    return;
 }
 
 

--- a/test/unit/UserCallbackTest.cpp
+++ b/test/unit/UserCallbackTest.cpp
@@ -121,8 +121,6 @@ BOOST_AUTO_TEST_CASE(test1)
     ok = worker.doWork();
     BOOST_CHECK(!ok);
     BOOST_CHECK_CLOSE(cb.getPercentComplete(), 51.0, 0.001);
-
-    return;
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/unit/UtilsTest.cpp
+++ b/test/unit/UtilsTest.cpp
@@ -129,8 +129,6 @@ BOOST_AUTO_TEST_CASE(test_buffer_read_write)
     boost::uint8_t tmp[30];
     Utils::read_n(tmp, istr, 15);
     BOOST_CHECK(memcmp(buf, tmp, 15) == 0);
-
-    return;
 }
 
 
@@ -152,8 +150,6 @@ BOOST_AUTO_TEST_CASE(test_field_read_write)
 
     BOOST_CHECK(x==one);
     BOOST_CHECK(Utils::compare_approx(y, two, std::numeric_limits<double>::min()) == true);
-
-    return;
 }
 
 
@@ -179,9 +175,6 @@ BOOST_AUTO_TEST_CASE(test_base64)
 
     BOOST_CHECK_EQUAL(decoded.size(), data.size());
     BOOST_CHECK_EQUAL(size, begin_size);
-
-
-    return;
 }
 
 

--- a/test/unit/VectorTest.cpp
+++ b/test/unit/VectorTest.cpp
@@ -134,7 +134,6 @@ BOOST_AUTO_TEST_CASE(test_dump)
     s << v;
 
     BOOST_CHECK(s.str() == "(1, 2, 3)");
-    return;
 }
 
 
@@ -153,8 +152,6 @@ BOOST_AUTO_TEST_CASE(VectorTest_ptree)
     const std::string ref = xml_header + "<0>12</0><1>23</1><2>34</2>";
 
     BOOST_CHECK_EQUAL(ref, out1);
-
-    return;
 }
 
 

--- a/test/unit/apps/pc2pcTest.cpp
+++ b/test/unit/apps/pc2pcTest.cpp
@@ -65,8 +65,6 @@ BOOST_AUTO_TEST_CASE(pc2pcTest_test_no_input)
 
     const std::string expected = "Usage error: --input";
     BOOST_CHECK_EQUAL(output.substr(0, expected.length()), expected);
-
-    return;
 }
 #endif
 
@@ -81,8 +79,6 @@ BOOST_AUTO_TEST_CASE(pc2pcTest_test_common_opts)
 
     stat = pdal::Utils::run_shell_command(cmd + " --version", output);
     BOOST_CHECK_EQUAL(stat, 0);
-
-    return;
 }
 
 
@@ -180,8 +176,6 @@ BOOST_AUTO_TEST_CASE(pc2pc_test_switches)
 
     pdal::FileUtils::deleteFile(outputLas);
     pdal::FileUtils::deleteFile(outputLaz);
-
-    return;
 }
 
 

--- a/test/unit/apps/pcinfoTest.cpp
+++ b/test/unit/apps/pcinfoTest.cpp
@@ -72,8 +72,6 @@ BOOST_AUTO_TEST_CASE(pdalinfo_test_common_opts)
 
     stat = pdal::Utils::run_shell_command(cmd + " --version", output);
     BOOST_CHECK_EQUAL(stat, 0);
-
-    return;
 }
 
 
@@ -120,8 +118,6 @@ BOOST_AUTO_TEST_CASE(pdalinfo_test_switches)
     BOOST_CHECK_EQUAL(stat, 1);
     expected = "Usage error: no action option specified";
     BOOST_CHECK_EQUAL(output.substr(0, expected.length()), expected);
-
-    return;
 }
 
 
@@ -202,8 +198,6 @@ BOOST_AUTO_TEST_CASE(pdalinfo_test_dumps)
 //         pdal::FileUtils::deleteFile(stage_test);
 //     else
 //         std::cout << command.str() << std::endl;
-
-    return;
 }
 
 

--- a/test/unit/apps/pcpipelineTest.cpp
+++ b/test/unit/apps/pcpipelineTest.cpp
@@ -62,8 +62,6 @@ BOOST_AUTO_TEST_CASE(pcpipelineTest_no_input)
 
     const std::string expected = "Usage error: input file name required";
     BOOST_CHECK_EQUAL(output.substr(0, expected.length()), expected);
-
-    return;
 }
 #endif
 
@@ -78,8 +76,6 @@ BOOST_AUTO_TEST_CASE(pcpipelineTest_test_common_opts)
 
     stat = pdal::Utils::run_shell_command(cmd + " --version", output);
     BOOST_CHECK_EQUAL(stat, 0);
-
-    return;
 }
 
 

--- a/test/unit/drivers/buffer/BufferReaderTest.cpp
+++ b/test/unit/drivers/buffer/BufferReaderTest.cpp
@@ -152,8 +152,6 @@ BOOST_AUTO_TEST_CASE(test_sequential_iter)
 
     delete iter;
     delete input;
-
-    return;
 }
 
 BOOST_AUTO_TEST_CASE(test_random_iter)
@@ -254,8 +252,6 @@ BOOST_AUTO_TEST_CASE(test_random_iter)
 
     delete iter;
     delete input;
-
-    return;
 }
 
 
@@ -291,7 +287,6 @@ BOOST_AUTO_TEST_CASE(test_iterator_write)
     FileUtils::deleteFile(out_filename.getValue<std::string>());
     
     delete input;
-    return;
 }
 
 

--- a/test/unit/drivers/caris/CarisReaderTest.cpp
+++ b/test/unit/drivers/caris/CarisReaderTest.cpp
@@ -61,8 +61,6 @@ BOOST_AUTO_TEST_SUITE(CarisReaderTest)
 
 BOOST_AUTO_TEST_CASE(test_one)
 {
-
-    return;
 }
 
 

--- a/test/unit/drivers/faux/FauxReaderTest.cpp
+++ b/test/unit/drivers/faux/FauxReaderTest.cpp
@@ -88,8 +88,6 @@ BOOST_AUTO_TEST_CASE(test_constant_mode_sequential_iter)
     }
 
     delete iter;
-
-    return;
 }
 
 
@@ -140,8 +138,6 @@ BOOST_AUTO_TEST_CASE(FauxReaderTest_test_options)
     }
 
     delete iter;
-
-    return;
 }
 
 
@@ -247,8 +243,6 @@ BOOST_AUTO_TEST_CASE(test_constant_mode_random_iter)
     }
 
     delete iter;
-
-    return;
 }
 
 
@@ -298,8 +292,6 @@ BOOST_AUTO_TEST_CASE(test_random_mode)
     }
 
     delete iter;
-
-    return;
 }
 
 BOOST_AUTO_TEST_CASE(test_ramp_mode_1)
@@ -345,8 +337,6 @@ BOOST_AUTO_TEST_CASE(test_ramp_mode_1)
 
 
     delete iter;
-
-    return;
 }
 
 
@@ -390,8 +380,6 @@ BOOST_AUTO_TEST_CASE(test_ramp_mode_2)
     }
 
     delete iter;
-
-    return;
 }
 
 
@@ -430,8 +418,6 @@ BOOST_AUTO_TEST_CASE(testUnknownPointCountType)
     BOOST_CHECK_EQUAL(numRead, 1000);
 
     delete iter;
-
-    return;
 }
 
 

--- a/test/unit/drivers/faux/FauxWriterTest.cpp
+++ b/test/unit/drivers/faux/FauxWriterTest.cpp
@@ -67,9 +67,6 @@ BOOST_AUTO_TEST_CASE(FauxWriterTest_test_1)
     BOOST_CHECK(Utils::compare_approx(writer.getAvgX(), 1.0, (std::numeric_limits<double>::min)()) == true);
     BOOST_CHECK(Utils::compare_approx(writer.getAvgY(), 2.0, (std::numeric_limits<double>::min)()) == true);
     BOOST_CHECK(Utils::compare_approx(writer.getAvgZ(), 3.0, (std::numeric_limits<double>::min)()) == true);
-
-
-    return;
 }
 
 BOOST_AUTO_TEST_CASE(test_2)
@@ -94,8 +91,6 @@ BOOST_AUTO_TEST_CASE(test_2)
     BOOST_CHECK(Utils::compare_approx<double>(writer.getAvgX(), 51.0, 10.0));
     BOOST_CHECK(Utils::compare_approx<double>(writer.getAvgY(), 52.0, 10.0));
     BOOST_CHECK(Utils::compare_approx<double>(writer.getAvgZ(), 53.0, 10.0));
-
-    return;
 }
 
 
@@ -200,8 +195,6 @@ BOOST_AUTO_TEST_CASE(test_callbacks)
         BOOST_CHECK_EQUAL(cb.getHeartbeats(), 7u);
         BOOST_CHECK_EQUAL(cb.getPercentComplete(), 60);
     }
-
-    return;
 }
 
 BOOST_AUTO_TEST_CASE(test_buffer_resize)

--- a/test/unit/drivers/las/LasReaderTest.cpp
+++ b/test/unit/drivers/las/LasReaderTest.cpp
@@ -83,8 +83,6 @@ BOOST_AUTO_TEST_CASE(test_base_options)
         BOOST_CHECK(reader.getVerboseLevel() == 99);
         BOOST_CHECK(reader.isDebug() == true);
     }
-
-    return;
 }
 
 
@@ -118,8 +116,6 @@ BOOST_AUTO_TEST_CASE(test_sequential)
     }
 
     delete iter;
-
-    return;
 }
 
 
@@ -163,8 +159,6 @@ BOOST_AUTO_TEST_CASE(test_random)
     }
 
     delete iter;
-
-    return;
 }
 
 
@@ -209,8 +203,6 @@ BOOST_AUTO_TEST_CASE(test_random_laz)
     }
 
     delete iter;
-
-    return;
 }
 #endif
 
@@ -251,8 +243,6 @@ BOOST_AUTO_TEST_CASE(test_two_iters)
 
         delete iter;
     }
-
-    return;
 }
 
 
@@ -371,8 +361,6 @@ BOOST_AUTO_TEST_CASE(test_simultaneous_iters)
     delete iterS2;
     delete iterR1;
     delete iterR2;
-
-    return;
 }
 
 static void test_a_format(const std::string& file, boost::uint8_t majorVersion, boost::uint8_t minorVersion, int pointFormat,
@@ -413,8 +401,6 @@ BOOST_AUTO_TEST_CASE(test_different_formats)
     test_a_format("1.2_1.las", 1, 2, 1, 470692.440000, 4602888.900000, 16.000000, 1205902800.000000, 0, 0, 0);
     test_a_format("1.2_2.las", 1, 2, 2, 470692.440000, 4602888.900000, 16.000000, 0, 255, 12, 234);
     test_a_format("1.2_3.las", 1, 2, 3, 470692.440000, 4602888.900000, 16.000000, 1205902800.000000, 255, 12, 234);
-
-    return;
 }
 
 
@@ -424,8 +410,6 @@ BOOST_AUTO_TEST_CASE(test_vlr)
     reader.initialize();
 
     BOOST_CHECK_EQUAL(reader.getLasHeader().getVLRs().getAll().size(), 390);
-
-    return;
 }
 
 
@@ -468,8 +452,6 @@ BOOST_AUTO_TEST_CASE(test_no_xyz)
 
 
     delete iter;
-
-    return;
 }
 
 

--- a/test/unit/drivers/las/LasWriterTest.cpp
+++ b/test/unit/drivers/las/LasWriterTest.cpp
@@ -89,8 +89,6 @@ BOOST_AUTO_TEST_CASE(LasWriterTest_test_simple_las)
     {
         FileUtils::deleteFile(Support::temppath(temp_filename));
     }
-
-    return;
 }
 
 #ifdef PDAL_HAVE_LASZIP
@@ -137,8 +135,6 @@ BOOST_AUTO_TEST_CASE(LasWriterTest_test_simple_laz)
     {
         FileUtils::deleteFile(Support::temppath("LasWriterTest_test_simple_laz.laz"));
     }
-
-    return;
 }
 #endif
 
@@ -183,8 +179,6 @@ static void test_a_format(const std::string& refFile, boost::uint8_t majorVersio
     {
         FileUtils::deleteFile(Support::temppath("temp.las"));
     }
-
-    return;
 }
 
 BOOST_AUTO_TEST_CASE(LasWriterTest_test_metadata)
@@ -260,8 +254,6 @@ BOOST_AUTO_TEST_CASE(LasWriterTest_test_metadata)
     BOOST_CHECK_EQUAL(r.getLength(), 70);    
     
     FileUtils::deleteFile(temp_filename);
-
-    return;
 }
 
 BOOST_AUTO_TEST_CASE(LasWriterTest_test_ignored_dimensions)
@@ -353,8 +345,6 @@ BOOST_AUTO_TEST_CASE(LasWriterTest_test_ignored_dimensions)
     }
 
     FileUtils::deleteFile(temp_filename);
-
-    return;
 }
 
 BOOST_AUTO_TEST_CASE(test_different_formats)
@@ -369,8 +359,6 @@ BOOST_AUTO_TEST_CASE(test_different_formats)
     test_a_format("1.2_1.las", 1, 2, 1);
     test_a_format("1.2_2.las", 1, 2, 2);
     test_a_format("1.2_3.las", 1, 2, 3);
-
-    return;
 }
 
 

--- a/test/unit/drivers/nitf/NitfReaderTest.cpp
+++ b/test/unit/drivers/nitf/NitfReaderTest.cpp
@@ -133,8 +133,6 @@ BOOST_AUTO_TEST_CASE(test_one)
 
     delete nitf_iter;
     delete las_iter;
-
-    return;
 }
 
 
@@ -165,8 +163,6 @@ BOOST_AUTO_TEST_CASE(test_chipper)
     BOOST_CHECK_EQUAL(num_blocks, 8u);
  
     delete iter;
-
-    return;
 }
 
 

--- a/test/unit/drivers/nitf/NitfWriterTest.cpp
+++ b/test/unit/drivers/nitf/NitfWriterTest.cpp
@@ -105,8 +105,6 @@ static void compare_contents(const std::string& las_file, const std::string& ntf
 
     delete ntf_iter;
     delete las_iter;
-
-    return;
 }
 #endif
 
@@ -174,8 +172,6 @@ BOOST_AUTO_TEST_CASE(test1)
 
 #endif
 
-    return;
-
 #if 0
     //
     // check the generated NITF
@@ -196,8 +192,6 @@ BOOST_AUTO_TEST_CASE(test1)
         FileUtils::deleteFile(Support::temppath(nitf_output));
     }
 #endif
-
-    return;
 }
 
 

--- a/test/unit/drivers/pipeline/PipelineReaderTest.cpp
+++ b/test/unit/drivers/pipeline/PipelineReaderTest.cpp
@@ -69,8 +69,6 @@ BOOST_AUTO_TEST_CASE(PipelineReaderTest_test1)
 
         delete iter;
     }
-
-    return;
 }
 
 
@@ -95,8 +93,6 @@ BOOST_AUTO_TEST_CASE(PipelineReaderTest_test2)
     }
 
     FileUtils::deleteFile(Support::datapath("pipeline/pdal-compressed.laz"));
-
-    return;
 }
 
 
@@ -172,8 +168,6 @@ BOOST_AUTO_TEST_CASE(PipelineReaderTest_test3)
     PipelineManager managerComments2;
     PipelineReader readerComments2(managerComments2);
     BOOST_CHECK_NO_THROW(readerComments2.readPipeline(Support::datapath("pipeline/pipeline_writecomments.xml")));
-
-    return;
 }
 
 
@@ -216,8 +210,6 @@ BOOST_AUTO_TEST_CASE(PipelineReaderTest_test4)
     }
 
     FileUtils::deleteFile(Support::datapath("pipeline/out2.las"));
-
-    return;
 }
 #endif
 
@@ -239,8 +231,6 @@ BOOST_AUTO_TEST_CASE(PipelineReaderTest_Reader)
 
         delete iter;
     }
-
-    return;
 }
 
 BOOST_AUTO_TEST_CASE(PipelineReaderTest_MultiOptions)
@@ -265,8 +255,6 @@ BOOST_AUTO_TEST_CASE(PipelineReaderTest_MultiOptions)
     Option meaning_of_life = more->getOption("somemore");
 
     BOOST_CHECK_EQUAL(meaning_of_life.getValue<int>(), 42);
-
-    return;
 }
 
 

--- a/test/unit/drivers/pipeline/PipelineWriterTest.cpp
+++ b/test/unit/drivers/pipeline/PipelineWriterTest.cpp
@@ -84,8 +84,6 @@ BOOST_AUTO_TEST_CASE(PipelineWriterTest_test1)
     }
 
     FileUtils::deleteFile(Support::datapath("pipeline/out.las"));
-
-    return;
 }
 
 
@@ -115,8 +113,6 @@ BOOST_AUTO_TEST_CASE(PipelineWriterTest_attr_test)
         BOOST_CHECK_EQUAL(tree.get<std::string>("x.<xmlattr>.b"), "bbb");
         BOOST_CHECK_EQUAL(tree.get<std::string>("child2"), "two");
     }
-
-    return;
 }
 
 
@@ -152,7 +148,6 @@ BOOST_AUTO_TEST_CASE(PipelineWriterTest_multioptions)
     }
 
     FileUtils::deleteFile(Support::temppath("test-multi.xml"));
-    return;
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/unit/drivers/qfit/QFITReaderTest.cpp
+++ b/test/unit/drivers/qfit/QFITReaderTest.cpp
@@ -121,8 +121,6 @@ BOOST_AUTO_TEST_CASE(test_10_word)
     Check_Point(data, 0, 221.826822, 59.205160, 32.0900, 0);
     Check_Point(data, 1, 221.826740, 59.205161, 32.0190, 0);
     Check_Point(data, 2, 221.826658, 59.205164, 32.0000, 0);
-
-    return;
 }
 
 BOOST_AUTO_TEST_CASE(test_14_word)

--- a/test/unit/drivers/sbet/SbetReaderTest.cpp
+++ b/test/unit/drivers/sbet/SbetReaderTest.cpp
@@ -139,8 +139,6 @@ BOOST_AUTO_TEST_CASE(testRead)
                3.252165276637165e-01, -1.558883225990844e-01,
                8.379685112283802e-04, 7.372886784718076e-03,
                7.179027672314571e-02);
-
-    return;
 }
 
 
@@ -169,8 +167,6 @@ BOOST_AUTO_TEST_CASE(testSkip)
                3.252165276637165e-01, -1.558883225990844e-01,
                8.379685112283802e-04, 7.372886784718076e-03,
                7.179027672314571e-02);
-
-    return;
 }
 
 
@@ -194,8 +190,6 @@ BOOST_AUTO_TEST_CASE(testPipeline)
     const boost::uint64_t numPoints = manager.execute();
     BOOST_CHECK_EQUAL(numPoints, 2);
     pdal::FileUtils::deleteFile(Support::datapath("sbet/outfile.txt"));
-
-    return;
 }
 
 
@@ -226,8 +220,6 @@ BOOST_AUTO_TEST_CASE(testRandomIterator)
                3.252165276637165e-01, -1.558883225990844e-01,
                8.379685112283802e-04, 7.372886784718076e-03,
                7.179027672314571e-02);
-
-    return;
 }
 
 

--- a/test/unit/drivers/sqlite/Writer.cpp
+++ b/test/unit/drivers/sqlite/Writer.cpp
@@ -188,8 +188,6 @@ BOOST_AUTO_TEST_CASE(SqliteWriterTest_test_simple_las)
     FileUtils::closeFile(ofs);
 
     FileUtils::deleteFile(temp_filename);
-
-    return;
 #endif
 }
 

--- a/test/unit/drivers/terrasolid/TerraSolidReaderTest.cpp
+++ b/test/unit/drivers/terrasolid/TerraSolidReaderTest.cpp
@@ -129,9 +129,6 @@ BOOST_AUTO_TEST_CASE(test_tsolid)
     Check_Point(data, 0, 363127.94, 3437612.33, 55.26, 580220.5528);
     Check_Point(data, 1, 363128.12, 3437613.01, 55.33, 580220.5530);
     Check_Point(data, 2, 363128.29, 3437613.66, 55.28, 580220.5530);
-
-
-    return;
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/unit/drivers/text/TextWriterTest.cpp
+++ b/test/unit/drivers/text/TextWriterTest.cpp
@@ -83,9 +83,6 @@ BOOST_AUTO_TEST_CASE(TextWriterTest_test_1)
         pdal::FileUtils::deleteFile(output_file);
     else
         std::cout << "comparison of " << Support::datapath("autzen-point-format-3.txt") << " and " << output_file << " failed.";
-
-
-    return;
 }
 
 
@@ -141,8 +138,6 @@ BOOST_AUTO_TEST_CASE(TextWriterTest_geojson)
     {
         FileUtils::deleteFile(Support::temppath(output));
     }    
-
-    return;
 }
 #endif
 

--- a/test/unit/filters/ByteSwapFilterTest.cpp
+++ b/test/unit/filters/ByteSwapFilterTest.cpp
@@ -142,8 +142,6 @@ BOOST_AUTO_TEST_CASE(test_swapping)
         SWAP_ENDIANNESS(reflipped_t);
         BOOST_CHECK_EQUAL(unflipped_t, reflipped_t);
     }
-
-    return;
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/unit/filters/CacheFilterTest.cpp
+++ b/test/unit/filters/CacheFilterTest.cpp
@@ -113,8 +113,6 @@ BOOST_AUTO_TEST_CASE(CacheFilterTest_test_options)
 
     delete iter1;
     delete iter2;
-
-    return;
 }
 
 
@@ -177,8 +175,6 @@ BOOST_AUTO_TEST_CASE(CacheFilterTest_test_use_counts)
 
     delete iter1;
     delete iter2;
-
-    return;
 }
 
 
@@ -232,8 +228,6 @@ BOOST_AUTO_TEST_CASE(CacheFilterTest_test_random)
     
     delete sequential;
     delete random;
-
-    return;
 }
 
 
@@ -334,8 +328,6 @@ BOOST_AUTO_TEST_CASE(test_two_iters_with_cache)
    
         delete iter;
     }
-
-    return;
 }
 
 BOOST_AUTO_TEST_CASE(CacheFilterTest_test_large)
@@ -394,8 +386,6 @@ BOOST_AUTO_TEST_CASE(CacheFilterTest_test_large)
     
     delete sequential;
     delete random;
-
-    return;
 }
 
 

--- a/test/unit/filters/ChipperTest.cpp
+++ b/test/unit/filters/ChipperTest.cpp
@@ -122,8 +122,6 @@ BOOST_AUTO_TEST_CASE(test_construction)
         // BOOST_CHECK_EQUAL(buffer.getField<boost::int32_t>(dimZ, 2), 42651);
 
     }
-
-    return;
 }
 
 

--- a/test/unit/filters/ColorFilterTest.cpp
+++ b/test/unit/filters/ColorFilterTest.cpp
@@ -46,8 +46,6 @@ BOOST_AUTO_TEST_SUITE(ColorFilterTest)
 BOOST_AUTO_TEST_CASE(test1)
 {
     // BUG: tbd
-
-    return;
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/unit/filters/ColorizationFilterTest.cpp
+++ b/test/unit/filters/ColorizationFilterTest.cpp
@@ -135,9 +135,6 @@ BOOST_AUTO_TEST_CASE(ColorizationFilterTest_test_1)
 // #endif
 
     }
-
-
-    return;
 }
 
 #endif

--- a/test/unit/filters/CropFilterTest.cpp
+++ b/test/unit/filters/CropFilterTest.cpp
@@ -92,8 +92,6 @@ BOOST_AUTO_TEST_CASE(test_crop)
     BOOST_CHECK_CLOSE(avgX, 5.00000, delX);
     BOOST_CHECK_CLOSE(avgY, 50.00000, delY);
     BOOST_CHECK_CLOSE(avgZ, 500.00000, delZ);
-
-    return;
 }
 
 
@@ -136,7 +134,6 @@ BOOST_AUTO_TEST_CASE(test_crop_polygon)
     FileUtils::closeFile(wkt_stream);
     
 #endif
-    return;
 }
 
 BOOST_AUTO_TEST_CASE(test_crop_polygon_reprojection)
@@ -201,7 +198,6 @@ BOOST_AUTO_TEST_CASE(test_crop_polygon_reprojection)
     FileUtils::closeFile(wkt_stream);
     
 #endif
-    return;
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/unit/filters/DecimationFilterTest.cpp
+++ b/test/unit/filters/DecimationFilterTest.cpp
@@ -76,8 +76,6 @@ BOOST_AUTO_TEST_CASE(DecimationFilterTest_test1)
     BOOST_CHECK_EQUAL(t2, 20);
 
     delete iter;
-
-    return;
 }
 
 BOOST_AUTO_TEST_CASE(DecimationFilterTest_test_options)
@@ -113,8 +111,6 @@ BOOST_AUTO_TEST_CASE(DecimationFilterTest_test_options)
     BOOST_CHECK_EQUAL(t2, 20);
 
     delete iter;
-
-    return;
 }
 
 
@@ -160,8 +156,6 @@ BOOST_AUTO_TEST_CASE(DecimationFilterTest_test_random)
     // BOOST_CHECK_EQUAL(t2, 28);
 
     delete iter;
-
-    return;
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/unit/filters/HexbinFilterTest.cpp
+++ b/test/unit/filters/HexbinFilterTest.cpp
@@ -94,10 +94,6 @@ BOOST_AUTO_TEST_CASE(HexbinFilterTest_test_1)
 
 
         delete iter;
-
-
-
-    return;
 }
 
 

--- a/test/unit/filters/InPlaceReprojectionFilterTest.cpp
+++ b/test/unit/filters/InPlaceReprojectionFilterTest.cpp
@@ -152,9 +152,6 @@ BOOST_AUTO_TEST_CASE(InPlaceReprojectionFilterTest_test_1)
         delete iter;
 
     }
-
-
-    return;
 }
 
 
@@ -225,9 +222,6 @@ BOOST_AUTO_TEST_CASE(InPlaceReprojectionFilterTest_test_2)
         delete iter;
 
     }
-
-
-    return;
 }
 #endif
 

--- a/test/unit/filters/MosaicFilterTest.cpp
+++ b/test/unit/filters/MosaicFilterTest.cpp
@@ -122,8 +122,6 @@ BOOST_AUTO_TEST_CASE(basic_test)
     }
 
     delete iter;
-
-    return;
 }
 
 
@@ -159,9 +157,6 @@ BOOST_AUTO_TEST_CASE(pipeline_mosaic)
     // BOOST_CHECK_EQUAL(x2, 0); // Past 1066, is the other data set due to mosaic filter
     //         
     delete iter;
-
-
-    return;
 }
 #endif
 

--- a/test/unit/filters/PCLBlockFilterTest.cpp
+++ b/test/unit/filters/PCLBlockFilterTest.cpp
@@ -82,8 +82,6 @@ BOOST_AUTO_TEST_CASE(PCLBlockFilterTest_passthrough)
     pdal::filters::iterators::sequential::PCLBlock* b = static_cast<pdal::filters::iterators::sequential::PCLBlock*>(iter);
 
     delete iter;
-
-    return;
 }
 
 BOOST_AUTO_TEST_CASE(PCLBlockFilterTest_outlier_removal)
@@ -121,8 +119,6 @@ BOOST_AUTO_TEST_CASE(PCLBlockFilterTest_outlier_removal)
     pdal::filters::iterators::sequential::PCLBlock* b = static_cast<pdal::filters::iterators::sequential::PCLBlock*>(iter);
 
     delete iter;
-
-    return;
 }
 
 #endif

--- a/test/unit/filters/ScalingFilterTest.cpp
+++ b/test/unit/filters/ScalingFilterTest.cpp
@@ -91,8 +91,6 @@ BOOST_AUTO_TEST_CASE(ScalingFilterTest_test_1)
 
     BOOST_CHECK_EQUAL(x, 63701224);
     BOOST_CHECK_EQUAL(y, 84902831);
-
-    return;
 }
 
 
@@ -182,8 +180,6 @@ BOOST_AUTO_TEST_CASE(ScalingFilterFloat_test)
     }
 
     delete iter;
-
-    return;
 }
 
 
@@ -231,8 +227,6 @@ BOOST_AUTO_TEST_CASE(ScalingFilterTest_test_2)
 
     BOOST_CHECK_EQUAL(x, 63603753);
     BOOST_CHECK_EQUAL(y, 84933845);
-
-    return;
 }
 
 

--- a/test/unit/filters/SelectorFilterTest.cpp
+++ b/test/unit/filters/SelectorFilterTest.cpp
@@ -81,8 +81,6 @@ BOOST_AUTO_TEST_CASE(test1)
 
     // We created Greenish
     BOOST_CHECK_EQUAL(new_schema.getDimension("Greenish").isIgnored(), false);
-
-    return;
 }
 
 

--- a/test/unit/filters/SplitterTest.cpp
+++ b/test/unit/filters/SplitterTest.cpp
@@ -116,8 +116,6 @@ BOOST_AUTO_TEST_CASE(test_tile_filter)
         BOOST_CHECK(s.getTile(22).getNumPoints() == 34); // lower left xy: 637000, 853000
         BOOST_CHECK(s.getTile(23).getNumPoints() == 37); // lower left xy: 638000, 853000
     }
-
-    return;
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/unit/filters/StatsFilterTest.cpp
+++ b/test/unit/filters/StatsFilterTest.cpp
@@ -94,8 +94,6 @@ BOOST_AUTO_TEST_CASE(StatsFilterTest_test1)
     BOOST_CHECK_CLOSE(statsX.average(), 1.0, 0.0001);
     BOOST_CHECK_CLOSE(statsY.average(), 2.0, 0.0001);
     BOOST_CHECK_CLOSE(statsZ.average(), 3.0, 0.0001);
-
-    return;
 }
 
 
@@ -143,8 +141,6 @@ BOOST_AUTO_TEST_CASE(test_random_iterator)
     }
 
     delete iter;
-
-    return;
 }
 
 
@@ -208,8 +204,6 @@ BOOST_AUTO_TEST_CASE(test_multiple_dims_same_name)
     BOOST_CHECK_EQUAL(statsZ.count(), 1000u);
     
     pdal::Metadata m = iterator->toMetadata();
-
-    return;
 }
 
 
@@ -279,9 +273,6 @@ BOOST_AUTO_TEST_CASE(test_specified_stats)
     
     BOOST_CHECK_CLOSE(statsX.minimum(), -117.2686466233, 0.0001);
     BOOST_CHECK_CLOSE(statsY.minimum(), 848899.700, 0.0001);    
-
-
-    return;
 }
 
 BOOST_AUTO_TEST_CASE(test_pointbuffer_stats)
@@ -342,9 +333,6 @@ BOOST_AUTO_TEST_CASE(test_pointbuffer_stats)
     pdal::Metadata m = data.getMetadata();
     
     BOOST_CHECK_EQUAL(m.toPTree().get<int>("metadata.filters_stats.metadata.Classification.metadata.counts.metadata.count-1.metadata.count.value"), 737);
-
-
-    return;
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/unit/plang/PLangTest.cpp
+++ b/test/unit/plang/PLangTest.cpp
@@ -55,8 +55,6 @@ BOOST_AUTO_TEST_CASE(PLangTest_basic)
     pdal::plang::Invocation meth(script);
     meth.compile();
     meth.execute();
-
-    return;
 }
 
 
@@ -78,8 +76,6 @@ BOOST_AUTO_TEST_CASE(PLangTest_compile_error)
     pdal::plang::Invocation meth(script);
 
     BOOST_REQUIRE_THROW(meth.compile(), pdal::python_error);
-
-    return;
 }
 
 
@@ -97,8 +93,6 @@ BOOST_AUTO_TEST_CASE(PLangTest_runtime_error)
     meth.compile();
 
     BOOST_REQUIRE_THROW(meth.execute(), pdal::python_error);
-
-    return;
 }
 
 
@@ -116,8 +110,6 @@ BOOST_AUTO_TEST_CASE(PLangTest_toofewinputs)
     meth.compile();
 
     BOOST_REQUIRE_THROW(meth.execute(), pdal::python_error);
-
-    return;
 }
 
 
@@ -135,8 +127,6 @@ BOOST_AUTO_TEST_CASE(PLangTest_toomanyinputs)
     meth.compile();
 
     BOOST_REQUIRE_THROW(meth.execute(), pdal::python_error);
-
-    return;
 }
 
 
@@ -154,8 +144,6 @@ BOOST_AUTO_TEST_CASE(PLangTest_returnvoid)
     meth.compile();
 
     BOOST_REQUIRE_THROW(meth.execute(), pdal::python_error);
-
-    return;
 }
 
 
@@ -173,8 +161,6 @@ BOOST_AUTO_TEST_CASE(PLangTest_returnint)
     meth.compile();
 
     BOOST_REQUIRE_THROW(meth.execute(), pdal::python_error);
-
-    return;
 }
 
 
@@ -205,8 +191,6 @@ BOOST_AUTO_TEST_CASE(PLangTest_ins)
     meth.insertArgument("X", (boost::uint8_t*)data, 5, 8, pdal::dimension::Float, 8);
 
     meth.execute();
-
-    return;
 }
 
 
@@ -239,8 +223,6 @@ BOOST_AUTO_TEST_CASE(PLangTest_outs)
     BOOST_CHECK_CLOSE(data[2], 1.0, 0.00001);
     BOOST_CHECK_CLOSE(data[3], 1.0, 0.00001);
     BOOST_CHECK_CLOSE(data[4], 1.0, 0.00001);
-
-    return;
 }
 
 
@@ -314,8 +296,6 @@ BOOST_AUTO_TEST_CASE(PLangTest_aliases)
         BOOST_CHECK(names[0] == "Y");
         BOOST_CHECK(names[1] == "prefix.Y");
     }
-
-    return;
 }
 
 
@@ -333,8 +313,6 @@ BOOST_AUTO_TEST_CASE(PLangTest_returntrue)
 
     bool sts = meth.execute();
     BOOST_CHECK(sts);
-
-    return;
 }
 
 
@@ -352,8 +330,6 @@ BOOST_AUTO_TEST_CASE(PLangTest_returnfalse)
 
     bool sts = meth.execute();
     BOOST_CHECK(!sts);
-
-    return;
 }
 
 
@@ -411,8 +387,6 @@ BOOST_AUTO_TEST_CASE(PLangTest_reentry)
         BOOST_CHECK_CLOSE(outdata2[3], 41.0, 0.00001);
         BOOST_CHECK_CLOSE(outdata2[4], 51.0, 0.00001);
     }
-
-    return;
 }
 
 

--- a/test/unit/plang/PredicateFilterTest.cpp
+++ b/test/unit/plang/PredicateFilterTest.cpp
@@ -94,8 +94,6 @@ BOOST_AUTO_TEST_CASE(PredicateFilterTest_test1)
     BOOST_CHECK(Utils::compare_approx<double>(maxX, 1.0, 0.01));
     BOOST_CHECK(Utils::compare_approx<double>(maxY, 1.0, 0.01));
     BOOST_CHECK(Utils::compare_approx<double>(maxZ, 1.0, 0.01));
-
-    return;
 }
 
 
@@ -145,8 +143,6 @@ BOOST_AUTO_TEST_CASE(PredicateFilterTest_test2)
     BOOST_CHECK(Utils::compare_approx<double>(maxX, 2.0, 0.01));
     BOOST_CHECK(Utils::compare_approx<double>(maxY, 2.0, 0.01));
     BOOST_CHECK(Utils::compare_approx<double>(maxZ, 2.0, 0.01));
-
-    return;
 }
 
 
@@ -219,8 +215,6 @@ BOOST_AUTO_TEST_CASE(PredicateFilterTest_test3)
     BOOST_CHECK(Utils::compare_approx<double>(maxX, 1.0, 0.01));
     BOOST_CHECK(Utils::compare_approx<double>(maxY, 1.0, 0.01));
     BOOST_CHECK(Utils::compare_approx<double>(maxZ, 1.0, 0.01));
-
-    return;
 }
 
 
@@ -268,8 +262,6 @@ BOOST_AUTO_TEST_CASE(PredicateFilterTest_test4)
 
     BOOST_CHECK(processed == 1000);
     BOOST_CHECK(passed == 750);
-
-    return;
 }
 
 BOOST_AUTO_TEST_CASE(PredicateFilterTest_test5)
@@ -306,8 +298,6 @@ BOOST_AUTO_TEST_CASE(PredicateFilterTest_test5)
     boost::scoped_ptr<pdal::StageSequentialIterator> iter(filter.createSequentialIterator(data));
 
     BOOST_REQUIRE_THROW(iter->read(data), pdal::python_error);
-
-    return;
 }
 
 BOOST_AUTO_TEST_CASE(PredicateFilterTest_Pipeline)
@@ -328,8 +318,6 @@ BOOST_AUTO_TEST_CASE(PredicateFilterTest_Pipeline)
 
         delete iter;
     }
-
-    return;
 }
 
 BOOST_AUTO_TEST_CASE(PredicateFilterTest_Embed)
@@ -350,8 +338,6 @@ BOOST_AUTO_TEST_CASE(PredicateFilterTest_Embed)
 
         delete iter;
     }
-
-    return;
 }
 
 

--- a/test/unit/plang/ProgrammableFilterTest.cpp
+++ b/test/unit/plang/ProgrammableFilterTest.cpp
@@ -105,8 +105,6 @@ BOOST_AUTO_TEST_CASE(ProgrammableFilterTest_test1)
 
     BOOST_CHECK_CLOSE(minZ, 3.14, 0.001);
     BOOST_CHECK_CLOSE(maxZ, 3.14, 0.001);
-
-    return;
 }
 
 BOOST_AUTO_TEST_CASE(pipeline)
@@ -136,8 +134,6 @@ BOOST_AUTO_TEST_CASE(pipeline)
     }
             
     delete iter;
-
-    return;
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
These returns are not needed for the tests to run properly, and their inconsistent use could cause confusion down the road.

Fixes #337.
