### PR TITLE
Remove SET_STAGE_ENABLED and SET_KERNEL_ENABLED

### DIFF
--- a/doc/tutorial/overview.rst
+++ b/doc/tutorial/overview.rst
@@ -140,22 +140,6 @@ be hooked into the PDAL infrastructure:
     containing documentation about the stage.  It allows the information to be
     integrated into PDAL’s web site and user information.
 
-    SET_STAGE_ENABLED(<enabled>)
-
-    enabled: A boolean (the constant ‘true’ or ‘false’) that indicates whether
-    the stage is runnable as part of a PDAL build.  Some stages are not runnable
-    if certain prerequisite libraries and systems were not available at the time
-    that PDAL was built.  If this is the case, this macro will normally appear
-    twice:
-
-    ::
-
-        #ifdef HAVE_LIBRARY
-        SET_STAGE_ENABLED(true)
-        #else
-        SET_STAGE_ENABLED(false)
-        #endif
-
 When a pipeline is started, each of its stages is processed in two distinct
 steps.  First, all stages are prepared.
 

--- a/filters/chipper/ChipperFilter.hpp
+++ b/filters/chipper/ChipperFilter.hpp
@@ -138,7 +138,6 @@ class PDAL_DLL ChipperFilter : public pdal::Filter
 public:
     SET_STAGE_NAME("filters.chipper", CHIPPERDOCS)
     SET_STAGE_LINK("http://pdal.io/stages/filters.chipper.html")
-    SET_STAGE_ENABLED(true)
 
     ChipperFilter() : Filter(),
         m_xvec(DIR_X), m_yvec(DIR_Y), m_spare(DIR_NONE)

--- a/filters/colorization/ColorizationFilter.hpp
+++ b/filters/colorization/ColorizationFilter.hpp
@@ -77,7 +77,6 @@ struct BandInfo
 public:
     SET_STAGE_NAME("filters.colorization", COLORIZATIONDOC)
     SET_STAGE_LINK("http://pdal.io/stages/filters.colorization.html")
-    SET_STAGE_ENABLED(true)
 
     ColorizationFilter() : Filter()
         {}

--- a/filters/crop/CropFilter.hpp
+++ b/filters/crop/CropFilter.hpp
@@ -54,7 +54,6 @@ class PDAL_DLL CropFilter : public Filter
 public:
     SET_STAGE_NAME("filters.crop", CROPFILTERDOCS)
     SET_STAGE_LINK("http://pdal.io/stages/filters.crop.html")
-    SET_STAGE_ENABLED(true)
 
     CropFilter();
 

--- a/filters/decimation/DecimationFilter.hpp
+++ b/filters/decimation/DecimationFilter.hpp
@@ -45,7 +45,6 @@ class PDAL_DLL DecimationFilter : public Filter
 public:
     SET_STAGE_NAME("filters.decimation", "Rank decimation filter. Keep every Nth point.")
     SET_STAGE_LINK("http://pdal.io/stages/filters.decimation.html")
-    SET_STAGE_ENABLED(true)
 
     DecimationFilter();
 

--- a/filters/ferry/FerryFilter.hpp
+++ b/filters/ferry/FerryFilter.hpp
@@ -46,7 +46,6 @@ class PDAL_DLL FerryFilter : public Filter
 public:
     SET_STAGE_NAME("filters.ferry", "Copy data from one dimension to another.")
     SET_STAGE_LINK("http://pdal.io/stages/filters.ferry.html")
-    SET_STAGE_ENABLED(true)
 
     FerryFilter() : Filter() {};
     static Options getDefaultOptions();

--- a/filters/merge/MergeFilter.hpp
+++ b/filters/merge/MergeFilter.hpp
@@ -44,7 +44,6 @@ class PDAL_DLL MergeFilter : public MultiFilter
 public:
     SET_STAGE_NAME("filters.merge", "Merge data from two different readers into a single stream.")
     SET_STAGE_LINK("http://pdal.io/stages/filters.merge.html")
-    SET_STAGE_ENABLED(true)
 
     MergeFilter() : MultiFilter()
         {}

--- a/filters/mortonorder/MortonOrderFilter.hpp
+++ b/filters/mortonorder/MortonOrderFilter.hpp
@@ -46,7 +46,6 @@ class PDAL_DLL MortonOrderFilter : public pdal::Filter
 public:
     SET_STAGE_NAME("filters.mortonorder", MORTONDOCS)
     SET_STAGE_LINK("http://pdal.io/stages/filters.morton.html")
-    SET_STAGE_ENABLED(true)
 
     MortonOrderFilter() : Filter() {}
 

--- a/filters/reprojection/ReprojectionFilter.hpp
+++ b/filters/reprojection/ReprojectionFilter.hpp
@@ -51,7 +51,6 @@ class PDAL_DLL ReprojectionFilter : public Filter
 public:
     SET_STAGE_NAME("filters.reprojection", "Reproject data using GDAL from one coordinate system to another.")
     SET_STAGE_LINK("http://www.pdal.io/stages/filters.reprojection.html")
-    SET_STAGE_ENABLED(true)
 
     ReprojectionFilter();
     ReprojectionFilter(const SpatialReference& outSRS);

--- a/filters/sort/SortFilter.hpp
+++ b/filters/sort/SortFilter.hpp
@@ -45,7 +45,6 @@ class PDAL_DLL SortFilter : public Filter
 public:
     SET_STAGE_NAME("filters.sort", "Sort data based on a given dimension.")
     SET_STAGE_LINK("http://www.pdal.io/stages/filters.sort.html")
-    SET_STAGE_ENABLED(true)
 
     SortFilter()
     {}

--- a/filters/splitter/SplitterFilter.hpp
+++ b/filters/splitter/SplitterFilter.hpp
@@ -44,7 +44,6 @@ class PDAL_DLL SplitterFilter : public pdal::Filter
 public:
     SET_STAGE_NAME("filters.splitter", "Split data based on a X/Y box length.")
     SET_STAGE_LINK("http://pdal.io/stages/filters.splitter.html")
-    SET_STAGE_ENABLED(true)
 
     SplitterFilter() : Filter()
         {}

--- a/filters/stats/StatsFilter.hpp
+++ b/filters/stats/StatsFilter.hpp
@@ -95,7 +95,6 @@ class PDAL_DLL StatsFilter : public Filter
 public:
     SET_STAGE_NAME("filters.stats", "Compute statistics about each dimension (mean, min, max, etc.)")
     SET_STAGE_LINK("http://pdal.io/stages/filters.stats.html")
-    SET_STAGE_ENABLED(true)
 
     StatsFilter() : Filter()
         {}

--- a/include/pdal/Stage.hpp
+++ b/include/pdal/Stage.hpp
@@ -122,10 +122,6 @@ public:
     static std::string s_getInfoLink() { return infolink; }  \
     std::string getInfoLink() const { return infolink; }
 
-#define SET_STAGE_ENABLED(YES_OR_NO) \
-    static bool s_isEnabled() { return YES_OR_NO; } \
-    bool isEnabled() const { return YES_OR_NO; }
-
     virtual StageSequentialIterator* createSequentialIterator() const
         { return NULL; }
     inline MetadataNode getMetadata() const

--- a/include/pdal/StageFactory.hpp
+++ b/include/pdal/StageFactory.hpp
@@ -134,7 +134,6 @@ inline void StageFactory::registerDriverInfo()
 
     pdal::StageInfo info(T::s_getName(), T::s_getDescription());
     info.setInfoLink(T::s_getInfoLink());
-    info.setIsEnabled(T::s_isEnabled());
     info.addProvidedDimensions(T::getDefaultDimensions());
 
     std::vector<Option> options = T::getDefaultOptions().getOptions();

--- a/include/pdal/StageInfo.hpp
+++ b/include/pdal/StageInfo.hpp
@@ -110,16 +110,6 @@ public:
         return m_link;
     }
 
-    inline void setIsEnabled(bool isEnabled)
-    {
-        m_isEnabled = isEnabled;
-    }
-    
-    inline bool getIsEnabled() const
-    {
-        return m_isEnabled;
-    }
-        
     std::string optionsToRST() const;
     
     inline std::string toRST() const
@@ -127,7 +117,7 @@ public:
         std::ostringstream strm;
         std::string link(getInfoLink());
         bool bDoLink = link.size() > 0;
-    
+         
         // strm << headline << std::endl;
         if (bDoLink)
             strm << "`";
@@ -139,14 +129,6 @@ public:
 
         strm << headline << std::endl;
     
-        strm << std::endl;
-        std::string enabled("ENABLED");
-        if (!getIsEnabled())
-        {
-            enabled = std::string ("NOT ENABLED");
-        }
-        
-        strm << "Status: " << enabled << std::endl << std::endl;
         strm << getDescription() << std::endl;
         
         if (bDoLink)
@@ -163,7 +145,6 @@ private:
     Dimension::IdList m_dimensions;
     std::vector<Option> m_options;
     std::string m_link;
-    bool m_isEnabled;
 };
 
 /// Output operator for serialization

--- a/io/bpf/BpfReader.hpp
+++ b/io/bpf/BpfReader.hpp
@@ -54,7 +54,6 @@ class PDAL_DLL BpfReader : public Reader
 public:
     SET_STAGE_NAME("readers.bpf", BPFREADERDOC)
     SET_STAGE_LINK("http://pdal.io/stages/readers.bpf.html")
-    SET_STAGE_ENABLED(true)
 
     virtual point_count_t numPoints() const
         {  return (point_count_t)m_header.m_numPts; }

--- a/io/buffer/BufferReader.hpp
+++ b/io/buffer/BufferReader.hpp
@@ -45,7 +45,6 @@ class PDAL_DLL BufferReader : public pdal::Reader
 public:
     SET_STAGE_NAME("readers.buffer", "PointBuffer Reader")
     SET_STAGE_LINK("http://pdal.io/stages/readers.buffer.html")
-    SET_STAGE_ENABLED(true)
 
     BufferReader() : Reader()
         {}

--- a/io/faux/FauxReader.hpp
+++ b/io/faux/FauxReader.hpp
@@ -81,7 +81,6 @@ class PDAL_DLL FauxReader : public pdal::Reader
 {
 public:
     SET_STAGE_NAME("readers.faux", "Faux Reader")
-    SET_STAGE_ENABLED(true)
 
     FauxReader();
 

--- a/io/las/LasReader.hpp
+++ b/io/las/LasReader.hpp
@@ -57,7 +57,6 @@ class PDAL_DLL LasReader : public pdal::Reader
 public:
     SET_STAGE_NAME("readers.las", LASREADERDOCS)
     SET_STAGE_LINK("http://pdal.io/stages/readers.las.html")
-    SET_STAGE_ENABLED(true)
 
     LasReader() : pdal::Reader(), m_index(0),
             m_istream(NULL)

--- a/io/las/LasWriter.hpp
+++ b/io/las/LasWriter.hpp
@@ -65,7 +65,6 @@ class PDAL_DLL LasWriter : public pdal::Writer
 public:
     SET_STAGE_NAME("writers.las", LASWRITERDOC)
     SET_STAGE_LINK("http://pdal.io/stages/writers.las.html")
-    SET_STAGE_ENABLED(true)
 
     LasWriter() : m_ostream(NULL)
          { construct(); }

--- a/io/qfit/QfitReader.hpp
+++ b/io/qfit/QfitReader.hpp
@@ -88,7 +88,6 @@ class PDAL_DLL QfitReader : public pdal::Reader
 public:
     SET_STAGE_NAME("readers.qfit", "QFIT Reader")
     SET_STAGE_LINK("http://pdal.io/stages/readers.qfit.html")
-    SET_STAGE_ENABLED(true)
 
     QfitReader();
 

--- a/io/sbet/SbetReader.hpp
+++ b/io/sbet/SbetReader.hpp
@@ -47,7 +47,6 @@ class PDAL_DLL SbetReader : public pdal::Reader
 public:
     SET_STAGE_NAME("readers.sbet", "SBET Reader")
     SET_STAGE_LINK("http://pdal.io/stages/readers.sbet.html")
-    SET_STAGE_ENABLED(true)
 
     SbetReader() : Reader()
         {}

--- a/io/sbet/SbetWriter.hpp
+++ b/io/sbet/SbetWriter.hpp
@@ -46,7 +46,6 @@ class PDAL_DLL SbetWriter : public pdal::Writer
 public:
     SET_STAGE_NAME("writers.sbet", "SBET Writer")
     SET_STAGE_LINK("http://pdal.io/stages/writers.sbet.html")
-    SET_STAGE_ENABLED(true)
 
     SbetWriter() : pdal::Writer()
         {}

--- a/io/terrasolid/TerrasolidReader.hpp
+++ b/io/terrasolid/TerrasolidReader.hpp
@@ -96,7 +96,6 @@ class PDAL_DLL TerrasolidReader : public pdal::Reader
 {
 public:
     SET_STAGE_NAME("readers.terrasolid", "TerraSolid Reader")
-    SET_STAGE_ENABLED(true)
 
     TerrasolidReader() : pdal::Reader(),
         m_format(TERRASOLID_Format_Unknown)

--- a/io/text/TextWriter.hpp
+++ b/io/text/TextWriter.hpp
@@ -52,7 +52,6 @@ class PDAL_DLL TextWriter : public pdal::Writer
 public:
     SET_STAGE_NAME("writers.text", "Text Writer")
     SET_STAGE_LINK("http://pdal.io/stages/writers.text.html")
-    SET_STAGE_ENABLED(true)
 
     TextWriter() : pdal::Writer()
     {}

--- a/kernels/Kernel.hpp
+++ b/kernels/Kernel.hpp
@@ -124,10 +124,6 @@ public:
     static std::string s_getInfoLink() { return infolink; }  \
     std::string getInfoLink() const { return infolink; }
 
-#define SET_KERNEL_ENABLED(YES_OR_NO) \
-    static bool s_isEnabled() { return YES_OR_NO; } \
-    bool isEnabled() const { return YES_OR_NO; }
-
 protected:
     bool m_usestdin;
 

--- a/kernels/KernelFactory.hpp
+++ b/kernels/KernelFactory.hpp
@@ -100,7 +100,6 @@ inline void KernelFactory::registerKernelDriverInfo()
 
     pdal::KernelInfo info(T::s_getName(), T::s_getDescription());
     info.setInfoLink(T::s_getInfoLink());
-    info.setIsEnabled(T::s_isEnabled());
 
     m_driver_info.insert(
         std::pair<std::string, pdal::KernelInfo>(T::s_getName(), info));

--- a/kernels/KernelInfo.cpp
+++ b/kernels/KernelInfo.cpp
@@ -52,14 +52,13 @@ std::ostream& operator<<(std::ostream& ostr, const KernelInfo& info)
 }
 
 KernelInfo::KernelInfo(std::string const& name, std::string const& description)
-    : m_name(name), m_description(description), m_isEnabled(false) {}
+    : m_name(name), m_description(description) {}
 
 /// copy constructor
 KernelInfo::KernelInfo(KernelInfo const& other)
     : m_name(other.m_name)
     , m_description(other.m_description)
     , m_link(other.m_link)
-    , m_isEnabled(other.m_isEnabled)
 {
     return;
 }

--- a/kernels/KernelInfo.hpp
+++ b/kernels/KernelInfo.hpp
@@ -80,21 +80,10 @@ public:
         return m_link;
     }
 
-    inline void setIsEnabled(bool isEnabled)
-    {
-        m_isEnabled = isEnabled;
-    }
-
-    inline bool getIsEnabled() const
-    {
-        return m_isEnabled;
-    }
-
 private:
     std::string m_name;
     std::string m_description;
     std::string m_link;
-    bool m_isEnabled;
 };
 
 /// Output operator for serialization

--- a/kernels/delta/DeltaKernel.hpp
+++ b/kernels/delta/DeltaKernel.hpp
@@ -101,7 +101,6 @@ class PDAL_DLL DeltaKernel : public Kernel
 public:
     SET_KERNEL_NAME ("delta", "Delta Kernel")
     SET_KERNEL_LINK ("http://pdal.io/kernels/kernels.delta.html")
-    SET_KERNEL_ENABLED (true)
  
     DeltaKernel();
     int execute(); // overrride

--- a/kernels/diff/DiffKernel.hpp
+++ b/kernels/diff/DiffKernel.hpp
@@ -50,7 +50,6 @@ class PDAL_DLL DiffKernel : public Kernel
 public:
     SET_KERNEL_NAME ("diff", "Diff Kernel")
     SET_KERNEL_LINK ("http://pdal.io/kernels/kernels.diff.html")
-    SET_KERNEL_ENABLED (true)
  
     DiffKernel();
     int execute(); // overrride

--- a/kernels/info/InfoKernel.hpp
+++ b/kernels/info/InfoKernel.hpp
@@ -61,7 +61,6 @@ class PDAL_DLL InfoKernel : public Kernel
 public:
     SET_KERNEL_NAME ("info", "Info Kernel")
     SET_KERNEL_LINK ("http://pdal.io/kernels/kernels.info.html")
-    SET_KERNEL_ENABLED (true)
  
     InfoKernel();
     int execute(); // overrride

--- a/kernels/pipeline/PipelineKernel.hpp
+++ b/kernels/pipeline/PipelineKernel.hpp
@@ -49,7 +49,6 @@ class PDAL_DLL PipelineKernel : public Kernel
 public:
     SET_KERNEL_NAME ("pipeline", "Pipeline Kernel")
     SET_KERNEL_LINK ("http://pdal.io/kernels/kernels.pipeline.html")
-    SET_KERNEL_ENABLED (true)
 
     PipelineKernel();
     int execute();

--- a/kernels/random/RandomKernel.hpp
+++ b/kernels/random/RandomKernel.hpp
@@ -52,7 +52,6 @@ class PDAL_DLL RandomKernel : public Kernel
 public:
     SET_KERNEL_NAME ("random", "Random Kernel")
     SET_KERNEL_LINK ("http://pdal.io/kernels/kernels.random.html")
-    SET_KERNEL_ENABLED (true)
 
     RandomKernel();
     int execute();

--- a/kernels/sort/SortKernel.hpp
+++ b/kernels/sort/SortKernel.hpp
@@ -44,7 +44,6 @@ class PDAL_DLL SortKernel : public Kernel
 public:
     SET_KERNEL_NAME ("sort", "Sort Kernel")
     SET_KERNEL_LINK ("http://pdal.io/kernels/kernels.sort.html")
-    SET_KERNEL_ENABLED (true)
  
     SortKernel();
     int execute();

--- a/kernels/translate/TranslateKernel.hpp
+++ b/kernels/translate/TranslateKernel.hpp
@@ -44,7 +44,6 @@ class PDAL_DLL TranslateKernel : public Kernel
 public:
     SET_KERNEL_NAME ("translate", "Translate Kernel")
     SET_KERNEL_LINK ("http://pdal.io/kernels/kernels.translate.html")
-    SET_KERNEL_ENABLED (true)
  
     TranslateKernel();
     int execute();

--- a/plugins/attribute/filters/AttributeFilter.hpp
+++ b/plugins/attribute/filters/AttributeFilter.hpp
@@ -115,7 +115,6 @@ class PDAL_DLL AttributeFilter : public Filter
 public:
     SET_STAGE_NAME("filters.attribute", ATTRIBUTEDOCS)
     SET_STAGE_LINK("http://pdal.io/stages/filters.attribute.html")
-    SET_STAGE_ENABLED(true)
 
     AttributeFilter() : Filter(), m_geosEnvironment(0) {};
     static Options getDefaultOptions();

--- a/plugins/greyhound/io/GreyhoundReader.hpp
+++ b/plugins/greyhound/io/GreyhoundReader.hpp
@@ -58,7 +58,6 @@ class PDAL_DLL GreyhoundReader : public pdal::Reader
 public:
     SET_STAGE_NAME("readers.greyhound", "Greyhound Reader")
     SET_STAGE_LINK("http://pdal.io/stages/readers.greyhound.html")
-    SET_STAGE_ENABLED(true)
 
     GreyhoundReader();
     ~GreyhoundReader();

--- a/plugins/hexbin/filters/HexBin.hpp
+++ b/plugins/hexbin/filters/HexBin.hpp
@@ -48,7 +48,6 @@ class PDAL_DLL HexBin : public Filter
 public:
     SET_STAGE_NAME("filters.hexbin", "Tessellate the point's X/Y domain and determine point density and/or point boundary.")
     SET_STAGE_LINK("http://pdal.io/stages/filters.hexbin.html")
-    SET_STAGE_ENABLED(true)
 
     HexBin() : Filter()
         {}

--- a/plugins/icebridge/io/IcebridgeReader.hpp
+++ b/plugins/icebridge/io/IcebridgeReader.hpp
@@ -58,7 +58,6 @@ class PDAL_DLL IcebridgeReader : public pdal::Reader
 public:
     SET_STAGE_NAME("readers.icebridge", ICEBRIDGEDOCS)
     SET_STAGE_LINK("http://pdal.io/stages/readers.icebridge.html")
-    SET_STAGE_ENABLED(true)
 
     IcebridgeReader() : pdal::Reader()
         {}

--- a/plugins/mrsid/io/MrsidReader.hpp
+++ b/plugins/mrsid/io/MrsidReader.hpp
@@ -62,7 +62,6 @@ class PDAL_DLL MrsidReader : public pdal::Reader
 public:
     SET_STAGE_NAME("readers.mrsid", "MrSID Reader")
     SET_STAGE_LINK("http://www.pdal.io/stages/readers.mrsid.html")
-    SET_STAGE_ENABLED(true)
 
     virtual ~MrsidReader();
     MrsidReader() : Writer() {};

--- a/plugins/nitf/io/NitfReader.hpp
+++ b/plugins/nitf/io/NitfReader.hpp
@@ -47,7 +47,6 @@ class PDAL_DLL NitfReader : public LasReader
 public:
     SET_STAGE_NAME("readers.nitf", "NITF Reader")
     SET_STAGE_LINK("http://pdal.io/stages/readers.nitf.html")
-    SET_STAGE_ENABLED(true)
 
     NitfReader() : LasReader()
         {}

--- a/plugins/nitf/io/NitfWriter.hpp
+++ b/plugins/nitf/io/NitfWriter.hpp
@@ -46,7 +46,6 @@ class PDAL_DLL NitfWriter : public LasWriter
 public:
     SET_STAGE_NAME("writers.nitf", "NITF Writer")
     SET_STAGE_LINK("http://pdal.io/stages/writers.nitf.html")
-    SET_STAGE_ENABLED(true)
 
     NitfWriter() ;
 

--- a/plugins/oci/io/OciReader.hpp
+++ b/plugins/oci/io/OciReader.hpp
@@ -49,7 +49,6 @@ class PDAL_DLL OciReader : public DbReader
 public:
     SET_STAGE_NAME("readers.oci", "Read point cloud data from Oracle SDO_POINTCLOUD.")
     SET_STAGE_LINK("http://pdal.io/stages/readers.oci.html")
-    SET_STAGE_ENABLED(true)
 
     OciReader()
     {}

--- a/plugins/oci/io/OciWriter.hpp
+++ b/plugins/oci/io/OciWriter.hpp
@@ -50,7 +50,6 @@ class PDAL_DLL OciWriter : public DbWriter
 public:
     SET_STAGE_NAME("writers.oci", "Write data using SDO_PC objects to Oracle.")
     SET_STAGE_LINK("http://pdal.io/stages/writers.oci.html")
-    SET_STAGE_ENABLED(true)
     OciWriter();
 
     static Options getDefaultOptions();

--- a/plugins/p2g/io/P2gWriter.hpp
+++ b/plugins/p2g/io/P2gWriter.hpp
@@ -67,7 +67,6 @@ class PDAL_DLL P2gWriter : public pdal::Writer
 public:
     SET_STAGE_NAME("writers.p2g", "Points2Grid Writer")
     SET_STAGE_LINK("http://pdal.io/stages/writers.p2g.html")
-    SET_STAGE_ENABLED(true)
 
     P2gWriter() : Writer(), m_outputTypes(0), m_outputFormat(OUTPUT_FORMAT_ARC_ASCII) {};
     ~P2gWriter() {};

--- a/plugins/pcl/filters/PCLBlock.hpp
+++ b/plugins/pcl/filters/PCLBlock.hpp
@@ -47,7 +47,6 @@ class PDAL_DLL PCLBlock : public Filter
 public:
     SET_STAGE_NAME("filters.pclblock", "PCL Block implementation")
     SET_STAGE_LINK("http://www.pdal.io/stages/filters.pclblock.html")
-    SET_STAGE_ENABLED(true)
 
     PCLBlock() : Filter()
     {}

--- a/plugins/pcl/io/PCLVisualizer.hpp
+++ b/plugins/pcl/io/PCLVisualizer.hpp
@@ -46,7 +46,6 @@ class PDAL_DLL PclVisualizer : public pdal::Writer
 public:
     SET_STAGE_NAME("writers.pclvisualizer", "PCD Writer")
     SET_STAGE_LINK("http://pdal.io/stages/writers.pclvisualizer.html")
-    SET_STAGE_ENABLED(true)
 
     PclVisualizer() : pdal::Writer() {};
 

--- a/plugins/pcl/io/PcdReader.hpp
+++ b/plugins/pcl/io/PcdReader.hpp
@@ -48,7 +48,6 @@ class PDAL_DLL PcdReader : public pdal::Reader
 public:
     SET_STAGE_NAME("readers.pcd", "Read data from Point Cloud Library (PCL).")
     SET_STAGE_LINK("http://pdal.io/stages/readers.pcd.html")
-    SET_STAGE_ENABLED(true)
 
     PcdReader() : Reader() {};
 

--- a/plugins/pcl/io/PcdWriter.hpp
+++ b/plugins/pcl/io/PcdWriter.hpp
@@ -49,7 +49,6 @@ class PDAL_DLL PcdWriter : public pdal::Writer
 public:
     SET_STAGE_NAME("writers.pcd", "Write data in Point Cloud Library (PCL) format.")
     SET_STAGE_LINK("http://pdal.io/stages/writers.pcd.html")
-    SET_STAGE_ENABLED(true)
 
     PcdWriter() : pdal::Writer() {};
 

--- a/plugins/pcl/kernel/GroundKernel.hpp
+++ b/plugins/pcl/kernel/GroundKernel.hpp
@@ -47,7 +47,6 @@ class PDAL_DLL GroundKernel : public Kernel
 public:
     SET_KERNEL_NAME("ground", "Ground Kernel")
     SET_KERNEL_LINK("http://pdal.io/kernels/kernels.ground.html")
-    SET_KERNEL_ENABLED(true)
 
     GroundKernel();
     int execute();

--- a/plugins/pcl/kernel/PCLKernel.hpp
+++ b/plugins/pcl/kernel/PCLKernel.hpp
@@ -44,7 +44,6 @@ class PDAL_DLL PCLKernel : public Kernel
 public:
     SET_KERNEL_NAME("pcl", "PCL Kernel")
     SET_KERNEL_LINK("http://pdal.io/kernels/kernels.pcl.html")
-    SET_KERNEL_ENABLED(true)
 
     PCLKernel();
     int execute();

--- a/plugins/pcl/kernel/SmoothKernel.hpp
+++ b/plugins/pcl/kernel/SmoothKernel.hpp
@@ -47,7 +47,6 @@ class PDAL_DLL SmoothKernel : public Kernel
 public:
     SET_KERNEL_NAME("smooth", "Smooth Kernel")
     SET_KERNEL_LINK("http://pdal.io/kernels/kernels.smooth.html")
-    SET_KERNEL_ENABLED(true)
 
     SmoothKernel() {};
     int execute();

--- a/plugins/pcl/kernel/ViewKernel.hpp
+++ b/plugins/pcl/kernel/ViewKernel.hpp
@@ -47,7 +47,6 @@ class PDAL_DLL ViewKernel : public Kernel
 public:
     SET_KERNEL_NAME("view", "View Kernel")
     SET_KERNEL_LINK("http://pdal.io/kernels/kernels.view.html")
-    SET_KERNEL_ENABLED(true)
 
     ViewKernel();
     int execute();

--- a/plugins/pgpointcloud/io/PgReader.hpp
+++ b/plugins/pgpointcloud/io/PgReader.hpp
@@ -85,11 +85,6 @@ public:
     SET_STAGE_NAME("readers.pgpointcloud",
         "Read data from pgpointcloud format. \"query\" option needs to be a SQL statment selecting the data.")
     SET_STAGE_LINK("http://pdal.io/stages/readers.pgpointcloud.html")
-#ifdef PDAL_HAVE_POSTGRESQL
-    SET_STAGE_ENABLED(true)
-#else
-    SET_STAGE_ENABLED(false)
-#endif
 
     PgReader();
     ~PgReader();

--- a/plugins/pgpointcloud/io/PgWriter.hpp
+++ b/plugins/pgpointcloud/io/PgWriter.hpp
@@ -48,11 +48,6 @@ public:
     SET_STAGE_NAME("writers.pgpointcloud",
         "Write points to PostgreSQL pgpointcloud output")
     SET_STAGE_LINK("http://pdal.io/stages/writers.pgpointcloud.html")
-#ifdef PDAL_HAVE_POSTGRESQL
-    SET_STAGE_ENABLED(true)
-#else
-    SET_STAGE_ENABLED(false)
-#endif
 
     PgWriter();
     ~PgWriter();

--- a/plugins/python/filters/PredicateFilter.hpp
+++ b/plugins/python/filters/PredicateFilter.hpp
@@ -46,7 +46,6 @@ class PDAL_DLL PredicateFilter : public Filter
 public:
     SET_STAGE_NAME("filters.predicate", "Filter data using inline Python expressions.")
     SET_STAGE_LINK("http://pdal.io/stages/filters.predicate.html")
-    SET_STAGE_ENABLED(true)
 
     PredicateFilter() : Filter(), m_script(NULL)
         {}

--- a/plugins/python/filters/ProgrammableFilter.hpp
+++ b/plugins/python/filters/ProgrammableFilter.hpp
@@ -48,7 +48,6 @@ class PDAL_DLL ProgrammableFilter : public Filter
 public:
     SET_STAGE_NAME("filters.programmable", "Manipulate data using inline Python")
     SET_STAGE_LINK("http://pdal.io/stages/filters.programmable.html")
-    SET_STAGE_ENABLED(true)
 
     ProgrammableFilter() : Filter(), m_script(NULL)
         {}

--- a/plugins/rxp/io/RxpReader.hpp
+++ b/plugins/rxp/io/RxpReader.hpp
@@ -143,7 +143,6 @@ class PDAL_DLL RxpReader : public pdal::Reader
 public:
     SET_STAGE_NAME("readers.rxp", "RXP Reader")
     SET_STAGE_LINK("http://pdal.io/stages/readers.rxp.html")
-    SET_STAGE_ENABLED(true)
 
     RxpReader()
         : pdal::Reader()

--- a/plugins/sqlite/io/SQLiteReader.hpp
+++ b/plugins/sqlite/io/SQLiteReader.hpp
@@ -49,7 +49,6 @@ class PDAL_DLL SQLiteReader : public DbReader
 {
 public:
     SET_STAGE_NAME("readers.sqlite", "Read data from SQLite3 database files.")
-    SET_STAGE_ENABLED(true)
 
     SQLiteReader()
     {}

--- a/plugins/sqlite/io/SQLiteWriter.hpp
+++ b/plugins/sqlite/io/SQLiteWriter.hpp
@@ -46,7 +46,6 @@ class PDAL_DLL SQLiteWriter : public DbWriter
 {
 public:
     SET_STAGE_NAME("writers.sqlite", "Write data to SQLite3 database files.")
-    SET_STAGE_ENABLED(true)
     SQLiteWriter();
 
 private:

--- a/src/StageInfo.cpp
+++ b/src/StageInfo.cpp
@@ -52,7 +52,7 @@ std::ostream& operator<<(std::ostream& ostr, const StageInfo& info)
 }
 
 StageInfo::StageInfo(std::string const& name, std::string const& description)
-    : m_name(name), m_description(description), m_isEnabled(false) {}
+    : m_name(name), m_description(description) {}
 
 /// copy constructor
 StageInfo::StageInfo(StageInfo const& other)
@@ -61,7 +61,6 @@ StageInfo::StageInfo(StageInfo const& other)
     , m_dimensions(other.m_dimensions)
     , m_options(other.m_options)
     , m_link(other.m_link)
-    , m_isEnabled(other.m_isEnabled)
 {
     return;
 }


### PR DESCRIPTION
We no longer have a situation in which a driver is built but would not be enabled. Drivers that have dependencies will simply not be built if the dependency is not met; this is controlled by CMake. Running `pdal
drivers` will still provide visibility at runtime into which drivers are available.