### PR TITLE
Rename Stage::getDefaultOptions to Stage::getAnsweredOptions

### DIFF
--- a/apps/pdal.cpp
+++ b/apps/pdal.cpp
@@ -139,7 +139,7 @@ void outputOptions(std::string const& n)
     std::cout << n << std::endl;
     std::cout << headline << std::endl;
 
-    std::vector<Option> options = s->getDefaultOptions().getOptions();
+    std::vector<Option> options = s->getAnsweredOptions().getOptions();
     if (options.empty())
     {
         std::cout << "No options" << std::endl << std::endl;

--- a/doc/tutorial/writing-filter.rst
+++ b/doc/tutorial/writing-filter.rst
@@ -68,7 +68,7 @@ Finally, we implement a method to get the plugin name, which is primarily used b
    :language: cpp
    :lines: 20-23
 
-Now that the filter has implemented the proper plugin interface, we will begin to implement some methods that actually implement the filter. First, ``getDefaultOptions()`` is used to advertise those options that the filter provides. Within PDAL, this is primarily used as a means of displaying options via the PDAL CLI with the ``--options`` argument. It provides the user with the option names, descriptions, and default values.
+Now that the filter has implemented the proper plugin interface, we will begin to implement some methods that actually implement the filter. First, ``getAnsweredOptions()`` is used to advertise those options that the filter provides. Within PDAL, this is primarily used as a means of displaying options via the PDAL CLI with the ``--options`` argument. It provides the user with the option names, descriptions, and default values.
 
 .. literalinclude:: ../../examples/writing-filter/MyFilter.cpp
    :language: cpp

--- a/include/pdal/Stage.hpp
+++ b/include/pdal/Stage.hpp
@@ -114,7 +114,7 @@ public:
     const std::vector<Stage*>& getInputs() const
         { return m_inputs; }
     std::vector<Stage *> findStage(std::string name);
-    virtual Options getDefaultOptions()
+    virtual Options getAnsweredOptions()
         { return Options(); }
     static Dimension::IdList getDefaultDimensions()
         { return Dimension::IdList(); }
@@ -127,6 +127,11 @@ public:
     /// Sets the UserCallback to manage progress/cancel operations
     void setUserCallback(UserCallback* userCallback)
         { m_callback.reset(userCallback); }
+
+    // Don't use this. It is around to allow plugins to catch
+    // up to the rename to getAnsweredOptions
+    Options getDefaultOptions()
+        { return getAnsweredOptions(); }
 
 protected:
     std::unique_ptr<UserCallback> m_callback;

--- a/plugins/attribute/filters/AttributeFilter.cpp
+++ b/plugins/attribute/filters/AttributeFilter.cpp
@@ -111,7 +111,7 @@ void AttributeFilter::initialize()
 }
 
 
-Options AttributeFilter::getDefaultOptions()
+Options AttributeFilter::getAnsweredOptions()
 {
     Options options;
 

--- a/plugins/attribute/filters/AttributeFilter.hpp
+++ b/plugins/attribute/filters/AttributeFilter.hpp
@@ -67,7 +67,7 @@ public:
     static int32_t destroy(void *);
     std::string getName() const { return "filters.attribute"; }
 
-    Options getDefaultOptions();
+    Options getAnsweredOptions();
 
 private:
     virtual void initialize();

--- a/plugins/geowave/io/GeoWaveReader.cpp
+++ b/plugins/geowave/io/GeoWaveReader.cpp
@@ -143,7 +143,7 @@ std::string pdal::GeoWaveReader::getName() const { return s_info.name; }
 namespace pdal
 {
 
-    Options GeoWaveReader::getDefaultOptions()
+    Options GeoWaveReader::getAnsweredOptions()
     {
         Options options;
 

--- a/plugins/geowave/io/GeoWaveReader.hpp
+++ b/plugins/geowave/io/GeoWaveReader.hpp
@@ -59,7 +59,7 @@ namespace pdal
         static int32_t destroy(void *);
         std::string getName() const;
 
-	Options getDefaultOptions();
+	Options getAnsweredOptions();
 
     private:
         virtual void initialize();

--- a/plugins/geowave/io/GeoWaveWriter.cpp
+++ b/plugins/geowave/io/GeoWaveWriter.cpp
@@ -150,7 +150,7 @@ std::string pdal::GeoWaveWriter::getName() const { return s_info.name; }
 namespace pdal
 {
 
-    Options GeoWaveWriter::getDefaultOptions()
+    Options GeoWaveWriter::getAnsweredOptions()
     {
         Options options;
 

--- a/plugins/geowave/io/GeoWaveWriter.hpp
+++ b/plugins/geowave/io/GeoWaveWriter.hpp
@@ -53,7 +53,7 @@ namespace pdal
         static int32_t destroy(void *);
         std::string getName() const;
 
-        Options getDefaultOptions();
+        Options getAnsweredOptions();
 
     private:
         virtual void initialize();

--- a/plugins/icebridge/io/IcebridgeReader.cpp
+++ b/plugins/icebridge/io/IcebridgeReader.cpp
@@ -71,7 +71,7 @@ CREATE_SHARED_PLUGIN(1, 0, IcebridgeReader, Reader, s_info)
 
 std::string IcebridgeReader::getName() const { return s_info.name; }
 
-Options IcebridgeReader::getDefaultOptions()
+Options IcebridgeReader::getAnsweredOptions()
 {
     Options options;
     options.add("filename", "", "file to read from");

--- a/plugins/icebridge/io/IcebridgeReader.hpp
+++ b/plugins/icebridge/io/IcebridgeReader.hpp
@@ -62,7 +62,7 @@ public:
     static int32_t destroy(void *);
     std::string getName() const;
 
-    Options getDefaultOptions();
+    Options getAnsweredOptions();
     static Dimension::IdList getDefaultDimensions();
 
 private:

--- a/plugins/mrsid/io/MrsidReader.cpp
+++ b/plugins/mrsid/io/MrsidReader.cpp
@@ -158,7 +158,7 @@ void MrsidReader::ready(PointTableRef table, MetadataNode& m)
     m_index = 0;
 }
 
-Options MrsidReader::getDefaultOptions()
+Options MrsidReader::getAnsweredOptions()
 {
     Options options;
     options.add("filename", "", "file to read from");

--- a/plugins/mrsid/io/MrsidReader.hpp
+++ b/plugins/mrsid/io/MrsidReader.hpp
@@ -64,7 +64,7 @@ public:
     static int32_t destroy(void *);
     std::string getName() const;
 
-    Options getDefaultOptions();
+    Options getAnsweredOptions();
 
     point_count_t getNumPoints() const
         { if (m_PS)

--- a/plugins/oci/io/OciReader.cpp
+++ b/plugins/oci/io/OciReader.cpp
@@ -137,7 +137,7 @@ void OciReader::defineBlock(Statement stmt, BlockPtr block) const
 }
 
 
-Options OciReader::getDefaultOptions()
+Options OciReader::getAnsweredOptions()
 {
     Options options;
 

--- a/plugins/oci/io/OciReader.hpp
+++ b/plugins/oci/io/OciReader.hpp
@@ -54,7 +54,7 @@ public:
     static int32_t destroy(void *);
     std::string getName() const;
 
-    Options getDefaultOptions();
+    Options getAnsweredOptions();
 
 private:
     virtual void initialize();

--- a/plugins/oci/io/OciWriter.cpp
+++ b/plugins/oci/io/OciWriter.cpp
@@ -82,7 +82,7 @@ void OciWriter::initialize()
 }
 
 
-Options OciWriter::getDefaultOptions()
+Options OciWriter::getAnsweredOptions()
 {
     Options options;
 

--- a/plugins/oci/io/OciWriter.hpp
+++ b/plugins/oci/io/OciWriter.hpp
@@ -53,7 +53,7 @@ public:
     static int32_t destroy(void *);
     std::string getName() const;
 
-    Options getDefaultOptions();
+    Options getAnsweredOptions();
 
 private:
     template<typename T>
@@ -61,7 +61,7 @@ private:
         const std::string& option_name)
     {
         T default_value =
-            getDefaultOptions().getOption(option_name).getValue<T>();
+            getAnsweredOptions().getOption(option_name).getValue<T>();
         return options.getValueOrDefault<T>(option_name, default_value);
     }
 

--- a/plugins/p2g/io/P2gWriter.cpp
+++ b/plugins/p2g/io/P2gWriter.cpp
@@ -127,7 +127,7 @@ void P2gWriter::ready(PointTableRef table)
 }
 
 
-Options P2gWriter::getDefaultOptions()
+Options P2gWriter::getAnsweredOptions()
 {
     Options options;
 

--- a/plugins/p2g/io/P2gWriter.hpp
+++ b/plugins/p2g/io/P2gWriter.hpp
@@ -72,7 +72,7 @@ public:
     static int32_t destroy(void *);
     std::string getName() const;
 
-    Options getDefaultOptions();
+    Options getAnsweredOptions();
 
 private:
     P2gWriter& operator=(const P2gWriter&); // not implemented

--- a/plugins/pcl/filters/DartSampleFilter.cpp
+++ b/plugins/pcl/filters/DartSampleFilter.cpp
@@ -56,7 +56,7 @@ std::string DartSampleFilter::getName() const
     return s_info.name;
 }
 
-Options DartSampleFilter::getDefaultOptions()
+Options DartSampleFilter::getAnsweredOptions()
 {
     Options options;
     options.add("radius", 1.0, "Minimum distance criterion");

--- a/plugins/pcl/filters/DartSampleFilter.hpp
+++ b/plugins/pcl/filters/DartSampleFilter.hpp
@@ -50,7 +50,7 @@ public:
     static int32_t destroy(void *);
     std::string getName() const;
 
-    Options getDefaultOptions();
+    Options getAnsweredOptions();
 
 private:
     double m_radius;

--- a/plugins/pcl/filters/GreedyProjectionFilter.cpp
+++ b/plugins/pcl/filters/GreedyProjectionFilter.cpp
@@ -57,7 +57,7 @@ std::string GreedyProjectionFilter::getName() const
     return s_info.name;
 }
 
-Options GreedyProjectionFilter::getDefaultOptions()
+Options GreedyProjectionFilter::getAnsweredOptions()
 {
     Options options;
     // options.add("leaf_x", 1.0, "Leaf size in X dimension");

--- a/plugins/pcl/filters/GreedyProjectionFilter.hpp
+++ b/plugins/pcl/filters/GreedyProjectionFilter.hpp
@@ -50,7 +50,7 @@ public:
     static int32_t destroy(void *);
     std::string getName() const;
 
-    Options getDefaultOptions();
+    Options getAnsweredOptions();
 
 private:
     // double m_leaf_x, m_leaf_y, m_leaf_z;

--- a/plugins/pcl/filters/GridProjectionFilter.cpp
+++ b/plugins/pcl/filters/GridProjectionFilter.cpp
@@ -57,7 +57,7 @@ std::string GridProjectionFilter::getName() const
     return s_info.name;
 }
 
-Options GridProjectionFilter::getDefaultOptions()
+Options GridProjectionFilter::getAnsweredOptions()
 {
     Options options;
     // options.add("leaf_x", 1.0, "Leaf size in X dimension");

--- a/plugins/pcl/filters/GridProjectionFilter.hpp
+++ b/plugins/pcl/filters/GridProjectionFilter.hpp
@@ -50,7 +50,7 @@ public:
     static int32_t destroy(void *);
     std::string getName() const;
 
-    Options getDefaultOptions();
+    Options getAnsweredOptions();
 
 private:
     // double m_leaf_x, m_leaf_y, m_leaf_z;

--- a/plugins/pcl/filters/GroundFilter.cpp
+++ b/plugins/pcl/filters/GroundFilter.cpp
@@ -62,7 +62,7 @@ std::string GroundFilter::getName() const
     return s_info.name;
 }
 
-Options GroundFilter::getDefaultOptions()
+Options GroundFilter::getAnsweredOptions()
 {
     Options options;
     options.add("max_window_size", 33, "Maximum window size");

--- a/plugins/pcl/filters/GroundFilter.hpp
+++ b/plugins/pcl/filters/GroundFilter.hpp
@@ -57,7 +57,7 @@ public:
     static int32_t destroy(void *);
     std::string getName() const;
 
-    Options getDefaultOptions();
+    Options getAnsweredOptions();
 
 private:
     double m_maxWindowSize;

--- a/plugins/pcl/filters/MovingLeastSquaresFilter.cpp
+++ b/plugins/pcl/filters/MovingLeastSquaresFilter.cpp
@@ -56,7 +56,7 @@ std::string MovingLeastSquaresFilter::getName() const
     return s_info.name;
 }
 
-Options MovingLeastSquaresFilter::getDefaultOptions()
+Options MovingLeastSquaresFilter::getAnsweredOptions()
 {
     Options options;
     // options.add("leaf_x", 1.0, "Leaf size in X dimension");

--- a/plugins/pcl/filters/MovingLeastSquaresFilter.hpp
+++ b/plugins/pcl/filters/MovingLeastSquaresFilter.hpp
@@ -50,7 +50,7 @@ public:
     static int32_t destroy(void *);
     std::string getName() const;
 
-    Options getDefaultOptions();
+    Options getAnsweredOptions();
 
 private:
     // double m_leaf_x, m_leaf_y, m_leaf_z;

--- a/plugins/pcl/filters/PoissonFilter.cpp
+++ b/plugins/pcl/filters/PoissonFilter.cpp
@@ -57,7 +57,7 @@ std::string PoissonFilter::getName() const
     return s_info.name;
 }
 
-Options PoissonFilter::getDefaultOptions()
+Options PoissonFilter::getAnsweredOptions()
 {
     Options options;
     options.add("depth", 8, "Maximum depth of the tree used for reconstruction");

--- a/plugins/pcl/filters/PoissonFilter.hpp
+++ b/plugins/pcl/filters/PoissonFilter.hpp
@@ -50,7 +50,7 @@ public:
     static int32_t destroy(void *);
     std::string getName() const;
 
-    Options getDefaultOptions();
+    Options getAnsweredOptions();
 
 private:
     int m_depth;

--- a/plugins/pcl/filters/RadiusOutlierFilter.cpp
+++ b/plugins/pcl/filters/RadiusOutlierFilter.cpp
@@ -61,7 +61,7 @@ std::string RadiusOutlierFilter::getName() const
     return s_info.name;
 }
 
-Options RadiusOutlierFilter::getDefaultOptions()
+Options RadiusOutlierFilter::getAnsweredOptions()
 {
     Options options;
     options.add("min_neighbors", 2, "Minimum number of neighbors in radius");

--- a/plugins/pcl/filters/RadiusOutlierFilter.hpp
+++ b/plugins/pcl/filters/RadiusOutlierFilter.hpp
@@ -57,7 +57,7 @@ public:
     static int32_t destroy(void *);
     std::string getName() const;
 
-    Options getDefaultOptions();
+    Options getAnsweredOptions();
 
 private:
     int m_min_neighbors;

--- a/plugins/pcl/filters/StatisticalOutlierFilter.cpp
+++ b/plugins/pcl/filters/StatisticalOutlierFilter.cpp
@@ -61,7 +61,7 @@ std::string StatisticalOutlierFilter::getName() const
     return s_info.name;
 }
 
-Options StatisticalOutlierFilter::getDefaultOptions()
+Options StatisticalOutlierFilter::getAnsweredOptions()
 {
     Options options;
     options.add("mean_k", 8, "Mean number of neighbors");

--- a/plugins/pcl/filters/StatisticalOutlierFilter.hpp
+++ b/plugins/pcl/filters/StatisticalOutlierFilter.hpp
@@ -57,7 +57,7 @@ public:
     static int32_t destroy(void *);
     std::string getName() const;
 
-    Options getDefaultOptions();
+    Options getAnsweredOptions();
 
 private:
     int m_meanK;

--- a/plugins/pcl/filters/VoxelGridFilter.cpp
+++ b/plugins/pcl/filters/VoxelGridFilter.cpp
@@ -56,7 +56,7 @@ std::string VoxelGridFilter::getName() const
     return s_info.name;
 }
 
-Options VoxelGridFilter::getDefaultOptions()
+Options VoxelGridFilter::getAnsweredOptions()
 {
     Options options;
     options.add("leaf_x", 1.0, "Leaf size in X dimension");

--- a/plugins/pcl/filters/VoxelGridFilter.hpp
+++ b/plugins/pcl/filters/VoxelGridFilter.hpp
@@ -50,7 +50,7 @@ public:
     static int32_t destroy(void *);
     std::string getName() const;
 
-    Options getDefaultOptions();
+    Options getAnsweredOptions();
 
 private:
     double m_leaf_x, m_leaf_y, m_leaf_z;

--- a/plugins/pcl/io/PcdWriter.cpp
+++ b/plugins/pcl/io/PcdWriter.cpp
@@ -68,7 +68,7 @@ void PcdWriter::processOptions(const Options& ops)
 }
 
 
-Options PcdWriter::getDefaultOptions()
+Options PcdWriter::getAnsweredOptions()
 {
     Options options;
 

--- a/plugins/pcl/io/PcdWriter.hpp
+++ b/plugins/pcl/io/PcdWriter.hpp
@@ -54,7 +54,7 @@ public:
     static int32_t destroy(void *);
     std::string getName() const;
 
-    Options getDefaultOptions();
+    Options getAnsweredOptions();
 
 private:
     virtual void processOptions(const Options&);

--- a/plugins/pgpointcloud/io/PgReader.cpp
+++ b/plugins/pgpointcloud/io/PgReader.cpp
@@ -65,7 +65,7 @@ PgReader::~PgReader()
 }
 
 
-Options PgReader::getDefaultOptions()
+Options PgReader::getAnsweredOptions()
 {
     Options ops;
 

--- a/plugins/pgpointcloud/io/PgReader.hpp
+++ b/plugins/pgpointcloud/io/PgReader.hpp
@@ -89,7 +89,7 @@ public:
     static int32_t destroy(void *);
     std::string getName() const;
 
-    Options getDefaultOptions();
+    Options getAnsweredOptions();
     virtual point_count_t getNumPoints() const;
     point_count_t getMaxPoints() const;
     std::string getDataQuery() const;

--- a/plugins/pgpointcloud/io/PgWriter.cpp
+++ b/plugins/pgpointcloud/io/PgWriter.cpp
@@ -126,7 +126,7 @@ void PgWriter::initialize()
 // Called from somewhere (?) in PDAL core presumably to provide a user-friendly
 // means of editing the reader options.
 //
-Options PgWriter::getDefaultOptions()
+Options PgWriter::getAnsweredOptions()
 {
     Options options;
 

--- a/plugins/pgpointcloud/io/PgWriter.hpp
+++ b/plugins/pgpointcloud/io/PgWriter.hpp
@@ -52,7 +52,7 @@ public:
     static int32_t destroy(void *);
     std::string getName() const;
 
-    Options getDefaultOptions();
+    Options getAnsweredOptions();
 
 private:
 

--- a/plugins/python/filters/PredicateFilter.cpp
+++ b/plugins/python/filters/PredicateFilter.cpp
@@ -61,7 +61,7 @@ void PredicateFilter::processOptions(const Options& options)
 }
 
 
-Options PredicateFilter::getDefaultOptions()
+Options PredicateFilter::getAnsweredOptions()
 {
     Options options;
     options.add("script", "");

--- a/plugins/python/filters/PredicateFilter.hpp
+++ b/plugins/python/filters/PredicateFilter.hpp
@@ -52,7 +52,7 @@ public:
     static int32_t destroy(void *);
     std::string getName() const;
 
-    Options getDefaultOptions();
+    Options getAnsweredOptions();
 
 private:
     plang::BufferedInvocation* m_pythonMethod;

--- a/plugins/python/filters/ProgrammableFilter.cpp
+++ b/plugins/python/filters/ProgrammableFilter.cpp
@@ -50,7 +50,7 @@ CREATE_SHARED_PLUGIN(1, 0, ProgrammableFilter, Filter, s_info)
 
 std::string ProgrammableFilter::getName() const { return s_info.name; }
 
-Options ProgrammableFilter::getDefaultOptions()
+Options ProgrammableFilter::getAnsweredOptions()
 {
     Options options;
     options.add("script", "");

--- a/plugins/python/filters/ProgrammableFilter.hpp
+++ b/plugins/python/filters/ProgrammableFilter.hpp
@@ -54,7 +54,7 @@ public:
     static int32_t destroy(void *);
     std::string getName() const;
 
-    Options getDefaultOptions();
+    Options getAnsweredOptions();
 
 private:
     plang::Script* m_script;

--- a/plugins/rxp/io/RxpReader.cpp
+++ b/plugins/rxp/io/RxpReader.cpp
@@ -97,7 +97,7 @@ Dimension::IdList getRxpDimensions(bool syncToPps, bool minimal)
 }
 
 
-Options RxpReader::getDefaultOptions()
+Options RxpReader::getAnsweredOptions()
 {
     Options options;
     options.add("sync_to_pps", DEFAULT_SYNC_TO_PPS, "");

--- a/plugins/rxp/io/RxpReader.hpp
+++ b/plugins/rxp/io/RxpReader.hpp
@@ -75,7 +75,7 @@ public:
     static int32_t destroy(void *);
     std::string getName() const;
 
-    Options getDefaultOptions();
+    Options getAnsweredOptions();
     static Dimension::IdList getDefaultDimensions()
     {
         return getRxpDimensions(DEFAULT_SYNC_TO_PPS, DEFAULT_MINIMAL);

--- a/plugins/sqlite/io/SQLiteReader.cpp
+++ b/plugins/sqlite/io/SQLiteReader.cpp
@@ -90,7 +90,7 @@ void SQLiteReader::initialize()
 }
 
 
-Options SQLiteReader::getDefaultOptions()
+Options SQLiteReader::getAnsweredOptions()
 {
     Options options;
 

--- a/plugins/sqlite/io/SQLiteReader.hpp
+++ b/plugins/sqlite/io/SQLiteReader.hpp
@@ -55,7 +55,7 @@ public:
     static int32_t destroy(void *);
     std::string getName() const;
 
-    Options getDefaultOptions();
+    Options getAnsweredOptions();
     SpatialReference fetchSpatialReference(std::string const& query) const;
     SQLite& getSession()
         { return *m_session.get(); }


### PR DESCRIPTION
The previous method name is still available as a public method, but
it is aliased to getAnsweredOptions. We are going to do this for a
while to attempt not to break plugins for a version or two.