### PR TITLE
add PCL VoxelGrid as a decimation option (not the default)

### DIFF
--- a/include/pdal/filters/Decimation.hpp
+++ b/include/pdal/filters/Decimation.hpp
@@ -54,10 +54,15 @@ public:
 private:
     uint32_t m_step;
     uint32_t m_offset;
+    double m_leaf_size;
+    std::string m_method;
 
     virtual void processOptions(const Options& options);
     PointBufferSet run(PointBufferPtr buffer);
     void decimate(PointBuffer& input, PointBuffer& output);
+#ifdef PDAL_HAVE_PCL
+    void voxel_grid(PointBuffer& input, PointBuffer& output);
+#endif
 
     Decimation& operator=(const Decimation&); // not implemented
     Decimation(const Decimation&); // not implemented

--- a/include/pdal/kernel/Translate.hpp
+++ b/include/pdal/kernel/Translate.hpp
@@ -68,6 +68,8 @@ private:
     bool m_bForwardMetadata;
     boost::uint32_t m_decimation_step;
     boost::uint32_t m_decimation_offset;
+    double m_decimation_leaf_size;
+    std::string m_decimation_method;
 
 };
 

--- a/include/stubs/pcl/filters/voxel_grid.h
+++ b/include/stubs/pcl/filters/voxel_grid.h
@@ -1,0 +1,22 @@
+#pragma once
+
+namespace pcl
+{
+
+template<typename POINT>
+struct VoxelGrid
+{
+    template <typename T>
+    void setInputCloud(T& cloud)
+    { (void)cloud; }
+
+    template <typename T>
+    void filter(T& cloud)
+    { (void)cloud; }
+
+    template <typename T>
+    void setLeafSize(T x, T y, T z)
+    { (void)x; (void)y; (void)z; }
+};
+
+} //namespace pcl

--- a/src/kernel/Translate.cpp
+++ b/src/kernel/Translate.cpp
@@ -51,7 +51,7 @@ Translate::Translate(int argc, const char* argv[]) :
     m_numPointsToWrite(0), m_numSkipPoints(0),
     m_input_srs(pdal::SpatialReference()),
     m_output_srs(pdal::SpatialReference()), m_bForwardMetadata(false),
-    m_decimation_step(1), m_decimation_offset(0)
+    m_decimation_step(1), m_decimation_offset(0), m_decimation_leaf_size(1)
 {}
 
 
@@ -170,6 +170,12 @@ void Translate::addSwitches()
         ("d_offset",
          po::value<boost::uint32_t>(&m_decimation_offset)->default_value(0),
          "Decimation filter offset")
+        ("d_leaf_size",
+         po::value<double>(&m_decimation_leaf_size)->default_value(1),
+         "Decimation filter leaf size")
+        ("d_method",
+         po::value<std::string>(&m_decimation_method)->default_value("RankOrder"),
+         "Decimation filter method (RankOrder, VoxelGrid)")
         ;
 
     addSwitchSet(file_options);
@@ -263,6 +269,8 @@ Stage* Translate::makeReader(Options readerOptions)
         decimationOptions.add<uint32_t>("verbose", getVerboseLevel());
         decimationOptions.add<uint32_t>("step", m_decimation_step);
         decimationOptions.add<uint32_t>("offset", m_decimation_offset);
+        decimationOptions.add<double>("leaf_size", m_decimation_leaf_size);
+        decimationOptions.add<std::string>("method", m_decimation_method);
         Stage *decimation_stage = new filters::Decimation(decimationOptions);
         decimation_stage->setInput(final_stage);
         final_stage = decimation_stage;


### PR DESCRIPTION
Creates a new buffer of points (a thinned point cloud), where each point is the centroid of it's enclosing voxel neighbors. Voxel size is user-defined and uniform in X, Y, and Z.
