### PR TITLE
Use ninja when building with clang

### DIFF
--- a/scripts/ci/before_install.sh
+++ b/scripts/ci/before_install.sh
@@ -1,33 +1,49 @@
 #!/bin/bash -e
 # Installs requirements for PDAL
 source ./scripts/ci/common.sh
+
 sudo apt-key adv --recv-keys --keyserver keyserver.ubuntu.com 16126D3A3E5C1192
 sudo apt-get update -y
-
 sudo apt-get install software-properties-common -y
 sudo apt-get install python-software-properties -y
-
 sudo add-apt-repository ppa:ubuntugis/ppa -y
 sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-# Use embedded boost for clang builds
-# pdal_test segfaults when built against external g++-built boost,
-# and I haven't found a good boost package built with clang yet
-if [[ "$CXX" == "g++" ]]
+if [[ $PDAL_EMBED_BOOST == "OFF" ]]
 then
     sudo add-apt-repository ppa:boost-latest/ppa -y
 fi
 sudo apt-get update -qq
 
 # Install g++-4.8 (even if we're building clang) for updated libstdc++
-sudo apt-get install \
-    cmake \
-    g++-4.8
-if [[ "$CXX" == "g++" ]]
+sudo apt-get install g++-4.8
+
+if [[ $PDAL_EMBED_BOOST == "OFF" ]]
 then
     sudo apt-get install boost1.55
 fi
 
-if [ "$PDAL_OPTIONAL_COMPONENTS" == "all" ]
+if [[ $PDAL_CMAKE_GENERATOR == "Ninja" ]]
+then
+    # Need newer cmake for Ninja generator
+    wget http://www.cmake.org/files/v2.8/cmake-2.8.12.2.tar.gz
+    tar -xzf cmake-2.8.12.2.tar.gz
+    cd cmake-2.8.12.2
+    ./bootstrap
+    make
+    sudo make install
+    cd ..
+
+    git clone https://github.com/martine/ninja.git
+    cd ninja
+    git checkout release
+    ./bootstrap.py
+    sudo ln -s "$PWD/ninja" /usr/local/bin/ninja
+    cd ..
+else
+    sudo apt-get install cmake
+fi
+
+if [[ $PDAL_OPTIONAL_COMPONENTS == "all" ]]
 then
     sudo apt-get install \
         libgdal-dev \

--- a/scripts/ci/common.sh
+++ b/scripts/ci/common.sh
@@ -3,8 +3,10 @@ if [[ "$TRAVIS" != "true" ]] ; then
 	echo "Running this script makes no sense outside of travis-ci.org"
 	exit 1
 fi
+
 # Functions
 tmstamp() { echo -n "[$(date '+%H:%M:%S')]" ; }
+
 # Environment
 NUMTHREADS=4
 if [[ -f /sys/devices/system/cpu/online ]]; then
@@ -13,3 +15,15 @@ if [[ -f /sys/devices/system/cpu/online ]]; then
 fi
 #NUMTHREADS=1 # disable MP
 export NUMTHREADS
+
+# For clang, use embedded boost and ninja as our 'funky' setup
+# pdal_test segfaults when built against external g++-built boost,
+# and I haven't found a good boost package built with clang yet
+if [[ "$CXX" == "clang++" ]]
+then
+    export PDAL_CMAKE_GENERATOR="Ninja"
+    export PDAL_EMBED_BOOST="ON"
+else
+    export PDAL_CMAKE_GENERATOR="Unix Makefiles"
+    export PDAL_EMBED_BOOST="OFF"
+fi

--- a/scripts/ci/script.sh
+++ b/scripts/ci/script.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 # Builds and tests PDAL
 source ./scripts/ci/common.sh
+
 mkdir -p _build || exit 1
 cd _build || exit 1
 
@@ -19,9 +20,6 @@ esac
 if [[ "$CXX" == "g++" ]]
 then
     export CXX="g++-4.8"
-    export PDAL_EMBED_BOOST=OFF
-else
-    export PDAL_EMBED_BOOST=ON
 fi
 
 cmake \
@@ -44,8 +42,14 @@ cmake \
     -DENABLE_CTEST=OFF \
     -DWITH_HDF5=OFF \
     -DPDAL_EMBED_BOOST=$PDAL_EMBED_BOOST \
+    -G "$PDAL_CMAKE_GENERATOR" \
     ..
 
-make -j ${NUMTHREADS}
+if [[ $PDAL_CMAKE_GENERATOR == "Unix Makefiles" ]]
+then
+    make -j ${NUMTHREADS}
+else
+    ninja
+fi
 
 ctest -V --output-on-failure .


### PR DESCRIPTION
Our clang side of the travis matrix is going to be our 'funky stuff zone'. This pull request might iterate a bit again, as I test on Travis.
