### PR TITLE
Only Windows needs to have the object libraries included in apps/tests

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -49,9 +49,11 @@ if(APPLE)
 endif()
 
 if(PDAL_UTILITY)
-    set(srcs
-        pdal.cpp
-    )
+    set(srcs pdal.cpp)
+
+    if(WIN32)
+        list(APPEND srcs ${PDAL_TARGET_OBJECTS})
+    endif()
 
     list(APPEND PDAL_UTILITIES ${PDAL_UTILITY})
     if (APPLE AND PDAL_BUNDLE)

--- a/include/pdal/PDALUtils.hpp
+++ b/include/pdal/PDALUtils.hpp
@@ -228,7 +228,7 @@ namespace reST
 
 std::ostream& toRST(const ptree&, std::ostream& os);
 
-void write_rst(std::ostream& ost,
+void PDAL_DLL write_rst(std::ostream& ost,
                const boost::property_tree::ptree& pt,
                int level=0);
 

--- a/plugins/pcl/CMakeLists.txt
+++ b/plugins/pcl/CMakeLists.txt
@@ -57,12 +57,17 @@ if(PCL_FOUND)
         set(deps ${PCL_LIBRARIES})
         PDAL_ADD_PLUGIN(pclvisualizer_writer_lib_name writer pclvisualizer "${srcs}" "${incs}" "${deps}")
 
-	#
+        #
         # View Kernel
         #
         set(srcs
             kernel/ViewKernel.cpp
+            ${PDAL_TARGET_OBJECTS}
         )
+
+        if(WIN32)
+            list(APPEND srcs ${PDAL_TARGET_OBJECTS})
+	endif()
 
         set(incs
             kernel/ViewKernel.hpp
@@ -133,7 +138,13 @@ if(PCL_FOUND)
     #
     set(srcs
         kernel/PCLKernel.cpp
+        ${PDAL_TARGET_OBJECTS}
     )
+
+    if(WIN32)
+        list(APPEND srcs ${PDAL_TARGET_OBJECTS})
+    endif()
+
 
     set(incs
         kernel/PCLKernel.hpp
@@ -147,7 +158,12 @@ if(PCL_FOUND)
     #
     set(srcs
         kernel/GroundKernel.cpp
+        ${PDAL_TARGET_OBJECTS}
     )
+
+    if(WIN32)
+        list(APPEND srcs ${PDAL_TARGET_OBJECTS})
+    endif()
 
     set(incs
         kernel/GroundKernel.hpp
@@ -161,7 +177,12 @@ if(PCL_FOUND)
     #
     set(srcs
         kernel/SmoothKernel.cpp
+        ${PDAL_TARGET_OBJECTS}
     )
+
+    if(WIN32)
+        list(APPEND srcs ${PDAL_TARGET_OBJECTS})
+    endif()
 
     set(incs
         kernel/SmoothKernel.hpp

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -52,10 +52,20 @@ set(srcs
     UserCallbackTest.cpp
     UtilsTest.cpp
 )
+
+if(WIN32)
+    list(APPEND srcs ${PDAL_TARGET_OBJECTS})
+endif()
+
 PDAL_ADD_TEST(pdal_base_test "${srcs}" ${PDAL_LIB_NAME})
 
 if (PDAL_HAVE_LAZPERF)
     set(srcs CompressionTest.cpp)
+
+    if(WIN32)
+        list(APPEND srcs ${PDAL_TARGET_OBJECTS})
+    endif()
+	
     PDAL_ADD_TEST(lazperf_test "${srcs}" ${PDAL_LIB_NAME})
 endif()
 
@@ -74,6 +84,11 @@ set(srcs
 #    io/terrasolid/TerraSolidReaderTest.cpp
 #    io/text/TextWriterTest.cpp
 )
+
+if(WIN32)
+    list(APPEND srcs ${PDAL_TARGET_OBJECTS})
+endif()
+
 PDAL_ADD_TEST(pdal_io_test "${srcs}" ${PDAL_LIB_NAME})
 
 #
@@ -91,6 +106,11 @@ set(srcs
     filters/SplitterTest.cpp
     filters/StatsFilterTest.cpp
 )
+
+if(WIN32)
+    list(APPEND srcs ${PDAL_TARGET_OBJECTS})
+endif()
+
 PDAL_ADD_TEST(pdal_filters_test "${srcs}" ${PDAL_LIB_NAME})
 
 #
@@ -102,6 +122,11 @@ if (PDAL_HAVE_PYTHON)
         plang/PredicateFilterTest.cpp
         plang/ProgrammableFilterTest.cpp
     )
+
+    if(WIN32)
+        list(APPEND srcs ${PDAL_TARGET_OBJECTS})
+    endif()
+
     PDAL_ADD_TEST(pdal_plang_test "${srcs}" ${PDAL_LIB_NAME})
 endif()
 
@@ -120,10 +145,20 @@ if(WITH_APPS)
 #        apps/pcpipelineTest.cpp
 #    )
     set(srcs apps/pc2pcTest.cpp)
+
+    if(WIN32)
+        list(APPEND srcs ${PDAL_TARGET_OBJECTS})
+    endif()
+
     PDAL_ADD_TEST(pc2pc_test "${srcs}" ${PDAL_LIB_NAME})
 endif(WITH_APPS)
 
 if(LIBXML2_FOUND)
     set(srcs XMLSchemaTest.cpp)
+
+    if(WIN32)
+        list(APPEND srcs ${PDAL_TARGET_OBJECTS})
+    endif()
+
     PDAL_ADD_TEST(xml_schema_test "${srcs}" ${PDAL_LIB_NAME})
 endif()


### PR DESCRIPTION
This is a little ugly, but I think it takes care of some of our issues on Ubuntu and Windows. In a nutshell, if I don't include the object libs on MSVC, I get unresolved externals. If I do include them, Ubuntu complains. So, they are included conditionally. I may be able to tuck this inside the CMake macros, but we can address that down the road.
