### PR TITLE
Turn off NITF by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,7 +93,7 @@ option(BUILD_PLUGIN_GREYHOUND "Choose if Greyhound support should be built" FALS
 option(BUILD_PLUGIN_HEXBIN "Whether or not HexBin filter is built" FALSE)
 option(BUILD_PLUGIN_ICEBRIDGE "Choose if Icebridge support should be built" FALSE)
 option(BUILD_PLUGIN_MRSID "Choose if MrSID/LiDAR support should be built" FALSE)
-option(BUILD_PLUGIN_NITF "Choose if NITF support should be built (only install supported is from http://github.com/hobu/nitro)" TRUE)
+option(BUILD_PLUGIN_NITF "Choose if NITF support should be built (only install supported is from http://github.com/hobu/nitro)" FALSE)
 option(BUILD_PLUGIN_OCI "Choose if OCI support should be built" TRUE)
 option(BUILD_PLUGIN_P2G "Choose if Points2Grid support should be built" FALSE)
 option(BUILD_PLUGIN_PCL "Choose if PCL support should be built" FALSE)

--- a/plugins/nitf/CMakeLists.txt
+++ b/plugins/nitf/CMakeLists.txt
@@ -5,7 +5,7 @@
 include_directories(${PROJECT_SOURCE_DIR}/include)
 include_directories(${PROJECT_SOURCE_DIR}/plugins/nitf)
 
-find_package(Nitro 2.6)
+find_package(Nitro 2.6 REQUIRED)
 if(NITRO_FOUND)
     message(STATUS "Building with NITF support")
 
@@ -101,6 +101,4 @@ if(NITRO_FOUND)
 
     set(deps ${nitf_reader_lib_name} ${nitf_writer_lib_name})
     PDAL_ADD_TEST(nitftest "${srcs}" "${deps}")
-else()
-    message(STATUS "Building without NITF support")
 endif()


### PR DESCRIPTION
Change NITF default to OFF. If NITF support is requested, error if we can't find Nitro.
