### PR TITLE
Compare bundle value up to the length of expected value.

### DIFF
--- a/test/unit/io/bpf/BPFTest.cpp
+++ b/test/unit/io/bpf/BPFTest.cpp
@@ -433,13 +433,13 @@ TEST(BPFTest, bundled)
     auto findbundle1 = [](const MetadataNode& m)
         { return m.name() == "bundle1"; };
     outbuf = Utils::base64_decode(n.find(findbundle1).value());
-    EXPECT_EQ(memcmp(outbuf.data(), "This is a test",
-        outbuf.size() - 1), 0);
+    std::string expect = "This is a test";
+    EXPECT_EQ(memcmp(outbuf.data(), expect.data(), expect.size()), 0);
     auto findbundle2 = [](const MetadataNode& m)
         { return m.name() == "bundle2"; };
     outbuf = Utils::base64_decode(n.find(findbundle2).value());
-    EXPECT_EQ(memcmp(outbuf.data(), "This is another test",
-        outbuf.size() - 1), 0);
+    expect = "This is another test";
+    EXPECT_EQ(memcmp(outbuf.data(), expect.data(), expect.size()), 0);
 }
 
 TEST(BPFTest, inspect)


### PR DESCRIPTION
On Windows, for reasons unknown to me, outbuf receives some extra bytes at the end of buffer (ASCII: 10 and 204).

-----
For example, the line `outbuf = Utils::base64_decode(n.find(findbundle1).value());` fills the buffer with the garbage (?) at the end:

```
outbuf.size()
16
outbuf.data(),[outbuf.size()]
0x0000023f4cc2e070 "This is a test\nÌ"
    [0]: 84 'T'
    [1]: 104 'h'
    [2]: 105 'i'
    [3]: 115 's'
    [4]: 32 ' '
    [5]: 105 'i'
    [6]: 115 's'
    [7]: 32 ' '
    [8]: 97 'a'
    [9]: 32 ' '
    [10]: 116 't'
    [11]: 101 'e'
    [12]: 115 's'
    [13]: 116 't'
    [14]: 10 '\n'
    [15]: 204 'Ì'
```

I have no knowledge about BPF, so perhaps this patch actually hides a bug, so I'd appreciate review.