### PR TITLE
Change case of SQLiteTest.cpp

### DIFF
--- a/plugins/sqlite/CMakeLists.txt
+++ b/plugins/sqlite/CMakeLists.txt
@@ -48,7 +48,7 @@ if (SQLITE3_FOUND)
     #
     if(BUILD_SQLITE_TESTS)
 	set(srcs
-	    test/SqliteTest.cpp
+    test/SQLiteTest.cpp
 	)
 
 	PDAL_ADD_TEST(sqlitetest "${srcs}")


### PR DESCRIPTION
On case-sensitive systems sqlite's cmakelists was broken.
