### PR TITLE
Update m_lastStage in PipelineManager::addWriter

### DIFF
--- a/src/PipelineManager.cpp
+++ b/src/PipelineManager.cpp
@@ -147,6 +147,7 @@ Writer* PipelineManager::addWriter(const std::string& type, Stage *prevStage)
     Writer* writer = m_factory.createWriter(type);
     writer->setInput(prevStage);
     m_writers.push_back(writer);
+    m_lastStage = writer;
     m_lastWriter = writer;
     return writer;
 }

--- a/test/unit/PipelineManagerTest.cpp
+++ b/test/unit/PipelineManagerTest.cpp
@@ -43,7 +43,8 @@ using namespace pdal;
 
 TEST(PipelineManagerTest, basic)
 {
-    FileUtils::deleteFile("temp.las");
+    const char * outfile = "temp.las";
+    FileUtils::deleteFile(outfile);
 
     PipelineManager mgr;
 
@@ -53,14 +54,15 @@ TEST(PipelineManagerTest, basic)
     reader->setOptions(optsR);
 
     Options optsW;
-    optsW.add("filename", "temp.las", "file to write to");
+    optsW.add("filename", outfile, "file to write to");
     Writer* writer = mgr.addWriter("writers.las", reader);
     writer->setOptions(optsW);
 
     point_count_t np = mgr.execute();
     EXPECT_TRUE(np == 1065U);
 
-    FileUtils::deleteFile("temp.las");
+    EXPECT_TRUE(bool(std::ifstream(outfile)));
+    FileUtils::deleteFile(outfile);
 }
 
 


### PR DESCRIPTION
This fixes a bug where the PipelineManager would actually write to the last non-writer stage added, usually a reader or filter.

Includes change to existing unit test that demonstrates break.