### PR TITLE
Test changes for SRS setting in prepare().

### DIFF
--- a/io/las/LasReader.cpp
+++ b/io/las/LasReader.cpp
@@ -128,7 +128,7 @@ QuickInfo LasReader::inspect()
 }
 
 
-void LasReader::initialize()
+void LasReader::initialize(MetadataNode& m)
 {
     if (m_initialized)
         return;
@@ -168,6 +168,7 @@ void LasReader::initialize()
         readExtraBytesVlr();
     }
     fixupVlrs();
+    setSrsFromVlrs(m);
     m_initialized = true;
 }
 
@@ -176,7 +177,6 @@ void LasReader::ready(PointTableRef table, MetadataNode& m)
 {
     m_index = 0;
 
-    setSrsFromVlrs(m);
     MetadataNode forward = table.privateMetadata("lasforward");
     extractHeaderMetadata(forward, m);
     extractVlrMetadata(forward, m);

--- a/io/las/LasReader.hpp
+++ b/io/las/LasReader.hpp
@@ -111,7 +111,9 @@ private:
     std::string m_compression;
 
     virtual void processOptions(const Options& options);
-    virtual void initialize();
+    virtual void initialize()
+        { initialize(m_metadata); }
+    virtual void initialize(MetadataNode& m);
     virtual void addDimensions(PointLayoutPtr layout);
     void fixupVlrs();
     VariableLengthRecord *findVlr(const std::string& userId, uint16_t recordId);

--- a/plugins/nitf/io/NitfReader.cpp
+++ b/plugins/nitf/io/NitfReader.cpp
@@ -107,7 +107,10 @@ void NitfReader::initialize()
     m_metadata.add("DESDATA_LENGTH", m_length);
 
     nitf.close();
-    LasReader::initialize();
+
+    // Initialize the LAS stuff with its own metadata node.
+    MetadataNode lasNode = m_metadata.add(LasReader::getName());
+    LasReader::initialize(lasNode);
 }
 
 


### PR DESCRIPTION
OK, this passes tests, but I don't like it because I'm not sure that SRS is special.  Is there some reason we shouldn't promise, say, that all the header data is loaded when prepare() is complete?  We could do this too, but I'd have to change some more stuff to allow access to the table's private metadata.

We should really decide and write down what we're promising at this point since it seems semi-important.

Thoughts?