### PR TITLE
Add missing #include <algorithm>

### DIFF
--- a/include/pdal/UserCallback.hpp
+++ b/include/pdal/UserCallback.hpp
@@ -34,6 +34,8 @@
 
 #pragma once
 
+#include <algorithm>
+
 #include <pdal/pdal_internal.hpp>
 
 namespace pdal


### PR DESCRIPTION
Required by std::max.

Otherwise, building `pdal_user_callback_test` project with VS2015 fails with:
```
include\pdal/UserCallback.hpp(69): 
  error C2039: 'max': is not a member of 'std'
    (compiling source file D:\dev\PDAL\test\unit\UserCallbackTest.cpp)
```
