### PR TITLE
Define BOOST_ALL_NO_LIB to disable auto-linking

### DIFF
--- a/cmake/win32_compiler_options.cmake
+++ b/cmake/win32_compiler_options.cmake
@@ -12,6 +12,8 @@ if (MSVC)
       set(PDAL_COMPILER_VC8 1)
     endif()
 
+    add_definitions(-DBOOST_ALL_NO_LIB)
+
     # check for MSVC 8+
     if (NOT (MSVC_VERSION VERSION_LESS 1400))
         add_definitions(-D_CRT_SECURE_NO_DEPRECATE)


### PR DESCRIPTION
Fixes linker errors about missing `pdalboost_filesystem...lib` and others, while building with Visual Studio.

Fixes error while linking `pdal_util` against `pdal_boost`:

```
1>------ Build started: Project: pdal_util, Configuration: Debug x64 ------
1>LINK : fatal error LNK1104: cannot open file
'pdalboost_filesystem-vc110-mt-gd-1_60.lib'
========== Build: 0 succeeded, 1 failed, 0 up-to-date, 0 skipped ==========
```

Related ml thread https://lists.osgeo.org/pipermail/pdal/2016-February/000870.html