### PR TITLE
Add transformation filter

### DIFF
--- a/doc/stages/filters.transformation.rst
+++ b/doc/stages/filters.transformation.rst
@@ -1,0 +1,51 @@
+.. _filters.transformation:
+
+filters.transformation
+======================
+
+The transformation filter applies an arbitrary rotation+translation transformation, represented as a 4x4 matrix, to each xyz triplet.
+The filter does *no* checking to ensure the matrix is a valid affine transformation — buyer beware.
+
+
+Example
+-------
+
+This example rotates the points around the z-axis while translating them.
+
+.. code-block:: xml
+
+  <?xml version="1.0" encoding="utf-8"?>
+  <Pipeline version="1.0">
+    <Writer type="writers.las">
+      <Option name="filename">
+        transformed.las
+      </Option>
+      <Filter type="filters.transformation">
+        <Option name="matrix">
+          0 -1  0  1
+          1  0  0  2
+          0  0  1  3
+          0  0  0  1
+        </Option>
+        <Reader type="readers.las">
+          <Option name="filename">
+            untransformed.las
+          </Option>
+        </Reader>
+      </Filter>
+    </Writer>
+  </Pipeline>
+
+
+Options
+-------
+
+matrix
+  A whitespace-delimited transformation matrix.
+  The matrix is assumed to be presented in row-major order.
+  Only matrices with sixteen elements are allowed.
+
+Notes
+-----
+
+The transformation filter does not apply any spatial reference information — if spatial reference information is desired, it must be specified on another filter.

--- a/doc/stages/index.rst
+++ b/doc/stages/index.rst
@@ -55,4 +55,5 @@ Filters
    filters.programmable
    filters.reprojection
    filters.sort
+   filters.transformation
 

--- a/filters/CMakeLists.txt
+++ b/filters/CMakeLists.txt
@@ -9,5 +9,6 @@ add_subdirectory(reprojection)
 add_subdirectory(sort)
 add_subdirectory(splitter)
 add_subdirectory(stats)
+add_subdirectory(transformation)
 
 set(PDAL_TARGET_OBJECTS ${PDAL_TARGET_OBJECTS} PARENT_SCOPE)

--- a/filters/transformation/CMakeLists.txt
+++ b/filters/transformation/CMakeLists.txt
@@ -1,0 +1,18 @@
+#
+# Transformation filter CMake configuration
+#
+
+#
+# Transformation Filter
+#
+set(srcs
+    TransformationFilter.cpp
+)
+
+set(incs
+    TransformationFilter.hpp
+)
+
+PDAL_ADD_DRIVER(filter transformation "${srcs}" "${incs}" objects)
+set(PDAL_TARGET_OBJECTS ${PDAL_TARGET_OBJECTS} ${objects} PARENT_SCOPE)
+

--- a/filters/transformation/TransformationFilter.cpp
+++ b/filters/transformation/TransformationFilter.cpp
@@ -1,0 +1,108 @@
+/******************************************************************************
+* Copyright (c) 2014, Pete Gadomski <pete.gadomski@gmail.com>
+*
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following
+* conditions are met:
+*
+*     * Redistributions of source code must retain the above copyright
+*       notice, this list of conditions and the following disclaimer.
+*     * Redistributions in binary form must reproduce the above copyright
+*       notice, this list of conditions and the following disclaimer in
+*       the documentation and/or other materials provided
+*       with the distribution.
+*     * Neither the name of Hobu, Inc. or Flaxen Geo Consulting nor the
+*       names of its contributors may be used to endorse or promote
+*       products derived from this software without specific prior
+*       written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+* FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+* COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+* BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+* OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+* AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+* OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+* OF SUCH DAMAGE.
+****************************************************************************/
+
+#include "TransformationFilter.hpp"
+
+#include <sstream>
+
+#include <pdal/pdal_error.hpp>
+
+
+namespace pdal
+{
+
+
+TransformationMatrix transformationMatrixFromString(const std::string& s)
+{
+    std::istringstream iss(s);        
+    TransformationMatrix matrix;
+    double entry;
+    TransformationMatrix::size_type i = 0;
+    while (iss >> entry)
+    {
+        if (i + 1 > matrix.size())
+        {
+            std::stringstream msg;
+            msg << "Too many entries in transformation matrix, should be "
+                << matrix.size();
+            throw invalid_format(msg.str());
+        }
+        matrix[i++] = entry;
+    }
+
+    if (i != matrix.size())
+    {
+        std::stringstream msg;
+        msg << "Too few entries in transformation matrix: "
+            << i
+            << " (should be "
+            << matrix.size()
+            << ")";
+
+        throw invalid_format(msg.str());
+    }
+
+    return matrix;
+}
+
+
+void TransformationFilter::processOptions(const Options& options)
+{
+    m_matrix = transformationMatrixFromString(options.getValueOrThrow<std::string>("matrix"));
+}
+
+
+void TransformationFilter::ready(PointContext ctx)
+{}
+
+
+void TransformationFilter::done(PointContext ctx)
+{}
+
+
+void TransformationFilter::filter(PointBuffer& data)
+{
+    for (PointId idx = 0; idx < data.size(); ++idx)
+    {
+        double x = data.getFieldAs<double>(Dimension::Id::X, idx);
+        double y = data.getFieldAs<double>(Dimension::Id::Y, idx);
+        double z = data.getFieldAs<double>(Dimension::Id::Z, idx);
+        data.setField(Dimension::Id::X, idx, x * m_matrix[0] + y * m_matrix[1] + z * m_matrix[2] + m_matrix[3]);
+        data.setField(Dimension::Id::Y, idx, x * m_matrix[4] + y * m_matrix[5] + z * m_matrix[6] + m_matrix[7]);
+        data.setField(Dimension::Id::Z, idx, x * m_matrix[8] + y * m_matrix[9] + z * m_matrix[10] + m_matrix[11]);
+    }
+}
+
+
+} // namespace pdal

--- a/filters/transformation/TransformationFilter.cpp
+++ b/filters/transformation/TransformationFilter.cpp
@@ -83,14 +83,6 @@ void TransformationFilter::processOptions(const Options& options)
 }
 
 
-void TransformationFilter::ready(PointContext ctx)
-{}
-
-
-void TransformationFilter::done(PointContext ctx)
-{}
-
-
 void TransformationFilter::filter(PointBuffer& data)
 {
     for (PointId idx = 0; idx < data.size(); ++idx)

--- a/filters/transformation/TransformationFilter.hpp
+++ b/filters/transformation/TransformationFilter.hpp
@@ -64,8 +64,6 @@ private:
     TransformationFilter& operator=(const TransformationFilter&); // not implemented
     TransformationFilter(const TransformationFilter&); // not implemented
     virtual void processOptions(const Options& options);
-    virtual void ready(PointContext ctx);
-    virtual void done(PointContext ctx);
     virtual void filter(PointBuffer& data);
 
     TransformationMatrix m_matrix;

--- a/filters/transformation/TransformationFilter.hpp
+++ b/filters/transformation/TransformationFilter.hpp
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (c) 2014, Howard Butler, hobu.inc@gmail.com
+* Copyright (c) 2014, Pete Gadomski <pete.gadomski@gmail.com>
 *
 * All rights reserved.
 *
@@ -34,15 +34,42 @@
 
 #pragma once
 
-#include <chipper/ChipperFilter.hpp>
-#include <colorization/ColorizationFilter.hpp>
-#include <crop/CropFilter.hpp>
-#include <decimation/DecimationFilter.hpp>
-#include <ferry/FerryFilter.hpp>
-#include <merge/MergeFilter.hpp>
-#include <mortonorder/MortonOrderFilter.hpp>
-#include <reprojection/ReprojectionFilter.hpp>
-#include <sort/SortFilter.hpp>
-#include <splitter/SplitterFilter.hpp>
-#include <stats/StatsFilter.hpp>
-#include <transformation/TransformationFilter.hpp>
+#include <array>
+#include <string>
+
+#include <pdal/Filter.hpp>
+
+
+namespace pdal
+{
+
+
+// Transformation matrices are assumed to be stored in row-major order
+typedef std::array<double, 16> TransformationMatrix;
+
+
+TransformationMatrix transformationMatrixFromString(const std::string& s);
+
+
+class PDAL_DLL TransformationFilter : public Filter
+{
+public:
+    SET_STAGE_NAME("filters.transformation", "Transform each point using a 4x4 transformation matrix")
+    SET_STAGE_LINK("http://pdal.io/stages/filters.transformation.html")
+
+    TransformationFilter() : Filter()
+    {}
+
+private:
+    TransformationFilter& operator=(const TransformationFilter&); // not implemented
+    TransformationFilter(const TransformationFilter&); // not implemented
+    virtual void processOptions(const Options& options);
+    virtual void ready(PointContext ctx);
+    virtual void done(PointContext ctx);
+    virtual void filter(PointBuffer& data);
+
+    TransformationMatrix m_matrix;
+};
+
+
+} // namespace pdal

--- a/src/StageFactory.cpp
+++ b/src/StageFactory.cpp
@@ -83,6 +83,7 @@ MAKE_FILTER_CREATOR(Reprojection, pdal::ReprojectionFilter)
 MAKE_FILTER_CREATOR(Sort, pdal::SortFilter)
 MAKE_FILTER_CREATOR(Splitter, pdal::SplitterFilter)
 MAKE_FILTER_CREATOR(Stats, pdal::StatsFilter)
+MAKE_FILTER_CREATOR(Transformation, pdal::TransformationFilter)
 
 //
 // define the functions to create the writers
@@ -324,6 +325,7 @@ void StageFactory::registerKnownFilters()
     REGISTER_FILTER(Sort, pdal::SortFilter);
     REGISTER_FILTER(Splitter, pdal::SplitterFilter);
     REGISTER_FILTER(Stats, pdal::StatsFilter);
+    REGISTER_FILTER(Transformation, pdal::TransformationFilter);
 }
 
 

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -37,6 +37,7 @@ include_directories(
     ${PROJECT_SOURCE_DIR}/filters/sort
     ${PROJECT_SOURCE_DIR}/filters/splitter
     ${PROJECT_SOURCE_DIR}/filters/stats
+    ${PROJECT_SOURCE_DIR}/filters/transformation
     ${PROJECT_SOURCE_DIR}/kernels/info
 )
 
@@ -92,6 +93,7 @@ PDAL_ADD_TEST(pdal_filters_reprojection_test FILES filters/ReprojectionFilterTes
 PDAL_ADD_TEST(pdal_filters_sort_test FILES filters/SortFilterTest.cpp)
 PDAL_ADD_TEST(pdal_filters_splitter_test FILES filters/SplitterTest.cpp)
 PDAL_ADD_TEST(pdal_filters_stats_test FILES filters/StatsFilterTest.cpp)
+PDAL_ADD_TEST(pdal_filters_transformation_test FILES filters/TransformationFilterTest.cpp)
 
 #
 # sources for plang

--- a/test/unit/filters/TransformationFilterTest.cpp
+++ b/test/unit/filters/TransformationFilterTest.cpp
@@ -1,0 +1,175 @@
+/******************************************************************************
+* Copyright (c) 2014, Pete Gadomski <pete.gadomski@gmail.com>
+*
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following
+* conditions are met:
+*
+*     * Redistributions of source code must retain the above copyright
+*       notice, this list of conditions and the following disclaimer.
+*     * Redistributions in binary form must reproduce the above copyright
+*       notice, this list of conditions and the following disclaimer in
+*       the documentation and/or other materials provided
+*       with the distribution.
+*     * Neither the name of Hobu, Inc. or Flaxen Geo Consulting nor the
+*       names of its contributors may be used to endorse or promote
+*       products derived from this software without specific prior
+*       written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+* FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+* COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+* BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+* OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+* AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+* OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+* OF SUCH DAMAGE.
+****************************************************************************/
+
+#include "gtest/gtest.h"
+#include <TransformationFilter.hpp>
+
+#include <pdal/StageFactory.hpp>
+
+
+namespace pdal
+{
+
+
+class TransformationFilterTest : public ::testing::Test
+{
+public:
+
+    TransformationFilterTest()
+        : factory()
+        , reader(factory.createReader("readers.faux"))
+        , filter(factory.createFilter("filters.transformation"))
+    {}
+
+    virtual void SetUp()
+    {
+        StageFactory f;
+
+        BOX3D bounds(1, 2, 3, 4, 5, 6);
+        Options readerOpts;
+        readerOpts.add("mode", "constant");
+        readerOpts.add("num_points", 3);
+        readerOpts.add("bounds", bounds);
+        reader->setOptions(readerOpts);
+
+        filter->setInput(reader.get());
+    }
+
+    StageFactory factory;
+    ReaderPtr reader;
+    FilterPtr filter;
+
+};
+
+
+TEST(TransformationMatrix, FromString)
+{
+    std::string s = "1 0 0 0\n0 1 0 0\n0 0 1 0\n0 0 0 1";
+    TransformationMatrix m = transformationMatrixFromString(s);
+    EXPECT_DOUBLE_EQ(1, m[0]);
+    EXPECT_DOUBLE_EQ(0, m[1]);
+    EXPECT_DOUBLE_EQ(0, m[2]);
+    EXPECT_DOUBLE_EQ(0, m[3]);
+    EXPECT_DOUBLE_EQ(0, m[4]);
+    EXPECT_DOUBLE_EQ(1, m[5]);
+    EXPECT_DOUBLE_EQ(0, m[6]);
+    EXPECT_DOUBLE_EQ(0, m[7]);
+    EXPECT_DOUBLE_EQ(0, m[8]);
+    EXPECT_DOUBLE_EQ(0, m[9]);
+    EXPECT_DOUBLE_EQ(1, m[10]);
+    EXPECT_DOUBLE_EQ(0, m[11]);
+    EXPECT_DOUBLE_EQ(0, m[12]);
+    EXPECT_DOUBLE_EQ(0, m[13]);
+    EXPECT_DOUBLE_EQ(0, m[14]);
+    EXPECT_DOUBLE_EQ(1, m[15]);
+}
+
+
+TEST(TransformationMatrix, TooShort)
+{
+    std::string s = "1 0 0 0\n0 1 0 0\n0 0 1 0\n0 0 0";
+    EXPECT_THROW(transformationMatrixFromString(s), invalid_format);
+}
+
+
+TEST(TransformationMatrix, TooLong)
+{
+    std::string s = "1 0 0 0\n0 1 0 0\n0 0 1 0\n0 0 0 1 0";
+    EXPECT_THROW(transformationMatrixFromString(s), invalid_format);
+}
+
+
+TEST_F(TransformationFilterTest, NoChange)
+{
+    Options filterOpts;
+    filterOpts.add("matrix", "1 0 0 0\n0 1 0 0\n0 0 1 0\n0 0 0 1");
+    filter->setOptions(filterOpts);
+
+    PointContext ctx;
+    filter->prepare(ctx);
+    PointBufferSet pbSet = filter->execute(ctx);
+    EXPECT_EQ(1u, pbSet.size());
+    PointBufferPtr buf = *pbSet.begin();
+    EXPECT_EQ(3u, buf->size());
+
+    for (point_count_t i = 0; i < buf->size(); ++i)
+    {
+        EXPECT_DOUBLE_EQ(1, buf->getFieldAs<double>(Dimension::Id::X, i));
+        EXPECT_DOUBLE_EQ(2, buf->getFieldAs<double>(Dimension::Id::Y, i));
+        EXPECT_DOUBLE_EQ(3, buf->getFieldAs<double>(Dimension::Id::Z, i));
+    }
+}
+
+
+TEST_F(TransformationFilterTest, Translation)
+{
+    Options filterOpts;
+    filterOpts.add("matrix", "1 0 0 1\n0 1 0 2\n0 0 1 3\n0 0 0 1");
+    filter->setOptions(filterOpts);
+
+    PointContext ctx;
+    filter->prepare(ctx);
+    PointBufferSet pbSet = filter->execute(ctx);
+    PointBufferPtr buf = *pbSet.begin();
+
+    for (point_count_t i = 0; i < buf->size(); ++i)
+    {
+        EXPECT_DOUBLE_EQ(2, buf->getFieldAs<double>(Dimension::Id::X, i));
+        EXPECT_DOUBLE_EQ(4, buf->getFieldAs<double>(Dimension::Id::Y, i));
+        EXPECT_DOUBLE_EQ(6, buf->getFieldAs<double>(Dimension::Id::Z, i));
+    }
+}
+
+
+TEST_F(TransformationFilterTest, Rotation)
+{
+    Options filterOpts;
+    filterOpts.add("matrix", "0 1 0 0\n-1 0 0 0\n0 0 1 0\n0 0 0 1");
+    filter->setOptions(filterOpts);
+
+    PointContext ctx;
+    filter->prepare(ctx);
+    PointBufferSet pbSet = filter->execute(ctx);
+    PointBufferPtr buf = *pbSet.begin();
+
+    for (point_count_t i = 0; i < buf->size(); ++i)
+    {
+        EXPECT_DOUBLE_EQ(2, buf->getFieldAs<double>(Dimension::Id::X, i));
+        EXPECT_DOUBLE_EQ(-1, buf->getFieldAs<double>(Dimension::Id::Y, i));
+        EXPECT_DOUBLE_EQ(3, buf->getFieldAs<double>(Dimension::Id::Z, i));
+    }
+}
+
+
+}


### PR DESCRIPTION
This filter applies an arbitrary 4x4 matrix to each xyz triplet. There is no checking to ensure the matrix is a valid affine transformation, or anything of the sort.