### PR TITLE
Reprojection re-culling

### DIFF
--- a/filters/reprojection/ReprojectionFilter.cpp
+++ b/filters/reprojection/ReprojectionFilter.cpp
@@ -187,7 +187,7 @@ bool ReprojectionFilter::transform(double& x, double& y, double& z)
     catch (pdal::pdal_error& e)
     {
         if (m_cullBadPoints) return false;
-        else throw e.what();
+        else throw e;
     }
 }
 

--- a/filters/reprojection/ReprojectionFilter.cpp
+++ b/filters/reprojection/ReprojectionFilter.cpp
@@ -164,7 +164,7 @@ void ReprojectionFilter::ready(PointTableRef table)
 }
 
 
-bool ReprojectionFilter::transform(double& x, double& y, double& z, bool bThrowOnFailure)
+bool ReprojectionFilter::transform(double& x, double& y, double& z)
 {
     try
     {
@@ -172,20 +172,22 @@ bool ReprojectionFilter::transform(double& x, double& y, double& z, bool bThrowO
         // if there is an error. We don't expect the return value
         // unless the GDAL handler gets shut off for whatever reason. In
         // that case, we'll just throw.
-        int ret = OCTTransform(m_transform_ptr, 1, &x, &y, &z);
-        if (ret == 0)
+        if (OCTTransform(m_transform_ptr, 1, &x, &y, &z))
+        {
+            return true;
+        }
+        else
         {
             std::ostringstream msg;
             msg << "Could not project point for ReprojectionTransform::" <<
-                CPLGetLastErrorMsg() << ret;
+                CPLGetLastErrorMsg();
             throw pdal_error(msg.str());
         }
-        return true;
-    } catch (pdal::pdal_error& e)
+    }
+    catch (pdal::pdal_error& e)
     {
-        if (bThrowOnFailure)
-            throw;
-        return false;
+        if (m_cullBadPoints) return false;
+        else throw e.what();
     }
 }
 
@@ -195,14 +197,15 @@ PointViewSet ReprojectionFilter::run(PointViewPtr view)
     PointViewSet viewSet;
     PointViewPtr outView = view->makeNew();
 
+    double x, y, z;
+
     for (PointId id = 0; id < view->size(); ++id)
     {
-        double x = view->getFieldAs<double>(Dimension::Id::X, id);
-        double y = view->getFieldAs<double>(Dimension::Id::Y, id);
-        double z = view->getFieldAs<double>(Dimension::Id::Z, id);
+        x = view->getFieldAs<double>(Dimension::Id::X, id);
+        y = view->getFieldAs<double>(Dimension::Id::Y, id);
+        z = view->getFieldAs<double>(Dimension::Id::Z, id);
 
-        bool keep_point = transform(x, y, z, m_cullBadPoints);
-        if (keep_point)
+        if (transform(x, y, z))
         {
             view->setField(Dimension::Id::X, id, x);
             view->setField(Dimension::Id::Y, id, y);
@@ -214,5 +217,25 @@ PointViewSet ReprojectionFilter::run(PointViewPtr view)
 
     return viewSet;
 }
+
+
+void ReprojectionFilter::filter(PointView& view)
+{
+    double x, y, z;
+
+    for (PointId id = 0; id < view.size(); ++id)
+    {
+        x = view.getFieldAs<double>(Dimension::Id::X, id);
+        y = view.getFieldAs<double>(Dimension::Id::Y, id);
+        z = view.getFieldAs<double>(Dimension::Id::Z, id);
+
+        OCTTransform(m_transform_ptr, 1, &x, &y, &z);
+
+        view.setField(Dimension::Id::X, id, x);
+        view.setField(Dimension::Id::Y, id, y);
+        view.setField(Dimension::Id::Z, id, z);
+    }
+}
+
 
 } // namespace pdal

--- a/filters/reprojection/ReprojectionFilter.hpp
+++ b/filters/reprojection/ReprojectionFilter.hpp
@@ -64,9 +64,10 @@ private:
     virtual void ready(PointTableRef table);
     virtual void initialize();
     virtual PointViewSet run(PointViewPtr view);
+    virtual void filter(PointView& view);
 
     void updateBounds();
-    bool transform(double& x, double& y, double& z, bool bThrowOnFailure);
+    bool transform(double& x, double& y, double& z);
 
     SpatialReference m_inSRS;
     SpatialReference m_outSRS;


### PR DESCRIPTION
I made lots of tweaks in #1020 based on a misunderstanding.  This reverts those, but keeps the addition of `filter` from that PR.  Behavior should be the same as before, except with the `m_cullBadPoints` logic negated.