### PR TITLE
ReprojectionFilter updates

### DIFF
--- a/filters/reprojection/ReprojectionFilter.cpp
+++ b/filters/reprojection/ReprojectionFilter.cpp
@@ -37,9 +37,6 @@
 #include <pdal/PointView.hpp>
 #include <pdal/GlobalEnvironment.hpp>
 
-#include <gdal.h>
-#include <ogr_spatialref.h>
-
 #include <memory>
 
 namespace pdal
@@ -55,7 +52,8 @@ CREATE_STATIC_PLUGIN(1, 0, ReprojectionFilter, Filter, s_info)
 std::string ReprojectionFilter::getName() const { return s_info.name; }
 
 ReprojectionFilter::ReprojectionFilter() : m_inferInputSRS(true),
-    m_in_ref_ptr(NULL), m_out_ref_ptr(NULL), m_transform_ptr(NULL), m_cullBadPoints(false)
+    m_in_ref_ptr(NULL), m_out_ref_ptr(NULL), m_transform_ptr(NULL),
+    m_cullBadPoints(false)
 {}
 
 ReprojectionFilter::~ReprojectionFilter()
@@ -164,45 +162,20 @@ void ReprojectionFilter::ready(PointTableRef table)
 }
 
 
-bool ReprojectionFilter::transform(double& x, double& y, double& z, bool bThrowOnFailure)
-{
-    try
-    {
-        // OCTTransform will throw via GDAL error handler
-        // if there is an error. We don't expect the return value
-        // unless the GDAL handler gets shut off for whatever reason. In
-        // that case, we'll just throw.
-        int ret = OCTTransform(m_transform_ptr, 1, &x, &y, &z);
-        if (ret == 0)
-        {
-            std::ostringstream msg;
-            msg << "Could not project point for ReprojectionTransform::" <<
-                CPLGetLastErrorMsg() << ret;
-            throw pdal_error(msg.str());
-        }
-        return true;
-    } catch (pdal::pdal_error& e)
-    {
-        if (bThrowOnFailure)
-            throw;
-        return false;
-    }
-}
-
-
 PointViewSet ReprojectionFilter::run(PointViewPtr view)
 {
     PointViewSet viewSet;
     PointViewPtr outView = view->makeNew();
 
+    double x, y, z;
+
     for (PointId id = 0; id < view->size(); ++id)
     {
-        double x = view->getFieldAs<double>(Dimension::Id::X, id);
-        double y = view->getFieldAs<double>(Dimension::Id::Y, id);
-        double z = view->getFieldAs<double>(Dimension::Id::Z, id);
+        x = view->getFieldAs<double>(Dimension::Id::X, id);
+        y = view->getFieldAs<double>(Dimension::Id::Y, id);
+        z = view->getFieldAs<double>(Dimension::Id::Z, id);
 
-        bool keep_point = transform(x, y, z, m_cullBadPoints);
-        if (keep_point)
+        if (transform(x, y, z))
         {
             view->setField(Dimension::Id::X, id, x);
             view->setField(Dimension::Id::Y, id, y);
@@ -210,9 +183,30 @@ PointViewSet ReprojectionFilter::run(PointViewPtr view)
             outView->appendPoint(*view, id);
         }
     }
+
     viewSet.insert(outView);
 
     return viewSet;
+}
+
+
+void ReprojectionFilter::filter(PointView& view)
+{
+    double x, y, z;
+
+    for (PointId id = 0; id < view.size(); ++id)
+    {
+        x = view.getFieldAs<double>(Dimension::Id::X, id);
+        y = view.getFieldAs<double>(Dimension::Id::Y, id);
+        z = view.getFieldAs<double>(Dimension::Id::Z, id);
+
+        if (transform(x, y, z))
+        {
+            view.setField(Dimension::Id::X, id, x);
+            view.setField(Dimension::Id::Y, id, y);
+            view.setField(Dimension::Id::Z, id, z);
+        }
+    }
 }
 
 } // namespace pdal

--- a/filters/reprojection/ReprojectionFilter.hpp
+++ b/filters/reprojection/ReprojectionFilter.hpp
@@ -36,6 +36,9 @@
 
 #include <pdal/Filter.hpp>
 
+#include <gdal.h>
+#include <ogr_spatialref.h>
+
 #include <memory>
 
 extern "C" int32_t ReprojectionFilter_ExitFunc();
@@ -64,9 +67,22 @@ private:
     virtual void ready(PointTableRef table);
     virtual void initialize();
     virtual PointViewSet run(PointViewPtr view);
+    virtual void filter(PointView& view);
 
     void updateBounds();
-    bool transform(double& x, double& y, double& z, bool bThrowOnFailure);
+    bool transform(double& x, double& y, double& z)
+    {
+        if (OCTTransform(m_transform_ptr, 1, &x, &y, &z))
+        {
+            return true;
+        }
+        else
+        {
+            if (m_cullBadPoints) return false;
+            else throw pdal_error(std::string("Could not reproject point: ") +
+                    CPLGetLastErrorMsg());
+        }
+    }
 
     SpatialReference m_inSRS;
     SpatialReference m_outSRS;


### PR DESCRIPTION
- Reintroduce `ReprojectionFilter::filter`, which is used by the FilterWrapper to modify a PointView in-place
- Remove per-point try-catch
- Minor performance tweaks like allowing `transform` to be inlined