### PR TITLE
BPF should use auto offsets by default for XYZ dimensions

### DIFF
--- a/doc/stages/writers.bpf.rst
+++ b/doc/stages/writers.bpf.rst
@@ -83,14 +83,19 @@ offset_x, offset_y, offset_z
     Offset to be subtracted from the X, Y and Z nominal values, respectively,
     before the value is scaled.  The special value "auto" can be specified,
     which causes the writer to set the offset to the minimum value of the
-    dimension.  [Default: 0]
+    dimension.  [Default: auto]
 
     .. note::
 
         written value = (nominal value - offset) / scale.
 
+    .. note::
+
+        Because BPF data is always stored in UTM, the XYZ offsets are set to
+        "auto" by default. This is to avoid truncation of the decimal digits
+        (which may occur with offsets left at 0).
+
 output_dims
     If specified, limits the dimensions written for each point.  Dimensions
     are listed by name and separated by commas.  X, Y and Z are required and
     must be explicitly listed.
-

--- a/io/bpf/BpfWriter.cpp
+++ b/io/bpf/BpfWriter.cpp
@@ -131,6 +131,18 @@ void BpfWriter::processOptions(const Options& options)
         }
         m_bundledFiles.push_back(ulemFile);
     }
+
+    // BPF coordinates are always in UTM meters, which can be quite large.
+    // Allowing the writer to proceed with the default offset of 0 can lead to
+    // unexpected quantization of the coordinates. Instead, we force use of
+    // auto offset to subtract the minimum value in XYZ, unless of course, the
+    // user chooses to override with their own offset.
+    if (!options.hasOption("offset_x"))
+        m_xXform.m_autoOffset = true;
+    if (!options.hasOption("offset_y"))
+        m_yXform.m_autoOffset = true;
+    if (!options.hasOption("offset_z"))
+        m_zXform.m_autoOffset = true;
 }
 
 
@@ -354,4 +366,3 @@ void BpfWriter::doneFile()
 }
 
 } //namespace pdal
-


### PR DESCRIPTION
@abellgithub Not sure if this is how you would have handled it, but it seems to work as expected.