### PR TITLE
Programmable filter can add dimensions to context

### DIFF
--- a/doc/stages/filters.programmable.rst
+++ b/doc/stages/filters.programmable.rst
@@ -21,6 +21,8 @@ This example scales the Z value by a factor of ten (of course, you could also us
 
 Note that the function always returns `True`. If the function returned `False`, an error would be thrown and the translation shut down.
 
+If you want to write a dimension that might not be available, use can use one or more `add_dimension` options.
+
 To filter points based on a `Python`_ function, use the :ref:`filters.predicate` filter.
 
 Example
@@ -75,6 +77,8 @@ function
 source
   The literal `Python`_ code to execute, when the script option is not being used.
 
+add_dimension
+  The name of a dimension to add to the pipeline that does not already exist.
 
 .. _Python: http://python.org/
 .. _NumPy: http://www.numpy.org/

--- a/include/pdal/filters/Programmable.hpp
+++ b/include/pdal/filters/Programmable.hpp
@@ -69,8 +69,10 @@ private:
     std::string m_source;
     std::string m_module;
     std::string m_function;
+    Dimension::IdList m_addDimensions;
 
     virtual void processOptions(const Options& options);
+    virtual void addDimensions(PointContext ctx);
     virtual void ready(PointContext ctx);
     virtual void filter(PointBuffer& buf);
     virtual void done(PointContext ctx);

--- a/src/filters/Programmable.cpp
+++ b/src/filters/Programmable.cpp
@@ -63,6 +63,21 @@ void Programmable::processOptions(const Options& options)
             options.getValueOrThrow<std::string>("filename"));
     m_module = options.getValueOrThrow<std::string>("module");
     m_function = options.getValueOrThrow<std::string>("function");
+
+    auto addDims = options.getOptions("add_dimension");
+    for (auto it = addDims.cbegin(); it != addDims.cend(); ++it)
+    {
+        m_addDimensions.push_back(Dimension::id(it->getValue<std::string>()));
+    }
+}
+
+
+void Programmable::addDimensions(PointContext ctx)
+{
+    for (auto it = m_addDimensions.cbegin(); it != m_addDimensions.cend(); ++it)
+    {
+        ctx.registerDim(*it);
+    }
 }
 
 

--- a/test/unit/plang/ProgrammableFilterTest.cpp
+++ b/test/unit/plang/ProgrammableFilterTest.cpp
@@ -130,6 +130,52 @@ BOOST_AUTO_TEST_CASE(pipeline)
     }
 }
 
+
+BOOST_AUTO_TEST_CASE(add_dimension)
+{
+    Bounds<double> bounds(0.0, 0.0, 0.0, 1.0, 1.0, 1.0);
+
+    Options ops;
+    ops.add("bounds", bounds);
+    ops.add("num_points", 10);
+    ops.add("mode", "ramp");
+
+    drivers::faux::Reader reader(ops);
+
+    Option source("source", "import numpy\n"
+        "def myfunc(ins,outs):\n"
+        "  outs['Intensity'] = np.zeros(ins['X'].size, dtype=numpy.uint16) + 1\n"
+        "  outs['PointSourceId'] = np.zeros(ins['X'].size, dtype=numpy.uint16) + 2\n"
+        "  return True\n"
+    );
+    Option module("module", "MyModule");
+    Option function("function", "myfunc");
+    Option intensity("add_dimension", "Intensity");
+    Option scanDirection("add_dimension", "PointSourceId");
+    Options opts;
+    opts.add(source);
+    opts.add(module);
+    opts.add(function);
+    opts.add(intensity);
+    opts.add(scanDirection);
+
+    filters::Programmable filter(opts);
+    filter.setInput(&reader);
+
+    PointContext ctx;
+    filter.prepare(ctx);
+    PointBufferSet pbSet = filter.execute(ctx);
+    BOOST_CHECK_EQUAL(pbSet.size(), 1);
+    PointBufferPtr buf = *pbSet.begin();
+
+    for (unsigned int i = 0; i < buf->size(); ++i)
+    {
+        BOOST_CHECK_EQUAL(buf->getFieldAs<uint16_t>(Dimension::Id::Intensity, i), 1);
+        BOOST_CHECK_EQUAL(buf->getFieldAs<uint16_t>(Dimension::Id::PointSourceId, i), 2);
+    }
+}
+
+
 BOOST_AUTO_TEST_SUITE_END()
 
 #endif  // PDAL_HAVE_PYTHON


### PR DESCRIPTION
Using one or more `add_dimension` options on a programmable filter will instruct the filter to add those dimensions to the primary PointContext. This way, the programmable filter can set dimensions that might not be present on the PointContext.

My use case for this is manually scaling and "renaming" a dimension coming in from a reader, e.g. this pipeline:

``` xml
<?xml version="1.0" encoding="utf-8"?>
<Pipeline version="1.0">
    <Writer type="drivers.las.writer">
        <Option name="filename">output.las</Option>
        <Option name="discard_high_return_numbers">true</Option>
        <Filter type="filters.programmable">
            <Option name="source">
import numpy
def reflectance_to_intensity(ins, outs):
    ref = ins["Reflectance"]
    min = numpy.amin(ref)
    max = numpy.amax(ref)
    outs["Intensity"] = (65536 * (ref - min) / (max - min)).astype(numpy.uint16)
    return True
            </Option>
            <Option name="function">reflectance_to_intensity</Option>
            <Option name="module">pyrxp</Option>
            <Option name="add_dimension">Intensity</Option>
            <Reader type="drivers.rxp.reader">
                <Option name="filename">/home/vagrant/PDAL/test/data/rxp/130501_232206_cut.rxp</Option>
            </Reader>
        </Filter>
    </Writer>
</Pipeline>
```

The **rxp** reader, which produces the "Reflectance" value, comes from [this branch](https://github.com/gadomski/PDAL/tree/rxp-driver).
