### PR TITLE
Open output file in binary mode to avoid EOL translation.

### DIFF
--- a/test/unit/PDALUtilsTest.cpp
+++ b/test/unit/PDALUtilsTest.cpp
@@ -55,7 +55,8 @@ TEST(PDALUtilsTest, options1)
     std::string testfile(Support::temppath("opts2json.txt"));
 
     {
-        std::ofstream out(testfile);
+        // Binary mode to avoid OS-specific translation of EOL
+        std::ofstream out(testfile, std::ios_base::binary);
         Utils::toJSON(ops, out);
     }
     EXPECT_TRUE(Support::compare_files(goodfile, testfile));


### PR DESCRIPTION
Otherwise, on Windows, EOL is translated to CRLF and test files do not compare as equal.