### PR TITLE
revert the explicitly deleted behavior of these functions, unavailable on MSVC2012

### DIFF
--- a/include/pdal/filters/Scaling.hpp
+++ b/include/pdal/filters/Scaling.hpp
@@ -80,8 +80,8 @@ public:
 
 
     Scaling(Stage& prevStage, const Options&);
-    Scaling& operator=(const Scaling&) = delete;
-    Scaling(const Scaling&) = delete;
+    Scaling& operator=(const Scaling&);
+    Scaling(const Scaling&);
 
     static Options getDefaultOptions();
     virtual void initialize();


### PR DESCRIPTION
Issue #358
