### PR TITLE
Some performance optimizations for naive readers.

### DIFF
--- a/include/pdal/PointBuffer.hpp
+++ b/include/pdal/PointBuffer.hpp
@@ -107,6 +107,12 @@ public:
         m_size += buf.size();
         clearTemps();
     }
+    point_count_t append()
+    {
+        const PointId rawId(m_context.rawPtBuf()->addPoint());
+        m_index.push_back(rawId);
+        return m_size++;
+    }
 
     /// Return a new point buffer with the same point context as this
     /// point buffer.
@@ -205,6 +211,8 @@ public:
         { return m_context.dimSize(id); }
     DimTypeList dimTypes() const
         { return m_context.dimTypes(); }
+    PointContextRef context() const
+        { return m_context; }
 
 
     /// Fill a buffer with point data specified by the dimension list.
@@ -488,7 +496,7 @@ bool PointBuffer::convertAndSet(Dimension::Id::Enum dim, PointId idx, T_IN in)
 //      block seemed somewhat expensive.
 //   2) Round to nearest instead of truncation without rounding before
 //      invoking the converter.
-// 
+//
     using namespace boost;
     static bool ok;
 

--- a/include/pdal/PointContext.hpp
+++ b/include/pdal/PointContext.hpp
@@ -76,10 +76,15 @@ private:
     RawPtBufPtr m_ptBuf;
     // Metadata storage;
     MetadataPtr m_metadata;
+    // Combined size of all registered dimensions (in bytes).
+    std::size_t m_pointSize;
 
 public:
-    PointContext() : m_dims(new DimInfo()), m_ptBuf(new RawPtBuf()),
-        m_metadata(new Metadata)
+    PointContext()
+        : m_dims(new DimInfo())
+        , m_ptBuf(new RawPtBuf())
+        , m_metadata(new Metadata)
+        , m_pointSize(0)
     {}
 
     RawPtBuf *rawPtBuf() const
@@ -216,10 +221,7 @@ public:
 
     size_t pointSize() const
     {
-        size_t size(0);
-        for (const auto& d : m_dims->m_detail)
-            size += d.size();
-        return size;
+        return m_pointSize;
     }
 
 private:
@@ -248,7 +250,8 @@ private:
             m_dims->m_detail[*ui].m_offset = offset;
             offset += (int)m_dims->m_detail[*ui].size();
         }
-        m_ptBuf->setPointSize((size_t)offset);
+        m_pointSize = static_cast<std::size_t>(offset);
+        m_ptBuf->setPointSize(m_pointSize);
     }
 
     Dimension::Type::Enum resolveType(Dimension::Type::Enum t1,

--- a/include/pdal/PointContext.hpp
+++ b/include/pdal/PointContext.hpp
@@ -76,15 +76,12 @@ private:
     RawPtBufPtr m_ptBuf;
     // Metadata storage;
     MetadataPtr m_metadata;
-    // Combined size of all registered dimensions (in bytes).
-    std::size_t m_pointSize;
 
 public:
     PointContext()
         : m_dims(new DimInfo())
         , m_ptBuf(new RawPtBuf())
         , m_metadata(new Metadata)
-        , m_pointSize(0)
     {}
 
     RawPtBuf *rawPtBuf() const
@@ -220,9 +217,7 @@ public:
         { return dimDetail(id)->size(); }
 
     size_t pointSize() const
-    {
-        return m_pointSize;
-    }
+        { return m_ptBuf->pointSize(); }
 
 private:
     Dimension::Detail *dimDetail(Dimension::Id::Enum id) const
@@ -250,8 +245,7 @@ private:
             m_dims->m_detail[*ui].m_offset = offset;
             offset += (int)m_dims->m_detail[*ui].size();
         }
-        m_pointSize = static_cast<std::size_t>(offset);
-        m_ptBuf->setPointSize(m_pointSize);
+        m_ptBuf->setPointSize(static_cast<std::size_t>(offset));
     }
 
     Dimension::Type::Enum resolveType(Dimension::Type::Enum t1,

--- a/include/pdal/RawPtBuf.hpp
+++ b/include/pdal/RawPtBuf.hpp
@@ -79,6 +79,20 @@ public:
         memcpy(value, buf + offset, d->size());
     }
 
+    void setPoint(PointId idx, const void *value)
+    {
+        char *buf = m_blocks[idx / m_blockPtCnt];
+        std::size_t offset = pointsToBytes(idx % m_blockPtCnt);
+        memcpy(buf + offset, value, m_pointSize);
+    }
+
+    void getPoint(PointId idx, void* value)
+    {
+        char *buf = m_blocks[idx / m_blockPtCnt];
+        std::size_t offset = pointsToBytes(idx % m_blockPtCnt);
+        memcpy(value, buf + offset, m_pointSize);
+    }
+
     void setPointSize(size_t size)
     {
         if (m_numPts != 0)
@@ -98,7 +112,7 @@ private:
 
     // The number of points in each memory block.
     static const point_count_t m_blockPtCnt = 65536;
-    
+
     std::size_t pointsToBytes(point_count_t numPts)
         { return m_pointSize * numPts; }
 };

--- a/include/pdal/RawPtBuf.hpp
+++ b/include/pdal/RawPtBuf.hpp
@@ -105,6 +105,11 @@ public:
         m_pointSize = size;
     }
 
+    std::size_t pointSize() const
+    {
+        return m_pointSize;
+    }
+
 private:
     std::vector<char *> m_blocks;
     point_count_t m_numPts;


### PR DESCRIPTION
- Add no-arg `append()` to push back an empty point onto the PointBuffer to be filled in later.  Returns index of the added point.
- Store the PointContext's pointSize when dimensions are added so the client doesn't have to store this separately to gain the speed benefits over looping through the dimensions.
- Add `set/getPoint` to the RawPtBuf (and allow access to it via a pointBuffer), which lets a client bulk-set/get an entire point without looping through the dimensions.  Only applicable to PointBuffers with identical PointContexts.

The latter two modifications sped up my test application considerably (about 40% time saved).