### PR TITLE
Clean up cmake's zlib logic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -483,15 +483,13 @@ endif()
 #
 # ZLIB support - required
 #
-find_package(ZLIB)
+find_package(ZLIB REQUIRED)
 if(ZLIB_FOUND)
     set(CMAKE_REQUIRED_LIBRARIES "${ZLIB_LIBRARY}")
 	include_directories(${ZLIB_INCLUDE_DIR})
 	mark_as_advanced(CLEAR ZLIB_INCLUDE_DIR)
 	mark_as_advanced(CLEAR ZLIB_LIBRARY)
 	set(PDAL_HAVE_ZLIB 1)
-else()
-    message(FATAL_ERROR "ZLIB support is required")
 endif()
 
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -900,10 +900,6 @@ if (WITH_LIBXML2)
     target_link_libraries(${PDAL_LIB_NAME} ${PDAL_LINKAGE} ${LIBXML2_LIBRARIES})
 endif()
 
-if (WITH_ZLIB)
-    target_link_libraries(${PDAL_LIB_NAME} ${PDAL_LINKAGE} ${ZLIB_LIBRARIES})
-endif()
-
 if (WITH_HDF5)
     target_link_libraries(${PDAL_LIB_NAME} ${PDAL_LINKAGE} ${HDF5_LIBRARIES})
 endif()
@@ -922,6 +918,7 @@ target_link_libraries(${PDAL_LIB_NAME} ${PDAL_LINKAGE}
     "${GEOS_LIBRARY}"
     "${HEXER_LIBRARY}"
     "${ORACLE_LIBRARY}"
+    "${ZLIB_LIBRARIES}"
 )
 
 message(STATUS "Using boost lib: ${Boost_LIBRARIES}")


### PR DESCRIPTION
Previously, we still only linked against zlib if the cmake variable WITH_ZLIB was true, but now that zlib is a required dependency, we should always link against its libraries.

Additionally, use the REQUIRED flag for the zlib find_package.
