### PR TITLE
Remove variable-length array use from ILVIS2 reader

### DIFF
--- a/io/ilvis2/Ilvis2MetadataReader.cpp
+++ b/io/ilvis2/Ilvis2MetadataReader.cpp
@@ -328,7 +328,7 @@ void Ilvis2MetadataReader::parseGPolygon(xmlNodePtr node, MetadataNode * m)
 
     // The number of boundaries is essentially the number of sub-polygons
     int numBoundaries = countChildElements(node, "Boundary");
-    GEOSGeom poly[numBoundaries];
+    std::vector<GEOSGeom> poly(numBoundaries); // size shall never change
     GEOSGeom fullPoly;
     int polyNum = 0;
 
@@ -391,7 +391,7 @@ void Ilvis2MetadataReader::parseGPolygon(xmlNodePtr node, MetadataNode * m)
     if (numBoundaries > 1)
     {
         fullPoly = GEOSGeom_createCollection(
-                GEOS_MULTIPOLYGON, poly, numBoundaries);
+                GEOS_MULTIPOLYGON, poly.data(), numBoundaries);
     }
     else
     {


### PR DESCRIPTION
Fixes compilation using Visual C++ (VS2015 Update 1) which has no support for C99 VLAs.

-----
Note, it does not correct potential memory leak in `Ilvis2MetadataReader::parseGPolygon`:
```
    if (numBoundaries > 1)
    {
        fullPoly = GEOSGeom_createCollection(
                GEOS_MULTIPOLYGON, poly.data(), numBoundaries);
    }
    else
    {
        fullPoly = poly[0];
    }
```

While `GEOSGeom_createCollection` takes ownership of the geometries passed in `poly` array, then in the `else` case, it is unclear who deallocates the single polygon.

