### PR TITLE
Output more convenient metadata for bbox and SRS

### DIFF
--- a/filters/stats/StatsFilter.cpp
+++ b/filters/stats/StatsFilter.cpp
@@ -38,10 +38,8 @@
 
 #include <pdal/pdal_export.hpp>
 #include <pdal/Options.hpp>
-/**
+#include <pdal/Polygon.hpp>
 #include <pdal/PDALUtils.hpp>
-#include <pdal/util/Utils.hpp>
-**/
 
 namespace pdal
 {
@@ -107,7 +105,7 @@ void StatsFilter::filter(PointView& view)
 
 void StatsFilter::done(PointTableRef table)
 {
-    extractMetadata();
+    extractMetadata(table);
 }
 
 
@@ -168,9 +166,9 @@ void StatsFilter::prepared(PointTableRef table)
         m_stats.insert(std::make_pair(layout->findDim(dv.first),
             Summary(dv.first, dv.second)));
 }
-    
 
-void StatsFilter::extractMetadata()
+
+void StatsFilter::extractMetadata(PointTableRef table)
 {
     uint32_t position(0);
 
@@ -181,6 +179,39 @@ void StatsFilter::extractMetadata()
         MetadataNode t = m_metadata.addList("statistic");
         t.add("position", position++);
         s.extractMetadata(t);
+    }
+
+    // If we have X, Y, & Z dims, output bboxes
+    auto xs = m_stats.find(Dimension::Id::X);
+    auto ys = m_stats.find(Dimension::Id::Y);
+    auto zs = m_stats.find(Dimension::Id::Z);
+    if (xs != m_stats.end() &&
+        ys != m_stats.end() &&
+        zs != m_stats.end())
+    {
+        BOX3D box(xs->second.minimum(), ys->second.minimum(), zs->second.minimum(),
+                  xs->second.maximum(), ys->second.maximum(), zs->second.maximum());
+        pdal::Polygon p(box);
+
+        MetadataNode mbox = Utils::toMetadata(box);
+        MetadataNode box_metadata = m_metadata.add("bbox");
+        MetadataNode metadata = box_metadata.add("native");
+        MetadataNode bbox = metadata.add(mbox);
+        SpatialReference ref = table.anySpatialReference();
+        // if we don't get an SRS from the PointTableRef,
+        // we won't add another metadata node
+        if (!ref.empty())
+        {
+            p.setSpatialReference(ref);
+            SpatialReference epsg4326("EPSG:4326");
+            pdal::Polygon pdd = p.transform(epsg4326);
+            BOX3D ddbox = pdd.bounds();
+            MetadataNode epsg_4326_box = Utils::toMetadata(ddbox);
+            MetadataNode dddbox = box_metadata.add("EPSG:4326");
+            dddbox.add(epsg_4326_box);
+
+
+        }
     }
 }
 

--- a/filters/stats/StatsFilter.hpp
+++ b/filters/stats/StatsFilter.hpp
@@ -129,7 +129,7 @@ private:
     virtual void prepared(PointTableRef table);
     virtual void done(PointTableRef table);
     virtual void filter(PointView& view);
-    void extractMetadata();
+    void extractMetadata(PointTableRef table);
 
     StringList m_dimNames;
     StringList m_enums;

--- a/include/pdal/Metadata.hpp
+++ b/include/pdal/Metadata.hpp
@@ -67,7 +67,7 @@ typedef std::vector<MetadataNodeImplPtr> MetadataImplList;
 typedef std::map<std::string, MetadataImplList> MetadataSubnodes;
 typedef std::vector<MetadataNode> MetadataNodeList;
 
-class MetadataNodeImpl
+class PDAL_DLL MetadataNodeImpl
 {
     friend class MetadataNode;
 

--- a/include/pdal/Metadata.hpp
+++ b/include/pdal/Metadata.hpp
@@ -673,7 +673,7 @@ public:
     MetadataNode getNode() const
         { return m_root; }
 
-    static std::string inferType(const std::string& val);
+    static std::string PDAL_DLL inferType(const std::string& val);
 private:
     MetadataNode m_root;
     MetadataNode m_private;

--- a/include/pdal/Metadata.hpp
+++ b/include/pdal/Metadata.hpp
@@ -39,7 +39,6 @@
 #include <pdal/util/Bounds.hpp>
 #include <pdal/util/Utils.hpp>
 #include <pdal/util/Uuid.hpp>
-#include <pdal/SpatialReference.hpp>
 
 #include <map>
 #include <memory>
@@ -48,6 +47,8 @@
 
 namespace pdal
 {
+
+class SpatialReference;
 
 namespace MetadataType
 {
@@ -240,11 +241,7 @@ inline void MetadataNodeImpl::setValue<double>(const double& d)
 }
 
 template <>
-inline void MetadataNodeImpl::setValue(const SpatialReference& ref)
-{
-    m_type = "spatialreference";
-    m_value = Utils::toString(ref);
-}
+void MetadataNodeImpl::setValue(const SpatialReference& ref);
 
 template <>
 inline void MetadataNodeImpl::setValue(const BOX3D& b)
@@ -676,7 +673,7 @@ public:
     MetadataNode getNode() const
         { return m_root; }
 
-    inline static std::string inferType(const std::string& val);
+    static std::string inferType(const std::string& val);
 private:
     MetadataNode m_root;
     MetadataNode m_private;
@@ -684,62 +681,6 @@ private:
 };
 typedef std::shared_ptr<Metadata> MetadataPtr;
 
-inline std::string Metadata::inferType(const std::string& val)
-{
-    size_t pos;
-
-    long l = 0;
-    try
-    {
-        pos = 0;
-        l = std::stol(val, &pos);
-    }
-    catch (std::invalid_argument)
-    {}
-    if (pos == val.length())
-        return (l < 0 ? "nonNegativeInteger" : "integer");
-
-    try
-    {
-        pos = 0;
-        std::stod(val, &pos);
-    }
-    catch(std::invalid_argument)
-    {}
-
-    if (pos == val.length())
-        return "double";
-
-    BOX2D b2d;
-    std::istringstream iss1(val);
-    iss1 >> b2d;
-    if (iss1.good())
-        return "bounds";
-
-    BOX3D b3d;
-    std::istringstream iss2(val);
-    iss2 >> b3d;
-    if (iss2.good())
-        return "bounds";
-
-    if (val == "true" || val == "false")
-        return "boolean";
-
-    try
-    {
-        SpatialReference s(val);
-        return "spatialreference";
-    }
-    catch (pdal_error&)
-    {
-    }
-
-    Uuid uuid(val);
-    if (!uuid.isNull())
-        return "uuid";
-
-    return "string";
-}
 
 } // namespace pdal
 

--- a/include/pdal/Metadata.hpp
+++ b/include/pdal/Metadata.hpp
@@ -241,7 +241,7 @@ inline void MetadataNodeImpl::setValue<double>(const double& d)
 }
 
 template <>
-void MetadataNodeImpl::setValue(const SpatialReference& ref);
+void PDAL_DLL MetadataNodeImpl::setValue(const SpatialReference& ref);
 
 template <>
 inline void MetadataNodeImpl::setValue(const BOX3D& b)

--- a/include/pdal/PDALUtils.hpp
+++ b/include/pdal/PDALUtils.hpp
@@ -266,6 +266,23 @@ inline MetadataNode toMetadata(const PointViewPtr view)
     return node;
 }
 
+inline MetadataNode toMetadata(const SpatialReference& ref)
+{
+    MetadataNode root("srs");
+    root.add("horizontal", ref.getHorizontal());
+    root.add("vertical", ref.getVertical());
+    root.add("isgeographic", ref.isGeographic());
+    root.add("isgeocentric", ref.isGeocentric());
+    root.add("proj4", ref.getProj4());
+    root.add("prettywkt", ref.getWKT(SpatialReference::eHorizontalOnly, true));
+    root.add("wkt", ref.getWKT(SpatialReference::eHorizontalOnly, false));
+    root.add("compoundwkt", ref.getWKT(SpatialReference::eCompoundOK, false));
+    root.add("prettycompoundwkt", ref.getWKT(SpatialReference::eCompoundOK, true));
+
+    return root;
+
+
+}
 inline MetadataNode toMetadata(const BOX2D& bounds)
 {
     MetadataNode output("bbox");

--- a/include/pdal/PDALUtils.hpp
+++ b/include/pdal/PDALUtils.hpp
@@ -266,6 +266,30 @@ inline MetadataNode toMetadata(const PointViewPtr view)
     return node;
 }
 
+inline MetadataNode toMetadata(const BOX2D& bounds)
+{
+    MetadataNode output("bbox");
+    output.add("minx", bounds.minx);
+    output.add("miny", bounds.miny);
+    output.add("maxx", bounds.maxx);
+    output.add("maxy", bounds.maxy);
+    return output;
+}
+
+inline MetadataNode toMetadata(const BOX3D& bounds)
+{
+    MetadataNode output("bbox");
+    output.add("minx", bounds.minx);
+    output.add("miny", bounds.miny);
+    output.add("minz", bounds.minz);
+    output.add("maxx", bounds.maxx);
+    output.add("maxy", bounds.maxy);
+    output.add("maxz", bounds.maxz);
+    return output;
+}
+
+
+
 /// Outputs a string-based boost::property_tree::ptree representation
 /// of the BOX3D instance
 inline ptree toPTree(const BOX3D& bounds)

--- a/include/pdal/PDALUtils.hpp
+++ b/include/pdal/PDALUtils.hpp
@@ -279,6 +279,10 @@ inline MetadataNode toMetadata(const SpatialReference& ref)
     root.add("compoundwkt", ref.getWKT(SpatialReference::eCompoundOK, false));
     root.add("prettycompoundwkt", ref.getWKT(SpatialReference::eCompoundOK, true));
 
+    MetadataNode units = root.add("units");
+    units.add("vertical", ref.getVerticalUnits());
+    units.add("horizontal", ref.getVerticalUnits());
+
     return root;
 
 

--- a/include/pdal/PointTable.hpp
+++ b/include/pdal/PointTable.hpp
@@ -37,6 +37,7 @@
 #include <set>
 #include <vector>
 
+#include "pdal/SpatialReference.hpp"
 #include "pdal/Dimension.hpp"
 #include "pdal/PointContainer.hpp"
 #include "pdal/PointLayout.hpp"
@@ -176,7 +177,7 @@ protected:
 
 public:
     /// Called when a new point should be added.  Probably a no-op for
-    /// streaming. 
+    /// streaming.
     virtual PointId addPoint()
     { return 0; }
     /// Called when execute() is started.  Typically used to set buffer size

--- a/include/pdal/Polygon.hpp
+++ b/include/pdal/Polygon.hpp
@@ -97,7 +97,7 @@ public:
     bool valid() const;
     std::string validReason() const;
 
-    std::string wkt(double precision=8) const;
+    std::string wkt(double precision=8, bool bOutputZ=false) const;
     std::string json(double precision=8) const;
 
     BOX3D bounds() const;

--- a/include/pdal/Polygon.hpp
+++ b/include/pdal/Polygon.hpp
@@ -58,6 +58,7 @@ public:
     Polygon(const std::string& wkt_or_json,
            SpatialReference ref = SpatialReference(),
            ErrorHandlerPtr ctx = pdal::GlobalEnvironment::get().geos());
+    Polygon(const BOX2D&);
     Polygon(const Polygon&);
     Polygon(GEOSGeometry* g, const SpatialReference& srs, ErrorHandlerPtr ctx);
     Polygon(OGRGeometryH g, const SpatialReference& srs, ErrorHandlerPtr ctx);

--- a/include/pdal/Polygon.hpp
+++ b/include/pdal/Polygon.hpp
@@ -58,7 +58,7 @@ public:
     Polygon(const std::string& wkt_or_json,
            SpatialReference ref = SpatialReference(),
            ErrorHandlerPtr ctx = pdal::GlobalEnvironment::get().geos());
-    Polygon(const BOX2D&);
+    Polygon(const BOX3D&);
     Polygon(const Polygon&);
     Polygon(GEOSGeometry* g, const SpatialReference& srs, ErrorHandlerPtr ctx);
     Polygon(OGRGeometryH g, const SpatialReference& srs, ErrorHandlerPtr ctx);
@@ -72,6 +72,11 @@ public:
     void setSpatialReference( const SpatialReference& ref)
     {
         m_srs = ref;
+    }
+
+    const SpatialReference& getSpatialReference() const
+    {
+        return m_srs;
     }
 
     Polygon transform(const SpatialReference& ref) const;

--- a/include/pdal/Polygon.hpp
+++ b/include/pdal/Polygon.hpp
@@ -58,6 +58,7 @@ public:
     Polygon(const std::string& wkt_or_json,
            SpatialReference ref = SpatialReference(),
            ErrorHandlerPtr ctx = pdal::GlobalEnvironment::get().geos());
+    Polygon(const BOX2D&);
     Polygon(const BOX3D&);
     Polygon(const Polygon&);
     Polygon(GEOSGeometry* g, const SpatialReference& srs, ErrorHandlerPtr ctx);
@@ -106,6 +107,7 @@ public:
         { return m_geom != NULL; }
 private:
 
+    void initializeFromBounds(const BOX3D& b);
     GEOSGeometry *m_geom;
     const GEOSPreparedGeometry *m_prepGeom;
 

--- a/include/pdal/SpatialReference.hpp
+++ b/include/pdal/SpatialReference.hpp
@@ -40,6 +40,7 @@ namespace pdal
 {
 
 class PDAL_DLL BOX3D;
+class PDAL_DLL MetadataNode;
 
 /// A SpatialReference defines a model of the earth that is used to describe
 /// the location of points.
@@ -125,6 +126,7 @@ public:
     void setProj4(std::string const& v);
 
     void dump() const;
+    MetadataNode toMetadata() const;
 
     bool isGeographic() const;
     bool isGeocentric() const;

--- a/include/pdal/SpatialReference.hpp
+++ b/include/pdal/SpatialReference.hpp
@@ -93,8 +93,6 @@ public:
     /// available.
     std::string getWKT(WKTModeFlag mode_flag = eHorizontalOnly) const;
     std::string getWKT(WKTModeFlag mode_flag, bool pretty) const;
-    std::string getRawWKT() const
-        { return m_wkt; }
 
     /// Sets the SRS using GDAL's OGC WKT. If GDAL is not linked, this
     /// operation has no effect.
@@ -129,7 +127,9 @@ public:
     void dump() const;
 
     bool isGeographic() const;
+    bool isGeocentric() const;
     int computeUTMZone(const BOX3D& box) const;
+
     const std::string& getName() const;
     static int calculateZone(double lon, double lat);
 

--- a/include/pdal/SpatialReference.hpp
+++ b/include/pdal/SpatialReference.hpp
@@ -115,7 +115,9 @@ public:
     std::string getProj4() const;
 
     std::string getHorizontal() const;
+    std::string getHorizontalUnits() const;
     std::string getVertical() const;
+    std::string getVerticalUnits() const;
 
     /// Sets the Proj.4 string describing the Spatial Reference System.
     /// If GDAL is linked, it uses GDAL's operations and methods to determine

--- a/include/pdal/util/Bounds.hpp
+++ b/include/pdal/util/Bounds.hpp
@@ -172,6 +172,19 @@ public:
         return oss.str();
     }
 
+    std::string toGeoJSON(uint32_t precision = 8) const
+    {
+        if (empty())
+            return std::string();
+
+        std::stringstream oss;
+
+        oss.precision(precision);
+        oss.setf(std::ios_base::fixed, std::ios_base::floatfield);
+        oss << "{\"bbox\":[" << minx << ", " << miny << ", " << maxx <<  "," << maxy << "]}";
+        return oss.str();
+    }
+
     /// Returns a staticly-allocated Bounds extent that represents infinity
     static const BOX2D& getDefaultSpatialExtent();
 };

--- a/include/pdal/util/Bounds.hpp
+++ b/include/pdal/util/Bounds.hpp
@@ -202,6 +202,10 @@ public:
     BOX3D()
        { clear(); }
 
+    BOX3D(const BOX2D& box)
+      : BOX2D(box), minz(0.0), maxz(0.0)
+    {}
+
     BOX3D(const BOX3D& box) :
         BOX2D(box), minz(box.minz), maxz(box.maxz)
     {}

--- a/include/pdal/util/Bounds.hpp
+++ b/include/pdal/util/Bounds.hpp
@@ -202,10 +202,6 @@ public:
     BOX3D()
        { clear(); }
 
-    BOX3D(const BOX2D& box)
-      : BOX2D(box), minz(0.0), maxz(0.0)
-    {}
-
     BOX3D(const BOX3D& box) :
         BOX2D(box), minz(box.minz), maxz(box.maxz)
     {}

--- a/kernels/info/InfoKernel.cpp
+++ b/kernels/info/InfoKernel.cpp
@@ -232,6 +232,8 @@ MetadataNode InfoKernel::dumpSummary(const QuickInfo& qi)
     MetadataNode summary;
     summary.add("num_points", qi.m_pointCount);
     summary.add("spatial_reference", qi.m_srs.getWKT());
+    MetadataNode srs = qi.m_srs.toMetadata();
+    summary.add(srs);
     MetadataNode bounds = summary.add("bounds");
     MetadataNode x = bounds.add("X");
     x.add("min", qi.m_bounds.minx);

--- a/kernels/info/InfoKernel.cpp
+++ b/kernels/info/InfoKernel.cpp
@@ -232,7 +232,7 @@ MetadataNode InfoKernel::dumpSummary(const QuickInfo& qi)
     MetadataNode summary;
     summary.add("num_points", qi.m_pointCount);
     summary.add("spatial_reference", qi.m_srs.getWKT());
-    MetadataNode srs = qi.m_srs.toMetadata();
+    MetadataNode srs = pdal::Utils::toMetadata(qi.m_srs);
     summary.add(srs);
     MetadataNode bounds = summary.add("bounds");
     MetadataNode x = bounds.add("X");

--- a/plugins/mrsid/test/MrsidTest.cpp
+++ b/plugins/mrsid/test/MrsidTest.cpp
@@ -37,7 +37,6 @@
 
 #include <pdal/PointView.hpp>
 #include <pdal/PipelineManager.hpp>
-#include <pdal/PipelineReader.hpp>
 #include <pdal/StageFactory.hpp>
 #include <las/LasWriter.hpp>
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -85,6 +85,7 @@ set(PDAL_BASE_CPP
   KernelFactory.cpp
   KernelSupport.cpp
   Log.cpp
+  Metadata.cpp
   Options.cpp
   PDALUtils.cpp
   PointLayout.cpp

--- a/src/GEOSUtils.cpp
+++ b/src/GEOSUtils.cpp
@@ -112,7 +112,6 @@ void ErrorHandler::error(char const* msg)
 
 ErrorHandler::~ErrorHandler()
 {
-    std::cout << "context is going away" <<std::endl;
 #ifdef GEOS_finish_r
     GEOS_finish_r(ctx);
 #else

--- a/src/Metadata.cpp
+++ b/src/Metadata.cpp
@@ -1,0 +1,107 @@
+/******************************************************************************
+ * Copyright (c) 2012, Howard Butler (howard@hobu.co)
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of the Martin Isenburg or Iowa Department
+ *       of Natural Resources nor the names of its contributors may be
+ *       used to endorse or promote products derived from this software
+ *       without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ ****************************************************************************/
+
+#include <pdal/Metadata.hpp>
+#include <pdal/SpatialReference.hpp>
+
+namespace pdal
+{
+
+template <>
+void MetadataNodeImpl::setValue(const SpatialReference& ref)
+{
+    m_type = "spatialreference";
+    m_value = Utils::toString(ref);
+}
+
+
+std::string Metadata::inferType(const std::string& val)
+{
+    size_t pos;
+
+    long l = 0;
+    try
+    {
+        pos = 0;
+        l = std::stol(val, &pos);
+    }
+    catch (std::invalid_argument)
+    {}
+    if (pos == val.length())
+        return (l < 0 ? "nonNegativeInteger" : "integer");
+
+    try
+    {
+        pos = 0;
+        std::stod(val, &pos);
+    }
+    catch(std::invalid_argument)
+    {}
+
+    if (pos == val.length())
+        return "double";
+
+    BOX2D b2d;
+    std::istringstream iss1(val);
+    iss1 >> b2d;
+    if (iss1.good())
+        return "bounds";
+
+    BOX3D b3d;
+    std::istringstream iss2(val);
+    iss2 >> b3d;
+    if (iss2.good())
+        return "bounds";
+
+    if (val == "true" || val == "false")
+        return "boolean";
+
+    try
+    {
+        SpatialReference s(val);
+        return "spatialreference";
+    }
+    catch (pdal_error&)
+    {
+    }
+
+    Uuid uuid(val);
+    if (!uuid.isNull())
+        return "uuid";
+
+    return "string";
+}
+
+
+} // namespace pdal

--- a/src/Polygon.cpp
+++ b/src/Polygon.cpp
@@ -170,7 +170,7 @@ Polygon::Polygon(OGRGeometryH g, const SpatialReference& srs, ErrorHandlerPtr ct
     prepare();
 
 }
-Polygon::Polygon(const BOX2D& box)
+Polygon::Polygon(const BOX3D& box)
 : m_ctx(pdal::GlobalEnvironment::get().geos())
 {
     GEOSCoordSequence* coords = GEOSCoordSeq_create_r((*m_ctx).ctx, 5, 2);

--- a/src/Polygon.cpp
+++ b/src/Polygon.cpp
@@ -170,8 +170,22 @@ Polygon::Polygon(OGRGeometryH g, const SpatialReference& srs, ErrorHandlerPtr ct
     prepare();
 
 }
+
+Polygon::Polygon(const BOX2D& box)
+: m_ctx(pdal::GlobalEnvironment::get().geos())
+{
+    BOX3D box3(box.minx, box.miny, 0.0,
+               box.maxx, box.maxy, 0.0);
+    initializeFromBounds(box3);
+}
+
 Polygon::Polygon(const BOX3D& box)
 : m_ctx(pdal::GlobalEnvironment::get().geos())
+{
+    initializeFromBounds(box);
+}
+
+void Polygon::initializeFromBounds(const BOX3D& box)
 {
     GEOSCoordSequence* coords = GEOSCoordSeq_create_r((*m_ctx).ctx, 5, 3);
     auto set_coordinate = [coords, this](int pt_num, const double&x, const double& y, const double& z)

--- a/src/SpatialReference.cpp
+++ b/src/SpatialReference.cpp
@@ -192,6 +192,33 @@ std::string SpatialReference::getVertical() const
     return tmp;
 }
 
+std::string SpatialReference::getVerticalUnits() const
+{
+    std::string tmp("");
+
+    std::string wkt = getWKT(eCompoundOK);
+    const char* poWKT = wkt.c_str();
+    OGRSpatialReference* poSRS =
+        (OGRSpatialReference*)OSRNewSpatialReference(m_wkt.c_str());
+    if (poSRS)
+    {
+        OGR_SRSNode* node = poSRS->GetAttrNode("VERT_CS");
+        if (node)
+        {
+            char* units(0);
+            double u = poSRS->GetLinearUnits(&units);
+            tmp = units;
+            CPLFree(units);
+
+            Utils::trim(tmp);
+
+        }
+    }
+
+    return tmp;
+}
+
+
 std::string SpatialReference::getHorizontal() const
 {
     std::string tmp("");
@@ -208,6 +235,26 @@ std::string SpatialReference::getHorizontal() const
         tmp = pszWKT;
         CPLFree(pszWKT);
         OSRDestroySpatialReference(poSRS);
+    }
+
+    return tmp;
+}
+
+std::string SpatialReference::getHorizontalUnits() const
+{
+    std::string tmp("");
+
+    std::string wkt = getWKT(eHorizontalOnly);
+    const char* poWKT = wkt.c_str();
+    OGRSpatialReference srs(NULL);
+    if (OGRERR_NONE == srs.importFromWkt(const_cast<char **>(&poWKT)))
+    {
+        char* units(0);
+        double u = srs.GetLinearUnits(&units);
+        tmp = units;
+        CPLFree(units);
+
+        Utils::trim(tmp);
     }
 
     return tmp;

--- a/src/SpatialReference.cpp
+++ b/src/SpatialReference.cpp
@@ -272,6 +272,14 @@ bool SpatialReference::isGeographic() const
     return output;
 }
 
+bool SpatialReference::isGeocentric() const
+{
+    OGRSpatialReferenceH current =
+        OSRNewSpatialReference(getWKT(eCompoundOK, false).c_str());
+    bool output = OSRIsGeocentric(current);
+    OSRDestroySpatialReference(current);
+    return output;
+}
 
 int SpatialReference::calculateZone(double lon, double lat)
 {

--- a/src/SpatialReference.cpp
+++ b/src/SpatialReference.cpp
@@ -413,23 +413,6 @@ void SpatialReference::dump() const
     std::cout << *this;
 }
 
-MetadataNode SpatialReference::toMetadata() const
-{
-
-    MetadataNode root("srs");
-    root.add("horizontal", getHorizontal());
-    root.add("vertical", getVertical());
-    root.add("isgeographic", isGeographic());
-    root.add("isgeocentric", isGeocentric());
-    root.add("proj4", getProj4());
-    root.add("prettywkt", getWKT(SpatialReference::eHorizontalOnly, true));
-    root.add("wkt", getWKT(SpatialReference::eHorizontalOnly, false));
-    root.add("compoundwkt", getWKT(SpatialReference::eCompoundOK, false));
-    root.add("prettycompoundwkt", getWKT(SpatialReference::eCompoundOK, true));
-
-    return root;
-}
-
 
 std::ostream& operator<<(std::ostream& ostr, const SpatialReference& srs)
 {

--- a/src/SpatialReference.cpp
+++ b/src/SpatialReference.cpp
@@ -34,6 +34,7 @@
 
 #include <pdal/SpatialReference.hpp>
 #include <pdal/PDALUtils.hpp>
+#include <pdal/Metadata.hpp>
 
 // gdal
 #ifdef PDAL_COMPILER_CLANG
@@ -410,6 +411,23 @@ int SpatialReference::computeUTMZone(const BOX3D& box) const
 void SpatialReference::dump() const
 {
     std::cout << *this;
+}
+
+MetadataNode SpatialReference::toMetadata() const
+{
+
+    MetadataNode root("srs");
+    root.add("horizontal", getHorizontal());
+    root.add("vertical", getVertical());
+    root.add("isgeographic", isGeographic());
+    root.add("isgeocentric", isGeocentric());
+    root.add("proj4", getProj4());
+    root.add("prettywkt", getWKT(SpatialReference::eHorizontalOnly, true));
+    root.add("wkt", getWKT(SpatialReference::eHorizontalOnly, false));
+    root.add("compoundwkt", getWKT(SpatialReference::eCompoundOK, false));
+    root.add("prettycompoundwkt", getWKT(SpatialReference::eCompoundOK, true));
+
+    return root;
 }
 
 

--- a/src/Stage.cpp
+++ b/src/Stage.cpp
@@ -376,6 +376,7 @@ void Stage::setSpatialReference(MetadataNode& m,
     MetadataNode spatialNode = m.findChild(pred);
     if (spatialNode.empty())
     {
+        m.add(spatialRef.toMetadata());
         m.add("spatialreference",
            spatialRef.getWKT(SpatialReference::eHorizontalOnly, false),
            "SRS of this stage");

--- a/src/Stage.cpp
+++ b/src/Stage.cpp
@@ -37,6 +37,7 @@
 #include <pdal/Stage.hpp>
 #include <pdal/SpatialReference.hpp>
 #include <pdal/UserCallback.hpp>
+#include <pdal/PDALUtils.hpp>
 
 #include "StageRunner.hpp"
 
@@ -376,7 +377,7 @@ void Stage::setSpatialReference(MetadataNode& m,
     MetadataNode spatialNode = m.findChild(pred);
     if (spatialNode.empty())
     {
-        m.add(spatialRef.toMetadata());
+        m.add(Utils::toMetadata(spatialRef));
         m.add("spatialreference",
            spatialRef.getWKT(SpatialReference::eHorizontalOnly, false),
            "SRS of this stage");

--- a/test/unit/BoundsTest.cpp
+++ b/test/unit/BoundsTest.cpp
@@ -266,6 +266,12 @@ TEST(BoundsTest, test_wkt)
     std::string out2 = "POLYHEDRON Z ( ((1.1 2.2 3.3, 101.1 2.2 3.3, 101.1 102.2 3.3, 1.1 102.2 3.3, 1.1 2.2 3.3, )), ((1.1 2.2 3.3, 101.1 2.2 3.3, 101.1 2.2 103.3, 1.1 2.2 103.3, 1.1 2.2 3.3, )), ((101.1 2.2 3.3, 101.1 102.2 3.3, 101.1 102.2 103.3, 101.1 2.2 103.3, 101.1 2.2 3.3, )), ((101.1 102.2 3.3, 1.1 102.2 3.3, 1.1 102.2 103.3, 101.1 102.2 103.3, 101.1 102.2 3.3, )), ((1.1 102.2 3.3, 1.1 2.2 3.3, 1.1 2.2 103.3, 1.1 102.2 103.3, 1.1 102.2 3.3, )), ((1.1 2.2 103.3, 101.1 2.2 103.3, 101.1 102.2 103.3, 1.1 102.2 103.3, 1.1 2.2 103.3, )) )";
     EXPECT_EQ(b2.toWKT(1), out2);
 }
+TEST(BoundsTest, test_json)
+{
+    BOX2D b(1.1,2.2,101.1,102.2);
+    std::string out = "{\"bbox\":[1.1, 2.2, 101.1,102.2]}";
+    EXPECT_EQ(b.toGeoJSON(1), out);
+}
 
 TEST(BoundsTest, test_2d_input)
 {
@@ -285,7 +291,7 @@ TEST(BoundsTest, test_precisionloss)
     // when you do something like:
     //   options.getValueOrDefault<BOX3D>("bounds", BOX3D());
     std::ostringstream oss;
-    oss << b1; 
+    oss << b1;
 
     // convert it back
     std::istringstream iss(oss.str());

--- a/test/unit/MetadataTest.cpp
+++ b/test/unit/MetadataTest.cpp
@@ -37,6 +37,7 @@
 #include <boost/algorithm/string.hpp>
 
 #include <pdal/Metadata.hpp>
+#include <pdal/SpatialReference.hpp>
 
 using namespace pdal;
 

--- a/test/unit/PolygonTest.cpp
+++ b/test/unit/PolygonTest.cpp
@@ -160,6 +160,35 @@ TEST(PolygonTest, bounds)
     EXPECT_FLOAT_EQ(b.maxz, 438.70996);
 }
 
+TEST(PolygonTest, bounds2d)
+{
+    BOX2D box(636539.12, 850511.81, 637589.94, 851528.5);
+    pdal::Polygon p(box);
+
+    BOX3D b = p.bounds();
+    EXPECT_FLOAT_EQ(b.minx, 636539.12);
+    EXPECT_FLOAT_EQ(b.miny, 850511.81);
+    EXPECT_FLOAT_EQ(b.minz, 0.0);
+    EXPECT_FLOAT_EQ(b.maxx, 637589.94);
+    EXPECT_FLOAT_EQ(b.maxy, 851528.5);
+    EXPECT_FLOAT_EQ(b.maxz, 0.0);
+}
+
+TEST(PolygonTest, bounds3d)
+{
+    BOX3D box(636539.12, 850511.81, 420.50977, 637589.94, 851528.5, 438.70996);
+    pdal::Polygon p(box);
+
+    BOX3D b = p.bounds();
+    EXPECT_FLOAT_EQ(b.minx, 636539.12);
+    EXPECT_FLOAT_EQ(b.miny, 850511.81);
+    EXPECT_FLOAT_EQ(b.minz, 420.50977);
+    EXPECT_FLOAT_EQ(b.maxx, 637589.94);
+    EXPECT_FLOAT_EQ(b.maxy, 851528.5);
+    EXPECT_FLOAT_EQ(b.maxz, 438.70996);
+}
+
+
 TEST(PolygonTest, streams)
 {
     pdal::Polygon p(getWKT());

--- a/test/unit/SpatialReferenceTest.cpp
+++ b/test/unit/SpatialReferenceTest.cpp
@@ -35,6 +35,7 @@
 #include <pdal/pdal_test_main.hpp>
 
 #include <pdal/SpatialReference.hpp>
+#include <pdal/Polygon.hpp>
 #include <pdal/util/FileUtils.hpp>
 #include <ReprojectionFilter.hpp>
 #include <MergeFilter.hpp>
@@ -396,4 +397,34 @@ TEST(SpatialReferenceTest, merge)
     Support::checkXYZ(Support::temppath("triple.las"),
         Support::datapath("las/test_epsg_4326x3.las"));
 }
+
 #endif
+
+TEST(SpatialReferenceTest, test_bounds)
+{
+
+#if GDAL_VERSION_MAJOR <=1
+    const std::string utm17_wkt = "PROJCS[\"WGS 84 / UTM zone 17N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",-81],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AUTHORITY[\"EPSG\",\"32617\"]]";
+#else
+    const std::string utm17_wkt = "PROJCS[\"WGS 84 / UTM zone 17N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",-81],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"32617\"]]";
+#endif
+
+    SpatialReference utm17(utm17_wkt);
+
+    std::string wgs84_wkt = "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]";
+
+
+    SpatialReference wgs84(wgs84_wkt);
+    BOX2D box17(289814.15, 4320978.61, 289818.50, 4320980.59);
+    Polygon p(box17);
+    p.setSpatialReference(utm17);
+    Polygon p2 = p.transform(wgs84);
+
+    BOX3D b2 = p2.bounds();
+    EXPECT_FLOAT_EQ(b2.minx, -83.42759776);
+    EXPECT_FLOAT_EQ(b2.miny, 39.01259905);
+    EXPECT_FLOAT_EQ(b2.maxx, -83.427551);
+    EXPECT_FLOAT_EQ(b2.maxy, 39.01261687);
+
+}
+

--- a/test/unit/SpatialReferenceTest.cpp
+++ b/test/unit/SpatialReferenceTest.cpp
@@ -416,9 +416,9 @@ TEST(SpatialReferenceTest, test_bounds)
 
     SpatialReference wgs84(wgs84_wkt);
     BOX2D box17(289814.15, 4320978.61, 289818.50, 4320980.59);
-    Polygon p(box17);
+    pdal::Polygon p(box17);
     p.setSpatialReference(utm17);
-    Polygon p2 = p.transform(wgs84);
+    pdal::Polygon p2 = p.transform(wgs84);
 
     BOX3D b2 = p2.bounds();
     EXPECT_FLOAT_EQ(b2.minx, -83.42759776);


### PR DESCRIPTION
Output bbox information in `filter.stats`:
```
    "bbox":
    {
      "EPSG:4326":
      {
        "bbox":
        {
          "maxx": -123.0625001,
          "maxy": 44.0624972,
          "maxz": 178.73,
          "minx": -123.0749695,
          "miny": 44.0500086,
          "minz": 123.93
        }
      },
      "native":
      {
        "bbox":
        {
          "maxx": -123.0625001,
          "maxy": 44.0624972,
          "maxz": 178.73,
          "minx": -123.0749695,
          "miny": 44.0500086,
          "minz": 123.93
        }
      }
    },
```