### PR TITLE
Purge read_n and read_field from Utils.hpp

### DIFF
--- a/include/pdal/Utils.hpp
+++ b/include/pdal/Utils.hpp
@@ -101,27 +101,6 @@ namespace Utils
         return compare_approx<T>(actual, expected, epsilon);
     }
 
-    // Return a 'T' from a stream and increment src by the sizeof 'T'
-    template<class T>
-    T read_field(uint8_t*& src)
-    {
-        T tmp = *(T*)(void*)src;
-        src += sizeof(T);
-        return tmp;
-    }
-
-    // Read 'num' items from the source stream to the dest location
-    template <typename T>
-    void read_n(T& dest, std::istream& src, std::streamsize const& num)
-    {
-        if (!src.good())
-            throw pdal::invalid_stream("pdal::Utils::read_n<T> input stream is "
-                "not readable");
-
-        src.read(as_buffer(dest), num);
-        assert(check_stream_state(src));
-    }
-
     // From http://stackoverflow.com/questions/485525/round-for-float-in-c
     inline double sround(double r)
         { return (r > 0.0) ? floor(r + 0.5) : ceil(r - 0.5); }

--- a/include/pdal/util/IStream.hpp
+++ b/include/pdal/util/IStream.hpp
@@ -76,6 +76,8 @@ public:
         { return (bool)(*m_stream); }
     void seek(std::streampos pos)
         { m_stream->seekg(pos, std::istream::beg); }
+    void seek(std::streampos pos, std::ios_base::seekdir way)
+        { m_stream->seekg(pos, way); }
     void skip(std::streamoff offset)
         { m_stream->seekg(offset, std::istream::cur); }
     std::streampos position() const

--- a/io/qfit/QfitReader.cpp
+++ b/io/qfit/QfitReader.cpp
@@ -169,8 +169,8 @@ Word #       Content
 #include "QfitReader.hpp"
 
 #include <pdal/PointBuffer.hpp>
-#include <pdal/util/FileUtils.hpp>
-#include <pdal/Utils.hpp>
+#include <pdal/portable_endian.hpp>
+#include <pdal/util/Extractor.hpp>
 
 #include <algorithm>
 #include <map>
@@ -178,6 +178,7 @@ Word #       Content
 #ifdef PDAL_COMPILER_MSVC
 #  pragma warning(disable: 4127)  // conditional expression is constant
 #endif
+
 
 namespace pdal
 {
@@ -191,25 +192,29 @@ CREATE_STATIC_PLUGIN(1, 0, QfitReader, Reader, s_info)
 
 std::string QfitReader::getName() const { return s_info.name; }
 
-QfitReader::QfitReader() : pdal::Reader(),
-    m_format(QFIT_Format_Unknown), m_size(0), m_littleEndian(false)
+QfitReader::QfitReader()
+    : pdal::Reader()
+    , m_format(QFIT_Format_Unknown)
+    , m_size(0)
+    , m_littleEndian(false)
+    , m_istream()
 {}
 
 
 void QfitReader::initialize()
 {
-    std::istream* str = FileUtils::openFile(m_filename);
-    if (str == 0)
+    ISwitchableStream str(m_filename);
+    if (!str)
     {
         std::ostringstream oss;
         oss << "Unable to open file '" << m_filename << "'";
         throw qfit_error(oss.str());
     }
-    str->seekg(0);
+    str.seek(0);
 
     int32_t int4(0);
 
-    Utils::read_n(int4, *str, sizeof(int4));
+    str >> int4;
 
     // They started writting little-endian data.
 
@@ -231,10 +236,16 @@ void QfitReader::initialize()
     // If the size comes back something other than 4*no_dimensions, we assume
     // The data were flipped
     if (int4 < 100)
+    {
         m_littleEndian = true;
+    }
+    else
+    {
+        str.switchToBigEndian();
+    }
 
     if (!m_littleEndian)
-        QFIT_SWAP_BE_TO_LE(int4);
+        int4 = int32_t(be32toh(uint32_t(int4)));
 
     if (int4 % 4 != 0)
         throw qfit_error("Base QFIT format is not a multiple of 4, "
@@ -244,21 +255,18 @@ void QfitReader::initialize()
     m_format = static_cast<QFIT_Format_Type>(m_size / sizeof(m_size));
 
     // The offset to start reading point data should be here.
-    str->seekg(m_size + sizeof(int4));
+    str.seek(m_size + sizeof(int4));
 
-    Utils::read_n(int4, *str, sizeof(int4));
-    if (!m_littleEndian)
-        QFIT_SWAP_BE_TO_LE(int4);
+    str >> int4;
     m_offset = static_cast<std::size_t>(int4);
 
     // Seek to the end
-    str->seekg(0, std::ios::end);
-    std::ios::pos_type end = str->tellg();
+    str.seek(0, std::istream::end);
+    std::ios::pos_type end = str.position();
 
     // First integer is the format of the file
     std::ios::off_type offset = static_cast<std::ios::off_type>(m_offset);
     m_point_bytes = end - offset;
-    delete str;
 }
 
 
@@ -332,8 +340,8 @@ void QfitReader::ready(PointContextRef ctx)
         throw qfit_error(msg.str());
     }
     m_index = 0;
-    m_istream = FileUtils::openFile(m_filename);
-    m_istream->seekg(getPointDataOffset());
+    m_istream.reset(new IStream(m_filename));
+    m_istream->seek(getPointDataOffset());
 }
 
 
@@ -343,109 +351,61 @@ point_count_t QfitReader::read(PointBuffer& data, point_count_t count)
     {
         throw pdal_error("QFIT file stream is no good!");
     }
-    if (m_istream->eof())
+    if (m_istream->stream()->eof())
     {
         throw pdal_error("QFIT file stream is eof!");
     }
 
     count = std::min(m_numPoints - m_index, count);
-    uint8_t *buf = new uint8_t[m_size];
+    std::vector<char> buf(m_size);
     PointId nextId = data.size();
     point_count_t numRead = 0;
     while (count--)
     {
-        Utils::read_n(buf, *m_istream, m_size);
-        uint8_t* p = buf;
+        m_istream->get(buf);
+        SwitchableExtractor extractor(buf.data(), m_size, m_littleEndian);
 
         // always read the base fields
         {
-            int32_t time = Utils::read_field<int32_t>(p);
-            if (!m_littleEndian)
-                QFIT_SWAP_BE_TO_LE(time);
-            data.setField(Dimension::Id::OffsetTime, nextId, time);
-
-            int32_t y = Utils::read_field<int32_t>(p);
-            if (!m_littleEndian)
-                QFIT_SWAP_BE_TO_LE(y);
-            data.setField(Dimension::Id::Y, nextId, y / 1000000.0);
-
-            int32_t xi = Utils::read_field<int32_t>(p);
-            if (!m_littleEndian)
-                QFIT_SWAP_BE_TO_LE(xi);
+            int32_t time, y, xi, z, start_pulse, reflected_pulse, scan_angle,
+                pitch, roll;
+            extractor >> time >> y >> xi >> z >> start_pulse >>
+                reflected_pulse >> scan_angle >> pitch >> roll;
             double x = xi / 1000000.0;
             if (m_flip_x && x > 180)
                 x -= 360;
+
+            data.setField(Dimension::Id::OffsetTime, nextId, time);
+            data.setField(Dimension::Id::Y, nextId, y / 1000000.0);
             data.setField(Dimension::Id::X, nextId, x);
-
-            int32_t z = Utils::read_field<int32_t>(p);
-            if (!m_littleEndian)
-                QFIT_SWAP_BE_TO_LE(z);
             data.setField(Dimension::Id::Z, nextId, z * m_scale_z);
-
-            int32_t start_pulse = Utils::read_field<int32_t>(p);
-            if (!m_littleEndian)
-                QFIT_SWAP_BE_TO_LE(start_pulse);
             data.setField(Dimension::Id::StartPulse, nextId, start_pulse);
-
-            int32_t reflected_pulse = Utils::read_field<int32_t>(p);
-            if (!m_littleEndian)
-                QFIT_SWAP_BE_TO_LE(reflected_pulse);
             data.setField(Dimension::Id::ReflectedPulse, nextId,
                 reflected_pulse);
-
-            int32_t scan_angle = Utils::read_field<int32_t>(p);
-            if (!m_littleEndian)
-                QFIT_SWAP_BE_TO_LE(scan_angle);
             data.setField(Dimension::Id::ScanAngleRank, nextId,
                 scan_angle / 1000.0);
-
-            int32_t pitch = Utils::read_field<int32_t>(p);
-            if (!m_littleEndian)
-                QFIT_SWAP_BE_TO_LE(pitch);
             data.setField(Dimension::Id::Pitch, nextId, pitch / 1000.0);
-
-            int32_t roll = Utils::read_field<int32_t>(p);
-            if (!m_littleEndian)
-                QFIT_SWAP_BE_TO_LE(roll);
             data.setField(Dimension::Id::Roll, nextId, roll / 1000.0);
         }
 
         if (m_format == QFIT_Format_12)
         {
-            int32_t pdop = Utils::read_field<int32_t>(p);
-            if (!m_littleEndian)
-                QFIT_SWAP_BE_TO_LE(pdop);
+            int32_t pdop, pulse_width;
+            extractor >> pdop >> pulse_width;
             data.setField(Dimension::Id::Pdop, nextId, pdop / 10.0);
-
-            int32_t pulse_width = Utils::read_field<int32_t>(p);
-            if (!m_littleEndian)
-                QFIT_SWAP_BE_TO_LE(pulse_width);
             data.setField(Dimension::Id::PulseWidth, nextId, pulse_width);
         }
         else if (m_format == QFIT_Format_14)
         {
-            int32_t passive_signal = Utils::read_field<int32_t>(p);
-            if (!m_littleEndian)
-                QFIT_SWAP_BE_TO_LE(passive_signal);
-            data.setField(Dimension::Id::PassiveSignal, nextId, passive_signal);
-
-            int32_t passive_y = Utils::read_field<int32_t>(p);
-            if (!m_littleEndian)
-                QFIT_SWAP_BE_TO_LE(passive_y);
-            data.setField(Dimension::Id::PassiveY, nextId,
-                passive_y / 1000000.0);
-
-            int32_t passive_x = Utils::read_field<int32_t>(p);
-            if (!m_littleEndian)
-                QFIT_SWAP_BE_TO_LE(passive_x);
+            int32_t passive_signal, passive_y, passive_x, passive_z;
+            extractor >> passive_signal >> passive_y >> passive_x >> passive_z;
             double x = passive_x / 1000000.0;
             if (m_flip_x && x > 180)
                 x -= 360;
+            data.setField(Dimension::Id::PassiveSignal, nextId, passive_signal);
+            data.setField(Dimension::Id::PassiveY, nextId,
+                passive_y / 1000000.0);
             data.setField(Dimension::Id::PassiveX, nextId, x);
-
-            int32_t passive_z = Utils::read_field<int32_t>(p);
-            if (!m_littleEndian)
-                QFIT_SWAP_BE_TO_LE(passive_z);
             data.setField(Dimension::Id::PassiveZ, nextId,
                 passive_z * m_scale_z);
         }
@@ -454,12 +414,12 @@ point_count_t QfitReader::read(PointBuffer& data, point_count_t count)
         // 20 seconds 100 milliseconds.
         // Not sure why we have that AND the other offset time.  For now
         // we'll just extract this time and drop it.
-        int32_t gpstime = Utils::read_field<int32_t>(p);
+        int32_t gpstime;
+        extractor >> gpstime;
 
         numRead++;
         nextId++;
     }
-    delete[] buf;
     m_index += numRead;
 
     return numRead;
@@ -492,7 +452,7 @@ Dimension::IdList QfitReader::getDefaultDimensions()
 
 void QfitReader::done(PointContextRef ctx)
 {
-    FileUtils::closeFile(m_istream);
+    m_istream.reset();
 }
 
 } // namespace pdal

--- a/io/qfit/QfitReader.hpp
+++ b/io/qfit/QfitReader.hpp
@@ -34,35 +34,14 @@
 
 #pragma once
 
+#include <memory>
 #include <vector>
-
-#include <boost/detail/endian.hpp>
 
 #include <pdal/plugin.h>
 #include <pdal/Reader.hpp>
 #include <pdal/Options.hpp>
+#include <pdal/util/IStream.hpp>
 
-#ifdef BOOST_LITTLE_ENDIAN
-# define QFIT_SWAP_BE_TO_LE(p) \
-    do { \
-        char* first = static_cast<char*>(static_cast<void*>(&p)); \
-        char* last = first + sizeof(p) - 1; \
-        for(; first < last; ++first, --last) { \
-            char const x = *last; \
-            *last = *first; \
-            *first = x; \
-        }} while(false)
-
-# define QFIT_SWAP_BE_TO_LE_N(p, n) \
-    do { \
-        char* first = static_cast<char*>(static_cast<void*>(&p)); \
-        char* last = first + n - 1; \
-        for(; first < last; ++first, --last) { \
-            char const x = *last; \
-            *last = *first; \
-            *first = x; \
-        }} while(false)
-#endif
 
 extern "C" int32_t QfitReader_ExitFunc();
 extern "C" PF_ExitFunc QfitReader_InitPlugin();
@@ -123,7 +102,7 @@ private:
     double m_scale_z;
     bool m_littleEndian;
     point_count_t m_numPoints;
-    std::istream* m_istream;
+    std::unique_ptr<IStream> m_istream;
     point_count_t m_index;
 
     virtual void processOptions(const Options& ops);

--- a/io/terrasolid/TerrasolidReader.cpp
+++ b/io/terrasolid/TerrasolidReader.cpp
@@ -267,6 +267,7 @@ point_count_t TerrasolidReader::read(PointBuffer& data, point_count_t count)
             data.setField(Dimension::Id::Alpha, nextId, alpha);
         }
         nextId++;
+        m_index++;
     }
 
     delete[] buf;

--- a/io/terrasolid/TerrasolidReader.hpp
+++ b/io/terrasolid/TerrasolidReader.hpp
@@ -111,6 +111,8 @@ public:
     point_count_t getNumPoints() const
         { return m_header->PntCnt; }
 
+    const TerraSolidHeader& getHeader() const { return *m_header; }
+
     // this is called by the stage's iterator
     uint32_t processBuffer(PointBuffer& PointBuffer, std::istream& stream,
         uint64_t numPointsLeft) const;

--- a/io/terrasolid/TerrasolidReader.hpp
+++ b/io/terrasolid/TerrasolidReader.hpp
@@ -37,8 +37,7 @@
 #include <pdal/Options.hpp>
 #include <pdal/plugin.h>
 #include <pdal/Reader.hpp>
-
-#include <boost/detail/endian.hpp>
+#include <pdal/util/IStream.hpp>
 
 #include <memory>
 #include <vector>
@@ -124,7 +123,7 @@ private:
     bool m_haveColor;
     bool m_haveTime;
     uint32_t m_baseTime;
-    std::istream* m_istream;
+    std::unique_ptr<IStream> m_istream;
     point_count_t m_index;
 
     virtual void initialize();

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -83,6 +83,7 @@ set(srcs
     io/sbet/SbetWriterTest.cpp
 )
 PDAL_ADD_TEST(pdal_io_sbet_test FILES "${srcs}")
+PDAL_ADD_TEST(pdal_io_terrasolid_test FILES io/terrasolid/TerrasolidReaderTest.cpp)
 
 #
 # sources for the native filters

--- a/test/unit/io/terrasolid/TerrasolidReaderTest.cpp
+++ b/test/unit/io/terrasolid/TerrasolidReaderTest.cpp
@@ -1,0 +1,128 @@
+/******************************************************************************
+* Copyright (c) 2015, Peter J. Gadomski <pete.gadomski@gmail.com>
+*
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following
+* conditions are met:
+*
+*     * Redistributions of source code must retain the above copyright
+*       notice, this list of conditions and the following disclaimer.
+*     * Redistributions in binary form must reproduce the above copyright
+*       notice, this list of conditions and the following disclaimer in
+*       the documentation and/or other materials provided
+*       with the distribution.
+*     * Neither the name of Hobu, Inc. or Flaxen Geo Consulting nor the
+*       names of its contributors may be used to endorse or promote
+*       products derived from this software without specific prior
+*       written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+* FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+* COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+* BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+* OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+* AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+* OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+* OF SUCH DAMAGE.
+****************************************************************************/
+
+#include "gtest/gtest.h"
+
+#include "TerrasolidReader.hpp"
+
+#include <pdal/StageFactory.hpp>
+#include "Support.hpp"
+
+
+namespace pdal
+{
+
+
+namespace
+{
+
+
+std::string getTestfilePath()
+{
+    return Support::datapath("terrasolid/20020715-time-color.bin");
+}
+
+
+class TerrasolidReaderTest : public ::testing::Test
+{
+public:
+    TerrasolidReaderTest()
+        : ::testing::Test()
+        , m_reader()
+    {
+        Options options;
+        options.add("filename", getTestfilePath());
+        m_reader.setOptions(options);
+    }
+
+    TerrasolidReader m_reader;
+};
+}
+
+
+TEST(TerrasolidReader, Constructor)
+{
+    TerrasolidReader reader1;
+
+    StageFactory f;
+    std::unique_ptr<Stage> reader2(f.createStage("readers.terrasolid"));
+}
+
+
+TEST_F(TerrasolidReaderTest, Header)
+{
+    PointContext ctx;
+    m_reader.prepare(ctx);
+    TerraSolidHeader header = m_reader.getHeader();
+
+    EXPECT_EQ(56, header.HdrSize);
+    EXPECT_EQ(20020715, header.HdrVersion);
+    EXPECT_EQ(970401, header.RecogVal);
+    EXPECT_STREQ("CXYZ\xe8\x3", header.RecogStr);
+    EXPECT_EQ(1000, header.PntCnt);
+    EXPECT_EQ(100, header.Units);
+    EXPECT_DOUBLE_EQ(0, header.OrgX);
+    EXPECT_DOUBLE_EQ(0, header.OrgY);
+    EXPECT_DOUBLE_EQ(0, header.OrgZ);
+    EXPECT_EQ(1, header.Time);
+    EXPECT_EQ(1, header.Color);
+}
+
+
+TEST_F(TerrasolidReaderTest, ReadingPoints)
+{
+    PointContext ctx;
+    m_reader.prepare(ctx);
+    PointBufferSet pbSet = m_reader.execute(ctx);
+    EXPECT_EQ(pbSet.size(), 1u);
+    PointBufferPtr buf = *pbSet.begin();
+    EXPECT_EQ(buf->size(), 1000u);
+
+    EXPECT_DOUBLE_EQ(363127.94, buf->getFieldAs<double>(Dimension::Id::X, 0));
+    EXPECT_DOUBLE_EQ(3437612.33, buf->getFieldAs<double>(Dimension::Id::Y, 0));
+    EXPECT_DOUBLE_EQ(55.26, buf->getFieldAs<double>(Dimension::Id::Z, 0));
+    EXPECT_DOUBLE_EQ(0, buf->getFieldAs<double>(Dimension::Id::OffsetTime, 0));
+    EXPECT_EQ(1840, buf->getFieldAs<uint16_t>(Dimension::Id::Intensity, 0));
+    EXPECT_EQ(27207, buf->getFieldAs<uint16_t>(Dimension::Id::PointSourceId, 0));
+    EXPECT_EQ(239, buf->getFieldAs<uint8_t>(Dimension::Id::Red, 0));
+    EXPECT_EQ(252, buf->getFieldAs<uint8_t>(Dimension::Id::Green, 0));
+    EXPECT_EQ(95, buf->getFieldAs<uint8_t>(Dimension::Id::Blue, 0));
+    EXPECT_EQ(0, buf->getFieldAs<uint8_t>(Dimension::Id::Alpha, 0));
+    EXPECT_EQ(1, buf->getFieldAs<uint8_t>(Dimension::Id::ReturnNumber, 0));
+    EXPECT_EQ(1, buf->getFieldAs<uint8_t>(Dimension::Id::NumberOfReturns, 0));
+    EXPECT_EQ(2, buf->getFieldAs<uint8_t>(Dimension::Id::Classification, 0));
+    EXPECT_EQ(0, buf->getFieldAs<uint8_t>(Dimension::Id::Flag, 0));
+    EXPECT_EQ(0, buf->getFieldAs<uint8_t>(Dimension::Id::Mark, 0));
+}
+}


### PR DESCRIPTION
V.a.v. #783, `Utils::read_n` and `Utils::read_field` have been superseded by the capabilities of `IStream`, `Extractor`, and friends. This pull request removes the superseded methods.

There are a series of commits in this pull request, all related to `read_n` and `read_field` cleanup.

- Add a new method to `IStream` that allows seeking by position (allows seek to end)
- Added new classes `ISwitchableStream` and `SwitchableExtractor` to support the wonky qfit format. Qfit files sometimes are big endian and sometimes are little endian, and you can't tell until you read the file itself. The `*Switchable*` flavors of `IStream` and `Extractor` provide `switchToBigEndian()` and `switchToLittleEndian()` methods, which switches the read mode of the `IStream` or `Extractor`. I did not use virtual methods because I wanted to avoid polluting the interface of the existing `IStream` and `Extractor` classes.
- Refactored the qfit reader to use `*Switchable*` `IStream` and `Extractor`
- Add tests for the `TerrasolidReader` (it was untested)
- Fixed two bugs in the `TerrasolidReader`; one was a critical bug which trapped the reader in an infinite loop when reading the test file, one was a bug with the way the TerrasolidReader handles return numbers
- Refactor the TerrasolidReader to use `IStream` and `Extractor`
- Remove the offending methods, `read_n` and `read_field`