### PR TITLE
slightly alter path to test executable in macro

### DIFF
--- a/cmake/pdal_targets.cmake
+++ b/cmake/pdal_targets.cmake
@@ -126,7 +126,7 @@ macro(PDAL_ADD_TEST _name _srcs _deps)
     endif()
     target_link_libraries(${_name} ${PDAL_LINKAGE} ${PDAL_LIB_NAME})
     target_link_libraries(${_name} ${PDAL_LINKAGE} ${_deps})
-    add_test(NAME ${_name} COMMAND "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${_name}" "${PROJECT_SOURCE_DIR}/test/data" --catch_system_errors=no WORKING_DIRECTORY "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/..")
+    add_test(NAME ${_name} COMMAND "${PROJECT_BINARY_DIR}/bin/${_name}" "${PROJECT_SOURCE_DIR}/test/data" --catch_system_errors=no WORKING_DIRECTORY "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/..")
 endmacro(PDAL_ADD_TEST)
 
 ###############################################################################


### PR DESCRIPTION
`CMAKE_RUNTIME_OUTPUT_DIRECTORY` does not seem to be valid on Windows, but I think we can safely switch to `PROJECT_BINARY_DIR/bin` for locating test executables.
