### PR TITLE
Move PluginInfo out of anonymous namespace.

### DIFF
--- a/include/pdal/pdal_macros.hpp
+++ b/include/pdal/pdal_macros.hpp
@@ -38,16 +38,18 @@
 #include <pdal/plugin.hpp>
 #include <pdal/PluginManager.hpp>
 
-namespace {
+namespace pdal
+{
 
-typedef struct PluginInfo {
+struct PluginInfo
+{
     std::string name;
     std::string description;
     std::string link;
     PluginInfo(const std::string& n, const std::string& d, const std::string& l)
       : name(n), description(d), link(l)
     {}
-} PluginInfo;
+};
 
 }
 


### PR DESCRIPTION
Since PluginInfo is public type, move to pdal namespace.