### PR TITLE
Take a PointView reference instead of shared_ptr in filter().

### DIFF
--- a/filters/colorization/ColorizationFilter.cpp
+++ b/filters/colorization/ColorizationFilter.cpp
@@ -173,16 +173,16 @@ void ColorizationFilter::ready(PointTableRef table)
 }
 
 
-void ColorizationFilter::filter(PointViewPtr view)
+void ColorizationFilter::filter(PointView& view)
 {
     int32_t pixel(0);
     int32_t line(0);
 
     std::array<double, 2> pix = { {0.0, 0.0} };
-    for (PointId idx = 0; idx < view->size(); ++idx)
+    for (PointId idx = 0; idx < view.size(); ++idx)
     {
-        double x = view->getFieldAs<double>(Dimension::Id::X, idx);
-        double y = view->getFieldAs<double>(Dimension::Id::Y, idx);
+        double x = view.getFieldAs<double>(Dimension::Id::X, idx);
+        double y = view.getFieldAs<double>(Dimension::Id::Y, idx);
 
         if (!getPixelAndLinePosition(x, y, m_inverse_transform, pixel,
                 line, m_ds))
@@ -201,7 +201,7 @@ void ColorizationFilter::filter(PointViewPtr view)
             }
             if (GDALRasterIO(hBand, GF_Read, pixel, line, 1, 1,
                 &pix[0], 1, 1, GDT_CFloat64, 0, 0) == CE_None)
-                view->setField(b.m_dim, idx, pix[0] * b.m_scale);
+                view.setField(b.m_dim, idx, pix[0] * b.m_scale);
         }
     }
 }

--- a/filters/colorization/ColorizationFilter.hpp
+++ b/filters/colorization/ColorizationFilter.hpp
@@ -86,7 +86,7 @@ private:
     virtual void initialize();
     virtual void processOptions(const Options&);
     virtual void ready(PointTableRef table);
-    virtual void filter(PointViewPtr view);
+    virtual void filter(PointView& view);
     virtual void done(PointTableRef table);
 
     bool getPixelAndLinePosition(double x, double y,

--- a/filters/ferry/FerryFilter.cpp
+++ b/filters/ferry/FerryFilter.cpp
@@ -112,14 +112,14 @@ void FerryFilter::ready(PointTableRef table)
 }
 
 
-void FerryFilter::filter(PointViewPtr view)
+void FerryFilter::filter(PointView& view)
 {
-    for (PointId id = 0; id < view->size(); ++id)
+    for (PointId id = 0; id < view.size(); ++id)
     {
         for (const auto& dim_par : m_dimensions_map)
         {
-            double v = view->getFieldAs<double>(dim_par.first, id);
-            view->setField(dim_par.second, id, v);
+            double v = view.getFieldAs<double>(dim_par.first, id);
+            view.setField(dim_par.second, id, v);
         }
     }
 }

--- a/filters/ferry/FerryFilter.hpp
+++ b/filters/ferry/FerryFilter.hpp
@@ -62,7 +62,7 @@ private:
     virtual void processOptions(const Options&);
     virtual void addDimensions(PointLayoutPtr layout);
     virtual void ready(PointTableRef table);
-    virtual void filter(PointViewPtr view);
+    virtual void filter(PointView& view);
 
     FerryFilter& operator=(const FerryFilter&); // not implemented
     FerryFilter(const FerryFilter&); // not implemented

--- a/filters/reprojection/ReprojectionFilter.cpp
+++ b/filters/reprojection/ReprojectionFilter.cpp
@@ -193,19 +193,19 @@ void ReprojectionFilter::transform(double& x, double& y, double& z)
 }
 
 
-void ReprojectionFilter::filter(PointViewPtr view)
+void ReprojectionFilter::filter(PointView& view)
 {
-    for (PointId id = 0; id < view->size(); ++id)
+    for (PointId id = 0; id < view.size(); ++id)
     {
-        double x = view->getFieldAs<double>(Dimension::Id::X, id);
-        double y = view->getFieldAs<double>(Dimension::Id::Y, id);
-        double z = view->getFieldAs<double>(Dimension::Id::Z, id);
+        double x = view.getFieldAs<double>(Dimension::Id::X, id);
+        double y = view.getFieldAs<double>(Dimension::Id::Y, id);
+        double z = view.getFieldAs<double>(Dimension::Id::Z, id);
 
         transform(x, y, z);
 
-        view->setField(Dimension::Id::X, id, x);
-        view->setField(Dimension::Id::Y, id, y);
-        view->setField(Dimension::Id::Z, id, z);
+        view.setField(Dimension::Id::X, id, x);
+        view.setField(Dimension::Id::Y, id, y);
+        view.setField(Dimension::Id::Z, id, z);
     }
 }
 

--- a/filters/reprojection/ReprojectionFilter.hpp
+++ b/filters/reprojection/ReprojectionFilter.hpp
@@ -64,7 +64,7 @@ private:
     virtual void processOptions(const Options& options);
     virtual void ready(PointTableRef table);
     virtual void initialize();
-    virtual void filter(PointViewPtr view);
+    virtual void filter(PointView& view);
 
     void updateBounds();
     void transform(double& x, double& y, double& z);

--- a/filters/sort/SortFilter.hpp
+++ b/filters/sort/SortFilter.hpp
@@ -66,7 +66,7 @@ private:
     virtual void ready(PointTableRef table)
         { m_dim = table.layout()->findDim(m_dimName); }
 
-    virtual void filter(PointViewPtr view)
+    virtual void filter(PointView& view)
     {
         if (m_dim == Dimension::Id::Unknown)
             return;
@@ -74,7 +74,7 @@ private:
         auto cmp = [this](const PointRef& p1, const PointRef& p2)
             { return p1.compare(m_dim, p2); };
 
-        std::sort(view->begin(), view->end(), cmp);
+        std::sort(view.begin(), view.end(), cmp);
     }
 
     SortFilter& operator=(const SortFilter&); // not implemented

--- a/filters/stats/StatsFilter.cpp
+++ b/filters/stats/StatsFilter.cpp
@@ -66,15 +66,15 @@ void Summary::extractMetadata(MetadataNode &m) const
 
 using namespace stats;
 
-void StatsFilter::filter(PointViewPtr view)
+void StatsFilter::filter(PointView& view)
 {
-    for (PointId idx = 0; idx < view->size(); ++idx)
+    for (PointId idx = 0; idx < view.size(); ++idx)
     {
         for (auto p = m_stats.begin(); p != m_stats.end(); ++p)
         {
             Dimension::Id::Enum d = p->first;
             Summary& c = p->second;
-            c.insert(view->getFieldAs<double>(d, idx));
+            c.insert(view.getFieldAs<double>(d, idx));
         }
     }
 }

--- a/filters/stats/StatsFilter.hpp
+++ b/filters/stats/StatsFilter.hpp
@@ -111,7 +111,7 @@ private:
     virtual void processOptions(const Options& options);
     virtual void ready(PointTableRef table);
     virtual void done(PointTableRef table);
-    virtual void filter(PointViewPtr view);
+    virtual void filter(PointView& view);
     void extractMetadata();
 
     std::string m_dimNames;

--- a/filters/transformation/TransformationFilter.cpp
+++ b/filters/transformation/TransformationFilter.cpp
@@ -91,16 +91,22 @@ void TransformationFilter::processOptions(const Options& options)
 }
 
 
-void TransformationFilter::filter(PointViewPtr view)
+void TransformationFilter::filter(PointView& view)
 {
-    for (PointId idx = 0; idx < view->size(); ++idx)
+    for (PointId idx = 0; idx < view.size(); ++idx)
     {
-        double x = view->getFieldAs<double>(Dimension::Id::X, idx);
-        double y = view->getFieldAs<double>(Dimension::Id::Y, idx);
-        double z = view->getFieldAs<double>(Dimension::Id::Z, idx);
-        view->setField(Dimension::Id::X, idx, x * m_matrix[0] + y * m_matrix[1] + z * m_matrix[2] + m_matrix[3]);
-        view->setField(Dimension::Id::Y, idx, x * m_matrix[4] + y * m_matrix[5] + z * m_matrix[6] + m_matrix[7]);
-        view->setField(Dimension::Id::Z, idx, x * m_matrix[8] + y * m_matrix[9] + z * m_matrix[10] + m_matrix[11]);
+        double x = view.getFieldAs<double>(Dimension::Id::X, idx);
+        double y = view.getFieldAs<double>(Dimension::Id::Y, idx);
+        double z = view.getFieldAs<double>(Dimension::Id::Z, idx);
+
+        view.setField(Dimension::Id::X, idx,
+            x * m_matrix[0] + y * m_matrix[1] + z * m_matrix[2] + m_matrix[3]);
+
+        view.setField(Dimension::Id::Y, idx,
+            x * m_matrix[4] + y * m_matrix[5] + z * m_matrix[6] + m_matrix[7]);
+
+        view.setField(Dimension::Id::Z, idx,
+            x * m_matrix[8] + y * m_matrix[9] + z * m_matrix[10] + m_matrix[11]);
     }
 }
 

--- a/filters/transformation/TransformationFilter.hpp
+++ b/filters/transformation/TransformationFilter.hpp
@@ -69,7 +69,7 @@ private:
     TransformationFilter& operator=(const TransformationFilter&); // not implemented
     TransformationFilter(const TransformationFilter&); // not implemented
     virtual void processOptions(const Options& options);
-    virtual void filter(PointViewPtr view);
+    virtual void filter(PointView& view);
 
     TransformationMatrix m_matrix;
 };

--- a/include/pdal/Filter.hpp
+++ b/include/pdal/Filter.hpp
@@ -66,11 +66,11 @@ private:
     virtual PointViewSet run(PointViewPtr view)
     {
         PointViewSet viewSet;
-        filter(view);
+        filter(*view);
         viewSet.insert(view);
         return viewSet;
     }
-    virtual void filter(PointViewPtr /*view*/)
+    virtual void filter(PointView& /*view*/)
     {}
 
     Filter& operator=(const Filter&); // not implemented

--- a/include/pdal/QuadIndex.hpp
+++ b/include/pdal/QuadIndex.hpp
@@ -40,10 +40,11 @@
 #include <pdal/pdal_export.hpp>
 #include <pdal/pdal_types.hpp>
 #include <pdal/util/Bounds.hpp>
-#include <pdal/PointView.hpp>
 
 namespace pdal
 {
+
+class PointView;
 
 struct Point
 {
@@ -79,9 +80,9 @@ struct QuadPointRef
 class PDAL_DLL QuadIndex
 {
 public:
-    QuadIndex(const PointViewPtr view, std::size_t topLevel = 0);
+    QuadIndex(const PointView& view, std::size_t topLevel = 0);
     QuadIndex(
-            const PointViewPtr view,
+            const PointView& view,
             double xMin,
             double yMin,
             double xMax,

--- a/include/pdal/Stage.hpp
+++ b/include/pdal/Stage.hpp
@@ -152,17 +152,16 @@ private:
         { return QuickInfo(); }
     virtual void initialize()
         {}
-    virtual void addDimensions(PointLayoutPtr layout)
-        { (void)layout; }
-    virtual void prepared(PointTableRef table)
-        { (void)table; }
-    virtual void ready(PointTableRef table)
-        { (void)table; }
-    virtual void done(PointTableRef table)
-        { (void)table; }
-    virtual PointViewSet run(PointViewPtr view)
+    virtual void addDimensions(PointLayoutPtr /*layout*/)
+        {}
+    virtual void prepared(PointTableRef /*table*/)
+        {}
+    virtual void ready(PointTableRef /*table*/)
+        {}
+    virtual void done(PointTableRef /*table*/)
+        {}
+    virtual PointViewSet run(PointViewPtr /*view*/)
     {
-        (void)view;
         std::cerr << "Can't run stage = " << getName() << "!\n";
         return PointViewSet();
     }

--- a/include/pdal/StageWrapper.hpp
+++ b/include/pdal/StageWrapper.hpp
@@ -35,7 +35,7 @@ public:
 class FilterWrapper : public StageWrapper
 {
 public:
-    static void filter(Filter& f, PointViewPtr view)
+    static void filter(Filter& f, PointView& view)
         { f.filter(view); }
 };
 

--- a/include/pdal/plang/BufferedInvocation.hpp
+++ b/include/pdal/plang/BufferedInvocation.hpp
@@ -47,8 +47,8 @@ class PDAL_DLL BufferedInvocation : public Invocation
 public:
     BufferedInvocation(const Script& script);
 
-    void begin(PointViewPtr view);
-    void end(PointViewPtr view);
+    void begin(PointView& view);
+    void end(PointView& view);
 
 private:
     std::vector<void *> m_buffers;

--- a/plugins/attribute/filters/AttributeFilter.cpp
+++ b/plugins/attribute/filters/AttributeFilter.cpp
@@ -236,7 +236,7 @@ GEOSGeometry* createGEOSPoint(GEOSContextHandle_t ctx, double x, double y, doubl
     return p;
 }
 
-void AttributeFilter::UpdateGEOSBuffer(PointViewPtr view, AttributeInfo& info)
+void AttributeFilter::UpdateGEOSBuffer(PointView& view, AttributeInfo& info)
 {
     QuadIndex idx(view);
 
@@ -314,9 +314,9 @@ void AttributeFilter::UpdateGEOSBuffer(PointViewPtr view, AttributeInfo& info)
         for (const auto& i : ids)
         {
 
-            double x = view->getFieldAs<double>(Dimension::Id::X, i);
-            double y = view->getFieldAs<double>(Dimension::Id::Y, i);
-            double z = view->getFieldAs<double>(Dimension::Id::Z, i);
+            double x = view.getFieldAs<double>(Dimension::Id::X, i);
+            double y = view.getFieldAs<double>(Dimension::Id::Y, i);
+            double z = view.getFieldAs<double>(Dimension::Id::Z, i);
 
             GEOSGeometry* p = createGEOSPoint(m_geosEnvironment, x, y ,z);
 
@@ -324,7 +324,7 @@ void AttributeFilter::UpdateGEOSBuffer(PointViewPtr view, AttributeInfo& info)
             {
                 // We're in the poly, write the attribute value
                 int32_t v = OGR_F_GetFieldAsInteger(feature.get(), field_index);
-                view->setField(info.dim, i, v);
+                view.setField(info.dim, i, v);
 //                 log()->get(LogLevel::Debug) << "Setting value: " << v << std::endl;
             }
 
@@ -336,7 +336,7 @@ void AttributeFilter::UpdateGEOSBuffer(PointViewPtr view, AttributeInfo& info)
     }
 }
 
-void AttributeFilter::filter(PointViewPtr view)
+void AttributeFilter::filter(PointView& view)
 {
 
     for (auto& dim_par : m_dimensions)
@@ -346,10 +346,10 @@ void AttributeFilter::filter(PointViewPtr view)
             UpdateGEOSBuffer(view, dim_par.second);
         }  else
         {
-            for (PointId i = 0; i < view->size(); ++i)
+            for (PointId i = 0; i < view.size(); ++i)
             {
                 double v = boost::lexical_cast<double>(dim_par.second.value);
-                view->setField(dim_par.second.dim, i, v);
+                view.setField(dim_par.second.dim, i, v);
             }
 
         }

--- a/plugins/attribute/filters/AttributeFilter.hpp
+++ b/plugins/attribute/filters/AttributeFilter.hpp
@@ -123,7 +123,7 @@ private:
     virtual void initialize();
     virtual void processOptions(const Options&);
     virtual void ready(PointTableRef table);
-    virtual void filter(PointViewPtr view);
+    virtual void filter(PointView& view);
 
     AttributeFilter& operator=(const AttributeFilter&); // not implemented
     AttributeFilter(const AttributeFilter&); // not implemented
@@ -133,7 +133,7 @@ private:
     AttributeInfoMap m_dimensions;
     GEOSContextHandle_t m_geosEnvironment;
     std::shared_ptr<pdal::gdal::Debug> m_gdal_debug;
-    void UpdateGEOSBuffer(PointViewPtr view, AttributeInfo& info);
+    void UpdateGEOSBuffer(PointView& view, AttributeInfo& info);
 
 };
 

--- a/plugins/hexbin/filters/HexBin.cpp
+++ b/plugins/hexbin/filters/HexBin.cpp
@@ -75,12 +75,12 @@ void HexBin::ready(PointTableRef table)
 }
 
 
-void HexBin::filter(PointViewPtr view)
+void HexBin::filter(PointView& view)
 {
-    for (PointId idx = 0; idx < view->size(); ++idx)
+    for (PointId idx = 0; idx < view.size(); ++idx)
     {
-        double x = view->getFieldAs<double>(pdal::Dimension::Id::X, idx);
-        double y = view->getFieldAs<double>(pdal::Dimension::Id::Y, idx);
+        double x = view.getFieldAs<double>(pdal::Dimension::Id::X, idx);
+        double y = view.getFieldAs<double>(pdal::Dimension::Id::Y, idx);
         m_grid->addPoint(x, y);
     }
 }

--- a/plugins/hexbin/filters/HexBin.hpp
+++ b/plugins/hexbin/filters/HexBin.hpp
@@ -65,7 +65,7 @@ private:
 
     virtual void processOptions(const Options& options);
     virtual void ready(PointTableRef table);
-    virtual void filter(PointViewPtr view);
+    virtual void filter(PointView& view);
     virtual void done(PointTableRef table);
 
     HexBin& operator=(const HexBin&); // not implemented

--- a/plugins/python/filters/PredicateFilter.cpp
+++ b/plugins/python/filters/PredicateFilter.cpp
@@ -84,7 +84,7 @@ void PredicateFilter::ready(PointTableRef table)
 PointViewSet PredicateFilter::run(PointViewPtr view)
 {
     m_pythonMethod->resetArguments();
-    m_pythonMethod->begin(view);
+    m_pythonMethod->begin(*view);
     m_pythonMethod->execute();
 
     if (!m_pythonMethod->hasOutputVariable("Mask"))
@@ -98,7 +98,7 @@ PointViewSet PredicateFilter::run(PointViewPtr view)
     char *ok = (char *)pydata;
     for (PointId idx = 0; idx < view->size(); ++idx)
         if (*ok++)
-            outview->appendPoint(*view.get(), idx);
+            outview->appendPoint(*view, idx);
 
     PointViewSet viewSet;
     viewSet.insert(outview);

--- a/plugins/python/filters/ProgrammableFilter.cpp
+++ b/plugins/python/filters/ProgrammableFilter.cpp
@@ -97,10 +97,10 @@ void ProgrammableFilter::ready(PointTableRef table)
 }
 
 
-void ProgrammableFilter::filter(PointViewPtr view)
+void ProgrammableFilter::filter(PointView& view)
 {
     log()->get(LogLevel::Debug5) << "Python script " << *m_script <<
-        " processing " << view->size() << " points." << std::endl;
+        " processing " << view.size() << " points." << std::endl;
     m_pythonMethod->resetArguments();
     m_pythonMethod->begin(view);
     m_pythonMethod->execute();

--- a/plugins/python/filters/ProgrammableFilter.hpp
+++ b/plugins/python/filters/ProgrammableFilter.hpp
@@ -66,7 +66,7 @@ private:
     virtual void processOptions(const Options& options);
     virtual void addDimensions(PointLayoutPtr layout);
     virtual void ready(PointTableRef table);
-    virtual void filter(PointViewPtr view);
+    virtual void filter(PointView& view);
     virtual void done(PointTableRef table);
 
     ProgrammableFilter& operator=(const ProgrammableFilter&); // not implemented

--- a/src/QuadIndex.cpp
+++ b/src/QuadIndex.cpp
@@ -36,6 +36,7 @@
 #include <cmath>
 #include <memory>
 
+#include <pdal/PointView.hpp>
 #include <pdal/QuadIndex.hpp>
 #include <pdal/Utils.hpp>
 
@@ -480,9 +481,9 @@ void Tree::getPoints(
 
 struct QuadIndex::QImpl
 {
-    QImpl(const PointViewPtr view, std::size_t topLevel);
+    QImpl(const PointView& view, std::size_t topLevel);
     QImpl(
-            const PointViewPtr view,
+            const PointView& view,
             double xMin,
             double yMin,
             double xMax,
@@ -542,27 +543,27 @@ struct QuadIndex::QImpl
     std::vector<std::size_t> m_fills;
 };
 
-QuadIndex::QImpl::QImpl(const PointViewPtr view, std::size_t topLevel)
+QuadIndex::QImpl::QImpl(const PointView& view, std::size_t topLevel)
     : m_topLevel(topLevel)
     , m_pointRefVec()
     , m_tree()
     , m_depth(0)
     , m_fills()
 {
-    m_pointRefVec.resize(view->size());
+    m_pointRefVec.resize(view.size());
 
     double xMin(std::numeric_limits<double>::max());
     double yMin(std::numeric_limits<double>::max());
     double xMax(std::numeric_limits<double>::min());
     double yMax(std::numeric_limits<double>::min());
 
-    for (PointId i(0); i < view->size(); ++i)
+    for (PointId i(0); i < view.size(); ++i)
     {
         m_pointRefVec[i].reset(
                 new QuadPointRef(
                     Point(
-                        view->getFieldAs<double>(Dimension::Id::X, i),
-                        view->getFieldAs<double>(Dimension::Id::Y, i)),
+                        view.getFieldAs<double>(Dimension::Id::X, i),
+                        view.getFieldAs<double>(Dimension::Id::Y, i)),
                 i));
 
         const QuadPointRef* pointRef(m_pointRefVec[i].get());
@@ -581,7 +582,7 @@ QuadIndex::QImpl::QImpl(const PointViewPtr view, std::size_t topLevel)
 }
 
 QuadIndex::QImpl::QImpl(
-        const PointViewPtr view,
+        const PointView& view,
         double xMin,
         double yMin,
         double xMax,
@@ -593,15 +594,15 @@ QuadIndex::QImpl::QImpl(
     , m_depth(0)
     , m_fills()
 {
-    m_pointRefVec.resize(view->size());
+    m_pointRefVec.resize(view.size());
 
-    for (PointId i(0); i < view->size(); ++i)
+    for (PointId i(0); i < view.size(); ++i)
     {
         m_pointRefVec[i].reset(
                 new QuadPointRef(
                     Point(
-                        view->getFieldAs<double>(Dimension::Id::X, i),
-                        view->getFieldAs<double>(Dimension::Id::Y, i)),
+                        view.getFieldAs<double>(Dimension::Id::X, i),
+                        view.getFieldAs<double>(Dimension::Id::Y, i)),
                 i));
     }
 
@@ -775,12 +776,12 @@ std::vector<PointId> QuadIndex::QImpl::getPoints(
     return results;
 }
 
-QuadIndex::QuadIndex(const PointViewPtr view, std::size_t topLevel)
+QuadIndex::QuadIndex(const PointView& view, std::size_t topLevel)
     : m_qImpl(new QImpl(view, topLevel))
 { }
 
 QuadIndex::QuadIndex(
-        const PointViewPtr view,
+        const PointView& view,
         double xMin,
         double yMin,
         double xMax,

--- a/src/plang/BufferedInvocation.cpp
+++ b/src/plang/BufferedInvocation.cpp
@@ -52,30 +52,30 @@ BufferedInvocation::BufferedInvocation(const Script& script)
 {}
 
 
-void BufferedInvocation::begin(PointViewPtr view)
+void BufferedInvocation::begin(PointView& view)
 {
-    PointLayoutPtr layout(view->m_pointTable.layout());
+    PointLayoutPtr layout(view.m_pointTable.layout());
     Dimension::IdList const& dims = layout->dims();
 
     for (auto di = dims.begin(); di != dims.end(); ++di)
     {
         Dimension::Id::Enum d = *di;
         const Dimension::Detail *dd = layout->dimDetail(d);
-        void *data = malloc(dd->size() * view->size());
+        void *data = malloc(dd->size() * view.size());
         m_buffers.push_back(data);  // Hold pointer for deallocation
         char *p = (char *)data;
-        for (PointId idx = 0; idx < view->size(); ++idx)
+        for (PointId idx = 0; idx < view.size(); ++idx)
         {
-            view->getFieldInternal(d, idx, (void *)p);
+            view.getFieldInternal(d, idx, (void *)p);
             p += dd->size();
         }
         std::string name = layout->dimName(*di);
-        insertArgument(name, (uint8_t *)data, dd->type(), view->size());
+        insertArgument(name, (uint8_t *)data, dd->type(), view.size());
     }
 }
 
 
-void BufferedInvocation::end(PointViewPtr view)
+void BufferedInvocation::end(PointView& view)
 {
     // for each entry in the script's outs dictionary,
     // look up that entry's name in the schema and then
@@ -85,7 +85,7 @@ void BufferedInvocation::end(PointViewPtr view)
     std::vector<std::string> names;
     getOutputNames(names);
 
-    PointLayoutPtr layout(view->m_pointTable.layout());
+    PointLayoutPtr layout(view.m_pointTable.layout());
     Dimension::IdList const& dims = layout->dims();
 
     for (auto di = dims.begin(); di != dims.end(); ++di)
@@ -102,9 +102,9 @@ void BufferedInvocation::end(PointViewPtr view)
         size_t size = dd->size();
         void *data = extractResult(name, dd->type());
         char *p = (char *)data;
-        for (PointId idx = 0; idx < view->size(); ++idx)
+        for (PointId idx = 0; idx < view.size(); ++idx)
         {
-            view->setField(d, dd->type(), idx, (void *)p);
+            view.setField(d, dd->type(), idx, (void *)p);
             p += size;
         }
     }

--- a/test/unit/filters/SortFilterTest.cpp
+++ b/test/unit/filters/SortFilterTest.cpp
@@ -69,7 +69,7 @@ void doSort(point_count_t count)
 
     filter.prepare(table);
     FilterWrapper::ready(filter, table);
-    FilterWrapper::filter(filter, view);
+    FilterWrapper::filter(filter, *view.get());
     FilterWrapper::done(filter, table);
 
     EXPECT_EQ(count, view->size());


### PR DESCRIPTION
Streaming clients might manually filter Reader output point at a time.  Avoid shared_ptr-by-value overhead in this case.