### PR TITLE
sys/param.h is unavailable and unneeded on windows

### DIFF
--- a/include/pdal/portable_endian.hpp
+++ b/include/pdal/portable_endian.hpp
@@ -61,7 +61,6 @@
 #elif defined(__WINDOWS__)
                     
 #   include <winsock2.h>
-#   include <sys/param.h>
                      
 #   if BYTE_ORDER == LITTLE_ENDIAN
                       


### PR DESCRIPTION
Issue #359
