### PR TITLE
Allow build on GCC.

### DIFF
--- a/tools/lasdump/Dumper.cpp
+++ b/tools/lasdump/Dumper.cpp
@@ -124,7 +124,7 @@ void Dumper::dump()
 void Dumper::readPoints(ILeStream& in)
 {
     vector<char> buf(m_header.pointLen());
-    
+
     for (uint64_t i = 0; i < m_header.pointCount(); ++i)
     {
         in.get(buf);
@@ -185,7 +185,7 @@ int Dumper::processArgs(deque<string> args)
         }
         args.pop_front();
 
-        m_fout = ofstream(args[0]);
+        m_fout.open(args[0]);
         m_out = &m_fout;
         if (!*m_out)
         {

--- a/tools/lasdump/Lasdump.hpp
+++ b/tools/lasdump/Lasdump.hpp
@@ -63,7 +63,7 @@ inline int32_t cksum(const void *c, size_t size)
 {
     int32_t sum = 0;
 
-    int32_t *p = (int32_t *)c;
+    const int32_t *p = static_cast<const int32_t *>(c);
     while (size)
     {
         int32_t val = 0;
@@ -79,12 +79,12 @@ inline int32_t cksum(const void *c, size_t size)
 
 inline int32_t cksum(const std::vector<char>& v)
 {
-    return cksum((const void *)v.data(), v.size());
+    return cksum(static_cast<const void *>(v.data()), v.size());
 }
 
 inline int32_t cksum(const std::vector<unsigned char>& v)
 {
-    return cksum((const void *)v.data(), v.size());
+    return cksum(static_cast<const void *>(v.data()), v.size());
 }
 
 } // namespace lasdump


### PR DESCRIPTION
Fix cast that was removing const-qualification and use `ofstream::open` instead of `ofstream::operator=`.