### PR TITLE
No brace enclosed initializer lists

### DIFF
--- a/include/pdal/IStream.hpp
+++ b/include/pdal/IStream.hpp
@@ -56,7 +56,7 @@ class IStream
 public:
     IStream(const std::string& filename)
         { m_stream = m_fstream = new std::ifstream(filename); }
-    IStream(std::istream *stream) : m_stream{stream}, m_fstream{NULL}
+    IStream(std::istream *stream) : m_stream(stream), m_fstream(NULL)
         {}
     ~IStream()
         { delete m_fstream; }

--- a/include/pdal/RawPtBuf.hpp
+++ b/include/pdal/RawPtBuf.hpp
@@ -46,8 +46,8 @@ namespace pdal
 class RawPtBuf
 {
 public:
-    RawPtBuf(SchemaPtr schema) : m_numPts{0}, m_allocPts{0},
-        m_schema{schema}
+    RawPtBuf(SchemaPtr schema) : m_numPts(0), m_allocPts(0),
+        m_schema(schema)
     {}
 
     PointId addPoint()


### PR DESCRIPTION
We've found that these are no good on either MSVC2012 or gcc 4.6.3 (see 41b1506).
