### PR TITLE
Allow text writer precision to be configured

### DIFF
--- a/include/pdal/drivers/text/Writer.hpp
+++ b/include/pdal/drivers/text/Writer.hpp
@@ -86,6 +86,7 @@ private:
     std::string m_delimiter;
     bool m_quoteHeader;
     bool m_packRgb;
+    int m_precision;
 
     FileStreamPtr m_stream;
     Dimension::IdList m_dims;

--- a/src/drivers/text/Writer.cpp
+++ b/src/drivers/text/Writer.cpp
@@ -96,11 +96,15 @@ void Writer::processOptions(const Options& ops)
         m_delimiter = " ";
     m_quoteHeader = ops.getValueOrDefault<bool>("quote_header", true);
     m_packRgb = ops.getValueOrDefault<bool>("pack_rgb", true);
+    m_precision = ops.getValueOrDefault<int>("precision", 3);
 }
 
 
 void Writer::ready(PointContextRef ctx)
 {
+    m_stream->precision(m_precision);
+    *m_stream << std::fixed;
+
     typedef boost::tokenizer<boost::char_separator<char>> tokenizer;
 
     // Find the dimensions listed and put them on the id list.


### PR DESCRIPTION
This is super-dumb right now, but it allows basic precision configuration. This is untested as the text writer test is disabled ATM.
