### PR TITLE
Travis, build clang

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: cpp
 
 compiler:
   - g++
+  - clang
 
 env:
   - PDAL_OPTIONAL_COMPONENTS=all

--- a/scripts/ci/before_install.sh
+++ b/scripts/ci/before_install.sh
@@ -3,14 +3,29 @@
 source ./scripts/ci/common.sh
 sudo apt-key adv --recv-keys --keyserver keyserver.ubuntu.com 16126D3A3E5C1192
 sudo apt-get update -y
+
 sudo apt-get install software-properties-common -y
 sudo apt-get install python-software-properties -y
+
 sudo add-apt-repository ppa:ubuntugis/ppa -y
-sudo add-apt-repository ppa:boost-latest/ppa -y
+sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+# Use embedded boost for clang builds
+# pdal_test segfaults when built against external g++-built boost,
+# and I haven't found a good boost package built with clang yet
+if [[ "$CXX" == "g++" ]]
+then
+    sudo add-apt-repository ppa:boost-latest/ppa -y
+fi
 sudo apt-get update -qq
+
+# Install g++-4.8 (even if we're building clang) for updated libstdc++
 sudo apt-get install \
     cmake \
-    boost1.55
+    g++-4.8
+if [[ "$CXX" == "g++" ]]
+then
+    sudo apt-get install boost1.55
+fi
 
 if [ "$PDAL_OPTIONAL_COMPONENTS" == "all" ]
 then

--- a/scripts/ci/script.sh
+++ b/scripts/ci/script.sh
@@ -16,6 +16,14 @@ case "$PDAL_OPTIONAL_COMPONENTS" in
         exit 1
 esac
 
+if [[ "$CXX" == "g++" ]]
+then
+    export CXX="g++-4.8"
+    export PDAL_EMBED_BOOST=OFF
+else
+    export PDAL_EMBED_BOOST=ON
+fi
+
 cmake \
     -DWITH_APPS=ON \
     -DWITH_TESTS=ON \
@@ -34,8 +42,8 @@ cmake \
     -DWITH_CARIS=OFF \
     -DWITH_SQLITE=OFF \
     -DENABLE_CTEST=OFF \
-    -DPDAL_EMBED_BOOST=OFF \
     -DWITH_HDF5=OFF \
+    -DPDAL_EMBED_BOOST=$PDAL_EMBED_BOOST \
     ..
 
 make -j ${NUMTHREADS}


### PR DESCRIPTION
Many PDAL developers build with clang, so Travis should follow suit. This pull request is expected to fail for a bit as I iterate testing on Travis.

Would be nice to have a local Travis VM so I didn't have a fifteen minute push/build cycle, wouldn't it?
