### PR TITLE
Fixed documentation URL and line endings for geowave service script

### DIFF
--- a/doc/stages/readers.geowave.rst
+++ b/doc/stages/readers.geowave.rst
@@ -61,5 +61,5 @@ bounds
 
 
 .. _GeoWave: https://ngageoint.github.io/geowave/
-.. _here: https://ngageoint.github.io/geowave/documentation.html#jace-jni-proxies
+.. _here: https://ngageoint.github.io/geowave/documentation.html#jace-jni-proxies-2
 

--- a/doc/stages/writers.geowave.rst
+++ b/doc/stages/writers.geowave.rst
@@ -62,5 +62,5 @@ pointsPerEntry
 
 
 .. _GeoWave: https://ngageoint.github.io/geowave/
-.. _here: https://ngageoint.github.io/geowave/documentation.html#jace-jni-proxies
+.. _here: https://ngageoint.github.io/geowave/documentation.html#jace-jni-proxies-2
 

--- a/scripts/linux-install-scripts/geowave.sh
+++ b/scripts/linux-install-scripts/geowave.sh
@@ -13,6 +13,8 @@ echo "/usr/lib/jvm/java-7-oracle/jre/lib/amd64/server" | sudo tee --append /etc/
 sudo ldconfig
 
 # Install GeoWave as a service and configure to run at startup
-sudo cp /vagrant/scripts/linux-install-scripts/geowave /etc/init.d
+# Note: tr removes carriage returns and copies the file
+sudo tr -d '\r' < /vagrant/scripts/linux-install-scripts/geowave > /etc/init.d/geowave
+sudo chmod 755 /etc/init.d/geowave
 sudo update-rc.d geowave defaults
 sudo service geowave start


### PR DESCRIPTION
When setting up vagrant for PDAL on Windows, I ran into an issue where carriage returns in the GeoWave service script prevented the service from being run by Ubuntu.  Because git checks out the code using line endings which match the host OS, I added code to manually remove carriage returns during provisioning.  

After making that change, I was able to bring up PDAL through Vagrant on Windows without issue.  

I also threw in a quick fix for the URLs within the GeoWave docs.  