### PR TITLE
Fix UB caused by incrementing pass-the-end iterator

### DIFF
--- a/include/pdal/util/Utils.hpp
+++ b/include/pdal/util/Utils.hpp
@@ -229,14 +229,17 @@ namespace Utils
         if (s.empty())
             return result;
 
-        auto it = s.begin();
-        decltype(it) endIt;
+        auto it = s.cbegin();
+        auto const end = s.cend();
+        decltype(it) nextIt;
         do
         {
-            endIt = std::find_if(it, s.end(), p);
-            result.push_back(std::string(it, endIt));
-            it = endIt + 1;
-        } while (endIt != s.end());
+            nextIt = std::find_if(it, end, p);
+            result.push_back(std::string(it, nextIt));
+            if (nextIt != end)
+                it = nextIt + 1;
+        } while (nextIt != end);
+
         return result;
     }
 
@@ -254,15 +257,18 @@ namespace Utils
         if (s.empty())
             return result;
 
-        auto it = s.begin();
-        decltype(it) endIt;
+        auto it = s.cbegin();
+        auto const end = s.cend();
+        decltype(it) nextIt;
         do
         {
-            endIt = std::find_if(it, s.end(), p);
-            if (it != endIt)
-                result.push_back(std::string(it, endIt));
-            it = endIt + 1;
-        } while (endIt != s.end());
+            nextIt = std::find_if(it, end, p);
+            if (it != nextIt)
+                result.push_back(std::string(it, nextIt));
+            if (nextIt != end)
+                it = nextIt + 1;
+        } while (nextIt != end);
+
         return result;
     }
 


### PR DESCRIPTION
Iterator returned from `std::find_if` may point pass-the-end, but incrementing pass-the-end iterator is an undefined behaviour.

The bug was revealed by `stringsplit` case of the `OptionsTest`, where input string has separator(s) at as well as `UtilsTest`, where final `std::find_if` returns end iterator which must not be incremented.
