### PR TITLE
GEOS is no longer optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,7 +219,7 @@ set(PDAL_BUILD_TYPE ${CMAKE_BUILD_TYPE})
 #------------------------------------------------------------------------------
 
 include(${PDAL_CMAKE_DIR}/gdal.cmake)
-include(${PDAL_CMAKE_DIR}/geos.cmake)  # Optional
+include(${PDAL_CMAKE_DIR}/geos.cmake)
 include(${PDAL_CMAKE_DIR}/geotiff.cmake)  # Optional
 include(${PDAL_CMAKE_DIR}/lazperf.cmake)  # Optional
 include(${PDAL_CMAKE_DIR}/laszip.cmake)  # Optional


### PR DESCRIPTION
geos.cmake specifies REQUIRED property

It is confirmed by CMake error while configuring VS2015 32-bit build, if GEOS is not found:

```
-- The following REQUIRED packages have not been found:

 * GEOS (required version >= 3.3)
   Provides general purpose geometry support

CMake Error: The following variables are used in this project, but they are set to NOTFOUND.
Please set them or make sure they are set and tested correctly in the CMake files:
GEOS_INCLUDE_DIR
...
GEOS_LIBRARY
    linked by target "pdalcpp" in directory D:/dev/PDAL/src
```