### PR TITLE
Split inferWriterDriver into two

### DIFF
--- a/include/pdal/StageFactory.hpp
+++ b/include/pdal/StageFactory.hpp
@@ -93,10 +93,12 @@ public:
 
     // infer the driver to use based on filename extension
     // returns "" if no driver found
-    // 
-    // this may also add on an option to pass to the driver, such as the filename
-    // (or something inferred from the extension, such as .laz means we need to use compress=true)
-    static std::string inferWriterDriver(const std::string& filename, pdal::Options& options);
+    static std::string inferWriterDriver(const std::string& filename);
+
+    // modify options based upon expectations implicit in a given filename
+    // e.g. output files ending in .laz should be compressed
+    static void inferWriterOptionsChanges(const std::string& filename,
+                                          pdal::Options& options);
 
     Reader* createReader(const std::string& type, const Options& options);
     Filter* createFilter(const std::string& type, Stage& prevStage, const Options& options);

--- a/src/StageFactory.cpp
+++ b/src/StageFactory.cpp
@@ -201,23 +201,12 @@ std::string StageFactory::inferReaderDriver(const std::string& filename, pdal::O
     return driver; // will be "" if not found
 }
 
-std::string StageFactory::inferWriterDriver(const std::string& filename, pdal::Options& options)
+
+std::string StageFactory::inferWriterDriver(const std::string& filename)
 {
     std::string ext = boost::filesystem::extension(filename);
 
     boost::to_lower(ext);
-
-    if (boost::algorithm::iequals(ext,".laz"))
-    {
-        options.add("compression", true);
-    }
-
-    if (boost::algorithm::iequals(ext,".pcd"))
-    {
-        options.add("format","PCD");
-    }
-
-    options.add<std::string>("filename", filename);
 
     std::map<std::string, std::string> drivers;
     drivers["las"] = "drivers.las.writer";
@@ -240,6 +229,26 @@ std::string StageFactory::inferWriterDriver(const std::string& filename, pdal::O
     std::string driver = drivers[ext];
     return driver; // will be "" if not found
 }
+
+
+void StageFactory::inferWriterOptionsChanges(const std::string& filename, pdal::Options& options)
+{
+    std::string ext = boost::filesystem::extension(filename);
+    boost::to_lower(ext);
+
+    if (boost::algorithm::iequals(ext,".laz"))
+    {
+        options.add("compression", true);
+    }
+
+    if (boost::algorithm::iequals(ext,".pcd"))
+    {
+        options.add("format","PCD");
+    }
+
+    options.add<std::string>("filename", filename);
+}
+
 
 Reader* StageFactory::createReader(const std::string& type, const Options& options)
 {

--- a/src/kernel/Support.cpp
+++ b/src/kernel/Support.cpp
@@ -101,11 +101,12 @@ pdal::Writer* AppSupport::makeWriter(pdal::Options& options, pdal::Stage& stage)
     const std::string outputFile = options.getValueOrThrow<std::string>("filename");
 
     pdal::StageFactory factory;
-    std::string driver = factory.inferWriterDriver(outputFile, options);
+    std::string driver = factory.inferWriterDriver(outputFile);
     if (driver == "")
     {
         throw app_runtime_error("Cannot determine output file type of " + outputFile);
     }
+    factory.inferWriterOptionsChanges(outputFile, options);
         
     pdal::Writer* writer = factory.createWriter(driver, stage, options);
     if (!writer)


### PR DESCRIPTION
Per #340, the 2-argument `infer{Reader|Writer}Driver` might try to do too much by both modifying options and finding the correct driver. This patch splits the `inferWriterDriver` into two pieces. The `inferWriterDriver` part does just that, while a new method, `inferWriterOptionsChanges`, modifies an options object based upon a given filename.
