### PR TITLE
Don't use PATH_PREFIXES in FindLASzip

### DIFF
--- a/cmake/modules/FindLASzip.cmake
+++ b/cmake/modules/FindLASzip.cmake
@@ -37,8 +37,7 @@ ENDIF()
 
 
 FIND_PATH(LASZIP_INCLUDE_DIR
-  laszip.hpp
-  PATH_PREFIXES laszip
+  laszip/laszip.hpp
   PATHS
   /usr/include
   /usr/local/include


### PR DESCRIPTION
PATH_PREFIXES was getting confused by a /usr/local/bin/laszip.

Fixes #820.

@strk can you take this for a spin and see if it fixes?