### PR TITLE
Reading "off end of file" when las header point count is too big

### DIFF
--- a/test/unit/io/las/LasReaderTest.cpp
+++ b/test/unit/io/las/LasReaderTest.cpp
@@ -392,3 +392,21 @@ TEST(LasReaderTest, callback)
     EXPECT_EQ(count, (point_count_t)1065);
 }
 
+
+// The header of 1.2-with-color-clipped says that it has 1065 points,
+// but it really only has 1064.
+TEST(LasReaderTest, LasHeaderIncorrentPointcount)
+{
+    PointTable table;
+
+    Options readOps;
+    readOps.add("filename", Support::datapath("las/1.2-with-color-clipped.las"));
+    LasReader reader;
+    reader.setOptions(readOps);
+
+    reader.prepare(table);
+    PointViewSet viewSet = reader.execute(table);
+    PointViewPtr view = *viewSet.begin();
+
+    EXPECT_EQ(1064, view->size());
+}


### PR DESCRIPTION
If a las header says that the file has more points than it really does, the reader will zero-fill the `PointTable` up to the header-specified number of points. This changed in c63f198db2f08caa2a47b34f4c7409a248e22a12 — previously, we stopped reading at the end of file. Since we moved to chunked reading of the lasfile, we're essentially reading off the end of the file into our chunk buffer.

I'm opening this pull request with a test that illustrates the issue; we happened to have a file among our test data that advertised 1065 points in its header but only has 1064 points in the file itself (`las/1.2-with-color-clipped.las`). The "offending" read is [here](https://github.com/PDAL/PDAL/blob/master/io/las/LasReader.cpp#L622). The summary of the problem is presented below, line numbers from `io/las/LasReader.cpp`.

```cpp
count = std::min(count, getNumPoints() - m_index);  // L556, getNumPoints() spits out the header's point count
size_t bufsize = std::min<size_t>((point_count_t)1000000,  count * pointByteCount);  // L587, L588
std::vector<char> buf(bufsize);  // L589
point_count_t blockpoints = buf.size() / ptLen;  // L619
m_istream->read(buf.data(), blockpoints * ptLen);  // L622, possible read off end of m_istream
```

I haven't put in a fix because I'm not sure how we want to handle this scenario.

cc @abellgithub b/c git-blame