### PR TITLE
Simplify quad index interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ plugins/pgpointcloud/Pgtest-Support.hpp
 #
 # cmake stuff
 #
+PDALConfig.cmake
+PDALConfigVersion.cmake
+PDALTargets.cmake
 CMakeCache.txt
 CMakeFiles/
 CPackConfig.cmake

--- a/include/pdal/PointContext.hpp
+++ b/include/pdal/PointContext.hpp
@@ -219,6 +219,8 @@ public:
     //         with the given id.
     size_t dimSize(Dimension::Id::Enum id) const
         { return dimDetail(id)->size(); }
+    size_t dimOffset(Dimension::Id::Enum id) const
+        { return dimDetail(id)->offset(); }
 
     size_t pointSize() const
     {

--- a/include/pdal/QuadIndex.hpp
+++ b/include/pdal/QuadIndex.hpp
@@ -43,21 +43,55 @@
 namespace pdal
 {
 
+struct Point
+{
+    Point(double x, double y) : x(x), y(y) { }
+    Point(const Point& other) : x(other.x), y(other.y) { }
+
+    // Calculates the distance-squared to another point.
+    double sqDist(const Point& other) const
+    {
+        return (x - other.x) * (x - other.x) + (y - other.y) * (y - other.y);
+    }
+
+    const double x;
+    const double y;
+};
+
+struct QuadPointRef
+{
+    QuadPointRef(const Point& point, std::size_t pbIndex)
+        : point(point)
+        , pbIndex(pbIndex)
+    { }
+
+    const Point point;
+    const std::size_t pbIndex;
+};
+
 class PointBuffer;
 
 class PDAL_DLL QuadIndex
 {
 public:
     QuadIndex(const PointBuffer& pointBuffer, std::size_t topLevel = 0);
+    QuadIndex(
+            const PointBuffer& pointBuffer,
+            double xMin,
+            double yMin,
+            double xMax,
+            double yMax,
+            std::size_t topLevel = 0);
+    QuadIndex(
+            const std::vector<std::shared_ptr<QuadPointRef> >& points,
+            double xMin,
+            double yMin,
+            double xMax,
+            double yMax,
+            std::size_t topLevel = 0);
     ~QuadIndex();
 
-    // Build the quadtree index.  Could throw a runtime_error.
-    void build();
-    void build(double xMin, double yMin, double xMax, double yMax);
-
-    // Get bounds of the quad tree.  Return false if the tree has not been
-    // built.
-    bool getBounds(
+    void getBounds(
             double& xMin,
             double& yMin,
             double& xMax,
@@ -66,11 +100,6 @@ public:
     std::size_t getDepth() const;
 
     std::vector<std::size_t> getFills() const;
-
-    const PointBuffer& pointBuffer() const;
-
-    // All getPoints queries will return an empty vector if the tree has not
-    // been successfully built prior to the getPoints call.
 
     // Return all points at depth levels strictly less than depthEnd.
     // A depthEnd value of zero returns all points in the tree.

--- a/plugins/attribute/filters/AttributeFilter.cpp
+++ b/plugins/attribute/filters/AttributeFilter.cpp
@@ -233,7 +233,6 @@ GEOSGeometry* createGEOSPoint(GEOSContextHandle_t ctx, double x, double y, doubl
 void AttributeFilter::UpdateGEOSBuffer(PointBuffer& buffer, AttributeInfo& info)
 {
     QuadIndex idx(buffer);
-    idx.build();
 
     if (!info.lyr) // wake up the layer
     {


### PR DESCRIPTION
Build tree on construction instead of requiring a call to `build()`.  Better types system.