### PR TITLE
Port SBET Reader and Writer

### DIFF
--- a/cmake/pdal_targets.cmake
+++ b/cmake/pdal_targets.cmake
@@ -135,12 +135,13 @@ endmacro(PDAL_ADD_TEST)
 # _name The driver name.
 # _srcs The list of source files to add.
 # _incs The list of includes to add.
-macro(PDAL_ADD_DRIVER _type _name _srcs _incs)
+macro(PDAL_ADD_DRIVER _type _name _srcs _incs _objs)
     source_group("Header Files\\${_type}\\${_name}" FILES ${_incs})
     source_group("Source Files\\${_type}\\${_name}" FILES ${_srcs})
 
     set(libname ${_type}_${_name})
-    set(PDAL_TARGET_OBJECTS ${PDAL_TARGET_OBJECTS} $<TARGET_OBJECTS:${libname}> PARENT_SCOPE)
+    #set(PDAL_TARGET_OBJECTS ${PDAL_TARGET_OBJECTS} $<TARGET_OBJECTS:${libname}> PARENT_SCOPE)
+    set(${_objs} $<TARGET_OBJECTS:${libname}>)
     add_definitions("-fPIC")
     add_library(${libname} OBJECT ${_srcs} ${_incs})
 

--- a/doc/stages/index.rst
+++ b/doc/stages/index.rst
@@ -28,7 +28,7 @@ Readers & Writers
    drivers.pcd.writer
    drivers.qfit.reader
    drivers.rxp.reader
-   drivers.sbet.reader
+   readers.sbet
    drivers.text.writer
 
 

--- a/doc/stages/readers.sbet.rst
+++ b/doc/stages/readers.sbet.rst
@@ -1,7 +1,7 @@
-.. _drivers.sbet.reader:
+.. _readers.sbet:
 
-drivers.sbet.reader
-===================
+readers.sbet
+============
 
 The **SBET reader** read from files in the SBET format, used for exchange data from interital measurement units (IMUs).
 
@@ -15,7 +15,7 @@ Example
   <Pipeline version="1.0">
     <Writer type="drivers.las.writer">
       <Option name="filename">output.las</Option>
-      <Reader type="drivers.sbet.reader">
+      <Reader type="readers.sbet">
         <Option name="filename">
           sbetfile.sbet
         </Option>

--- a/drivers/CMakeLists.txt
+++ b/drivers/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory(faux)
+add_subdirectory(sbet)
 
 set(PDAL_TARGET_OBJECTS ${PDAL_TARGET_OBJECTS} PARENT_SCOPE)

--- a/drivers/faux/CMakeLists.txt
+++ b/drivers/faux/CMakeLists.txt
@@ -16,4 +16,5 @@ set(incs
     FauxReader.hpp
 )
 
-PDAL_ADD_DRIVER(reader faux "${srcs}" "${incs}")
+PDAL_ADD_DRIVER(reader faux "${srcs}" "${incs}" objects)
+set(PDAL_TARGET_OBJECTS ${PDAL_TARGET_OBJECTS} ${objects} PARENT_SCOPE)

--- a/drivers/sbet/CMakeLists.txt
+++ b/drivers/sbet/CMakeLists.txt
@@ -1,0 +1,41 @@
+#
+# SBET driver CMake configuration
+#
+
+include_directories(${PROJECT_SOURCE_DIR}/include)
+include_directories(${PROJECT_SOURCE_DIR}/drivers/sbet)
+
+set(objs "")
+
+add_library(sbetcommon OBJECT SbetCommon.cpp SbetCommon.hpp)
+set(objs ${objs} $<TARGET_OBJECTS:sbetcommon>)
+
+#
+# SBET Reader
+#
+set(srcs
+    SbetReader.cpp
+)
+
+set(incs
+    SbetReader.hpp
+)
+
+PDAL_ADD_DRIVER(reader sbet "${srcs}" "${incs}" reader_objs)
+set(objs ${objs} ${reader_objs})
+
+#
+# SBET Writer
+#
+set(srcs
+    SbetWriter.cpp
+)
+
+set(incs
+    SbetWriter.hpp
+)
+
+PDAL_ADD_DRIVER(writer sbet "${srcs}" "${incs}" writer_objs)
+set(objs ${objs} ${writer_objs})
+
+set(PDAL_TARGET_OBJECTS ${PDAL_TARGET_OBJECTS} ${objs} PARENT_SCOPE)

--- a/drivers/sbet/SbetCommon.cpp
+++ b/drivers/sbet/SbetCommon.cpp
@@ -32,41 +32,41 @@
 * OF SUCH DAMAGE.
 ****************************************************************************/
 
-#pragma once
-
-#include <pdal/drivers/sbet/Common.hpp>
-#include <pdal/OStream.hpp>
-#include <pdal/Writer.hpp>
+#include <SbetCommon.hpp>
 
 namespace pdal
 {
-namespace drivers
+
+Dimension::IdList fileDimensions()
 {
-namespace sbet
-{
+    Dimension::IdList ids;
 
-class PDAL_DLL SbetWriter : public pdal::Writer
-{
-public:
-    SET_STAGE_NAME("drivers.sbet.writer", "SBET Writer")
-    SET_STAGE_LINK("http://pdal.io/stages/drivers.sbet.writer.html")
+    // Data for each point is in the source file in the order these dimensions
+    // are listed, I would suppose.  Would be really nice to have a reference
+    // to the file spec.  I searched the Internet and found that it is from
+    // some company called Applanix (Trimble), but I can't find anything
+    // describing the file format on their website.
 
-    SbetWriter() : pdal::Writer()
-        {}
+    using namespace Dimension;
+    ids.push_back(Id::GpsTime);
+    ids.push_back(Id::Y);
+    ids.push_back(Id::X);
+    ids.push_back(Id::Z);
+    ids.push_back(Id::XVelocity);
+    ids.push_back(Id::YVelocity);
+    ids.push_back(Id::ZVelocity);
+    ids.push_back(Id::Roll);
+    ids.push_back(Id::Pitch);
+    ids.push_back(Id::PlatformHeading);
+    ids.push_back(Id::WanderAngle);
+    ids.push_back(Id::XBodyAccel);
+    ids.push_back(Id::YBodyAccel);
+    ids.push_back(Id::ZBodyAccel);
+    ids.push_back(Id::XBodyAngRate);
+    ids.push_back(Id::YBodyAngRate);
+    ids.push_back(Id::ZBodyAngRate);
 
-    static Dimension::IdList getDefaultDimensions()
-        { return fileDimensions(); }
+    return ids;
+}
 
-private:
-    std::unique_ptr<OLeStream> m_stream;
-    std::string m_filename;
-
-    virtual void processOptions(const Options& options);
-    virtual void ready(PointContextRef ctx);
-    virtual void write(const PointBuffer& buf);
-};
-
-} // namespace sbet
-} // namespace drivers
 } // namespace pdal
-

--- a/drivers/sbet/SbetCommon.hpp
+++ b/drivers/sbet/SbetCommon.hpp
@@ -34,47 +34,11 @@
 
 #pragma once
 
-#include <pdal/IStream.hpp>
-#include <pdal/PointBuffer.hpp>
-#include <pdal/Reader.hpp>
-#include <pdal/drivers/sbet/Common.hpp>
+#include <pdal/Dimension.hpp>
 
 namespace pdal
 {
-namespace drivers
-{
-namespace sbet
-{
 
-class PDAL_DLL SbetReader : public pdal::Reader
-{
-public:
-    SET_STAGE_NAME("drivers.sbet.reader", "SBET Reader")
-    SET_STAGE_LINK("http://pdal.io/stages/drivers.sbet.reader.html")
-    SET_STAGE_ENABLED(true)
+PDAL_DLL Dimension::IdList fileDimensions();
 
-    SbetReader() : Reader()
-        {}
-
-    static Options getDefaultOptions();
-    static Dimension::IdList getDefaultDimensions()
-        { return fileDimensions(); }
-
-private:
-    std::unique_ptr<ILeStream> m_stream;
-    // Number of points in the file.
-    point_count_t m_numPts;
-    point_count_t m_index;
-
-    virtual void addDimensions(PointContextRef ctx);
-    virtual void ready(PointContextRef ctx);
-    virtual point_count_t read(PointBuffer& buf, point_count_t count);
-    virtual bool eof();
-
-    void seek(PointId idx);
-};
-
-} // namespace sbet
-} // namespace drivers
 } // namespace pdal
-

--- a/drivers/sbet/SbetReader.cpp
+++ b/drivers/sbet/SbetReader.cpp
@@ -32,52 +32,70 @@
 * OF SUCH DAMAGE.
 ****************************************************************************/
 
-#include <pdal/drivers/sbet/Writer.hpp>
-
-#include <pdal/drivers/sbet/Common.hpp>
-#include <pdal/PointBuffer.hpp>
+#include <SbetReader.hpp>
 
 namespace pdal
 {
-namespace drivers
-{
-namespace sbet
-{
 
-void SbetWriter::processOptions(const Options& options)
+Options SbetReader::getDefaultOptions()
 {
-    m_filename = options.getOption("filename").getValue<std::string>();
+    Options options;
+    return options;
 }
 
 
-void SbetWriter::ready(PointContextRef ctx)
+void SbetReader::addDimensions(PointContextRef ctx)
 {
-    m_stream.reset(new OLeStream(m_filename));
+    ctx.registerDims(getDefaultDimensions());
 }
 
 
-void SbetWriter::write(const PointBuffer& buf)
+void SbetReader::ready(PointContextRef ctx)
 {
-    m_callback->setTotal(buf.size());
-    m_callback->invoke(0);
+    size_t fileSize = FileUtils::fileSize(m_filename);
+    size_t pointSize = getDefaultDimensions().size() * sizeof(double);
+    if (fileSize % pointSize != 0)
+        throw pdal_error("invalid sbet file size");
+    m_numPts = fileSize / pointSize;
+    m_index = 0;
+    m_stream.reset(new ILeStream(m_filename));
+}
 
+
+point_count_t SbetReader::read(PointBuffer& buf, point_count_t count)
+{
+    PointId nextId = buf.size();
+    PointId idx = m_index;
+    point_count_t numRead = 0;
+    seek(idx);
     Dimension::IdList dims = getDefaultDimensions();
-    for (PointId idx = 0; idx < buf.size(); ++idx)
+    while (numRead < count && idx < m_numPts)
     {
         for (auto di = dims.begin(); di != dims.end(); ++di)
         {
-            // If a dimension doesn't exist, write 0.
+            double d;
+            *m_stream >> d;
             Dimension::Id::Enum dim = *di;
-            *m_stream << (buf.hasDim(dim) ?
-                buf.getFieldAs<double>(dim, idx) : 0.0);
+            buf.setField(dim, nextId, d);
         }
-        if (idx % 100 == 0)
-            m_callback->invoke(idx + 1);
+        idx++;
+        nextId++;
+        numRead++;
     }
-    m_callback->invoke(buf.size());
+    m_index = idx;
+    return numRead;
 }
 
-} // namespace sbet
-} // namespace drivers
-} // namespace pdal
 
+bool SbetReader::eof()
+{
+    return m_index >= m_numPts;
+}
+
+
+void SbetReader::seek(PointId idx)
+{
+    m_stream->seek(idx * sizeof(double) * getDefaultDimensions().size());
+}
+
+} // namespace pdal

--- a/drivers/sbet/SbetReader.hpp
+++ b/drivers/sbet/SbetReader.hpp
@@ -34,18 +34,40 @@
 
 #pragma once
 
-#include <pdal/Dimension.hpp>
+#include <pdal/IStream.hpp>
+#include <pdal/PointBuffer.hpp>
+#include <pdal/Reader.hpp>
+#include <SbetCommon.hpp>
 
 namespace pdal
 {
-namespace drivers
-{
-namespace sbet
-{
 
-PDAL_DLL Dimension::IdList fileDimensions();
+class PDAL_DLL SbetReader : public pdal::Reader
+{
+public:
+    SET_STAGE_NAME("readers.sbet", "SBET Reader")
+    SET_STAGE_LINK("http://pdal.io/stages/readers.sbet.html")
+    SET_STAGE_ENABLED(true)
 
-} // namespace sbet
-} // namespace drivers
+    SbetReader() : Reader()
+        {}
+
+    static Options getDefaultOptions();
+    static Dimension::IdList getDefaultDimensions()
+        { return fileDimensions(); }
+
+private:
+    std::unique_ptr<ILeStream> m_stream;
+    // Number of points in the file.
+    point_count_t m_numPts;
+    point_count_t m_index;
+
+    virtual void addDimensions(PointContextRef ctx);
+    virtual void ready(PointContextRef ctx);
+    virtual point_count_t read(PointBuffer& buf, point_count_t count);
+    virtual bool eof();
+
+    void seek(PointId idx);
+};
+
 } // namespace pdal
-

--- a/drivers/sbet/SbetWriter.hpp
+++ b/drivers/sbet/SbetWriter.hpp
@@ -32,48 +32,35 @@
 * OF SUCH DAMAGE.
 ****************************************************************************/
 
-#include <pdal/drivers/sbet/Common.hpp>
+#pragma once
+
+#include <SbetCommon.hpp>
+#include <pdal/OStream.hpp>
+#include <pdal/Writer.hpp>
 
 namespace pdal
 {
-namespace drivers
+
+class PDAL_DLL SbetWriter : public pdal::Writer
 {
-namespace sbet
-{
+public:
+    SET_STAGE_NAME("writers.sbet", "SBET Writer")
+    SET_STAGE_LINK("http://pdal.io/stages/writers.sbet.html")
+    SET_STAGE_ENABLED(true)
 
-Dimension::IdList fileDimensions()
-{
-    Dimension::IdList ids;
+    SbetWriter() : pdal::Writer()
+        {}
 
-    // Data for each point is in the source file in the order these dimensions
-    // are listed, I would suppose.  Would be really nice to have a reference
-    // to the file spec.  I searched the Internet and found that it is from
-    // some company called Applanix (Trimble), but I can't find anything
-    // describing the file format on their website.
+    static Dimension::IdList getDefaultDimensions()
+        { return fileDimensions(); }
 
-    using namespace Dimension;
-    ids.push_back(Id::GpsTime);
-    ids.push_back(Id::Y);
-    ids.push_back(Id::X);
-    ids.push_back(Id::Z);
-    ids.push_back(Id::XVelocity);
-    ids.push_back(Id::YVelocity);
-    ids.push_back(Id::ZVelocity);
-    ids.push_back(Id::Roll);
-    ids.push_back(Id::Pitch);
-    ids.push_back(Id::PlatformHeading);
-    ids.push_back(Id::WanderAngle);
-    ids.push_back(Id::XBodyAccel);
-    ids.push_back(Id::YBodyAccel);
-    ids.push_back(Id::ZBodyAccel);
-    ids.push_back(Id::XBodyAngRate);
-    ids.push_back(Id::YBodyAngRate);
-    ids.push_back(Id::ZBodyAngRate);
+private:
+    std::unique_ptr<OLeStream> m_stream;
+    std::string m_filename;
 
-    return ids;
-}
+    virtual void processOptions(const Options& options);
+    virtual void ready(PointContextRef ctx);
+    virtual void write(const PointBuffer& buf);
+};
 
-} // namespace sbet
-} // namespace drivers
 } // namespace pdal
-

--- a/include/pdal/Drivers.hpp
+++ b/include/pdal/Drivers.hpp
@@ -44,7 +44,8 @@
 
 #include <pdal/drivers/bpf/BpfReader.hpp>
 
-#include <pdal/drivers/sbet/Reader.hpp>
+#include <SbetReader.hpp>
+#include <SbetWriter.hpp>
 
 #ifdef PDAL_HAVE_CARIS
 #include <pdal/drivers/caris/CloudReader.hpp>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -270,29 +270,6 @@ list (APPEND PDAL_HPP ${PDAL_DRIVERS_TEXT_HPP} )
 
 
 #
-# drivers/sbet
-#
-set(PDAL_SBET_PATH drivers/sbet)
-set(PDAL_SBET_HEADERS "${PDAL_HEADERS_DIR}/${PDAL_SBET_PATH}")
-set(PDAL_SBET_SRC "${PROJECT_SOURCE_DIR}/src/${PDAL_SBET_PATH}")
-
-set(PDAL_DRIVERS_SBET_HPP
-    "${PDAL_SBET_HEADERS}/Common.hpp"
-    "${PDAL_SBET_HEADERS}/Reader.hpp"
-    "${PDAL_SBET_HEADERS}/Writer.hpp"
-)
-
-set (PDAL_DRIVERS_SBET_CPP
-    "${PDAL_SBET_SRC}/Common.cpp"
-    "${PDAL_SBET_SRC}/Reader.cpp"
-    "${PDAL_SBET_SRC}/Writer.cpp"
-)
-
-list (APPEND PDAL_CPP ${PDAL_DRIVERS_SBET_CPP} )
-list (APPEND PDAL_HPP ${PDAL_DRIVERS_SBET_HPP} )
-
-
-#
 # filters
 #
 set(PDAL_FILTERS_PATH filters)
@@ -448,7 +425,6 @@ source_group("Header Files\\config" FILES ${PDAL_CONFIG_HPP})
 source_group("Header Files\\drivers\\caris" FILES ${PDAL_DRIVERS_CARIS_HPP})
 source_group("Header Files\\drivers\\las" FILES ${PDAL_DRIVERS_LAS_HPP})
 source_group("Header Files\\drivers\\qfit" FILES ${PDAL_DRIVERS_QFIT_HPP})
-source_group("Header Files\\drivers\\sbet" FILES ${PDAL_DRIVERS_SBET_HPP})
 source_group("Header Files\\drivers\\terrasolid" FILES ${PDAL_DRIVERS_TERRASOLID_HPP})
 source_group("Header Files\\drivers\\text" FILES ${PDAL_DRIVERS_TEXT_HPP})
 source_group("Header Files\\filters" FILES ${PDAL_FILTERS_HPP})
@@ -459,7 +435,6 @@ source_group("Source Files\\config" FILES ${PDAL_CONFIG_CPP})
 source_group("Source Files\\drivers\\caris" FILES ${PDAL_DRIVERS_CARIS_CPP})
 source_group("Source Files\\drivers\\las" FILES ${PDAL_DRIVERS_LAS_CPP})
 source_group("Source Files\\drivers\\qfit" FILES ${PDAL_DRIVERS_QFIT_CPP})
-source_group("Source Files\\drivers\\sbet" FILES ${PDAL_DRIVERS_SBET_CPP})
 source_group("Source Files\\drivers\\terrasolid" FILES ${PDAL_DRIVERS_TERRASOLID_CPP})
 source_group("Source Files\\drivers\\text" FILES ${PDAL_DRIVERS_TEXT_CPP})
 source_group("Source Files\\filters" FILES ${PDAL_FILTERS_CPP})
@@ -473,6 +448,7 @@ include_directories(../include)
 # Targets settings
 
 include_directories(${PROJECT_SOURCE_DIR}/drivers/faux)
+include_directories(${PROJECT_SOURCE_DIR}/drivers/sbet)
 
 set(PDAL_SOURCES
   ${PDAL_HPP}

--- a/src/StageFactory.cpp
+++ b/src/StageFactory.cpp
@@ -68,7 +68,7 @@ MAKE_READER_CREATOR(BpfReader, pdal::BpfReader)
 MAKE_READER_CREATOR(BufferReader, drivers::buffer::BufferReader)
 MAKE_READER_CREATOR(QfitReader, pdal::drivers::qfit::Reader)
 MAKE_READER_CREATOR(TerrasolidReader, pdal::drivers::terrasolid::Reader)
-MAKE_READER_CREATOR(SbetReader, pdal::drivers::sbet::SbetReader)
+MAKE_READER_CREATOR(SbetReader, pdal::SbetReader)
 
 //
 // define the functions to create the filters
@@ -96,6 +96,7 @@ MAKE_FILTER_CREATOR(Programmable, pdal::filters::Programmable)
 // define the functions to create the writers
 //
 MAKE_WRITER_CREATOR(LasWriter, pdal::drivers::las::Writer)
+MAKE_WRITER_CREATOR(SbetWriter, pdal::SbetWriter)
 MAKE_WRITER_CREATOR(TextWriter, pdal::drivers::text::Writer)
 
 StageFactory::StageFactory()
@@ -133,7 +134,7 @@ std::string StageFactory::inferReaderDriver(const std::string& filename)
         drivers["nsf"] = "drivers.nitf.reader";
     }
     drivers["bpf"] = "drivers.bpf.reader";
-    drivers["sbet"] = "drivers.sbet.reader";
+    drivers["sbet"] = "readers.sbet";
     drivers["icebridge"] = "drivers.icebridge.reader";
     drivers["sqlite"] = "drivers.sqlite.reader";
 
@@ -167,6 +168,7 @@ std::string StageFactory::inferWriterDriver(const std::string& filename)
         drivers["pcd"] = "drivers.pcd.writer";
     if (f.getWriterCreator("drivers.pclvisualizer.writer"))
         drivers["pclviz"] = "drivers.pclvisualizer.writer";
+    drivers["sbet"] = "writers.sbet";
     drivers["csv"] = "drivers.text.writer";
     drivers["json"] = "drivers.text.writer";
     drivers["xyz"] = "drivers.text.writer";
@@ -313,7 +315,7 @@ void StageFactory::registerKnownReaders()
     REGISTER_READER(QfitReader, pdal::drivers::qfit::Reader);
     REGISTER_READER(TerrasolidReader, pdal::drivers::terrasolid::Reader);
     REGISTER_READER(BpfReader, pdal::BpfReader);
-    REGISTER_READER(SbetReader, pdal::drivers::sbet::SbetReader);
+    REGISTER_READER(SbetReader, pdal::SbetReader);
 }
 
 
@@ -343,6 +345,7 @@ void StageFactory::registerKnownFilters()
 void StageFactory::registerKnownWriters()
 {
     REGISTER_WRITER(LasWriter, pdal::drivers::las::Writer);
+    REGISTER_WRITER(SbetWriter, pdal::SbetWriter);
     REGISTER_WRITER(TextWriter, pdal::drivers::text::Writer);
 }
 

--- a/test/data/sbet/pipeline.xml
+++ b/test/data/sbet/pipeline.xml
@@ -2,7 +2,7 @@
 <Pipeline version="1.0">
   <Writer type="drivers.text.writer">
     <Option name="filename">outfile.txt</Option>
-    <Reader type="drivers.sbet.reader">
+    <Reader type="readers.sbet">
       <Option name="filename">2-points.sbet</Option>
     </Reader>
   </Writer>

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -121,6 +121,7 @@ include_directories(
     ${GDAL_INCLUDE_DIR}
     ${GEOTIFF_INCLUDE_DIR}
     ${PROJECT_SOURCE_DIR}/drivers/faux
+    ${PROJECT_SOURCE_DIR}/drivers/sbet
 )
 set(deps ${PDAL_LIB_NAME})
 PDAL_ADD_TEST(pdal_test "${PDAL_UNITTEST_SRCS}" "${deps}")

--- a/test/unit/drivers/sbet/SbetReaderTest.cpp
+++ b/test/unit/drivers/sbet/SbetReaderTest.cpp
@@ -39,7 +39,7 @@
 #include <pdal/PipelineManager.hpp>
 #include <pdal/PointBuffer.hpp>
 
-#include <pdal/drivers/sbet/Reader.hpp>
+#include <SbetReader.hpp>
 
 #include "../../StageTester.hpp"
 #include "Support.hpp"
@@ -86,7 +86,7 @@ BOOST_AUTO_TEST_CASE(testRead)
 {
     Option filename("filename", Support::datapath("sbet/2-points.sbet"), "");
     Options options(filename);
-    drivers::sbet::SbetReader reader;
+    SbetReader reader;
     reader.setOptions(options);
 
     PointContext ctx;
@@ -122,7 +122,7 @@ BOOST_AUTO_TEST_CASE(testBadFile)
 {
     Option filename("filename", Support::datapath("sbet/badfile.sbet"), "");
     Options options(filename);
-    drivers::sbet::SbetReader reader;
+    SbetReader reader;
     reader.setOptions(options);
     PointContext ctx;
     reader.prepare(ctx);

--- a/test/unit/drivers/sbet/SbetWriterTest.cpp
+++ b/test/unit/drivers/sbet/SbetWriterTest.cpp
@@ -34,8 +34,8 @@
 
 #include "UnitTest.hpp"
 
-#include <pdal/drivers/sbet/Reader.hpp>
-#include <pdal/drivers/sbet/Writer.hpp>
+#include <SbetReader.hpp>
+#include <SbetWriter.hpp>
 
 #include "Support.hpp"
 
@@ -63,14 +63,14 @@ BOOST_AUTO_TEST_SUITE(SbetWriterTest)
 
 BOOST_AUTO_TEST_CASE(testConstructor)
 {
-    drivers::sbet::SbetReader reader;
+    SbetReader reader;
     reader.setOptions(makeReaderOptions());
-    drivers::sbet::SbetWriter writer;
+    SbetWriter writer;
     writer.setOptions(makeWriterOptions());
     writer.setInput(&reader);
 
     BOOST_CHECK(writer.getDescription() == "SBET Writer");
-    BOOST_CHECK_EQUAL(writer.getName(), "drivers.sbet.writer");
+    BOOST_CHECK_EQUAL(writer.getName(), "writers.sbet");
 }
 
 BOOST_AUTO_TEST_CASE(testWrite)
@@ -80,9 +80,9 @@ BOOST_AUTO_TEST_CASE(testWrite)
     // Scope forces the writer's buffer to get written to the file.  Otherwise
     // the output file will show a file size of zero and no contents.
     {
-        drivers::sbet::SbetReader reader;
+        SbetReader reader;
         reader.setOptions(makeReaderOptions());
-        drivers::sbet::SbetWriter writer;
+        SbetWriter writer;
         writer.setOptions(makeWriterOptions());
         writer.setInput(&reader);
 


### PR DESCRIPTION
This changes `PDAL_ADD_DRIVER` slightly. Instead of propagating `PDAL_TARGET_OBJECTS` to `PARENT_SCOPE` within the macro, we pass them back to the driver CMakeLists, where they can be combined with other object libraries and propagated to `PARENT_SCOPE`. This is necessary for drivers that may have both a reader and a writer (e.g., SBET).
