### PR TITLE
Revert RPATH to cmake's recommended setup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,9 +25,16 @@ cmake_policy(SET CMP0022 OLD) # interface link libraries
 cmake_policy(SET CMP0042 OLD) # osx rpath
 endif()
 
-if (CMAKE_SYSTEM_NAME MATCHES "Linux")
-set(CMAKE_SKIP_RPATH ON)
-endif()
+# per http://www.cmake.org/Wiki/CMake_RPATH_handling
+SET(CMAKE_SKIP_BUILD_RPATH FALSE)
+SET(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
+SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+LIST(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/lib" isSystemDir)
+IF("${isSystemDir}" STREQUAL "-1")
+    SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+ENDIF("${isSystemDir}" STREQUAL "-1")
+
 
 # Provided modules
 include(CMakeDependentOption)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -864,13 +864,6 @@ target_link_libraries(${PDAL_LIB_NAME}
 set_target_properties(${PDAL_LIB_NAME}
   PROPERTIES SOVERSION "${PDAL_LIB_SOVERSION}" )
 
-if (APPLE)
-  set_target_properties(
-    ${PDAL_LIB_NAME}
-    PROPERTIES
-    INSTALL_NAME_DIR "@rpath" BUILD_WITH_INSTALL_RPATH ON)
-endif()
-
 
 if (USE_PDAL_PLUGIN_TEXT)
     set(PDAL_TEXT_WRITER_LIB_NAME pdal_plugin_writer_text)
@@ -879,12 +872,6 @@ if (USE_PDAL_PLUGIN_TEXT)
                           ${PDAL_LIB_NAME})
     set_target_properties("${PDAL_TEXT_WRITER_LIB_NAME}"
     PROPERTIES SOVERSION "${PDAL_LIB_SOVERSION}" )
-    if (APPLE)
-    set_target_properties(
-      "${PDAL_TEXT_WRITER_LIB_NAME}"
-      PROPERTIES
-      INSTALL_NAME_DIR "@rpath" BUILD_WITH_INSTALL_RPATH ON)
-    endif()
 endif()
 
 if (WITH_SQLITE)
@@ -896,12 +883,6 @@ if (USE_PDAL_PLUGIN_SQLITE)
                           ${SQLITE_LIBRARIES})
     set_target_properties(${PDAL_SQLITE_WRITER_LIB_NAME}
     PROPERTIES SOVERSION "${PDAL_LIB_SOVERSION}" )
-    if (APPLE)
-    set_target_properties(
-      "${PDAL_SQLITE_WRITER_LIB_NAME}"
-      PROPERTIES
-      INSTALL_NAME_DIR "@rpath" BUILD_WITH_INSTALL_RPATH ON)
-    endif()
 
     set(PDAL_SQLITE_READER_LIB_NAME pdal_plugin_reader_sqlite)
     add_library(${PDAL_SQLITE_READER_LIB_NAME} SHARED ${PDAL_SQLITE_SRC}/Reader.cpp)
@@ -910,13 +891,6 @@ if (USE_PDAL_PLUGIN_SQLITE)
                           ${SQLITE_LIBRARIES})
     set_target_properties(${PDAL_SQLITE_READER_LIB_NAME}
     PROPERTIES SOVERSION "${PDAL_LIB_SOVERSION}" )
-    if (APPLE)
-    set_target_properties(
-      "${PDAL_SQLITE_READER_LIB_NAME}"
-      PROPERTIES
-      INSTALL_NAME_DIR "@rpath" BUILD_WITH_INSTALL_RPATH ON)
-    endif()
-
 endif()
 endif()
 
@@ -931,12 +905,6 @@ if (USE_PDAL_PLUGIN_OCI)
                           "${ORACLE_LIBRARY}")
     set_target_properties(${PDAL_OCI_WRITER_LIB_NAME}
     PROPERTIES SOVERSION "${PDAL_LIB_SOVERSION}" )
-    if (APPLE)
-    set_target_properties(
-      "${PDAL_OCI_WRITER_LIB_NAME}"
-      PROPERTIES
-      INSTALL_NAME_DIR "@rpath" BUILD_WITH_INSTALL_RPATH ON)
-    endif()
 endif()
 endif()
 ###############################################################################


### PR DESCRIPTION
Without this patch, a build on Linux will produce executables (pdal, pdal_test) that can't find the shared libraries just one folder over in `lib/`. This patch nukes all Apple-specific RPATH management and instead implements the RPATH suggestions in http://www.cmake.org/Wiki/CMake_RPATH_handling. RPATH stuff was last tweaked in fc52dec. I've manually tested on both a Vagrant Ubuntu box and my home MacOSX.

This patch could also potentially be backported to **master** before merging -- let me know if you'd like me to do that.
