### PR TITLE
Make the PointTable's Layout not be a shared pointer.

### DIFF
--- a/include/pdal/PipelineManager.hpp
+++ b/include/pdal/PipelineManager.hpp
@@ -50,7 +50,7 @@ class PDAL_DLL PipelineManager
 public:
     PipelineManager() : m_tablePtr(new PointTable()), m_table(*m_tablePtr)
         {}
-    PipelineManager(BasePointTable& table) : m_table(table)
+    PipelineManager(PointTableRef table) : m_table(table)
         {}
 
     // Use these to manually add stages into the pipeline manager.
@@ -82,8 +82,8 @@ public:
 private:
     StageFactory m_factory;
     std::unique_ptr<PointTable> m_tablePtr;
-    BasePointTable& m_table;
-    
+    PointTableRef m_table;
+
     PointViewSet m_viewSet;
 
     typedef std::vector<std::unique_ptr<Stage> > StagePtrList;

--- a/include/pdal/PointLayout.hpp
+++ b/include/pdal/PointLayout.hpp
@@ -111,7 +111,7 @@ protected:
     bool m_finalized;
 };
 
-typedef std::shared_ptr<PointLayout> PointLayoutPtr;
+typedef PointLayout* PointLayoutPtr;
 
 } // namespace pdal
 

--- a/include/pdal/PointTable.hpp
+++ b/include/pdal/PointTable.hpp
@@ -50,21 +50,14 @@ class PDAL_DLL BasePointTable
     friend class PointView;
 
 public:
-    BasePointTable() : m_layout(new PointLayout()), m_metadata(new Metadata())
-        {}
-    BasePointTable(PointLayoutPtr layout) : m_layout(layout),
-            m_metadata(new Metadata())
+    BasePointTable() : m_metadata(new Metadata())
         {}
     virtual ~BasePointTable()
         {}
 
 public:
     // Layout operations.
-    PointLayoutPtr layout()
-        { return m_layout; }
-
-    const PointLayoutPtr layout() const
-        { return m_layout; }
+    virtual PointLayoutPtr layout() const = 0;
 
     // Metadata operations.
     MetadataNode metadata()
@@ -82,7 +75,6 @@ private:
         void *value) = 0;
 
 protected:
-    PointLayoutPtr m_layout;
     MetadataPtr m_metadata;
 };
 typedef BasePointTable& PointTableRef;
@@ -96,13 +88,15 @@ private:
     // Point storage.
     std::vector<char *> m_blocks;
     point_count_t m_numPts;
+    std::unique_ptr<PointLayout> m_layout;
 
 public:
-    PointTable() : m_numPts(0)
-        {}
-    PointTable(PointLayoutPtr layout) : BasePointTable(layout), m_numPts(0)
+    PointTable() : m_numPts(0), m_layout(new PointLayout())
         {}
     virtual ~PointTable();
+
+    virtual PointLayoutPtr layout() const
+        { return m_layout.get(); }
 
 private:
     // Point data operations.


### PR DESCRIPTION
Allow virtual PointTable's to specify the ownership of their Layout and avoid shared_ptr overhead during reading.