### PR TITLE
Chipper: Fix crash for empty input buffer, rm unused var

### DIFF
--- a/src/filters/Chipper.cpp
+++ b/src/filters/Chipper.cpp
@@ -94,7 +94,8 @@ PointBufferSet Chipper::run(PointBufferPtr buffer)
     m_inbuf = buffer;
     load(*buffer, m_xvec, m_yvec, m_spare);
     partition(m_xvec.size());
-    decideSplit(m_xvec, m_yvec, m_spare, 0, m_partitions.size() - 1);
+    if (m_xvec.size() > 0) // fix for crash 
+		decideSplit(m_xvec, m_yvec, m_spare, 0, m_partitions.size() - 1);
     return m_buffers;
 }
 
@@ -102,7 +103,6 @@ PointBufferSet Chipper::run(PointBufferPtr buffer)
 void Chipper::load(PointBuffer& buffer, ChipRefList& xvec, ChipRefList& yvec, 
     ChipRefList& spare)
 {
-    ChipPtRef ref;
     boost::uint32_t idx;
     std::vector<ChipPtRef>::iterator it;
 


### PR DESCRIPTION
Howard, thanks a lot for pointing me to PDAL's Chipper, it was precisely what I needed for processing LAS files.

Below I am fixing a minor segfault issue if the input buffer is empty. The crash is in Chipper::DecideSplit() at the line:

v1range = v1[right].m_pos - v1[left].m_pos;

I also removed an unused variable. Hopefully this could be of help.
