### PR TITLE
Guard a PCLConversions include

### DIFF
--- a/src/filters/Decimation.cpp
+++ b/src/filters/Decimation.cpp
@@ -34,9 +34,9 @@
 
 #include <pdal/PointBuffer.hpp>
 #include <pdal/filters/Decimation.hpp>
-#include <pdal/PCLConversions.hpp>
 
 #ifdef PDAL_HAVE_PCL
+#include <pdal/PCLConversions.hpp>
 #include <pcl/filters/voxel_grid.h>
 #include <pcl/point_types.h>
 #include <pcl/io/pcd_io.h>


### PR DESCRIPTION
This passed Travis b/c stubs are now ON for Travis (f85550e6d3532460a18847b7f178e552961e3953). I'm not sure if it's worth the hassle to add a whole new row to the build matrix to test with stubs off, but a stubs off test would have been necessary to catch this problem.
