### PR TITLE
Use @loader_path/../lib

### DIFF
--- a/cmake/macros.cmake
+++ b/cmake/macros.cmake
@@ -118,7 +118,7 @@ macro(PDAL_ADD_PLUGIN _name _type _shortname)
         LIBRARY DESTINATION ${PDAL_LIB_INSTALL_DIR}
         ARCHIVE DESTINATION ${PDAL_LIB_INSTALL_DIR})
     if (APPLE)
-        set_target_properties(${${_name}} PROPERTIES INSTALL_NAME_DIR "@loader_path/")
+        set_target_properties(${${_name}} PROPERTIES INSTALL_NAME_DIR "@loader_path/../lib")
     endif()
 endmacro(PDAL_ADD_PLUGIN)
 


### PR DESCRIPTION
A solo `@loader_path/` breaks plugin tests on OSX when building out-of-tree. Going up then back down into lib shouldn't change the case when @loader_path = /usr/local/lib or something similar, but will fix the case when @loader_path = /usr/local/bin or whatnot.

@hobu can you check locally? You've done most of the work on this OSX loading stuff.