### PR TITLE
Catch up with changes in pdal output.

### DIFF
--- a/test/unit/apps/pc2pcTest.cpp
+++ b/test/unit/apps/pc2pcTest.cpp
@@ -55,12 +55,13 @@ static std::string appName()
 TEST(pc2pcTest, pc2pcTest_test_no_input)
 {
     std::string cmd = appName();
+    cmd += " 2>&1"; // pdal outputs to both, stdout and stderr
 
     std::string output;
     int stat = Utils::run_shell_command(cmd, output);
     EXPECT_EQ(stat, 1);
 
-    const std::string expected = "Usage error: --input";
+    const std::string expected = "PDAL: Missing value for positional argument 'input'.";
     EXPECT_EQ(output.substr(0, expected.length()), expected);
 }
 #endif


### PR DESCRIPTION
`Utils::run_shell_command` uses popen which only captures `stdout`, but pdal command outputs some
diagnostics to `stderr` too. So, `pc2pcTest` case has been updated to redirect pdal `stderr` to `stdout` to allow capturing expected output.

-----

Perhaps, not the test but `Utils::run_shell_command` should be updated to implicitly capture `stderr`. Let me know if such change would be desired, then I'll update the PR.

BTW, any reason the `pc2pcTest` is enabled only for MSVC?