### PR TITLE
Sqlite error handling

### DIFF
--- a/plugins/sqlite/io/SQLiteReader.cpp
+++ b/plugins/sqlite/io/SQLiteReader.cpp
@@ -64,13 +64,11 @@ void SQLiteReader::initialize()
 
         if (!bHaveSpatialite)
         {
-            std::ostringstream oss;
-            oss << "no spatialite enabled!";
-            throw sqlite_driver_error(oss.str());
+            throw pdal_error("no spatialite enabled!");
         }
 
     }
-    catch (sqlite_driver_error const& e)
+    catch (pdal_error const& e)
     {
         std::stringstream oss;
         oss << "Unable to connect to database with error '" << e.what() << "'";
@@ -188,7 +186,7 @@ void SQLiteReader::addDimensions(PointLayoutPtr layout)
     m_session->query(q);
     const row* r = m_session->get(); // First result better have our schema
     if (!r)
-        throw sqlite_driver_error("Unable to select schema from query!");
+        throw pdal_error("Unable to select schema from query!");
 
     column const& s = r->at(0); // First column is schema
 

--- a/plugins/sqlite/io/SQLiteWriter.cpp
+++ b/plugins/sqlite/io/SQLiteWriter.cpp
@@ -80,7 +80,7 @@ void SQLiteWriter::processOptions(const Options& options)
             options.getValueOrDefault<std::string>("filename", "");
 
         if (!m_connection.size())
-        throw sqlite_driver_error("unable to connect to database, "
+        throw pdal_error("unable to connect to database, "
             "no connection string was given!");
     }
     m_block_table =
@@ -119,7 +119,7 @@ void SQLiteWriter::initialize()
         }
 
     }
-    catch (sqlite_driver_error const& e)
+    catch (pdal_error const& e)
     {
         std::stringstream oss;
         oss << "Unable to connect to database with error '" << e.what() << "'";


### PR DESCRIPTION
fixes #927

- handle error returns consistently
- always call finalize()
- fix test case to flush files
