### PR TITLE
Update write kernel tutorial

### DIFF
--- a/doc/tutorial/writing-kernel.rst
+++ b/doc/tutorial/writing-kernel.rst
@@ -20,21 +20,12 @@ First, we provide a full listing of the kernel header.
 .. literalinclude:: ../../examples/writing-kernel/MyKernel.hpp
    :language: cpp
 
-In your MyKernel class, you will use two macros defined in Kernel.hpp to
-register some useful information about your kernel. SET_KERNEL_NAME sets the
-kernel name and description. These are extracted by the PDAL application to
-inform the user of the kernel's name and purpose. The name will be displayed
-when the user types `pdal --help`.
+As with other plugins, the MyKernel class needs to have the following three methods declared for the plugin interface to be satisfied:
 
 .. literalinclude:: ../../examples/writing-kernel/MyKernel.hpp
    :language: cpp
-   :lines: 12
+   :lines: 16-18
 
-SET_KERNEL_LINK will provide a link to a webpage that documents the kernel.
-
-.. literalinclude:: ../../examples/writing-kernel/MyKernel.hpp
-   :language: cpp
-   :lines: 13
 
 The source
 -------------------------------------------------------------------------------
@@ -44,31 +35,26 @@ Again, we start with a full listing of the kernel source.
 .. literalinclude:: ../../examples/writing-kernel/MyKernel.cpp
    :language: cpp
 
-In your kernel implementation, you will use a third macro defined in
-pdal_macros. This macro registers the plugin with the Kernel factory. It is
+In your kernel implementation, you will use a macro defined in pdal_macros.
+This macro registers the plugin with the Kernel factory. It is
 only required by plugins.
 
 .. literalinclude:: ../../examples/writing-kernel/MyKernel.cpp
    :language: cpp
-   :lines: 24
+   :lines: 23-29
 
-Native kernels will use a different set of macros added directly to the
-KernelFactory.cpp file to register themselves.
-
-.. code-block:: cpp
-
-  MAKE_KERNEL_CREATOR(mykernel, pdal::MyKernel)
-  REGISTER_KERNEL(mykernel, pdal::MyKernel);
+A static plugin macro can also be used to integrate the kernel with the main code.
+This will not be described here.  Using this as a shared plugin will be described later.
 
 To build up a processing pipeline in this
 example, we need to create two objects: the
-PointContext and the StageFactory. The latter is
+PointTable and the StageFactory. The latter is
 used to create the various stages that will be
 used within the kernel.
 
 .. literalinclude:: ../../examples/writing-kernel/MyKernel.cpp
    :language: cpp
-   :lines: 50-51
+   :lines: 60
 
 The Reader is created from the StageFactory, and
 is specified by the stage name, in this case an
@@ -78,7 +64,7 @@ read.
 
 .. literalinclude:: ../../examples/writing-kernel/MyKernel.cpp
    :language: cpp
-   :lines: 53-56
+   :lines: 62-65
 
 The Filter is also created from the StageFactory.
 Here, we create a decimation filter that will
@@ -88,7 +74,7 @@ the reader.
 
 .. literalinclude:: ../../examples/writing-kernel/MyKernel.cpp
    :language: cpp
-   :lines: 58-62
+   :lines: 67-71
 
 Finally, the Writer is created from the
 StageFactory. This text writer, takes as input
@@ -97,7 +83,7 @@ the output filename as its sole option.
 
 .. literalinclude:: ../../examples/writing-kernel/MyKernel.cpp
    :language: cpp
-   :lines: 64-68
+   :lines: 73-77
 
 The final two steps are to prepare and execute
 the pipeline. This is achieved by calling prepare
@@ -105,4 +91,12 @@ and execute on the final stage.
 
 .. literalinclude:: ../../examples/writing-kernel/MyKernel.cpp
    :language: cpp
-   :lines: 69-70
+   :lines: 78-79
+
+When compiled, a dynamic library file will be created; in this case:
+::
+   libpdal_plugin_kernel_mykernel.dylib
+
+Put this file in whatever directory ``PDAL_DRIVER_PATH`` is pointing to.  Then, if you run ``pdal --help``, you should see ``mykernel`` listed in the possible commands.
+
+To run this kernel, you would use ``pdal mykernel -i <input las file> -o <output text file>``.

--- a/doc/tutorial/writing-kernel.rst
+++ b/doc/tutorial/writing-kernel.rst
@@ -93,9 +93,7 @@ and execute on the final stage.
    :language: cpp
    :lines: 78-79
 
-When compiled, a dynamic library file will be created; in this case:
-::
-   libpdal_plugin_kernel_mykernel.dylib
+When compiled, a dynamic library file will be created; in this case, ``libpdal_plugin_kernel_mykernel.dylib``
 
 Put this file in whatever directory ``PDAL_DRIVER_PATH`` is pointing to.  Then, if you run ``pdal --help``, you should see ``mykernel`` listed in the possible commands.
 

--- a/examples/writing-kernel/MyKernel.cpp
+++ b/examples/writing-kernel/MyKernel.cpp
@@ -10,64 +10,75 @@
 #include <pdal/KernelSupport.hpp>
 #include <pdal/Options.hpp>
 #include <pdal/pdal_macros.hpp>
-#include <pdal/PointBuffer.hpp>
-#include <pdal/PointContext.hpp>
-#include <pdal/Reader.hpp>
 #include <pdal/StageFactory.hpp>
-#include <pdal/Writer.hpp>
+#include <pdal/PointTable.hpp>
 
 #include <memory>
 #include <string>
 
 namespace po = boost::program_options;
 
-CREATE_KERNEL_PLUGIN(mykernel, MyKernel)
+namespace pdal {
 
-void MyKernel::validateSwitches()
-{
-  if (m_input_file == "")
-    throw pdal::app_usage_error("--input/-i required");
-  if (m_output_file == "")
-    throw pdal::app_usage_error("--output/-o required");
-}
+  static PluginInfo const s_info {
+    "kernels.mykernel",
+    "MyKernel",
+    "http://link/to/documentation"
+  };
 
-void MyKernel::addSwitches()
-{
-  po::options_description* options = new po::options_description("file options");
-  options->add_options()
-  ("input,i", po::value<std::string>(&m_input_file)->default_value(""), "input file name")
-  ("output,o", po::value<std::string>(&m_output_file)->default_value(""), "output file name")
-  ;
+  CREATE_SHARED_PLUGIN(1, 0, MyKernel, Kernel, s_info);
 
-  addSwitchSet(options);
-  addPositionalSwitch("input", 1);
-  addPositionalSwitch("output", 1);
-}
+  std::string MyKernel::getName() const { return s_info.name; }
 
-int MyKernel::execute()
-{
-  pdal::PointContextRef ctx;
-  pdal::StageFactory f;
+  MyKernel::MyKernel() : Kernel()
+  {}
 
-  std::unique_ptr<pdal::Reader> reader(f.createReader("readers.las"));
-  pdal::Options readerOptions;
-  readerOptions.add("filename", m_input_file);
-  reader->setOptions(readerOptions);
+  void MyKernel::validateSwitches()
+  {
+    if (m_input_file == "")
+      throw pdal::app_usage_error("--input/-i required");
+    if (m_output_file == "")
+      throw pdal::app_usage_error("--output/-o required");
+  }
 
-  std::unique_ptr<pdal::Filter> filter(f.createFilter("filters.decimation"));
-  pdal::Options filterOptions;
-  filterOptions.add("step", 10);
-  filter->setOptions(filterOptions);
-  filter->setInput(reader.get());
+  void MyKernel::addSwitches()
+  {
+    po::options_description* options = new po::options_description("file options");
+    options->add_options()
+    ("input,i", po::value<std::string>(&m_input_file)->default_value(""), "input file name")
+    ("output,o", po::value<std::string>(&m_output_file)->default_value(""), "output file name")
+    ;
 
-  std::unique_ptr<pdal::Writer> writer(f.createWriter("writers.text"));
-  pdal::Options writerOptions;
-  writerOptions.add("filename", m_output_file);
-  writer->setOptions(writerOptions);
-  writer->setInput(filter.get());
-  writer->prepare(ctx);
-  writer->execute(ctx);
+    addSwitchSet(options);
+    addPositionalSwitch("input", 1);
+    addPositionalSwitch("output", 1);
+  }
 
-  return 0;
-}
+  int MyKernel::execute()
+  {
+    PointTable table;
+    StageFactory f;
 
+    Stage * reader = f.createStage("readers.las");
+    Options readerOptions;
+    readerOptions.add("filename", m_input_file);
+    reader->setOptions(readerOptions);
+
+    Stage * filter = f.createStage("filters.decimation");
+    Options filterOptions;
+    filterOptions.add("step", 10);
+    filter->setOptions(filterOptions);
+    filter->setInput(*reader);
+
+    Stage * writer = f.createStage("writers.text");
+    Options writerOptions;
+    writerOptions.add("filename", m_output_file);
+    writer->setOptions(writerOptions);
+    writer->setInput(*filter);
+    writer->prepare(table);
+    writer->execute(table);
+
+    return 0;
+  }
+
+} // namespace pdal

--- a/examples/writing-kernel/MyKernel.hpp
+++ b/examples/writing-kernel/MyKernel.hpp
@@ -3,23 +3,28 @@
 #pragma once
 
 #include <pdal/Kernel.hpp>
+#include <pdal/plugin.hpp>
 
 #include <string>
 
-class MyKernel : public pdal::Kernel
+namespace pdal
 {
-public:
-  SET_KERNEL_NAME ("MyKernel", "My Awesome Kernel")
-  SET_KERNEL_LINK ("http://link/to/documentation")
 
-  MyKernel() : Kernel() {};
-  int execute();
+  class PDAL_DLL MyKernel : public Kernel
+  {
+  public:
+    static void * create();
+    static int32_t destroy(void *);
+    std::string getName() const;
+    int execute(); // override
 
-private:
-  void validateSwitches();
-  void addSwitches();
+  private:
+    MyKernel();
+    void validateSwitches();
+    void addSwitches();
 
-  std::string m_input_file;
-  std::string m_output_file;
-};
+    std::string m_input_file;
+    std::string m_output_file;
+  };
 
+} // namespace pdal


### PR DESCRIPTION
The macros described in the tutorial don't exist anymore, so the tutorial was updated to include the process used by other kernel plugins.  StageFactory is used for all stages (although makeReader and makeWriter could be used, I don't think there's something like that for filters, so using StageFactory for all three seemed to be cleaner and more consistent).

The tutorial itself was also extended to talk about how to let PDAL find the compiled library.