### PR TITLE
Actually use numberOfReturns in FauxReader

### DIFF
--- a/src/drivers/faux/Reader.cpp
+++ b/src/drivers/faux/Reader.cpp
@@ -173,7 +173,7 @@ point_count_t FauxSeqIterator::readImpl(PointBuffer& buf, point_count_t count)
         {
             buf.setField(Dimension::Id::ReturnNumber, idx, m_returnNumber);
             buf.setField(Dimension::Id::NumberOfReturns, idx, m_numberOfReturns);
-            m_returnNumber = (m_returnNumber % 10) + 1;
+            m_returnNumber = (m_returnNumber % m_numberOfReturns) + 1;
         }
     }
     return count;

--- a/test/unit/drivers/faux/FauxReaderTest.cpp
+++ b/test/unit/drivers/faux/FauxReaderTest.cpp
@@ -216,7 +216,7 @@ BOOST_AUTO_TEST_CASE(test_return_number)
     ops.add("bounds", bounds);
     ops.add("num_points", 100);
     ops.add("mode", "constant");
-    ops.add("number_of_returns", 10);
+    ops.add("number_of_returns", 9);
     drivers::faux::Reader reader(ops);
 
     PointContext ctx;
@@ -231,8 +231,8 @@ BOOST_AUTO_TEST_CASE(test_return_number)
         uint8_t returnNumber = buf.getFieldAs<uint8_t>(Dimension::Id::ReturnNumber, i);
         uint8_t numberOfReturns = buf.getFieldAs<uint8_t>(Dimension::Id::NumberOfReturns, i);
 
-        BOOST_CHECK_EQUAL(returnNumber, (i % 10) + 1);
-        BOOST_CHECK_EQUAL(numberOfReturns, 10);
+        BOOST_CHECK_EQUAL(returnNumber, (i % 9) + 1);
+        BOOST_CHECK_EQUAL(numberOfReturns, 9);
     }
 
     delete iter;


### PR DESCRIPTION
Previously, we were ignoring the value and just using 10. Thanks @abellgithub for the catch.
