### PR TITLE
Create transform for ReprojectionFilter as soon as necessary inputs are available.

### DIFF
--- a/filters/reprojection/ReprojectionFilter.cpp
+++ b/filters/reprojection/ReprojectionFilter.cpp
@@ -126,6 +126,9 @@ void ReprojectionFilter::initialize()
         throw pdal_error(oss.str());
     }
 
+    // If we have our input and output spatial references, create the transform
+    // now.  Otherwise, if this filter is used via the FilterWrapper, it will
+    // not be initialized properly since run() won't get called.
     if (!m_inferInputSRS)
     {
         createTransform(0);

--- a/filters/reprojection/ReprojectionFilter.cpp
+++ b/filters/reprojection/ReprojectionFilter.cpp
@@ -126,7 +126,10 @@ void ReprojectionFilter::initialize()
         throw pdal_error(oss.str());
     }
 
-    if (!m_inferInputSRS) createTransform(nullptr);
+    if (!m_inferInputSRS)
+    {
+        createTransform(0);
+    }
 }
 
 
@@ -134,11 +137,6 @@ void ReprojectionFilter::createTransform(PointView *view)
 {
     if (m_inferInputSRS)
     {
-        if (!view)
-        {
-            throw pdal_error(getName() + ": Cannot infer SRS from empty view");
-        }
-
         m_inSRS = view->spatialReference();
 
         if (m_inSRS.empty())
@@ -204,7 +202,10 @@ PointViewSet ReprojectionFilter::run(PointViewPtr view)
     PointViewSet viewSet;
     PointViewPtr outView = view->makeNew();
 
-    if (m_inferInputSRS) createTransform(view.get());
+    if (m_inferInputSRS)
+    {
+        createTransform(view.get());
+    }
 
     double x, y, z;
 

--- a/filters/reprojection/ReprojectionFilter.cpp
+++ b/filters/reprojection/ReprojectionFilter.cpp
@@ -125,6 +125,8 @@ void ReprojectionFilter::initialize()
             "for the 'out_srs' option.";
         throw pdal_error(oss.str());
     }
+
+    if (!m_inferInputSRS) createTransform(nullptr);
 }
 
 
@@ -132,7 +134,13 @@ void ReprojectionFilter::createTransform(PointView *view)
 {
     if (m_inferInputSRS)
     {
+        if (!view)
+        {
+            throw pdal_error(getName() + ": Cannot infer SRS from empty view");
+        }
+
         m_inSRS = view->spatialReference();
+
         if (m_inSRS.empty())
         {
             std::ostringstream oss;
@@ -196,7 +204,7 @@ PointViewSet ReprojectionFilter::run(PointViewPtr view)
     PointViewSet viewSet;
     PointViewPtr outView = view->makeNew();
 
-    createTransform(view.get());
+    if (m_inferInputSRS) createTransform(view.get());
 
     double x, y, z;
 


### PR DESCRIPTION
After `processOptions`, if an input SRS was explicitly provided, we can create the transform here instead of waiting until `run`, which the `FilterWrapper` does not call.  If this is the case, this PR creates the transform during `initialize` so the filter wrapper may be used to manage a reprojection filter.