### PR TITLE
Reimplement getFilename using filesystem::path

### DIFF
--- a/src/util/FileUtils.cpp
+++ b/src/util/FileUtils.cpp
@@ -270,16 +270,7 @@ string toAbsolutePath(const string& filename, const string base)
 
 string getFilename(const string& path)
 {
-#ifdef _WIN32
-    char pathsep = '\\';
-#else
-    char pathsep = '/';
-#endif
-
-    string::size_type pos = path.find_last_of(pathsep);
-    if (pos == string::npos)
-        return path;
-    return path.substr(pos + 1);
+    return pdalboost::filesystem::path(path).filename().string();
 }
 
 


### PR DESCRIPTION
Previously, on Windows, `getFilename` always looked for preferred separator only while it should look for both, preferred (backslash) and portable (slash) which are equally supported by Windows. PDAL in general seems to prefer portable slash separator anyway, so this change only aligns the impl. with the tests, docs, etc.

Fixes #1131.