### PR TITLE
Remove leftover embedded boost cruft

### DIFF
--- a/include/pdal/pdal_config.hpp
+++ b/include/pdal/pdal_config.hpp
@@ -55,7 +55,6 @@ PDAL_DLL bool IsLibLASEnabled();
 PDAL_DLL bool IsGDALEnabled();
 PDAL_DLL bool IsLibGeoTIFFEnabled();
 PDAL_DLL bool IsLasZipEnabled();
-PDAL_DLL bool IsEmbeddedBoost();
 
 PDAL_DLL std::string GetFullVersionString();
 PDAL_DLL std::string GetVersionString();

--- a/src/pdal_config.cpp
+++ b/src/pdal_config.cpp
@@ -107,15 +107,6 @@ bool IsLasZipEnabled()
 #endif
 }
 
-bool IsEmbeddedBoost()
-{
-#ifdef PDAL_EMBED_BOOST
-    return true;
-#else
-    return false;
-#endif
-}
-
 int GetVersionMajor()
 {
     return PDAL_VERSION_MAJOR;
@@ -166,11 +157,6 @@ std::string GetFullVersionString()
        << LASZIP_VERSION_MINOR << "."
        << LASZIP_VERSION_REVISION;
 #endif
-
-    if (IsEmbeddedBoost())
-        os << " Embed ";
-    else
-        os << " System ";
 
     std::string info(os.str());
     os.str("");

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -228,16 +228,7 @@ if(WIN32)
         #add_definitions("-DBOOST_TEST_DYN_LINK")
     endif()
 else()
-    # Our own static build of embedded boost should do BOOST_TEST_DYN_LINK 
-    # when it is compiled, but regular static builds of Boost will 
-    # not do this. 
-    if(Boost_PROGRAM_OPTIONS_LIBRARY MATCHES "\\.a$" )
-        # pass, we can compile static
-        message(STATUS "Static boost for boost::unit_test, not setting BOOST_TEST_DYN_LINK")
-    else()
-        message(STATUS "No non-embed static boost library found, setting BOOST_TEST_DYN_LINK")
-        add_definitions("-DBOOST_TEST_DYN_LINK")
-    endif()
+    add_definitions("-DBOOST_TEST_DYN_LINK")
 endif()
 
 TARGET_LINK_LIBRARIES(  ${PDAL_UNIT_TEST} ${PDAL_LINKAGE}


### PR DESCRIPTION
Removes IsEmbeddedBoost() and calls, as well as embedded boost check in test/unit/CMakeLists.txt. Embedded boost was removed in c1af2bb.

I'm not entirely sure if the test/unit/CMakeLists.txt cleanup is the correct call, but I went for it anyways. If its not correct I can remove.
