### PR TITLE
Fix `maxy` bug for 2D BOX3Ds

### DIFF
--- a/src/util/Bounds.cpp
+++ b/src/util/Bounds.cpp
@@ -213,7 +213,7 @@ std::istream& operator>>(std::istream& istr, BOX3D& bounds)
         xxx.minx = v[0];
         xxx.maxx = v[1];
         xxx.miny = v[2];
-        xxx.maxx = v[3];
+        xxx.maxy = v[3];
     }
     else if (v.size() == 6)
     {

--- a/test/unit/BoundsTest.cpp
+++ b/test/unit/BoundsTest.cpp
@@ -226,3 +226,12 @@ TEST(BoundsTest, test_wkt)
     const BOX3D b(1.1,2.2,3.3,101.1,102.2,103.3);
     EXPECT_EQ(b.toWKT(1), "POLYGON ((1.1 2.2, 1.1 102.2, 101.1 102.2, 101.1 2.2, 1.1 2.2))");
 }
+
+TEST(BoundsTest, test_2d_input)
+{
+    std::stringstream ss("([1.1, 101.1], [2.2, 102.2])", std::stringstream::in | std::stringstream::out);
+    BOX3D rr;
+    ss >> rr;
+    BOX3D r(1.1,2.2,101.1,102.2);
+    EXPECT_EQ(r, rr);
+}


### PR DESCRIPTION
A copy-paste bug rendered 2D BOX3Ds created from input text invalid, the maxy was left with garbage. This patch fixes the bug, with a test demonstrating the error.