### PR TITLE
Issues/1012 misleading summary

### DIFF
--- a/include/pdal/QuickInfo.hpp
+++ b/include/pdal/QuickInfo.hpp
@@ -49,13 +49,6 @@ public:
     SpatialReference m_srs;
     point_count_t m_pointCount;
     std::vector<std::string> m_dimNames;
-    bool m_valid;
-
-    QuickInfo() : m_pointCount(0), m_valid(false)
-        {}
-
-    bool valid() const
-        { return m_valid; }
 };
 
 } // namespace pdal

--- a/include/pdal/Stage.hpp
+++ b/include/pdal/Stage.hpp
@@ -75,7 +75,13 @@ public:
     {
         l_processOptions(m_options);
         processOptions(m_options);
-        return inspect();
+        auto quickInfo = inspect();
+        if (!quickInfo) {
+            std::stringstream ss;
+            ss << "Cannot preview stage '" << getName() << "' because it does not implement `inspect()`";
+            throw pdal_error(ss.str());
+        }
+        return *quickInfo;
     }
     void prepare(PointTableRef table);
     PointViewSet execute(PointTableRef table);
@@ -155,8 +161,8 @@ private:
     virtual void writerProcessOptions(const Options& /*options*/)
         {}
     void l_initialize(PointTableRef table);
-    virtual QuickInfo inspect()
-        { return QuickInfo(); }
+    virtual std::unique_ptr<QuickInfo> inspect()
+        { return nullptr; }
     virtual void initialize(PointTableRef /*table*/)
         { initialize(); }
     virtual void initialize()

--- a/io/bpf/BpfReader.cpp
+++ b/io/bpf/BpfReader.cpp
@@ -63,32 +63,31 @@ void BpfReader::processOptions(const Options&)
 }
 
 
-QuickInfo BpfReader::inspect()
+std::unique_ptr<QuickInfo> BpfReader::inspect()
 {
-    QuickInfo qi;
+    std::unique_ptr<QuickInfo> qi(new QuickInfo());
 
     initialize();
-    qi.m_valid = true;
-    qi.m_pointCount = m_header.m_numPts;
-    qi.m_srs = getSpatialReference();
+    qi->m_pointCount = m_header.m_numPts;
+    qi->m_srs = getSpatialReference();
     for (auto di = m_dims.begin(); di != m_dims.end(); ++di)
     {
         BpfDimension& dim = *di;
-        qi.m_dimNames.push_back(dim.m_label);
+        qi->m_dimNames.push_back(dim.m_label);
         if (dim.m_label == "X")
         {
-            qi.m_bounds.minx = dim.m_min;
-            qi.m_bounds.maxx = dim.m_max;
+            qi->m_bounds.minx = dim.m_min;
+            qi->m_bounds.maxx = dim.m_max;
         }
         if (dim.m_label == "Y")
         {
-            qi.m_bounds.miny = dim.m_min;
-            qi.m_bounds.maxy = dim.m_max;
+            qi->m_bounds.miny = dim.m_min;
+            qi->m_bounds.maxy = dim.m_max;
         }
         if (dim.m_label == "Z")
         {
-            qi.m_bounds.minz = dim.m_min;
-            qi.m_bounds.maxz = dim.m_max;
+            qi->m_bounds.minz = dim.m_min;
+            qi->m_bounds.maxz = dim.m_max;
         }
     }
     return qi;

--- a/io/bpf/BpfReader.hpp
+++ b/io/bpf/BpfReader.hpp
@@ -82,7 +82,7 @@ private:
     Charbuf m_charbuf;
 
     virtual void processOptions(const Options& options);
-    virtual QuickInfo inspect();
+    virtual std::unique_ptr<QuickInfo> inspect();
     virtual void initialize();
     virtual void addDimensions(PointLayoutPtr Layout);
     virtual void ready(PointTableRef table);

--- a/io/gdal/GDALReader.cpp
+++ b/io/gdal/GDALReader.cpp
@@ -76,9 +76,9 @@ void GDALReader::initialize()
 }
 
 
-QuickInfo GDALReader::inspect()
+std::unique_ptr<QuickInfo> GDALReader::inspect()
 {
-    QuickInfo qi;
+    std::unique_ptr<QuickInfo> qi(new QuickInfo());
     std::unique_ptr<PointLayout> layout(new PointLayout());
 
     addDimensions(layout.get());
@@ -87,10 +87,9 @@ QuickInfo GDALReader::inspect()
     m_raster = std::unique_ptr<gdal::Raster>(new gdal::Raster(m_filename));
     m_raster->open();
 
-    qi.m_pointCount = m_raster->m_raster_x_size * m_raster->m_raster_y_size;
-    // qi.m_bounds = ???;
-    qi.m_srs = m_raster->getSpatialRef();
-    qi.m_valid = true;
+    qi->m_pointCount = m_raster->m_raster_x_size * m_raster->m_raster_y_size;
+//     qi.m_bounds = ???;
+    qi->m_srs = m_raster->getSpatialRef();
 
     return qi;
 }

--- a/io/gdal/GDALReader.hpp
+++ b/io/gdal/GDALReader.hpp
@@ -73,7 +73,7 @@ private:
     virtual point_count_t read(PointViewPtr view, point_count_t num);
     virtual void done(PointTableRef table)
         { m_raster->close(); }
-    virtual QuickInfo inspect();
+    virtual std::unique_ptr<QuickInfo> inspect();
 
     std::unique_ptr<gdal::Raster> m_raster;
     point_count_t m_index;

--- a/io/las/LasReader.cpp
+++ b/io/las/LasReader.cpp
@@ -104,9 +104,9 @@ CREATE_STATIC_PLUGIN(1, 0, LasReader, Reader, s_info)
 
 std::string LasReader::getName() const { return s_info.name; }
 
-QuickInfo LasReader::inspect()
+std::unique_ptr<QuickInfo> LasReader::inspect()
 {
-    QuickInfo qi;
+    std::unique_ptr<QuickInfo> qi(new QuickInfo());
     std::unique_ptr<PointLayout> layout(new PointLayout());
 
     PointTable table;
@@ -115,12 +115,11 @@ QuickInfo LasReader::inspect()
 
     Dimension::IdList dims = layout->dims();
     for (auto di = dims.begin(); di != dims.end(); ++di)
-        qi.m_dimNames.push_back(layout->dimName(*di));
-    if (!Utils::numericCast(m_lasHeader.pointCount(), qi.m_pointCount))
-        qi.m_pointCount = std::numeric_limits<point_count_t>::max();
-    qi.m_bounds = m_lasHeader.getBounds();
-    qi.m_srs = getSpatialReference();
-    qi.m_valid = true;
+        qi->m_dimNames.push_back(layout->dimName(*di));
+    if (!Utils::numericCast(m_lasHeader.pointCount(), qi->m_pointCount))
+        qi->m_pointCount = std::numeric_limits<point_count_t>::max();
+    qi->m_bounds = m_lasHeader.getBounds();
+    qi->m_srs = getSpatialReference();
 
     done(table);
 

--- a/io/las/LasReader.hpp
+++ b/io/las/LasReader.hpp
@@ -120,7 +120,7 @@ private:
     SpatialReference getSrsFromGeotiffVlr();
     void extractHeaderMetadata(MetadataNode& forward, MetadataNode& m);
     void extractVlrMetadata(MetadataNode& forward, MetadataNode& m);
-    virtual QuickInfo inspect();
+    virtual std::unique_ptr<QuickInfo> inspect();
     virtual void ready(PointTableRef table);
     virtual point_count_t read(PointViewPtr view, point_count_t count);
     virtual bool processOne(PointRef& point);

--- a/plugins/mrsid/io/MrsidReader.cpp
+++ b/plugins/mrsid/io/MrsidReader.cpp
@@ -166,9 +166,9 @@ Options MrsidReader::getDefaultOptions()
 }
 
 
-QuickInfo MrsidReader::inspect()
+std::unique_ptr<QuickInfo> MrsidReader::inspect()
 {
-    QuickInfo qi;
+    std::unique_ptr<QuickInfo> qi(new QuickInfo());
     std::unique_ptr<PointLayout> layout(new PointLayout());
 
     MrsidReader::initialize();
@@ -180,12 +180,11 @@ QuickInfo MrsidReader::inspect()
 
     Dimension::IdList dims = layout->dims();
     for (auto di = dims.begin(); di != dims.end(); ++di)
-        qi.m_dimNames.push_back(layout->dimName(*di));
-    if (!Utils::numericCast(m_PS->getNumPoints(), qi.m_pointCount))
-        qi.m_pointCount = std::numeric_limits<point_count_t>::max();
-    qi.m_bounds = b;
-    qi.m_srs = pdal::SpatialReference(m_PS->getWKT());
-    qi.m_valid = true;
+        qi->m_dimNames.push_back(layout->dimName(*di));
+    if (!Utils::numericCast(m_PS->getNumPoints(), qi->m_pointCount))
+        qi->m_pointCount = std::numeric_limits<point_count_t>::max();
+    qi->m_bounds = b;
+    qi->m_srs = pdal::SpatialReference(m_PS->getWKT());
 
     PointTable table;
     done(table);

--- a/plugins/mrsid/io/MrsidReader.hpp
+++ b/plugins/mrsid/io/MrsidReader.hpp
@@ -88,7 +88,7 @@ private:
     MrsidReader(const MrsidReader&); // not implemented
 
     void LayoutToPointInfo(const PointLayout &layout, LizardTech::PointInfo &pointInfo) const;
-    virtual QuickInfo inspect();
+    virtual std::unique_ptr<QuickInfo> inspect();
     virtual void ready(PointTableRef table)
         { ready(table, m_metadata); }
     virtual void ready(PointTableRef table, MetadataNode& m);


### PR DESCRIPTION
If a reader does not implement `inspect`, `pdal info --summary` produces misleading results. This patch fixes the problem by forcing readers to opt-in to summary information by explicitly implementing `inspect`. If a reader does not implement `inspect`, the default implementation returns `boost::none`, which is then upgraded to a `pdal_error` by `Stage::preview`.

This is not a perfect solution to the problem — it may be overly strict. But it is an attempt to clarify the policy for `Stage::inspect`, which [was ambiguous](https://github.com/PDAL/PDAL/issues/1038#issuecomment-157238262).

The second commit removes the default constructor and the `m_valid` flag from `QuickInfo`, since they are no longer needed (I think).

@abellgithub this is just one idea I had, feel free to modify/reject as needed.