### PR TITLE
Include ground kernel app only if we have PCL

### DIFF
--- a/apps/pdal.cpp
+++ b/apps/pdal.cpp
@@ -50,7 +50,9 @@ void outputVersion()
     std::cout << "  available actions: " << std::endl;
     std::cout << "     - delta" << std::endl;
     std::cout << "     - diff" << std::endl;
+#ifdef PDAL_HAVE_PCL
     std::cout << "     - ground" << std::endl;
+#endif
     std::cout << "     - info" << std::endl;
 #ifdef PDAL_HAVE_PCL
     std::cout << "     - pcl" << std::endl;
@@ -129,6 +131,12 @@ int main(int argc, char* argv[])
     }
 
 #ifdef PDAL_HAVE_PCL
+    if (boost::iequals(action, "ground"))
+    {
+        pdal::kernel::Ground app(count, args);
+        return app.run();
+    }
+    
     if (boost::iequals(action, "pcl"))
     {
         pdal::kernel::PCL app(count, args);
@@ -160,12 +168,6 @@ int main(int argc, char* argv[])
         return app.run();
     }
 
-    if (boost::iequals(action, "ground"))
-    {
-        pdal::kernel::Ground app(count, args);
-        return app.run();
-    }
-    
     std::cerr << "Action '" << action <<"' not recognized" << std::endl << std::endl;
     outputVersion();
     return 1;

--- a/include/pdal/Kernel.hpp
+++ b/include/pdal/Kernel.hpp
@@ -36,7 +36,9 @@
 #define INCLUDED_PDAL_KERNEL_HPP
 
 #include <pdal/kernel/Application.hpp>
+#ifdef PDAL_HAVE_PCL
 #include <pdal/kernel/Ground.hpp>
+#endif
 #include <pdal/kernel/Info.hpp>
 #include <pdal/kernel/Kernel.hpp>
 #include <pdal/kernel/Pipeline.hpp>

--- a/include/pdal/kernel/Kernel.hpp
+++ b/include/pdal/kernel/Kernel.hpp
@@ -38,7 +38,6 @@
 #include "Application.hpp"
 #include "Delta.hpp"
 #include "Diff.hpp"
-#include "Ground.hpp"
 #include "Info.hpp"
 #include "Pipeline.hpp"
 #include "Random.hpp"
@@ -46,5 +45,6 @@
 #include "Translate.hpp"
 
 #ifdef PDAL_HAVE_PCL
+#include "Ground.hpp"
 #include "PCL.hpp"
 #endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -707,7 +707,6 @@ set(PDAL_KERNEL_HPP
     ${PDAL_KERNEL_HEADERS}/Application.hpp
     ${PDAL_KERNEL_HEADERS}/Support.hpp
     ${PDAL_KERNEL_HEADERS}/Diff.hpp
-    ${PDAL_KERNEL_HEADERS}/Ground.hpp
     ${PDAL_KERNEL_HEADERS}/Info.hpp
     ${PDAL_KERNEL_HEADERS}/Kernel.hpp
     ${PDAL_KERNEL_HEADERS}/Pipeline.hpp
@@ -720,7 +719,6 @@ set(PDAL_KERNEL_CPP
     ${PDAL_KERNEL_SRC}/Application.cpp
     ${PDAL_KERNEL_SRC}/Support.cpp
     ${PDAL_KERNEL_SRC}/Diff.cpp
-    ${PDAL_KERNEL_SRC}/Ground.cpp
     ${PDAL_KERNEL_SRC}/Info.cpp
     ${PDAL_KERNEL_SRC}/Pipeline.cpp
     ${PDAL_KERNEL_SRC}/Delta.cpp
@@ -737,12 +735,14 @@ list (APPEND PDAL_HPP ${PDAL_KERNEL_HPP} )
 #
 if (PDAL_HAVE_PCL)
     set(PDAL_PCL_HPP
+	${PDAL_KERNEL_HEADERS}/Ground.hpp
 	${PDAL_KERNEL_HEADERS}/PCL.hpp
 	${PDAL_FILTERS_HEADERS}/PCLBlock.hpp
     )
 
     set(PDAL_PCL_CPP
 	${PDAL_FILTERS_SRC}/PCLBlock.cpp
+	${PDAL_KERNEL_SRC}/Ground.cpp
 	${PDAL_KERNEL_SRC}/PCL.cpp
     )
 


### PR DESCRIPTION
For now, the ground filter can't run without PCL, so we should ghost it away if we don't have PCL.
