### PR TITLE
Remove unused variable m_pclblockFilter

### DIFF
--- a/include/pdal/filters/PCLBlock.hpp
+++ b/include/pdal/filters/PCLBlock.hpp
@@ -104,8 +104,6 @@ private:
     boost::uint64_t skipImpl(boost::uint64_t);
     boost::uint32_t readBufferImpl(PointBuffer&);
     bool atEndImpl() const;
-
-    const pdal::filters::PCLBlock& m_pclblockFilter;
 };
 
 

--- a/src/filters/PCLBlock.cpp
+++ b/src/filters/PCLBlock.cpp
@@ -185,7 +185,6 @@ namespace sequential
 
 PCLBlock::PCLBlock(const pdal::filters::PCLBlock& filter, PointBuffer& buffer)
     : pdal::FilterSequentialIterator(filter, buffer)
-    , m_pclblockFilter(filter)
 {
     return;
 }


### PR DESCRIPTION
clang-503.0.40 was complaining about an unused member variable in
`pdal::filters::iterators::sequential::PCLBlock`.
