### PR TITLE
misc SQLite refactoring and cleanups

### DIFF
--- a/plugins/sqlite/io/SQLiteCommon.hpp
+++ b/plugins/sqlite/io/SQLiteCommon.hpp
@@ -40,8 +40,6 @@
 #include <pdal/XMLSchema.hpp>
 #include <pdal/Compression.hpp>
 
-#include <boost/algorithm/string.hpp>
-
 #include <sqlite3.h>
 #include <memory>
 #include <sstream>
@@ -306,10 +304,13 @@ public:
 
                     if (m_columns.size() != static_cast<std::vector<std::string>::size_type > (numCols))
                     {
-                        std::string ccolumnName = boost::to_upper_copy(std::string(sqlite3_column_name(m_statement, v)));
+                        std::string ccolumnName = Utils::toupper(std::string(sqlite3_column_name(m_statement, v)));
                         const char* coltype = sqlite3_column_decltype(m_statement, v);
-                        if (!coltype) coltype = "unknown";
-                        std::string ccolumnType = boost::to_upper_copy(std::string(coltype));
+                        if (!coltype)
+                        {
+                            coltype = "unknown";
+                        }
+                        std::string ccolumnType = Utils::toupper(std::string(coltype));
                         m_columns.insert(std::pair<std::string, int32_t>(ccolumnName, v));
                         m_types.push_back(ccolumnType);
                     }
@@ -506,7 +507,7 @@ public:
     {
         execute("SELECT InitSpatialMetadata(1)");
     }
-    
+
     bool doesTableExist(std::string const& name)
     {
         std::ostringstream oss;
@@ -523,7 +524,7 @@ public:
                 break ;// didn't have anything
 
             column const& c = r->at(0); // First column is table name!
-            if (boost::iequals(c.data, name))
+            if (Utils::iequals(c.data, name))
             {
                 return true;
             }
@@ -536,20 +537,20 @@ public:
         // TODO: ought to parse this numerically, so we can do version checks
         const std::string sql("SELECT spatialite_version()");
         query(sql);
-         
+
         const row* r = get();
         assert(r); // should get back exactly one row
         std::string ver = r->at(0).data;
         return ver;
     }
-    
+
     std::string getSQLiteVersion()
     {
          // TODO: parse this numerically, so we can do version checks
          std::string v(sqlite3_libversion());
          return v;
     }
-    
+
     LogPtr log() { return m_log; };
 
 private:
@@ -561,7 +562,7 @@ private:
     records::size_type m_position;
     std::map<std::string, int32_t> m_columns;
     std::vector<std::string> m_types;
-    
+
     void check_error(std::string const& msg)
     {
         const char *zErrMsg = sqlite3_errmsg(m_session);

--- a/plugins/sqlite/io/SQLiteCommon.hpp
+++ b/plugins/sqlite/io/SQLiteCommon.hpp
@@ -188,17 +188,13 @@ public:
         sqlite3_shutdown();
 
     }
-    void log(int num, char const* msg)
-    {
-        std::ostringstream oss;
-        oss << "SQLite code: " << num << " msg: '" << msg << "'";
-        m_log->get(LogLevel::Debug) << oss.str() << std::endl;
-    }
 
     static void log_callback(void *p, int num, char const* msg)
     {
         SQLite* sql = reinterpret_cast<SQLite*>(p);
-        sql->log(num, msg);
+        sql->log()->get(LogLevel::Debug) << "SQLite code: "
+            << num << " msg: '" << msg << "'"
+            << std::endl;
     }
 
 
@@ -253,6 +249,19 @@ public:
         execute("COMMIT", "Unable to commit transaction");
     }
 
+    // Executes an SQL query statement and provides the returned rows via
+    // an iterator.
+    //
+    // Usage example:
+    //   query("SELECT * from TABLE");
+    //     do
+    //     {
+    //       const row* r = get();
+    //       if (!r) break ; // no more rows
+    //       column const& c = r->at(0); // get 1st column of this row
+    //       ... use c.data ...
+    //     } while (next());
+    //
     void query(std::string const& query)
     {
         m_position = 0;
@@ -298,7 +307,9 @@ public:
                     if (m_columns.size() != static_cast<std::vector<std::string>::size_type > (numCols))
                     {
                         std::string ccolumnName = boost::to_upper_copy(std::string(sqlite3_column_name(m_statement, v)));
-                        std::string ccolumnType = boost::to_upper_copy(std::string(sqlite3_column_decltype(m_statement, v)));
+                        const char* coltype = sqlite3_column_decltype(m_statement, v);
+                        if (!coltype) coltype = "unknown";
+                        std::string ccolumnType = boost::to_upper_copy(std::string(coltype));
                         m_columns.insert(std::pair<std::string, int32_t>(ccolumnName, v));
                         m_types.push_back(ccolumnType);
                     }
@@ -440,7 +451,7 @@ public:
         return true;
     }
 
-    bool spatialite(const std::string& module_name="")
+    bool loadSpatialite(const std::string& module_name="")
     {
         std::string so_extension;
         std::string lib_extension;
@@ -486,8 +497,16 @@ public:
 
     }
 
+    bool haveSpatialite()
+    {
+        return doesTableExist("geometry_columns");
+    }
 
-
+    void initSpatialiteMetadata()
+    {
+        execute("SELECT InitSpatialMetadata(1)");
+    }
+    
     bool doesTableExist(std::string const& name)
     {
         std::ostringstream oss;
@@ -512,6 +531,27 @@ public:
         return false;
     }
 
+    std::string getSpatialiteVersion()
+    {
+        // TODO: ought to parse this numerically, so we can do version checks
+        const std::string sql("SELECT spatialite_version()");
+        query(sql);
+         
+        const row* r = get();
+        assert(r); // should get back exactly one row
+        std::string ver = r->at(0).data;
+        return ver;
+    }
+    
+    std::string getSQLiteVersion()
+    {
+         // TODO: parse this numerically, so we can do version checks
+         std::string v(sqlite3_libversion());
+         return v;
+    }
+    
+    LogPtr log() { return m_log; };
+
 private:
     pdal::LogPtr m_log;
     std::string m_connection;
@@ -521,7 +561,7 @@ private:
     records::size_type m_position;
     std::map<std::string, int32_t> m_columns;
     std::vector<std::string> m_types;
-
+    
     void check_error(std::string const& msg)
     {
         const char *zErrMsg = sqlite3_errmsg(m_session);

--- a/plugins/sqlite/io/SQLiteReader.cpp
+++ b/plugins/sqlite/io/SQLiteReader.cpp
@@ -56,10 +56,11 @@ void SQLiteReader::initialize()
         m_session = std::unique_ptr<SQLite>(new SQLite(m_connection, log()));
         m_session->connect(false); // don't connect in write mode
         log()->get(LogLevel::Debug) << "Connected to database" << std::endl;
-        bool bHaveSpatialite = m_session->doesTableExist("geometry_columns");
+        
+        bool bHaveSpatialite = m_session->haveSpatialite();
         log()->get(LogLevel::Debug) << "Have spatialite?: " <<
             bHaveSpatialite << std::endl;
-        m_session->spatialite(m_modulename);
+        m_session->loadSpatialite(m_modulename);
 
         if (!bHaveSpatialite)
         {

--- a/plugins/sqlite/io/SQLiteWriter.cpp
+++ b/plugins/sqlite/io/SQLiteWriter.cpp
@@ -107,16 +107,15 @@ void SQLiteWriter::initialize()
         m_session = std::unique_ptr<SQLite>(new SQLite(m_connection, log()));
         m_session->connect(true);
         log()->get(LogLevel::Debug) << "Connected to database" << std::endl;
-        bool bHaveSpatialite = m_session->doesTableExist("geometry_columns");
+        
+        bool bHaveSpatialite = m_session->haveSpatialite();
         log()->get(LogLevel::Debug) << "Have spatialite?: " <<
             bHaveSpatialite << std::endl;
-        m_session->spatialite(m_modulename);
+        m_session->loadSpatialite(m_modulename);
 
         if (!bHaveSpatialite)
         {
-            std::ostringstream oss;
-            oss << "SELECT InitSpatialMetadata()";
-            m_session->execute(oss.str());
+            m_session->initSpatialiteMetadata();
         }
 
     }

--- a/plugins/sqlite/test/SQLiteTest.cpp
+++ b/plugins/sqlite/test/SQLiteTest.cpp
@@ -230,3 +230,49 @@ TEST(SQLiteTest, Issue895)
         EXPECT_TRUE(ok);
     }
 }
+
+
+TEST(SQLiteTest, testSpatialite)
+{
+    LogPtr log = std::shared_ptr<pdal::Log>(new pdal::Log("spat", "stdout"));
+    log->setLevel(LogLevel::Debug);
+
+    const std::string filename(Support::temppath("spat.sqlite"));
+    
+    FileUtils::deleteFile(filename);
+    
+    SQLite db(filename, LogPtr(log));
+    db.connect(true);
+
+    EXPECT_FALSE(db.haveSpatialite());
+
+    db.loadSpatialite();
+    db.initSpatialiteMetadata();
+
+    EXPECT_TRUE(db.haveSpatialite());
+    
+    FileUtils::deleteFile(filename);
+}
+
+
+TEST(SQLiteTest, testVersionInfo)
+{
+    LogPtr log = std::shared_ptr<pdal::Log>(new pdal::Log("spver", "stdout"));
+    log->setLevel(LogLevel::Debug);
+
+    const std::string filename(Support::temppath("spver.sqlite"));
+    
+    FileUtils::deleteFile(filename);
+    
+    SQLite db(filename, LogPtr(log));
+    db.connect(true);
+    db.loadSpatialite();
+    
+    const std::string p = db.getSQLiteVersion();
+    EXPECT_EQ(p[0], '3'); // 3.8.9 as of this commit
+
+    const std::string q = db.getSpatialiteVersion();
+    EXPECT_EQ(q[0], '4'); // 4.2.0 as of this commit
+
+    FileUtils::deleteFile(filename);
+}

--- a/plugins/sqlite/test/SQLiteTest.cpp
+++ b/plugins/sqlite/test/SQLiteTest.cpp
@@ -163,13 +163,13 @@ TEST(SQLiteTest, readWriteCompressScale)
 
 TEST(SQLiteTest, Issue895)
 {
-    LogPtr log = std::shared_ptr<pdal::Log>(new pdal::Log("Issue895", "stdout"));
+    LogPtr log(new pdal::Log("Issue895", "stdout"));
     log->setLevel(LogLevel::Debug);
 
     const std::string filename(Support::temppath("issue895.sqlite"));
-    
+
     FileUtils::deleteFile(filename);
-    
+
     bool ok;
     const char* sql;
 
@@ -187,11 +187,11 @@ TEST(SQLiteTest, Issue895)
         db.connect(false);
         sql = "SELECT name FROM sqlite_master WHERE type = \"table\"";
         db.query(sql);
-    
-        // because order of the returned rows is undefined        
+
+        // because order of the returned rows is undefined
         bool foundMine = false;
         bool foundTheirs = false;
-        
+
         {
             const row* r = db.get();
             column const& c = r->at(0);
@@ -200,7 +200,7 @@ TEST(SQLiteTest, Issue895)
             foundTheirs = (strcmp(c.data.c_str(), "sqlite_sequence") == 0);
             //printf("%s %d %d\n", c.data.c_str(), (int)foundMine, (int)foundTheirs);
             EXPECT_TRUE(foundMine || foundTheirs);
-        }    
+        }
 
         ok = db.next();
         EXPECT_TRUE(ok);
@@ -213,11 +213,11 @@ TEST(SQLiteTest, Issue895)
             //printf("%s %d %d\n", c.data.c_str(), (int)foundMine, (int)foundTheirs);
             EXPECT_TRUE(foundMine && foundTheirs);
         }
-        
+
         ok = db.next();
         EXPECT_FALSE(ok);
     }
-    
+
     // open the DB, ask if the tables exist
     {
         SQLite db(filename, LogPtr(log));
@@ -234,13 +234,13 @@ TEST(SQLiteTest, Issue895)
 
 TEST(SQLiteTest, testSpatialite)
 {
-    LogPtr log = std::shared_ptr<pdal::Log>(new pdal::Log("spat", "stdout"));
+    LogPtr log(new pdal::Log("spat", "stdout"));
     log->setLevel(LogLevel::Debug);
 
     const std::string filename(Support::temppath("spat.sqlite"));
-    
+
     FileUtils::deleteFile(filename);
-    
+
     SQLite db(filename, LogPtr(log));
     db.connect(true);
 
@@ -250,7 +250,7 @@ TEST(SQLiteTest, testSpatialite)
     db.initSpatialiteMetadata();
 
     EXPECT_TRUE(db.haveSpatialite());
-    
+
     FileUtils::deleteFile(filename);
 }
 
@@ -261,13 +261,13 @@ TEST(SQLiteTest, testVersionInfo)
     log->setLevel(LogLevel::Debug);
 
     const std::string filename(Support::temppath("spver.sqlite"));
-    
+
     FileUtils::deleteFile(filename);
-    
+
     SQLite db(filename, LogPtr(log));
     db.connect(true);
     db.loadSpatialite();
-    
+
     const std::string p = db.getSQLiteVersion();
     EXPECT_EQ(p[0], '3'); // 3.8.9 as of this commit
 


### PR DESCRIPTION
- regularized the log() function
- added getVersion functions
- lifted a couple spatialite operations up into the header
- fixed a bug when column type is null (hit by spatialite version call)
- passing “1” to the spatialite init function now, which yields a big
speedup (http://hub.qgis.org/issues/8340)