### PR TITLE
Plugin marco changes

### DIFF
--- a/cmake/pdal_targets.cmake
+++ b/cmake/pdal_targets.cmake
@@ -93,7 +93,7 @@ endmacro(PDAL_ADD_EXECUTABLE)
 # Todo: accept deps for target_link_libraries
 macro(PDAL_ADD_PLUGIN _name _type _shortname _srcs _incs)
     add_library(${_name} SHARED ${_srcs} ${_incs})
-    target_link_libraries(${_name} ${PDAL_LIB_NAME} ${PCL_LIBRARIES})
+    target_link_libraries(${_name} ${PDAL_LINKAGE} ${PDAL_LIB_NAME})
 
     source_group("Header Files\\${_type}\\${_shortname}" FILES ${_incs})
     source_group("Source Files\\${_type}\\${_shortname}" FILES ${_srcs})


### PR DESCRIPTION
Add PDAL_ADD_TEST cmake macro, for use by plugins to create new test executables. Also, tweak PDAL_ADD_PLUGIN macros to _not_ include PCL_LIBRARIES and _do_ include PDAL_LINKAGE.

These were plucked from https://github.com/PDAL/PDAL/tree/issues/554-port-all-plugins for use by #567, with the idea of rebasing **issues/554-port-all-plugins** onto these changes.
