### PR TITLE
Require boost when finding package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -252,7 +252,7 @@ if(WIN32)
   endif(MSVC)
 endif(WIN32)
 
-find_package(Boost 1.55 COMPONENTS program_options thread iostreams filesystem system unit_test_framework random)
+find_package(Boost 1.55 COMPONENTS program_options thread iostreams filesystem system unit_test_framework random REQUIRED)
 
 if(Boost_FOUND)
   include_directories(${Boost_INCLUDE_DIRS})


### PR DESCRIPTION
Now that we don't have embedded boost as a fallback (51c6563e8af4cdb9f549fae7192b31772095ca3f), we should bomb if we are unable to find boost on the system.
