### PR TITLE
Fix Fetchpcid bug

### DIFF
--- a/src/drivers/pgpointcloud/Reader.cpp
+++ b/src/drivers/pgpointcloud/Reader.cpp
@@ -232,6 +232,7 @@ boost::uint32_t Reader::fetchPcid() const
     oss << "FROM pg_class c, pg_attribute a ";
     oss << "WHERE c.relname = '" << m_table_name << "' ";
     oss << "AND a.attname = '" << m_column_name << "' ";
+    oss << "AND c.oid = a.attrelid";
 
     char *pcid_str(0);
     pcid_str = pg_query_once(m_session, oss.str());


### PR DESCRIPTION
When there are more than one records in pointcloud_formats, fetchpcid( ) only return the first one.
