### PR TITLE
Metadata needs to sanitize names

### DIFF
--- a/include/pdal/Metadata.hpp
+++ b/include/pdal/Metadata.hpp
@@ -68,9 +68,8 @@ class MetadataNodeImpl
     friend class MetadataNode;
 
 private:
-    MetadataNodeImpl(const std::string& name) :
-        m_name(name), m_kind(MetadataType::Instance)
-    {}
+    MetadataNodeImpl(const std::string& name);
+
 
     MetadataNodeImpl() : m_kind(MetadataType::Instance)
     {}

--- a/src/Metadata.cpp
+++ b/src/Metadata.cpp
@@ -40,9 +40,29 @@
 #include <map>
 
 #include <boost/property_tree/xml_parser.hpp>
+#include <boost/algorithm/string.hpp>
+
+std::string sanitize(const std::string& name)
+{
+    std::vector<std::string> to_replace = {";", ":", " ", "'", "\""};
+
+    std::string v(name);
+    for (auto c: to_replace)
+    {
+        v = boost::algorithm::replace_all_copy(v, c, "_");
+    }
+    return v;
+
+}
 
 namespace pdal
 {
+
+MetadataNodeImpl::MetadataNodeImpl(const std::string& name)
+{
+    m_kind = MetadataType::Instance;
+    m_name = sanitize(name);
+}
 
 std::string MetadataNodeImpl::toJSON() const
 {


### PR DESCRIPTION
We shouldn't allow `:`'s or `;`'s or ` `'s in metadata names. Should we sanitize them when handed to us (I propose they all be turned into`_`'s, or should we error and make the client sanitize them (might not be possible)?
