### PR TITLE
apt-get install libgdal1h for Travis

### DIFF
--- a/scripts/ci/before_install.sh
+++ b/scripts/ci/before_install.sh
@@ -19,7 +19,7 @@ sudo apt-get install \
     libtiff4-dev \
     libxml2-dev \
     python-numpy \
-    boost1.55
+    boost1.55 -y
 
 # install libgeotiff from sources
 wget http://download.osgeo.org/geotiff/libgeotiff/libgeotiff-1.4.0.tar.gz


### PR DESCRIPTION
Travis [broke](https://travis-ci.org/PDAL/PDAL/builds/26602688) and this patch is trying to fix the break by manually installing a broken gdal dependency.
