### PR TITLE
pdal_test fails to link on MSVC2012

### DIFF
--- a/include/pdal/Charbuf.hpp
+++ b/include/pdal/Charbuf.hpp
@@ -34,6 +34,7 @@
 
 #pragma once
 
+#include <pdal/pdal_export.hpp>
 #include <streambuf>
 #include <vector>
 
@@ -41,7 +42,7 @@ namespace pdal
 {
 
 // Turns a vector into a streambuf.
-class Charbuf : public std::streambuf
+class PDAL_DLL Charbuf : public std::streambuf
 {
 public:
     Charbuf() : m_bufOffset(0)
@@ -54,15 +55,15 @@ public:
     void initialize(char *buf, size_t count, pos_type bufOffset = 0);
 
 protected:
-    pos_type seekpos(pos_type pos, std::ios_base::openmode which =
+    std::ios::pos_type seekpos(std::ios::pos_type pos, std::ios_base::openmode which =
         std::ios_base::in | std::ios_base::out);
-    pos_type seekoff(off_type off, std::ios_base::seekdir dir,
+    std::ios::pos_type seekoff(std::ios::off_type off, std::ios_base::seekdir dir,
         std::ios_base::openmode which = std::ios_base::in | std::ios_base::out);
 
 private:
     // The offset allows one to use offsets when seeking that refer not to
     // the positions in the backing vector, but to some other reference point.
-    pos_type m_bufOffset;
+    std::ios::pos_type m_bufOffset;
     // For the put pointer, it seems we need the beginning of the buffer
     // in order to deal with offsets.
     char *m_buf;

--- a/src/Charbuf.cpp
+++ b/src/Charbuf.cpp
@@ -40,7 +40,7 @@ namespace pdal
 {
 
 
-void Charbuf::initialize(char *buf, size_t count, pos_type bufOffset)
+void Charbuf::initialize(char *buf, size_t count, std::ios::pos_type bufOffset)
 {
     m_bufOffset = bufOffset;
     m_buf = buf;
@@ -49,7 +49,7 @@ void Charbuf::initialize(char *buf, size_t count, pos_type bufOffset)
 }
 
 
-Charbuf::pos_type Charbuf::seekpos(pos_type pos, std::ios_base::openmode which)
+std::ios::pos_type Charbuf::seekpos(std::ios::pos_type pos, std::ios_base::openmode which)
 {
     pos -= m_bufOffset;
     if (which & std::ios_base::in)
@@ -69,11 +69,11 @@ Charbuf::pos_type Charbuf::seekpos(pos_type pos, std::ios_base::openmode which)
     return pos;
 }
 
-Charbuf::pos_type
-Charbuf::seekoff(off_type off, std::ios_base::seekdir dir,
+std::ios::pos_type
+Charbuf::seekoff(std::ios::off_type off, std::ios_base::seekdir dir,
     std::ios_base::openmode which)
 {
-    Charbuf::pos_type pos;
+    std::ios::pos_type pos;
     char *cpos = nullptr;
     if (which & std::ios_base::in)
     {


### PR DESCRIPTION
A relatively minimal [1] build of PDAL master on MSVC2012 results in a couple of unresolved externals.

```
4>Link:
4>     Creating library C:/Users/chambersbj/TILT/pdal/build/msvc2012/lib/pdal_test.lib and object C:/Users/chambersbj/TILT/pdal/build/msvc2012/lib/pdal_test.exp
4>BPFTest.obj : error LNK2001: unresolved external symbol "protected: virtual class std::fpos<int> __cdecl pdal::Charbuf::seekpos(class std::fpos<int>,int)" (?seekpos@Charbuf@pdal@@MEAA?AV?$fpos@H@std@@V34@H@Z)
4>BPFTest.obj : error LNK2001: unresolved external symbol "protected: virtual class std::fpos<int> __cdecl pdal::Charbuf::seekoff(__int64,int,int)" (?seekoff@Charbuf@pdal@@MEAA?AV?$fpos@H@std@@_JHH@Z)
4>C:\Users\chambersbj\TILT\pdal\build\msvc2012\bin\pdal_test.exe : fatal error LNK1120: 2 unresolved externals
```

[1] WITH_APPS, WITH_GDAL, WITH_GEOTIFF, WITH_TESTS, WITH_ZLIB
