### PR TITLE
Prevent segfaults in outlier filters

### DIFF
--- a/plugins/pcl/filters/RadiusOutlierFilter.cpp
+++ b/plugins/pcl/filters/RadiusOutlierFilter.cpp
@@ -136,6 +136,14 @@ PointViewSet RadiusOutlierFilter::run(PointViewPtr input)
     pcl::PointIndicesPtr inliers(new pcl::PointIndices);
     ror.getRemovedIndices(*inliers);
 
+    PointViewSet viewSet;
+    if (inliers->indices.empty())
+    {
+        log()->get(LogLevel::Warning) << "Requested filter would remove all points. Try a larger radius/smaller minimum neighbors.\n";
+        viewSet.insert(input);
+        return viewSet;
+    }
+
     // inverse are the outliers
     std::vector<int> outliers(input->size()-inliers->indices.size());
     for (PointId i = 0, j = 0, k = 0; i < input->size(); ++i)
@@ -148,7 +156,6 @@ PointViewSet RadiusOutlierFilter::run(PointViewPtr input)
         outliers[k++] = i;
     }
 
-    PointViewSet viewSet;
     if (!outliers.empty() && (m_classify || m_extract))
     {
 
@@ -184,10 +191,10 @@ PointViewSet RadiusOutlierFilter::run(PointViewPtr input)
     else
     {
         if (outliers.empty())
-            log()->get(LogLevel::Debug2) << "Filtered cloud has no outliers!\n";
+            log()->get(LogLevel::Warning) << "Filtered cloud has no outliers!\n";
 
         if (!(m_classify || m_extract))
-            log()->get(LogLevel::Debug2) << "Must choose --classify or --extract\n";
+            log()->get(LogLevel::Warning) << "Must choose --classify or --extract\n";
 
         // return the input buffer unchanged
         viewSet.insert(input);

--- a/plugins/pcl/filters/StatisticalOutlierFilter.cpp
+++ b/plugins/pcl/filters/StatisticalOutlierFilter.cpp
@@ -136,6 +136,16 @@ PointViewSet StatisticalOutlierFilter::run(PointViewPtr input)
     pcl::PointIndicesPtr inliers(new pcl::PointIndices);
     sor.getRemovedIndices(*inliers);
 
+    log()->get(LogLevel::Debug2) << inliers->indices.size() << std::endl;
+
+    PointViewSet viewSet;
+    if (inliers->indices.empty())
+    {
+        log()->get(LogLevel::Warning) << "Requested filter would remove all points. Try increasing the multiplier.\n";
+        viewSet.insert(input);
+        return viewSet;
+    }
+
     // inverse are the outliers
     std::vector<int> outliers(input->size()-inliers->indices.size());
     for (PointId i = 0, j = 0, k = 0; i < input->size(); ++i)
@@ -148,7 +158,6 @@ PointViewSet StatisticalOutlierFilter::run(PointViewPtr input)
         outliers[k++] = i;
     }
 
-    PointViewSet viewSet;
     if (!outliers.empty() && (m_classify || m_extract))
     {
 
@@ -184,10 +193,10 @@ PointViewSet StatisticalOutlierFilter::run(PointViewPtr input)
     else
     {
         if (outliers.empty())
-            log()->get(LogLevel::Debug2) << "Filtered cloud has no outliers!\n";
+            log()->get(LogLevel::Warning) << "Filtered cloud has no outliers!\n";
 
         if (!(m_classify || m_extract))
-            log()->get(LogLevel::Debug2) << "Must choose --classify or --extract\n";
+            log()->get(LogLevel::Warning) << "Must choose --classify or --extract\n";
 
         // return the input buffer unchanged
         viewSet.insert(input);


### PR DESCRIPTION
If the radius or statistical outlier filters would remove all points, log it, and return the input cloud. This is especially problematic if `filters.radiusoutlier.radius` is chosen too small, and the minimum number of neighbors cannot be satisfied.