### PR TITLE
Set default value for boolean in RxpReader

### DIFF
--- a/plugins/rxp/io/RxpReader.hpp
+++ b/plugins/rxp/io/RxpReader.hpp
@@ -67,6 +67,7 @@ public:
         : pdal::Reader()
         , m_uri("")
         , m_syncToPps(DEFAULT_SYNC_TO_PPS)
+        , m_minimal(false)
         , m_pointcloud()
     {}
 


### PR DESCRIPTION
This boolean value was not initialized on default reader creation, which caused tests to fail on some machines. I don't know if this would affect actual usages, but its a bugfix.