### PR TITLE
empty does not need to be guarded on windows

### DIFF
--- a/src/Options.cpp
+++ b/src/Options.cpp
@@ -112,14 +112,6 @@ template<> void Option::setValue(const bool& value)
     m_value = value ? "true" : "false";
 }
 
-bool Option::empty()
-{
-    if (m_options)
-        return m_options->empty();
-    else
-        return false;
-}
-
 // explicit specialization:
 //   if we want to insert a string, we don't need lexical_cast
 template<> void Option::setValue(const std::string& value)
@@ -127,6 +119,14 @@ template<> void Option::setValue(const std::string& value)
     m_value = value;
 }
 #endif
+
+bool Option::empty()
+{
+    if (m_options)
+        return m_options->empty();
+    else
+        return false;
+}
 
 //---------------------------------------------------------------------------
 


### PR DESCRIPTION
AFAICT`Option::empty` does not need to be guarded by `#if !defined(PDAL_COMPILER_MSVC)`
