### PR TITLE
Add "tif" to p2g docs as an available output format

### DIFF
--- a/doc/stages/drivers.p2g.writer.rst
+++ b/doc/stages/drivers.p2g.writer.rst
@@ -84,5 +84,5 @@ output_type
   One or many options, specifying "min", "max", "mean", "idw" (inverse distance weighted), "den" (density), or "all" to get all variants with just one option. [Default: **all**]
 
 output_format
-  File output format to use, one of "grid" or "asc". [Default: **grid**]
+  File output format to use, one of "grid", "tif", or "asc". [Default: **grid**]
   


### PR DESCRIPTION
We can export tifs, so we should mention that in the docs.
