### PR TITLE
Fix out of range access bug in trimTrailing

### DIFF
--- a/src/util/Utils.cpp
+++ b/src/util/Utils.cpp
@@ -149,6 +149,9 @@ void Utils::trimLeading(std::string& s)
 
 void Utils::trimTrailing(std::string& s)
 {
+    if (s.empty())
+        return;
+
     size_t pos = s.size() - 1;
     while (isspace(s[pos]))
     {


### PR DESCRIPTION
If input string is empty, `size() - 1` overflows causing character access beyond valid range.