### PR TITLE
Add destructor to Kernel class to fix memleaks

### DIFF
--- a/include/pdal/Kernel.hpp
+++ b/include/pdal/Kernel.hpp
@@ -72,8 +72,7 @@ typedef std::shared_ptr<PointView> PointViewPtr;
 class PDAL_DLL Kernel
 {
 public:
-    virtual ~Kernel()
-    {}
+    virtual ~Kernel();
 
     // call this, to start the machine
     int run(int argc, const char* argv[], const std::string& appName);

--- a/src/Kernel.cpp
+++ b/src/Kernel.cpp
@@ -71,6 +71,18 @@ Kernel::Kernel()
 {}
 
 
+Kernel::~Kernel()
+{
+    for (auto & iter : m_public_options)
+    {
+        delete iter;
+    }
+    for (auto & iter : m_hidden_options)
+    {
+        delete iter;
+    }
+}
+
 std::ostream& operator<<(std::ostream& ostr, const Kernel& kernel)
 {
     ostr << "  Name: " << kernel.getName() << std::endl;


### PR DESCRIPTION
This for examples fixes leaks reported by
valgrind --leak-check=full ./bin/pdal  info --all ../test/data/las/simple.las