### PR TITLE
Default tests' data path to repo's data

### DIFF
--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -7,6 +7,11 @@
 ###############################################################################
 SET(PDAL_UNIT_TEST pdal_test)
 
+configure_file(
+    TestConfig.hpp.in
+    "${CMAKE_CURRENT_BINARY_DIR}/TestConfig.hpp")
+
+
 if (LIBXML2_FOUND)
 SET (PDAL_UNITTEST_XMLSCHEMA_TEST XMLSchemaTest.cpp)
 endif()

--- a/test/unit/TestConfig.cpp
+++ b/test/unit/TestConfig.cpp
@@ -36,7 +36,7 @@
 
 #include <boost/test/unit_test.hpp>
 
-std::string TestConfig::g_data_path = "../../test/data";
+std::string TestConfig::g_data_path = UNITTEST_TESTCONFIG_DATA_PATH;
 std::string TestConfig::g_oracle_connection = "";
 
 TestConfig::TestConfig()

--- a/test/unit/TestConfig.hpp.in
+++ b/test/unit/TestConfig.hpp.in
@@ -35,6 +35,8 @@
 #ifndef UNITTEST_TESTCONFIG_INCLUDED
 #define UNITTEST_TESTCONFIG_INCLUDED
 
+#define UNITTEST_TESTCONFIG_DATA_PATH "@CMAKE_SOURCE_DIR@/test/data"
+
 #include <string>
 
 struct TestConfig 


### PR DESCRIPTION
My rough guess is that 99% of the times pdal_test is run, it uses ${CMAKE_SOURCE_DIR}/test/data as its data path. This patch sets the default test data path to that directory, using cmake's configure_file. Now you can just run:

``` bash
pdal_test
```

to run the test suite.

The old invocations are still valid: `pdal_test /my/other/test/data`, etc.
