### PR TITLE
lint - lasreadertest

### DIFF
--- a/test/unit/io/las/LasReaderTest.cpp
+++ b/test/unit/io/las/LasReaderTest.cpp
@@ -408,5 +408,5 @@ TEST(LasReaderTest, LasHeaderIncorrentPointcount)
     PointViewSet viewSet = reader.execute(table);
     PointViewPtr view = *viewSet.begin();
 
-    EXPECT_EQ(1064, view->size());
+    EXPECT_EQ(1064u, view->size());
 }


### PR DESCRIPTION
warning under OS X build