### PR TITLE
Remove boost::numeric_cast.

### DIFF
--- a/include/pdal/PointView.hpp
+++ b/include/pdal/PointView.hpp
@@ -265,9 +265,6 @@ private:
     inline PointId getTemp(PointId id);
     void freeTemp(PointId id)
         { m_temps.push(id); }
-
-    // Awfulness to avoid exceptions in numeric cast.
-    static bool m_ok;
 };
 
 struct PointViewLess
@@ -416,24 +413,17 @@ inline T PointView::getFieldAs(Dimension::Id::Enum dim,
         val = 0;
         break;
     }
-#ifdef PDAL_COMPILER_MSVC
-// warning C4127: conditional expression is constant
-#pragma warning(push)
-#pragma warning(disable:4127)
-#endif
-    try
+
+    if (Utils::inRange<T>(val))
     {
-        if (std::is_same<T, double>::value)
-            retval = val;
-        else
+        if (std::is_integral<T>::value)
         {
-            if (std::is_integral<T>::value == true )
-                retval = boost::numeric_cast<T>(lround(val));
-            else
-                retval = boost::numeric_cast<T>(val);
+            val = Utils::sround(val);
         }
+
+        retval = static_cast<T>(val);
     }
-    catch (boost::numeric::bad_numeric_cast& )
+    else
     {
         std::ostringstream oss;
         oss << "Unable to fetch data and convert as requested: ";
@@ -442,11 +432,8 @@ inline T PointView::getFieldAs(Dimension::Id::Enum dim,
             "(" << (double)val << ") -> " << Utils::typeidName<T>();
         throw pdal_error(oss.str());
     }
+
     return retval;
-#ifdef PDAL_COMPILER_MSVC
-// warning C4127: conditional expression is constant
-#pragma warning(pop)
-#endif
 }
 
 
@@ -454,57 +441,21 @@ inline T PointView::getFieldAs(Dimension::Id::Enum dim,
 template<typename T_IN, typename T_OUT>
 bool PointView::convertAndSet(Dimension::Id::Enum dim, PointId idx, T_IN in)
 {
-// This mess, instead of just using boost::numeric_cast, is here to:
-//   1) Prevent the throwing of exceptions.  The entrance/exit of the try
-//      block seemed somewhat expensive.
-//   2) Round to nearest instead of truncation without rounding before
-//      invoking the converter.
-//
-    using namespace boost;
+    bool success(false);
 
-    struct RangeHandler
+    if (Utils::inRange<T_IN, T_OUT>(in))
     {
-        void operator() (numeric::range_check_result r)
+        if (std::is_integral<T_OUT>::value)
         {
-            m_ok = (r == numeric::cInRange);
+            in = Utils::sround(in);
         }
-    };
 
-    T_OUT out;
+        const T_OUT out(static_cast<T_OUT>(in));
+        setFieldInternal(dim, idx, &out);
+        success = true;
+    }
 
-    typedef numeric::conversion_traits<T_OUT, T_IN> conv_traits;
-    typedef numeric::numeric_cast_traits<T_OUT, T_IN> cast_traits;
-    typedef numeric::converter<
-        T_OUT,
-        T_IN,
-        conv_traits,
-        RangeHandler,
-        numeric::RoundEven<T_IN>,
-        numeric::raw_converter<conv_traits>,
-        typename cast_traits::range_checking_policy>
-            localConverter;
-
-#ifdef PDAL_COMPILER_MSVC
-// warning C4127: conditional expression is constant
-#pragma warning(push)
-#pragma warning(disable:4127)
-#endif
-    m_ok = true;
-    // This is an optimization.
-    if (std::is_same<T_IN, T_OUT>::value == true)
-        out = in;
-    else
-        out = localConverter::convert(in);
-    if (!m_ok)
-        return false;
-
-#ifdef PDAL_COMPILER_MSVC
-// warning C4127: conditional expression is constant
-#pragma warning(pop)
-#endif
-
-    setFieldInternal(dim, idx, (void *)&out);
-    return true;
+    return success;
 }
 
 

--- a/include/pdal/Utils.hpp
+++ b/include/pdal/Utils.hpp
@@ -353,6 +353,30 @@ namespace Utils
         out.rdbuf(redir.m_buf);
         redir.m_out->close();
     }
+
+    // Determine whether a value of a given input type may be safely
+    // statically casted to the given output type without over/underflow.  If
+    // the output type is integral, inRange() will determine whether the
+    // rounded input value, rather than truncated, may be safely converted.
+    template<typename T_OUT>
+    bool inRange(double in)
+    {
+        if (std::is_integral<T_OUT>::value)
+        {
+            in = sround(in);
+        }
+
+        return std::is_same<double, T_OUT>::value ||
+           (in >= static_cast<double>(std::numeric_limits<T_OUT>::lowest()) &&
+            in <= static_cast<double>(std::numeric_limits<T_OUT>::max()));
+    }
+
+    template<typename T_IN, typename T_OUT>
+    bool inRange(T_IN in)
+    {
+        return std::is_same<T_IN, T_OUT>::value ||
+            inRange<T_OUT>(static_cast<double>(in));
+    }
 };
 
 } // namespace pdal

--- a/src/PointView.cpp
+++ b/src/PointView.cpp
@@ -42,8 +42,6 @@
 namespace pdal
 {
 
-bool PointView::m_ok;
-
 PointViewIter PointView::begin()
 {
     return PointViewIter(this, 0);


### PR DESCRIPTION
This is an attempt to replace `boost::numeric_cast` with a simple range-checking function.  I have not yet profiled its performance vs. the prior version.

Some benefits to this method:
- Easy to understand (does anyone fully understand how `numeric_cast` works?)
- Thread safe
- One less boost dependency

It's almost certainly less robust than `numeric_cast` - but hopefully still stands up to our casting requirements.