### PR TITLE
Check point view size in `getFieldInternal`

### DIFF
--- a/include/pdal/PointView.hpp
+++ b/include/pdal/PointView.hpp
@@ -381,6 +381,7 @@ template <class T>
 inline T PointView::getFieldAs(Dimension::Id::Enum dim,
     PointId pointIndex) const
 {
+    assert(pointIndex < m_size);
     T retval;
     const Dimension::Detail *dd = m_pointTable.layout()->dimDetail(dim);
     double val;

--- a/test/unit/PointViewTest.cpp
+++ b/test/unit/PointViewTest.cpp
@@ -446,3 +446,14 @@ TEST(PointViewTest, order)
         pi = si;
     }
 }
+
+// Per discussions with @abellgithub (https://github.com/gadomski/PDAL/commit/c1d54e56e2de841d37f2a1b1c218ed723053f6a9#commitcomment-14415138)
+// we only do bounds checking on `PointView`s when in debug mode.
+#ifndef NDEBUG
+TEST(PointViewDeathTest, out_of_bounds)
+{
+    PointTable point_table;
+    auto point_view = makeTestView(point_table, 1);
+    EXPECT_DEATH(point_view->getFieldAs<uint8_t>(Dimension::Id::X, 1), "< m_size");
+}
+#endif


### PR DESCRIPTION
`PointView::getFieldInternal` uses `deque::operator[]` to map index values to raw point ids. This means that a user can silently access beyond the end of of the `m_index` deque with an ill-advised `getFieldAs` call, leading to either garbage results or a segfault. I recokon we should sanitize this situation, since `PointView::getFieldAs` is part of our oft-used public API.

This patch proposes the simplest possible solution, a switch to `deque::at` inside `getFieldInternal`. It also adds a test case.

NB I haven't done an audit to see if there is other unsafe m_index access in the codebase.