### PR TITLE
scale/offset now in Application.cpp

### DIFF
--- a/include/pdal/kernel/Application.hpp
+++ b/include/pdal/kernel/Application.hpp
@@ -93,6 +93,7 @@ protected:
 
     void addSwitchSet(boost::program_options::options_description* options);
     void addPositionalSwitch(const char* name, int max_count);
+    void setCommonOptions(Options &options);
 
     void setProgressShellCommand(std::vector<std::string> const& command) { m_heartbeat_shell_command = command; }
     std::vector<std::string> getProgressShellCommand() { return m_heartbeat_shell_command; }
@@ -125,6 +126,8 @@ private:
     bool m_hardCoreDebug;
     std::vector<std::string> m_heartbeat_shell_command;
     bool m_reportDebug;
+    std::string m_scales;
+    std::string m_offsets;
 
     std::vector<boost::program_options::options_description*> m_options;
     boost::program_options::positional_options_description m_positionalOptions;

--- a/include/pdal/kernel/Translate.hpp
+++ b/include/pdal/kernel/Translate.hpp
@@ -63,8 +63,6 @@ private:
     pdal::SpatialReference m_output_srs;
     pdal::Bounds<double> m_bounds;
     std::string m_wkt;
-    std::string m_scales;
-    std::string m_offsets;
     bool m_bForwardMetadata;
     boost::uint32_t m_decimation_step;
     boost::uint32_t m_decimation_offset;

--- a/src/kernel/Application.cpp
+++ b/src/kernel/Application.cpp
@@ -365,6 +365,67 @@ void Application::addSwitchSet(po::options_description* options)
 }
 
 
+void Application::setCommonOptions(Options &options)
+{
+    options.add("debug", m_isDebug);
+    options.add("verbose", m_verboseLevel);
+
+    boost::char_separator<char> sep(",| ");
+
+    if (m_variablesMap.count("scale"))
+    {
+        std::vector<double> scales;
+        tokenizer scale_tokens(m_scales, sep);
+        for (auto t = scale_tokens.begin(); t != scale_tokens.end(); ++t)
+            scales.push_back(boost::lexical_cast<double>(*t));
+        if(scales.size())
+        {
+            if (scales.size() <= 1)
+            {
+                options.add<double >("scale_x", scales[0]);
+            }
+            else if (scales.size() <= 2)
+            {
+                options.add<double >("scale_x", scales[0]);
+                options.add<double >("scale_y", scales[1]);
+            }
+            else if (scales.size() <= 3)
+            {
+                options.add<double >("scale_x", scales[0]);
+                options.add<double >("scale_y", scales[1]);
+                options.add<double >("scale_z", scales[2]);
+            }
+        }
+    }
+
+    if (m_variablesMap.count("offset"))
+    {
+        std::vector<double> offsets;
+        tokenizer offset_tokens(m_offsets, sep);
+        for (auto t = offset_tokens.begin(); t != offset_tokens.end(); ++t)
+            offsets.push_back(boost::lexical_cast<double>(*t));
+        if(offsets.size())
+        {
+            if (offsets.size() <= 1)
+            {
+                options.add<double >("offset_x", offsets[0]);
+            }
+            else if (offsets.size() <= 2)
+            {
+                options.add<double >("offset_x", offsets[0]);
+                options.add<double >("offset_y", offsets[1]);
+            }
+            else if (offsets.size() <= 3)
+            {
+                options.add<double >("offset_x", offsets[0]);
+                options.add<double >("offset_y", offsets[1]);
+                options.add<double >("offset_z", offsets[2]);
+            }
+        }
+    }
+}
+
+
 void Application::addPositionalSwitch(const char* name, int max_count)
 {
     m_positionalOptions.add(name, max_count);
@@ -436,6 +497,14 @@ void Application::addBasicSwitchSet()
         ("timer", po::value<bool>(&m_showTime)->zero_tokens()->implicit_value(true), "Show execution time")
         ("stdin,s", po::value<bool>(&m_usestdin)->zero_tokens()->implicit_value(true), "Read pipeline XML from stdin")
         ("heartbeat", po::value< std::vector<std::string> >(&m_heartbeat_shell_command), "Shell command to run for every progress heartbeat")
+        ("scale", po::value< std::string >(&m_scales),
+         "A comma-separated or quoted, space-separated list of scales to "
+         "set on the output file: \n--scale 0.1,0.1,0.00001\n--scale \""
+         "0.1 0.1 0.00001\"")
+        ("offset", po::value< std::string >(&m_offsets),
+         "A comma-separated or quoted, space-separated list of offsets to "
+         "set on the output file: \n--offset 0,0,0\n--offset "
+         "\"1234 5678 91011\"")
 
         ;
 
@@ -476,5 +545,6 @@ void Application::parseSwitches()
 
     return;
 }
+
 
 }} // pdal::kernel

--- a/src/kernel/PCL.cpp
+++ b/src/kernel/PCL.cpp
@@ -120,8 +120,7 @@ int PCL::execute()
 
     Options writerOptions;
     writerOptions.add<std::string>("filename", m_outputFile);
-    writerOptions.add<bool>("debug", isDebug());
-    writerOptions.add<boost::uint32_t>("verbose", getVerboseLevel());
+    setCommonOptions(writerOptions);
 
     if (m_bCompress)
         writerOptions.add<bool>("compression", true);

--- a/src/kernel/Random.cpp
+++ b/src/kernel/Random.cpp
@@ -150,8 +150,7 @@ int Random::execute()
     Options writerOptions;
     {
         writerOptions.add<std::string>("filename", m_outputFile);
-        writerOptions.add<bool>("debug", isDebug());
-        writerOptions.add<boost::uint32_t>("verbose", getVerboseLevel());
+        setCommonOptions(writerOptions);
 
         if (m_bCompress)
         {

--- a/src/kernel/Translate.cpp
+++ b/src/kernel/Translate.cpp
@@ -153,14 +153,6 @@ void Translate::addSwitches()
          "Extent (in XYZ to clip output to)")
         ("polygon", po::value<std::string >(&m_wkt),
          "POLYGON WKT to use for precise crop of data (2d or 3d)")
-        ("scale", po::value< std::string >(&m_scales),
-         "A comma-separated or quoted, space-separated list of scales to "
-         "set on the output file: \n--scale 0.1,0.1,0.00001\n--scale \""
-         "0.1 0.1 0.00001\"")
-        ("offset", po::value< std::string >(&m_offsets),
-         "A comma-separated or quoted, space-separated list of offsets to "
-         "set on the output file: \n--offset 0,0,0\n--offset "
-         "\"1234 5678 91011\"")
         ("metadata,m",
          po::value< bool >(&m_bForwardMetadata)->implicit_value(true),
          "Forward metadata (VLRs, header entries, etc) from previous stages")
@@ -290,8 +282,7 @@ int Translate::execute()
 
     Options writerOptions;
     writerOptions.add("filename", m_outputFile);
-    writerOptions.add("debug", isDebug());
-    writerOptions.add("verbose", getVerboseLevel());
+    setCommonOptions(writerOptions);
     
     if (!m_input_srs.empty())
         writerOptions.add("spatialreference", m_input_srs.getWKT());


### PR DESCRIPTION
- --scale and --offset are once again available as Translate options
  (see #445), but are now available to Random and PCL kernels as well
- scale and offset are now set at the Application (vice Translate) level
- scale and offset are set (along with debug and verbosity level) via
  setCommonOptions()
- there are a number of things that could be bubbled up from the
  individual kernels, so this is likely the first of a few commits aimed
  at streamlining things
