### PR TITLE
Allow sqlite driver to specify spatialite module name

### DIFF
--- a/include/pdal/drivers/sqlite/SQLiteReader.hpp
+++ b/include/pdal/drivers/sqlite/SQLiteReader.hpp
@@ -69,6 +69,7 @@ private:
     std::string m_query;
     std::string m_schemaFile;
     std::string m_connection;
+    std::string m_modulename;
     boost::optional<SpatialReference> m_spatialRef;
     PatchPtr m_patch;
 

--- a/include/pdal/drivers/sqlite/SQLiteWriter.hpp
+++ b/include/pdal/drivers/sqlite/SQLiteWriter.hpp
@@ -102,6 +102,7 @@ private:
     std::string m_cloud_table;
     std::string m_cloud_column;
     std::string m_connection;
+    std::string m_modulename;
     bool m_is3d;
 
 };

--- a/src/drivers/sqlite/SQLiteReader.cpp
+++ b/src/drivers/sqlite/SQLiteReader.cpp
@@ -63,7 +63,7 @@ void SQLiteReader::initialize()
         bool bHaveSpatialite = m_session->doesTableExist("geometry_columns");
         log()->get(LogLevel::Debug) << "Have spatialite?: " <<
             bHaveSpatialite << std::endl;
-        m_session->spatialite();
+        m_session->spatialite(m_modulename);
 
         if (!bHaveSpatialite)
         {
@@ -155,6 +155,7 @@ void SQLiteReader::processOptions(const Options& options)
                 "spatialreference"));
     m_query = options.getValueOrThrow<std::string>("query");
     m_connection = options.getValueOrDefault<std::string>("connection", "");
+    m_modulename = options.getValueOrDefault<std::string>("module", "");
 }
 
 

--- a/src/drivers/sqlite/SQLiteWriter.cpp
+++ b/src/drivers/sqlite/SQLiteWriter.cpp
@@ -90,6 +90,8 @@ void SQLiteWriter::processOptions(const Options& options)
         options.getValueOrThrow<std::string>("cloud_table_name");
     m_cloud_column =
         options.getValueOrDefault<std::string>("cloud_column_name", "id");
+    m_modulename =
+        options.getValueOrDefault<std::string>("module", "");
     m_srid =
         m_options.getValueOrDefault<boost::uint32_t>("srid", 4326);
     m_is3d = m_options.getValueOrDefault<bool>("is3d", false);
@@ -106,7 +108,7 @@ void SQLiteWriter::initialize()
         log()->get(LogLevel::Debug) << "Connected to database" << std::endl;
         bool bHaveSpatialite = m_session->doesTableExist("geometry_columns");
         log()->get(LogLevel::Debug) << "Have spatialite?: " << bHaveSpatialite << std::endl;
-        m_session->spatialite();
+        m_session->spatialite(m_modulename);
 
         if (!bHaveSpatialite)
         {


### PR DESCRIPTION
The naming possibilities of spatialite's dll are pretty much infinite. Allow them to be set via option.
