### PR TITLE
Don't decrement returnNumber

### DIFF
--- a/src/drivers/las/SummaryData.cpp
+++ b/src/drivers/las/SummaryData.cpp
@@ -57,9 +57,11 @@ SummaryData::SummaryData() :
 
 void SummaryData::addPoint(double x, double y, double z, int returnNumber)
 {
-    // The las.Reader does not *increment* the return number on the way out
-    // so why do we decrement it here?
-    // returnNumber--;
+    // Only decrement returnNumber if it's positive, this effectively treats
+    // 0 as the same as 1 in the summary.
+    if ( returnNumber > 0)
+        returnNumber--;
+
     if (returnNumber < 0 || (size_t)returnNumber > m_returnCounts.size())
         throw invalid_point_data("addPoint: returnNumber is out "
             "of range", 0);


### PR DESCRIPTION
The LAS reader doesn't _increment_ the return number, but for some reason the LAS writer _decrements_ it when calculating the summary stats for the dimension. For files with a lot of return numbers of '0' (like the sthelens test las file) this causes an error.
