### PR TITLE
Byte order/warnings

### DIFF
--- a/include/pdal/IStream.hpp
+++ b/include/pdal/IStream.hpp
@@ -40,6 +40,7 @@
 #include <memory>
 #include <stack>
 #include <vector>
+#include <cstring>
 
 #include <pdal/portable_endian.hpp>
 #include <pdal/pdal_export.hpp>
@@ -124,7 +125,7 @@ protected:
 
 private:
     std::stack<std::istream *> m_streams;
-	IStream(const IStream&);	
+	IStream(const IStream&);
 };
 
 /// Stream wrapper for input of binary data that converts from little-endian
@@ -197,7 +198,7 @@ public:
     {
         m_stream->read((char *)&v, sizeof(v));
         uint32_t tmp = le32toh(*(uint32_t *)(&v));
-        v = *(float *)(&tmp);
+        std::memcpy(&v, &tmp, sizeof(tmp));
         return *this;
     }
 
@@ -205,7 +206,7 @@ public:
     {
         m_stream->read((char *)&v, sizeof(v));
         uint64_t tmp = le64toh(*(uint64_t *)(&v));
-        v = *(double *)(&tmp);
+        std::memcpy(&v, &tmp, sizeof(tmp));
         return *this;
     }
 };
@@ -228,7 +229,7 @@ private:
     std::streampos m_pos;
     IStream& m_stream;
 	IStreamMarker(const IStreamMarker&);
-    IStreamMarker& operator=(const IStreamMarker&); // not implemented	
+    IStreamMarker& operator=(const IStreamMarker&); // not implemented
 };
 
 } // namespace pdal

--- a/include/pdal/OStream.hpp
+++ b/include/pdal/OStream.hpp
@@ -37,6 +37,7 @@
 #include <stdint.h>
 
 #include <fstream>
+#include <cstring>
 
 #include <pdal/portable_endian.hpp>
 #include <pdal/pdal_internal.hpp>
@@ -159,14 +160,18 @@ public:
 
     OLeStream& operator << (float v)
     {
-        uint32_t tmp = htole32(*(uint32_t *)(&v));
+        uint32_t tmp(0);
+        std::memcpy(&tmp, &v, sizeof(v));
+        tmp = htole32(tmp);
         m_stream->write((char *)&tmp, sizeof(tmp));
         return *this;
     }
 
     OLeStream& operator << (double v)
     {
-        uint64_t tmp = htole64(*(uint64_t *)(&v));
+        uint64_t tmp(0);
+        std::memcpy(&tmp, &v, sizeof(v));
+        tmp = htole64(tmp);
         m_stream->write((char *)&tmp, sizeof(tmp));
         return *this;
     }

--- a/include/pdal/OStream.hpp
+++ b/include/pdal/OStream.hpp
@@ -123,7 +123,7 @@ public:
     }
 
     OLeStream& operator << (int16_t v)
-    { 
+    {
         v = (int16_t)htole16((uint16_t)v);
         m_stream->write((char *)&v, sizeof(v));
         return *this;
@@ -159,14 +159,14 @@ public:
 
     OLeStream& operator << (float v)
     {
-        uint32_t tmp = le32toh(*(uint32_t *)(&v));
+        uint32_t tmp = htole32(*(uint32_t *)(&v));
         m_stream->write((char *)&tmp, sizeof(tmp));
         return *this;
     }
 
     OLeStream& operator << (double v)
     {
-        uint64_t tmp = le64toh(*(uint64_t *)(&v));
+        uint64_t tmp = htole64(*(uint64_t *)(&v));
         m_stream->write((char *)&tmp, sizeof(tmp));
         return *this;
     }


### PR DESCRIPTION
Write OStream floating point vals in little-endian.  Get rid of casts that emit type-punned pointer/strict-aliasing warnings on GCC.