### PR TITLE
try using ctest to run all tests on Travis again

### DIFF
--- a/scripts/ci/script.sh
+++ b/scripts/ci/script.sh
@@ -50,5 +50,5 @@ fi
 # Don't use ninja's default number of threads becuase it can
 # saturate Travis's available memory.
 ${MAKECMD} -j ${NUMTHREADS} && \
-    LD_LIBRARY_PATH=./lib ./bin/pdal_test "../test/data" "--catch_system_errors=no" && \
+    LD_LIBRARY_PATH=./lib ctest -V && \
     sudo ${MAKECMD} install


### PR DESCRIPTION
Right now this kind of a noop, but if our Travis build changes to include any plugins, or if we add additional tests via `add_test` then this will pick them up without having to modify the Travis script.
