### PR TITLE
Properly quote PG identifiers

### DIFF
--- a/plugins/pgpointcloud/io/PgCommon.hpp
+++ b/plugins/pgpointcloud/io/PgCommon.hpp
@@ -41,6 +41,7 @@
 #include <pdal/pdal_error.hpp>
 #include <pdal/Options.hpp>
 #include <pdal/Compression.hpp>
+#include <pdal/Utils.hpp>
 
 namespace pdal
 {
@@ -144,6 +145,13 @@ inline PGresult* pg_query_result(PGconn* session, std::string const& sql)
     return result;
 }
 
+inline std::string pg_quote_identifier(std::string const& name) {
+  return std::string("\"") + Utils::replaceAll(name, "\"", "\"\"") + "\"";
+}
+
+inline std::string pg_quote_literal(std::string const& lit) {
+  return std::string("'") + Utils::replaceAll(lit, "'", "'") + "'";
+}
 
 
 } // pdal

--- a/plugins/pgpointcloud/io/PgReader.cpp
+++ b/plugins/pgpointcloud/io/PgReader.cpp
@@ -108,11 +108,11 @@ point_count_t PgReader::getNumPoints() const
         return m_cached_point_count;
 
     std::ostringstream oss;
-    oss << "SELECT Sum(PC_NumPoints(" << m_column_name << ")) AS numpoints, ";
-    oss << "Max(PC_NumPoints(" << m_column_name << ")) AS maxpoints FROM ";
+    oss << "SELECT Sum(PC_NumPoints(" << pg_quote_identifier(m_column_name) << ")) AS numpoints, ";
+    oss << "Max(PC_NumPoints(" << pg_quote_identifier(m_column_name) << ")) AS maxpoints FROM ";
     if (m_schema_name.size())
-        oss << m_schema_name << ".";
-    oss << m_table_name;
+        oss << pg_quote_identifier(m_schema_name) << ".";
+    oss << pg_quote_identifier(m_table_name);
     if (m_where.size())
         oss << " WHERE " << m_where;
 
@@ -134,12 +134,12 @@ point_count_t PgReader::getNumPoints() const
 std::string PgReader::getDataQuery() const
 {
     std::ostringstream oss;
-    oss << "SELECT text(PC_Uncompress(" << m_column_name << ")) AS pa, ";
-    oss << "PC_NumPoints(" << m_column_name << ") AS npoints FROM ";
-    if (m_schema_name.size())
-        oss << m_schema_name << ".";
-    oss << m_table_name;
-    if (m_where.size())
+    oss << "SELECT text(PC_Uncompress(" << pg_quote_identifier(m_column_name) << ")) AS pa, ";
+    oss << "PC_NumPoints(" << pg_quote_identifier(m_column_name) << ") AS npoints FROM ";
+    if (!m_schema_name.empty())
+        oss << pg_quote_identifier(m_schema_name) << ".";
+    oss << pg_quote_identifier(m_table_name);
+    if (!m_where.empty())
         oss << " WHERE " << m_where;
 
     log()->get(LogLevel::Debug) << "Constructed data query " <<
@@ -166,8 +166,8 @@ uint32_t PgReader::fetchPcid() const
     std::ostringstream oss;
     oss << "SELECT PC_Typmod_Pcid(a.atttypmod) AS pcid ";
     oss << "FROM pg_class c, pg_attribute a ";
-    oss << "WHERE c.relname = '" << m_table_name << "' ";
-    oss << "AND a.attname = '" << m_column_name << "' ";
+    oss << "WHERE c.relname = " << pg_quote_literal(m_table_name) << " ";
+    oss << "AND a.attname = " << pg_quote_literal(m_column_name) << " ";
 
     char *pcid_str = pg_query_once(m_session, oss.str());
 

--- a/plugins/pgpointcloud/io/PgWriter.cpp
+++ b/plugins/pgpointcloud/io/PgWriter.cpp
@@ -473,7 +473,8 @@ void PgWriter::writeTile(PointBuffer const& buffer)
     }
 
     std::string insert_into("INSERT INTO ");
-    std::string values(" (pa) VALUES ('");
+    std::string values(" (" + pg_quote_identifier(m_column_name) +
+                       ") VALUES ('");
 
     m_insert.append(insert_into);
 

--- a/plugins/pgpointcloud/io/PgWriter.cpp
+++ b/plugins/pgpointcloud/io/PgWriter.cpp
@@ -404,7 +404,6 @@ bool PgWriter::CheckTableExists(std::string const& name)
     return false;
 }
 
-
 void PgWriter::CreateTable(std::string const& schema_name,
     std::string const& table_name, std::string const& column_name,
     uint32_t pcid)
@@ -412,9 +411,10 @@ void PgWriter::CreateTable(std::string const& schema_name,
     std::ostringstream oss;
     oss << "CREATE TABLE ";
     if (schema_name.size())
-        oss << schema_name << ".";
-    oss << table_name;
-    oss << " (id SERIAL PRIMARY KEY, " << column_name << " PcPatch";
+        oss << pg_quote_identifier(schema_name) << ".";
+    oss << pg_quote_identifier(table_name);
+    oss << " (id SERIAL PRIMARY KEY, " <<
+        pg_quote_identifier(column_name) << " PcPatch";
     if (pcid)
         oss << "(" << pcid << ")";
     oss << ")";
@@ -479,11 +479,11 @@ void PgWriter::writeTile(PointBuffer const& buffer)
 
     if (m_schema_name.size())
     {
-        m_insert.append(m_schema_name);
+        m_insert.append(pg_quote_identifier(m_schema_name));
         m_insert.append(".");
     }
 
-    m_insert.append(m_table_name);
+    m_insert.append(pg_quote_identifier(m_table_name));
     m_insert.append(values);
 
     std::ostringstream options;

--- a/plugins/pgpointcloud/io/PgWriter.hpp
+++ b/plugins/pgpointcloud/io/PgWriter.hpp
@@ -55,6 +55,8 @@ public:
     Options getDefaultOptions();
 
 private:
+
+
     PgWriter& operator=(const PgWriter&); // not implemented
     PgWriter(const PgWriter&); // not implemented
 

--- a/plugins/pgpointcloud/test/PgpointcloudWriterTest.cpp
+++ b/plugins/pgpointcloud/test/PgpointcloudWriterTest.cpp
@@ -81,7 +81,8 @@ Options getDbOptions()
     Options options;
 
     options.add(Option("connection", getTestDBTempConn()));
-    options.add(Option("table", "pdal_test_table"));
+    options.add(Option("table", "pdal-\"test\"-table")); // intentional quotes
+    options.add(Option("column", "p\"a")); // intentional quotes
     options.add(Option("srid", "4326"));
     options.add(Option("capacity", "10000"));
 


### PR DESCRIPTION
Includes test.
Allows naming tables after filenames with no "pre-washing".