### PR TITLE
Load only one plugin when guessing plugin names

### DIFF
--- a/src/PluginManager.cpp
+++ b/src/PluginManager.cpp
@@ -246,6 +246,12 @@ int32_t PluginManager::guessLoadByPath(const std::string& driverName)
             if (ext != dynamicLibraryExtension)
                 continue;
 
+            std::string stem = full_path.stem().string();
+            std::string::size_type pos = stem.find_last_of('_');
+            if (pos == std::string::npos || pos == stem.size() - 1 ||
+                    stem.substr(pos + 1) != driverNameVec[1])
+                continue;
+
             PF_PluginType type;
             if (driverNameVec[0] == "readers")
                 type = PF_PluginType_Reader;
@@ -258,10 +264,13 @@ int32_t PluginManager::guessLoadByPath(const std::string& driverName)
             else
                 type = PF_PluginType_Reader;
 
-            loadByPath(full_path.string(), type);
+            if (loadByPath(full_path.string(), type) == 0)
+            {
+                return 0;
+            }
         }
    }
-    return 0;
+    return -1;
 }
 
 


### PR DESCRIPTION
In `PluginManager::guessLoadByPath`, the driverName was not being entirely used when loading plugins. Only the plugin type (filter, reader, writer) was used. This patch checks the actual name of the driver (e.g. hexbin) against the filename of the library, and only loads the plugin if the name matches.

Since a plugin only needs to be loaded once, the return value of the `loadByPath` call is returned from `guessLoadByPath`. If no plugins are found, the `guessLoadByPath` now returns -1.

cc @chambbj 