### PR TITLE
Add origin selection in split kernel (it was already done for the filter but not for the kernel)

### DIFF
--- a/filters/splitter/SplitterFilter.cpp
+++ b/filters/splitter/SplitterFilter.cpp
@@ -65,7 +65,7 @@ void SplitterFilter::processOptions(const Options& options)
 Options SplitterFilter::getDefaultOptions()
 {
     Options options;
-    Option length("length", 1000, "Splitter length");
+    Option length("length", 1000.0, "Splitter length");
     options.add(length);
 
     return options;

--- a/kernels/split/SplitKernel.cpp
+++ b/kernels/split/SplitKernel.cpp
@@ -55,6 +55,9 @@ std::string SplitKernel::getName() const
     return s_info.name;
 }
 
+    double m_length;
+    double m_xOrigin;
+    double m_yOrigin;
 
 void SplitKernel::addSwitches()
 {
@@ -62,10 +65,14 @@ void SplitKernel::addSwitches()
         new po::options_description("file options");
 
     file_options->add_options()
-        ("length", po::value<uint32_t>(&m_length)->default_value(0),
+        ("length", po::value<double>(&m_length)->default_value(0.0),
          "Edge length for splitter cells")
         ("capacity", po::value<uint32_t>(&m_capacity)->default_value(0),
          "Point capacity of chipper cells")
+        ("origin_x", po::value<double>(&m_xOrigin)->default_value(std::numeric_limits<double>::quiet_NaN()),
+         "Origin in X axis for splitter cells")
+        ("origin_y", po::value<double>(&m_yOrigin)->default_value(std::numeric_limits<double>::quiet_NaN()),
+         "Origin in Y axis for splitter cells")
         ("input,i", po::value<std::string>(&m_inputFile)->default_value(""),
          "input file name")
         ("output,o", po::value<std::string>(&m_outputFile)->default_value(""),
@@ -128,6 +135,8 @@ int SplitKernel::execute()
     {
         f.reset(factory.createStage("filters.splitter"));
         filterOpts.add("length", m_length);
+        filterOpts.add("origin_x", m_xOrigin);
+        filterOpts.add("origin_y", m_yOrigin);
     }
     else
     {

--- a/kernels/split/SplitKernel.hpp
+++ b/kernels/split/SplitKernel.hpp
@@ -58,7 +58,9 @@ private:
     std::string m_inputFile;
     std::string m_outputFile;
     uint32_t m_capacity;
-    uint32_t m_length;
+    double m_length;
+    double m_xOrigin;
+    double m_yOrigin;
 };
 
 } // namespace pdal


### PR DESCRIPTION
Now the split kernel/app can be used with selection of X and Y origin. 

So, there are 3 modes to run the split kernel now as shown in the 3 examples below where the extent of the initial file is minX=85000 minY=446250 maxX=86000 maxY=447500:

## With origin selection and length which now has to be a double
``
pdal split -i /pak2/usrdata/ahn2/benchmarks/000020m/ahn_bench000020.las -o test_pdal1.laz --origin_x 84000 --origin_y 445000 --length 375.0
``
![pdal1](https://cloud.githubusercontent.com/assets/5469457/8747708/9ba83286-2c95-11e5-90cc-a7f0daed13d3.png)

## Without origin selection
``
pdal split -i /pak2/usrdata/ahn2/benchmarks/000020m/ahn_bench000020.las -o test_pdal3.laz --length 375.0
``
![pdal2](https://cloud.githubusercontent.com/assets/5469457/8747711/a1ac8902-2c95-11e5-97e6-f8dec0e112ce.png)

## With capacity (in this case the Chipper filter is used)
pdal split -i /pak2/usrdata/ahn2/benchmarks/000020m/ahn_bench000020.las -o test_pdal3.laz --capacity 1000000 

![pdal3](https://cloud.githubusercontent.com/assets/5469457/8747713/a3868b42-2c95-11e5-97d6-eaa1a94732fb.png)