### PR TITLE
Make getFilename aware of portable path separator on Windows.

### DIFF
--- a/src/util/FileUtils.cpp
+++ b/src/util/FileUtils.cpp
@@ -271,7 +271,7 @@ string toAbsolutePath(const string& filename, const string base)
 string getFilename(const string& path)
 {
 #ifdef _WIN32
-    char pathsep = '\\';
+    std::string pathsep("\\/");
 #else
     char pathsep = '/';
 #endif

--- a/test/unit/FileUtilsTest.cpp
+++ b/test/unit/FileUtilsTest.cpp
@@ -166,8 +166,31 @@ TEST(FileUtilsTest, test_isAbsolute)
 
 TEST(FileUtilsTest, filename)
 {
-    std::string filename = "/foo//bar//baz.c";
+    std::string filename = "";
+    EXPECT_EQ(FileUtils::getFilename(filename), "");
+
+    filename = "/";
+    EXPECT_EQ(FileUtils::getFilename(filename), "");
+
+    filename = "/foo/bar/";
+    EXPECT_EQ(FileUtils::getFilename(filename), "");
+
+    filename = "/foo//bar//baz.c";
     EXPECT_EQ(FileUtils::getFilename(filename), "baz.c");
+
+#ifdef _WIN32
+    filename = "C:/foo/bar/baz.c";
+    EXPECT_EQ(FileUtils::getFilename(filename), "baz.c");
+
+    filename = "C:\\foo\\bar\\baz.c";
+    EXPECT_EQ(FileUtils::getFilename(filename), "baz.c");
+
+    filename = "C:\\foo/bar\\meaw/baz.c";
+    EXPECT_EQ(FileUtils::getFilename(filename), "baz.c");
+#else
+    filename = "C:\\foo\\bar\\baz.c";
+    EXPECT_EQ(FileUtils::getFilename(filename), filename);
+#endif
 }
 
 TEST(FileUtilsTest, extension)


### PR DESCRIPTION
Previously, on Windows, getFilename always looked for preferred
separator only while it should look for both, preferred (backslash)
and portable (slash) which are equally supported by Windows.
PDAL in general seems to prefer portable slash separator anyway,
so this change only aligns the impl. with the tests, docs, etc.

Add more related test cases to FileUtilsTest.

Fixes #1131.