### PR TITLE
Allow running pgpointcloud tests against non-default installs

### DIFF
--- a/plugins/pgpointcloud/CMakeLists.txt
+++ b/plugins/pgpointcloud/CMakeLists.txt
@@ -34,12 +34,14 @@ PDAL_ADD_PLUGIN(writer_libname writer pgpointcloud
 # PgPointCloud tests
 #
 if (BUILD_PGPOINTCLOUD_TESTS)
-	set(PGPOINTCLOUD_TEST_DB_HOST localhost CACHE STRING
+	set(PGPOINTCLOUD_TEST_DB_USER $ENV{PGUSER} CACHE STRING
+            "Postgres test database user, must be able to create databases")
+	set(PGPOINTCLOUD_TEST_DB_HOST $ENV{PGHOST} CACHE STRING
             "Postgres test database host")
-	set(PGPOINTCLOUD_TEST_DB_PORT 5432 CACHE STRING
+	set(PGPOINTCLOUD_TEST_DB_PORT $ENV{PGPORT} CACHE STRING
             "Postgres test database port")
-	set(PGPOINTCLOUD_TEST_DB_NAME pdal_test CACHE STRING
-            "Postgres test database name, must exist and must be able to create databases")
+	set(PGPOINTCLOUD_TEST_DB_NAME template1 CACHE STRING
+            "Postgres master database name, must exist")
 	set(PGPOINTCLOUD_TEST_DB_TEMPNAME pdal_test_tmp CACHE STRING
             "Postgres test database temp database name")
 

--- a/plugins/pgpointcloud/test/PgpointcloudWriterTest.cpp
+++ b/plugins/pgpointcloud/test/PgpointcloudWriterTest.cpp
@@ -43,11 +43,44 @@
 
 using namespace pdal;
 
+namespace { // anonymous
+
+std::string getTestConnBase()
+{
+  std::string s;
+  if ( ! testDbPort.empty() )
+    s += " port='" + testDbPort + "'";
+  if ( ! testDbHost.empty() )
+    s += " host='" + testDbHost + "'";
+  if ( ! testDbUser.empty() )
+    s += " user='" + testDbUser + "'";
+  return s;
+}
+
+std::string getConnectionString(const std::string& dbname)
+{
+  std::string s = getTestConnBase()
+                + " dbname='" + dbname + "'";
+  return s;
+}
+
+std::string getTestDBTempConn()
+{
+  return getConnectionString(testDbTempname);
+}
+
+std::string getMasterDBConn()
+{
+  return getConnectionString(testDbName);
+}
+
+} // anonymous namespace
+
 Options getWriterOptions()
 {
     Options options;
 
-    options.add(Option("connection", testDbTempConn));
+    options.add(Option("connection", getTestDBTempConn()));
     options.add(Option("table", "pdal_test_table"));
     options.add(Option("srid", "4326"));
     options.add(Option("capacity", "10000"));
@@ -64,7 +97,8 @@ protected:
     {
         try
         {
-            m_masterConnection = pg_connect(testDbConn);
+            std::string connstr = getMasterDBConn();
+            m_masterConnection = pg_connect( connstr );
         } catch (pdal::pdal_error&)
         {
             m_masterConnection = 0;
@@ -84,8 +118,7 @@ protected:
 
         try
         {
-
-            m_testConnection = pg_connect( testDbTempConn);
+            m_testConnection = pg_connect( getTestDBTempConn() );
         } catch (pdal::pdal_error&)
         {
             m_testConnection = 0;

--- a/plugins/pgpointcloud/test/Pgtest-Support.hpp.in
+++ b/plugins/pgpointcloud/test/Pgtest-Support.hpp.in
@@ -38,17 +38,11 @@ namespace pdal
 {
 
 
+static const std::string testDbUser("@PGPOINTCLOUD_TEST_DB_USER@");
 static const std::string testDbHost("@PGPOINTCLOUD_TEST_DB_HOST@");
 static const std::string testDbPort("@PGPOINTCLOUD_TEST_DB_PORT@");
 static const std::string testDbName("@PGPOINTCLOUD_TEST_DB_NAME@");
 static const std::string testDbTempname("@PGPOINTCLOUD_TEST_DB_TEMPNAME@");
-
-static const std::string testDbConn(std::string("dbname='@PGPOINTCLOUD_TEST_DB_NAME@' ") +
-        "user='postgres' host='@PGPOINTCLOUD_TEST_DB_HOST@' port='@PGPOINTCLOUD_TEST_DB_PORT@'");
-static const std::string testDbTempConn(std::string("dbname='@PGPOINTCLOUD_TEST_DB_TEMPNAME@'") +
-        "user='postgres' host='@PGPOINTCLOUD_TEST_DB_HOST@' port='@PGPOINTCLOUD_TEST_DB_PORT@'");
-
-
 
 
 


### PR DESCRIPTION
Adds a PGPOINTCLOUD_TEST_DB_USER configuration, allows using
environment variables and libpq defaults to drive operations.

Fixes #742