### PR TITLE
Fix Windows linker errors (LNK2005, LNK2019)

### DIFF
--- a/include/pdal/OStream.hpp
+++ b/include/pdal/OStream.hpp
@@ -39,6 +39,7 @@
 #include <fstream>
 
 #include <pdal/portable_endian.hpp>
+#include <pdal/pdal_internal.hpp>
 
 namespace pdal
 {
@@ -92,7 +93,7 @@ protected:
 
 /// Stream wrapper for output of binary data that converts from host ordering
 /// to little endian format
-class OLeStream : public OStream
+class PDAL_DLL OLeStream : public OStream
 {
 public:
     OLeStream()

--- a/include/pdal/drivers/las/VariableLengthRecord.hpp
+++ b/include/pdal/drivers/las/VariableLengthRecord.hpp
@@ -93,11 +93,7 @@ public:
         { return m_data.size(); }
     void setDataLen(uint64_t size)
         { m_data.resize((size_t)size); }
-    void write(OLeStream& out, uint16_t recordSig)
-    {
-        m_recordSig = recordSig;
-        out << *this;
-    }
+    void write(OLeStream& out, uint16_t recordSig);
 
     friend ILeStream& operator>>(ILeStream& in, VariableLengthRecord& v);
     friend OLeStream& operator<<(OLeStream& out, const VariableLengthRecord& v);

--- a/include/pdal/kernel/Support.hpp
+++ b/include/pdal/kernel/Support.hpp
@@ -47,7 +47,7 @@ namespace pdal
 namespace kernel
 {
 
-class app_usage_error : public pdal::pdal_error
+class PDAL_DLL app_usage_error : public pdal::pdal_error
 {
 public:
     app_usage_error(std::string const& msg)
@@ -56,7 +56,7 @@ public:
 };
 
 
-class app_runtime_error : public pdal::pdal_error
+class PDAL_DLL app_runtime_error : public pdal::pdal_error
 {
 public:
     app_runtime_error(std::string const& msg)
@@ -66,7 +66,7 @@ public:
 
 
 // this is a static class with some helper functions the cmd line apps need
-class AppSupport
+class PDAL_DLL AppSupport
 {
 public:
     // makes a reader/stage, from just the filename and some other options
@@ -83,7 +83,7 @@ private:
 };
 
 
-class PercentageCallback : public pdal::UserCallback
+class PDAL_DLL PercentageCallback : public pdal::UserCallback
 {
 public:
     PercentageCallback(double major = 10.0, double minor = 2.0);
@@ -96,7 +96,7 @@ protected:
 };
 
 
-class HeartbeatCallback : public pdal::UserCallback
+class PDAL_DLL HeartbeatCallback : public pdal::UserCallback
 {
 public:
     virtual void callback()
@@ -104,7 +104,7 @@ public:
 };
 
 
-class ShellScriptCallback : public PercentageCallback
+class PDAL_DLL ShellScriptCallback : public PercentageCallback
 {
 public:
     ShellScriptCallback(const std::vector<std::string>& command);

--- a/src/drivers/las/Header.cpp
+++ b/src/drivers/las/Header.cpp
@@ -50,8 +50,10 @@ namespace las
 
 const std::string LasHeader::FILE_SIGNATURE("LASF");
 const std::string LasHeader::SYSTEM_IDENTIFIER("PDAL");
+#ifndef WIN32
 const size_t LasHeader::LEGACY_RETURN_COUNT;
 const size_t LasHeader::RETURN_COUNT;
+#endif
 
 std::string GetDefaultSoftwareId()
 {

--- a/src/drivers/las/VariableLengthRecord.cpp
+++ b/src/drivers/las/VariableLengthRecord.cpp
@@ -106,6 +106,12 @@ OLeStream& operator<<(OLeStream& out, const ExtVariableLengthRecord& v)
     return out;
 }
 
+    void VariableLengthRecord::write(OLeStream& out, uint16_t recordSig)
+    {
+        m_recordSig = recordSig;
+        out << *this;
+    }
+
 } // namespace las
 } // namespace drivers
 } // namespace pdal


### PR DESCRIPTION
OLeStream and AppSupport need to be exported, else they show up as unresolved on MSVC2012.

LEGACY_RETURN_COUNT and RETURN_COUNT are already initialized in the header and show up as multiply defined when appearing in the implementation as well.
