### PR TITLE
provide inline accessor to SYSTEM_IDENTIFIER

### DIFF
--- a/include/pdal/drivers/las/Header.hpp
+++ b/include/pdal/drivers/las/Header.hpp
@@ -66,7 +66,7 @@ public:
     static const size_t LEGACY_RETURN_COUNT = 5;
     static const size_t RETURN_COUNT = 15;
     static const std::string FILE_SIGNATURE;
-    static const std::string SYSTEM_IDENTIFIER;
+    inline std::string getSystemIdentifier() const { return "PDAL"; }
 
     LasHeader();
 

--- a/src/drivers/las/Header.cpp
+++ b/src/drivers/las/Header.cpp
@@ -49,7 +49,6 @@ namespace las
 {
 
 const std::string LasHeader::FILE_SIGNATURE("LASF");
-const std::string LasHeader::SYSTEM_IDENTIFIER("PDAL");
 #ifndef WIN32
 const size_t LasHeader::LEGACY_RETURN_COUNT;
 const size_t LasHeader::RETURN_COUNT;
@@ -68,7 +67,7 @@ std::string GetDefaultSoftwareId()
 }
 
 LasHeader::LasHeader() : m_fileSig(FILE_SIGNATURE), m_sourceId(0),
-    m_globalEncoding(0), m_versionMinor(2), m_systemId(SYSTEM_IDENTIFIER),
+    m_globalEncoding(0), m_versionMinor(2), m_systemId(getSystemIdentifier()),
     m_createDOY(0), m_createYear(0), m_vlrOffset(0), m_pointOffset(0),
     m_vlrCount(0), m_pointFormat(0), m_pointLen(0), m_pointCount(0),
     m_isCompressed(false), m_eVlrOffset(0), m_eVlrCount(0)

--- a/src/drivers/las/Writer.cpp
+++ b/src/drivers/las/Writer.cpp
@@ -85,7 +85,8 @@ Options Writer::getDefaultOptions()
     Option minor_version("minor_version", 2, "LAS Minor version");
     Option day_of_year("creation_doy", 0, "Day of Year for file");
     Option year("creation_year", 2011, "4-digit year value for file");
-    Option system_id("system_id", LasHeader::SYSTEM_IDENTIFIER,
+    LasHeader header;
+    Option system_id("system_id", header.getSystemIdentifier(),
         "System ID for this file");
     Option software_id("software_id", GetDefaultSoftwareId(),
         "Software ID for this file");
@@ -155,7 +156,8 @@ void Writer::getHeaderOptions(const Options &options)
     metaOptionValue("creation_year", std::to_string(year));
     metaOptionValue("creation_doy", std::to_string(doy));
     metaOptionValue("software_id", GetDefaultSoftwareId());
-    metaOptionValue("system_id", LasHeader::SYSTEM_IDENTIFIER);
+    LasHeader header;
+    metaOptionValue("system_id", header.getSystemIdentifier());
     metaOptionValue("project_id",
         boost::lexical_cast<std::string>(boost::uuids::uuid()));
     metaOptionValue("global_encoding", "0");

--- a/test/unit/drivers/las/LasWriterTest.cpp
+++ b/test/unit/drivers/las/LasWriterTest.cpp
@@ -149,7 +149,8 @@ BOOST_AUTO_TEST_CASE(metadata_options)
 
     // Since the option specifies forward and there is not associated
     // metadata, the value should be the default.
-    BOOST_CHECK_EQUAL(systemId, drivers::las::LasHeader::SYSTEM_IDENTIFIER);
+    drivers::las::LasHeader header;
+    BOOST_CHECK_EQUAL(systemId, header.getSystemIdentifier());
 
     // In this case, we should have metadata to override the default.
     uint8_t minorVersion =


### PR DESCRIPTION
this is a bit of a hack, but it clears up the issue of the static variable not being exported with the DLL on MSVC
