### PR TITLE
Re-enable Ninja, but set the thread count

### DIFF
--- a/scripts/ci/common.sh
+++ b/scripts/ci/common.sh
@@ -20,11 +20,7 @@ export NUMTHREADS
 # and I haven't found a good boost package built with clang yet
 if [[ "$CXX" == "clang++" ]]
 then
-    # We tried Ninja in 0a72021fee914e28df0ce2dc9fb3291d62b5183d,
-    # but our tests were taking too long so we went back to Unix Makefiles.
-    # If we find/make a cmake 2.8.12  (or close) package from
-    # a PPA we could re-enable Ninja
-    export PDAL_CMAKE_GENERATOR="Unix Makefiles"
+    export PDAL_CMAKE_GENERATOR="Ninja"
     export PDAL_EMBED_BOOST="ON"
 else
     export PDAL_CMAKE_GENERATOR="Unix Makefiles"

--- a/scripts/ci/script.sh
+++ b/scripts/ci/script.sh
@@ -49,7 +49,9 @@ if [[ $PDAL_CMAKE_GENERATOR == "Unix Makefiles" ]]
 then
     make -j ${NUMTHREADS}
 else
-    ninja
+    # Don't use ninja's default number of threads becuase it can
+    # saturate Travis's available memory.
+    ninja -j ${NUMTHREADS}
 fi
 
 ctest -V --output-on-failure .


### PR DESCRIPTION
Pull request test for setting Ninja's thread count explicitly, which (hopefully) will prevent memory saturation and a kill from Travis.
