### PR TITLE
Use correct cmake version variable in pdal-config

### DIFF
--- a/apps/pdal-config.in
+++ b/apps/pdal-config.in
@@ -53,7 +53,7 @@ case $1 in
     ;;
     
   --version)
-    echo @VERSION@
+    echo @PDAL_VERSION_STRING@
     ;;
 
   *)


### PR DESCRIPTION
`pdal-config` didn't spit out the version with the old way.

[skip ci]