### PR TITLE
Modify pdal app outputs

### DIFF
--- a/src/StageInfo.cpp
+++ b/src/StageInfo.cpp
@@ -105,6 +105,9 @@ std::string StageInfo::optionsToRST() const
     uint32_t default_column(15);
     uint32_t name_column(32);
     uint32_t description_column(40);
+
+    strm << std::left;
+
     for (std::vector<Option>::const_iterator it = options.begin();
         it != options.end();
         ++it)
@@ -128,7 +131,7 @@ std::string StageInfo::optionsToRST() const
             
             strm   << std::setw(name_column) << opt.getName() << " " 
                    << std::setw(default_column) << default_value << " " 
-                   << std::left << std::setw(description_column) << description << std::endl;
+                   << std::setw(description_column) << description << std::endl;
         } else
             strm   << std::setw(name_column) << opt.getName() << " " 
                    << std::setw(default_column) << default_value << " " 


### PR DESCRIPTION
`--drivers` output is condensed into a table without links.

`--options` output is added (was previously only available through kernels/subcommands).

`--help` now displays program_options and commonly used kernels/subcommands, but no version information. Calling pdal with wrong arguments now displays help.

`--version` now displays only version information (not help).

`--debug` and `--drivers` are now parsed as program_options, not actions.

Renamed actions as commands.