### PR TITLE
export overloaded toJSON, make appveyor/windows happy

### DIFF
--- a/include/pdal/PDALUtils.hpp
+++ b/include/pdal/PDALUtils.hpp
@@ -202,8 +202,8 @@ inline ptree toPTree(const SpatialReference& ref)
 
 std::string PDAL_DLL toJSON(const MetadataNode& m);
 void PDAL_DLL toJSON(const MetadataNode& m, std::ostream& o);
-std::string toJSON(const Options& opts);
-void toJSON(const Options& opts, std::ostream& o);
+std::string PDAL_DLL toJSON(const Options& opts);
+void PDAL_DLL toJSON(const Options& opts, std::ostream& o);
 
 namespace reST
 {


### PR DESCRIPTION
Windows has been unhappy since d7c05756d95c770f8d3187a96fb0ae1529e07127. Just need to export toJSON.