### PR TITLE
Always test WITH_STUBS=OFF

### DIFF
--- a/scripts/ci/script.sh
+++ b/scripts/ci/script.sh
@@ -42,7 +42,7 @@ cmake \
     -DWITH_SQLITE=OFF \
     -DENABLE_CTEST=OFF \
     -DWITH_HDF5=OFF \
-    -DWITH_STUBS=ON \
+    -DWITH_STUBS=OFF \
     -G "$PDAL_CMAKE_GENERATOR" \
     ..
 


### PR DESCRIPTION
More useful than WITH_STUBS=ON, since our out-of-the-box builds are no stubs.

Doing via PR to force a Travis run.
