### PR TITLE
Add SpatialReference::GetHorizontal() and ::GetVertical methods

### DIFF
--- a/include/pdal/SpatialReference.hpp
+++ b/include/pdal/SpatialReference.hpp
@@ -95,6 +95,9 @@ public:
     /// support more coordinate systems and descriptions.
     std::string getProj4() const;
 
+    std::string getHorizontal() const;
+    std::string getVertical() const;
+
     /// Sets the Proj.4 string describing the Spatial Reference System.
     /// If GDAL is linked, it uses GDAL's operations and methods to determine
     /// the Proj.4 string -- otherwise, if libgeotiff is linked, it uses

--- a/src/SpatialReference.cpp
+++ b/src/SpatialReference.cpp
@@ -151,6 +151,54 @@ std::string SpatialReference::getProj4() const
     return tmp;
 }
 
+std::string SpatialReference::getVertical() const
+{
+    std::string tmp("");
+
+#ifdef PDAL_SRS_ENABLED
+
+    OGRSpatialReference* poSRS =
+        (OGRSpatialReference*)OSRNewSpatialReference(m_wkt.c_str());
+    char *pszWKT = NULL;
+
+    OGR_SRSNode* node = poSRS->GetAttrNode("VERT_CS");
+    if (node && poSRS)
+    {
+        node->exportToWkt(&pszWKT);
+        tmp = pszWKT;
+        CPLFree(pszWKT);
+        OSRDestroySpatialReference(poSRS);
+    }
+
+
+
+#endif
+    return tmp;
+}
+
+std::string SpatialReference::getHorizontal() const
+{
+    std::string tmp("");
+
+#ifdef PDAL_SRS_ENABLED
+
+    OGRSpatialReference* poSRS =
+        (OGRSpatialReference*)OSRNewSpatialReference(m_wkt.c_str());
+    char *pszWKT = NULL;
+
+    if (poSRS)
+    {
+        poSRS->StripVertical();
+
+        poSRS->exportToWkt(&pszWKT);
+        tmp = pszWKT;
+        CPLFree(pszWKT);
+        OSRDestroySpatialReference(poSRS);
+    }
+
+#endif
+    return tmp;
+}
 
 void SpatialReference::setProj4(std::string const& v)
 {

--- a/test/unit/SpatialReferenceTest.cpp
+++ b/test/unit/SpatialReferenceTest.cpp
@@ -413,6 +413,22 @@ BOOST_AUTO_TEST_CASE(test_io)
     BOOST_CHECK(ref == ref2);
 }
 
+BOOST_AUTO_TEST_CASE(test_vertical_and_horizontal)
+{
+
+    const std::string wkt = "COMPD_CS[\"WGS 84 + VERT_CS\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],VERT_CS[\"NAVD88 height\",VERT_DATUM[\"North American Vertical Datum 1988\",2005,AUTHORITY[\"EPSG\",\"5103\"],EXTENSION[\"PROJ4_GRIDS\",\"g2003conus.gtx\"]],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Up\",UP],AUTHORITY[\"EPSG\",\"5703\"]]]";
+    pdal::SpatialReference srs(wkt);
+
+    std::string horiz = "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]";
+    std::string vert = "VERT_CS[\"NAVD88 height\",VERT_DATUM[\"North American Vertical Datum 1988\",2005,AUTHORITY[\"EPSG\",\"5103\"],EXTENSION[\"PROJ4_GRIDS\",\"g2003conus.gtx\"]],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Up\",UP],AUTHORITY[\"EPSG\",\"5703\"]]";
+    std::string horizontal = srs.getHorizontal();
+    std::string vertical = srs.getVertical();
+
+    BOOST_CHECK_EQUAL(horiz, horizontal);
+    BOOST_CHECK_EQUAL(vert, vertical);
+
+}
+
 #endif
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
There needs to be methods to get the horizontal and vertical components of the coordinate system when it is `COMP_CS`.
