### PR TITLE
Switch AppVeyor to Visual Studio 2015

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -87,10 +87,10 @@ deploy:
     artifact: pdalmaster
     set_public: true
 
-#test_script:
-#  - "SET PATH=%OSGEODIR%\\bin;%PATH%"
-#  - echo %PATH%
-#  - ctest --output-on-failure -C Release -VV
+test_script:
+  - set PATH=%OSGEODIR%\\bin;%PATH%
+  - echo %PATH%
+  - ctest -V --output-on-failure -C Release -R pdal_file_utils_test
 
 matrix:
   fast_finish: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,8 +41,8 @@ install:
   ## TODO: Clean up packages list once GDAL deps are fixed https://trac.osgeo.org/osgeo4w/ticket/485
   - C:\temp\osgeo4w-setup.exe -s http://download.osgeo.org/osgeo4w/ -a -q -r -P boost-devel,curl,eigen,expat,freexl,gdal,gdal110dll,gdal111dll,geos,hdf4,hdf5,hexer,iconv,laszip,libjpeg,libjpeg12,libgeotiff,libmysql,libpng,libpq,libtiff,libxml2,netcdf,nitro,ogdi,openjpeg,pcl,points2grid,proj,python-numpy,spatialite,sqlite3,zlib,xerces-c-vc10,xerces-c-vc9 -R %OSGEO4W_ROOT% > null
   ## TODO: remove this work-around once szip is fixed https://trac.osgeo.org/osgeo4w/ticket/486
-  - ps: wget http://download.osgeo.org/osgeo4w/x86_64/release/szip/szip-2.1-1.tar.bz2 -OutFile %OSGEO4W_ROOT%\szip-2.1-1.tar.bz2 | out-null
-  - 7z x -so szip-2.1-1.tar.bz2 | 7z x -si -ttar
+  - ps: wget http://download.osgeo.org/osgeo4w/x86_64/release/szip/szip-2.1-1.tar.bz2 -OutFile C:\temp\szip-2.1-1.tar.bz2 | out-null
+  - 7z x -so C:\temp\szip-2.1-1.tar.bz2 | 7z x -si -ttar -o%OSGEO4W_ROOT%
   # call our PDAL install script
   - call .\\scripts\\appveyor\\config.cmd
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -59,7 +59,9 @@ after_build:
   - 7z a pdal.zip %APPVEYOR_BUILD_FOLDER%\bin\*.*
 
 test_script:
-  - set PATH=%OSGEO4W_ROOT%\\bin;%PATH%
+  # FIXME: Clear PATH to avoid OSGeo4W loading incompatible DLLs
+  - set PATH=
+  - set PATH=%OSGEO4W_ROOT%\bin;C:\Program Files (x86)\MSBuild\14.0\Bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\Program Files\7-Zip;C:\Program Files\Microsoft Windows Performance Toolkit\;C:\Program Files (x86)\Windows Kits\8.1\Windows Performance Toolkit\;C:\Python27;C:\Tools\GitVersion;C:\Program Files (x86)\CMake\bin;C:\Program Files\Git\cmd;C:\Program Files\Git\usr\bin;C:\Program Files\AppVeyor\BuildAgent\
   - echo %PATH%
   - ctest -V --output-on-failure -C Release -R pdal_config_test
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,8 +38,11 @@ install:
   - ps: wget http://download.osgeo.org/osgeo4w/osgeo4w-setup-x86_64.exe -OutFile C:\temp\osgeo4w-setup.exe | out-null
 
   # and install our dependencies
-  - C:\temp\osgeo4w-setup.exe -s http://download.osgeo.org/osgeo4w/ -a -q -P boost-devel,eigen,gdal,geos,hexer,iconv,laszip,libgeotiff,libtiff,libpq,libxml2,nitro,pcl,points2grid,proj,python-numpy,zlib -R %OSGEO4W_ROOT% > nul
-
+  ## TODO: Clean up packages list once GDAL deps are fixed https://trac.osgeo.org/osgeo4w/ticket/485
+  - C:\temp\osgeo4w-setup.exe -s http://download.osgeo.org/osgeo4w/ -a -q -r -P boost-devel,curl,eigen,expat,freexl,gdal,gdal110dll,gdal111dll,geos,hdf4,hdf5,hexer,iconv,laszip,libjpeg,libjpeg12,libgeotiff,libmysql,libpng,libpq,libtiff,libxml2,netcdf,nitro,ogdi,openjpeg,pcl,points2grid,proj,python-numpy,spatialite,sqlite3,szip,zlib,xerces-c-vc10,xerces-c-vc9 -R %OSGEO4W_ROOT% > null
+  ## TODO: remove this work-around once szip is fixed https://trac.osgeo.org/osgeo4w/ticket/486
+  - ps: wget http://download.osgeo.org/osgeo4w/x86_64/release/szip/szip-2.1-1.tar.bz2 -OutFile %OSGEO4W_ROOT%\szip-2.1-1.tar.bz2 | out-null
+  - 7z x -so szip-2.1-1.tar.bz2 | 7z x -si -ttar
   # call our PDAL install script
   - call .\\scripts\\appveyor\\config.cmd
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,7 @@ platform:
 init:
   - set PATH=C:\Program Files (x86)\MSBuild\14.0\Bin;%PATH%
   - set PATH=C:\Python27-x64\;%PATH%
+  - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
 configuration: Release
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -63,7 +63,7 @@ test_script:
   - set PATH=
   - set PATH=%OSGEO4W_ROOT%\bin;C:\Program Files (x86)\MSBuild\14.0\Bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\Program Files\7-Zip;C:\Program Files\Microsoft Windows Performance Toolkit\;C:\Program Files (x86)\Windows Kits\8.1\Windows Performance Toolkit\;C:\Python27;C:\Tools\GitVersion;C:\Program Files (x86)\CMake\bin;C:\Program Files\Git\cmd;C:\Program Files\Git\usr\bin;C:\Program Files\AppVeyor\BuildAgent\
   - echo %PATH%
-  - ctest -V --output-on-failure -C Release -R pdal_config_test
+  - ctest -V --output-on-failure -C Release
 
 artifacts:
   - path: pdal.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,24 +2,24 @@ version: 1.0.{build}
 
 os:  Visual Studio 2015
 
-platform:
-  - x64
+platform: x64
+
+configuration: Release
+
+matrix:
+  fast_finish: true
+
+environment:
+  OSGEO4W_ROOT: C:\OSGeo4W64
+
+  matrix:
+    - PDAL_OPTIONAL_COMPONENTS: OFF
+    - PDAL_OPTIONAL_COMPONENTS: ON
 
 init:
   - set PATH=C:\Program Files (x86)\MSBuild\14.0\Bin;%PATH%
   - set PATH=C:\Python27-x64\;%PATH%
   - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
-
-configuration: Release
-
-environment:
-  # set the directory to use for OSGeo4W install, our CMake find packages know
-  # to look here
-  OSGEODIR: C:\OSGeo4W64
-
-  matrix:
-    - PDAL_OPTIONAL_COMPONENTS: OFF
-    - PDAL_OPTIONAL_COMPONENTS: ON
 
 install:
   # make a temp directory for downloading osgeo4w-setup.exe
@@ -29,7 +29,7 @@ install:
   - ps: mkdir C:\temp | out-null
 
   # make the osgeo directory
-  - ps: mkdir %OSGEODIR% | out-null
+  - ps: mkdir %OSGEO4W_ROOT% | out-null
 
   # make an install directory for packacing
   - ps: mkdir C:\pdalbin | out-null
@@ -38,7 +38,7 @@ install:
   - ps: wget http://download.osgeo.org/osgeo4w/osgeo4w-setup-x86_64.exe -OutFile C:\temp\osgeo4w-setup.exe | out-null
 
   # and install our dependencies
-  - C:\temp\osgeo4w-setup.exe -s http://download.osgeo.org/osgeo4w/ -a -q -P boost-devel,eigen,gdal,geos,hexer,iconv,laszip,libgeotiff,libtiff,libpq,libxml2,nitro,pcl,points2grid,proj,python-numpy,zlib -R %OSGEODIR% > nul
+  - C:\temp\osgeo4w-setup.exe -s http://download.osgeo.org/osgeo4w/ -a -q -P boost-devel,eigen,gdal,geos,hexer,iconv,laszip,libgeotiff,libtiff,libpq,libxml2,nitro,pcl,points2grid,proj,python-numpy,zlib -R %OSGEO4W_ROOT% > nul
 
   # call our PDAL install script
   - call .\\scripts\\appveyor\\config.cmd
@@ -52,25 +52,13 @@ build:
   project: PDAL.sln
   verbosity: minimal
 
-# after_build:
-#   - call .\\scripts\\appveyor\\install.cmd
-
-notifications:
-  - provider: Email
-    on_build_success: false
-    on_build_failure: false
-    on_build_status_changed: false
-
-  - provider: Slack
-    auth_token:
-      secure: Ycvea4CbhP10k3tQwTr9vU2QMdYa4JusDfbCoOwkns2O87afn/G5eBsUakdM/eyW
-    channel: '#pdal'
-    on_build_failure: true
-    on_build_success: false
-    on_build_status_changed: true
-
 after_build:
   - 7z a pdal.zip %APPVEYOR_BUILD_FOLDER%\bin\*.*
+
+test_script:
+  - set PATH=%OSGEO4W_ROOT%\\bin;%PATH%
+  - echo %PATH%
+  - ctest -V --output-on-failure -C Release -R pdal_file_utils_test
 
 artifacts:
   - path: pdal.zip
@@ -88,10 +76,16 @@ deploy:
     artifact: pdalmaster
     set_public: true
 
-test_script:
-  - set PATH=%OSGEODIR%\\bin;%PATH%
-  - echo %PATH%
-  - ctest -V --output-on-failure -C Release -R pdal_file_utils_test
+notifications:
+  - provider: Email
+    on_build_success: false
+    on_build_failure: false
+    on_build_status_changed: false
 
-matrix:
-  fast_finish: true
+  - provider: Slack
+    auth_token:
+      secure: Ycvea4CbhP10k3tQwTr9vU2QMdYa4JusDfbCoOwkns2O87afn/G5eBsUakdM/eyW
+    channel: '#pdal'
+    on_build_failure: true
+    on_build_success: false
+    on_build_status_changed: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -63,6 +63,8 @@ test_script:
   - set PATH=
   - set PATH=%OSGEO4W_ROOT%\bin;C:\Program Files (x86)\MSBuild\14.0\Bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\Program Files\7-Zip;C:\Program Files\Microsoft Windows Performance Toolkit\;C:\Program Files (x86)\Windows Kits\8.1\Windows Performance Toolkit\;C:\Python27;C:\Tools\GitVersion;C:\Program Files (x86)\CMake\bin;C:\Program Files\Git\cmd;C:\Program Files\Git\usr\bin;C:\Program Files\AppVeyor\BuildAgent\
   - echo %PATH%
+  - set GDAL_DATA=%OSGEO4W_ROOT%\share\epsg_csv
+  - set PROJ_LIB=%OSGEO4W_ROOT%\share\proj
   - ctest -V --output-on-failure -C Release
 
 artifacts:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,7 +39,7 @@ install:
 
   # and install our dependencies
   ## TODO: Clean up packages list once GDAL deps are fixed https://trac.osgeo.org/osgeo4w/ticket/485
-  - C:\temp\osgeo4w-setup.exe -s http://download.osgeo.org/osgeo4w/ -a -q -r -P boost-devel,curl,eigen,expat,freexl,gdal,gdal110dll,gdal111dll,geos,hdf4,hdf5,hexer,iconv,laszip,libjpeg,libjpeg12,libgeotiff,libmysql,libpng,libpq,libtiff,libxml2,netcdf,nitro,ogdi,openjpeg,pcl,points2grid,proj,python-numpy,spatialite,sqlite3,zlib,xerces-c-vc10,xerces-c-vc9 -R %OSGEO4W_ROOT% > null
+  - C:\temp\osgeo4w-setup.exe -s http://download.osgeo.org/osgeo4w/ -a -q -r -P boost-devel,curl,eigen,expat,freexl,gdal,gdal110dll,gdal111dll,geos,hdf4,hdf5,hexer,iconv,laszip,libjpeg,libjpeg12,libgeotiff,libmysql,libpng,libpq,libtiff,libxml2,netcdf,nitro,ogdi,openjpeg,openssl,pcl,points2grid,proj,python-numpy,spatialite,sqlite3,zlib,xerces-c-vc10,xerces-c-vc9 -R %OSGEO4W_ROOT% > null
   ## TODO: remove this work-around once szip is fixed https://trac.osgeo.org/osgeo4w/ticket/486
   - ps: wget http://download.osgeo.org/osgeo4w/x86_64/release/szip/szip-2.1-1.tar.bz2 -OutFile C:\temp\szip-2.1-1.tar.bz2 | out-null
   - 7z x -so C:\temp\szip-2.1-1.tar.bz2 | 7z x -si -ttar -o%OSGEO4W_ROOT%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,8 @@ platform:
   - x64
 
 init:
-  - SET PATH=C:\Python27-x64\;%PATH%
+  - set PATH=C:\Program Files (x86)\MSBuild\14.0\Bin;%PATH%
+  - set PATH=C:\Python27-x64\;%PATH%
 
 configuration: Release
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 version: 1.0.{build}
 
-os: Windows Server 2012
+os:  Visual Studio 2015
 
 platform:
   - x64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -61,7 +61,7 @@ after_build:
 test_script:
   - set PATH=%OSGEO4W_ROOT%\\bin;%PATH%
   - echo %PATH%
-  - ctest -V --output-on-failure -C Release -R pdal_file_utils_test
+  - ctest -V --output-on-failure -C Release -R pdal_config_test
 
 artifacts:
   - path: pdal.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,7 +39,7 @@ install:
 
   # and install our dependencies
   ## TODO: Clean up packages list once GDAL deps are fixed https://trac.osgeo.org/osgeo4w/ticket/485
-  - C:\temp\osgeo4w-setup.exe -s http://download.osgeo.org/osgeo4w/ -a -q -r -P boost-devel,curl,eigen,expat,freexl,gdal,gdal110dll,gdal111dll,geos,hdf4,hdf5,hexer,iconv,laszip,libjpeg,libjpeg12,libgeotiff,libmysql,libpng,libpq,libtiff,libxml2,netcdf,nitro,ogdi,openjpeg,pcl,points2grid,proj,python-numpy,spatialite,sqlite3,szip,zlib,xerces-c-vc10,xerces-c-vc9 -R %OSGEO4W_ROOT% > null
+  - C:\temp\osgeo4w-setup.exe -s http://download.osgeo.org/osgeo4w/ -a -q -r -P boost-devel,curl,eigen,expat,freexl,gdal,gdal110dll,gdal111dll,geos,hdf4,hdf5,hexer,iconv,laszip,libjpeg,libjpeg12,libgeotiff,libmysql,libpng,libpq,libtiff,libxml2,netcdf,nitro,ogdi,openjpeg,pcl,points2grid,proj,python-numpy,spatialite,sqlite3,zlib,xerces-c-vc10,xerces-c-vc9 -R %OSGEO4W_ROOT% > null
   ## TODO: remove this work-around once szip is fixed https://trac.osgeo.org/osgeo4w/ticket/486
   - ps: wget http://download.osgeo.org/osgeo4w/x86_64/release/szip/szip-2.1-1.tar.bz2 -OutFile %OSGEO4W_ROOT%\szip-2.1-1.tar.bz2 | out-null
   - 7z x -so szip-2.1-1.tar.bz2 | 7z x -si -ttar

--- a/scripts/appveyor/config.cmd
+++ b/scripts/appveyor/config.cmd
@@ -1,6 +1,6 @@
 @echo off
 
-cmake -G "Visual Studio 11 2012 Win64" ^
+cmake -G "Visual Studio 14 2015 Win64" ^
     -DBUILD_PLUGIN_ATTRIBUTE=%PDAL_OPTIONAL_COMPONENTS% ^
     -DBUILD_PLUGIN_CPD=OFF ^
     -DBUILD_PLUGIN_GREYHOUND=OFF ^


### PR DESCRIPTION
A few workarounds were required:
- Clear PATH to avoid OSGeo4W loading incompatible DLLs
- List all packages, including all GDAL dependencies due to https://trac.osgeo.org/osgeo4w/ticket/485
- Manually deploy szip package due to https://trac.osgeo.org/osgeo4w/ticket/486

All those are documented with TODO comments in the appveyor.xml, so the hacks are cleaned up once OSGeo4W is fixed.

-----
The tests seem to be in good shape: `98% tests passed, 1 tests failed out of 53`, though there is one that fails:

```
[ RUN      ] SpatialReferenceTest.test_proj4_roundtrip
16: C:\projects\pdal\test\unit\SpatialReferenceTest.cpp(95): error: Value of: ret == proj4_out
16:   Actual: false
16: Expected: true
16: C:\projects\pdal\test\unit\SpatialReferenceTest.cpp(102): error: Value of: ret == proj4_out
16:   Actual: false
16: Expected: true
16: C:\projects\pdal\test\unit\SpatialReferenceTest.cpp(109): error: Value of: ret == proj4_out
16:   Actual: false
16: Expected: true
16: [  FAILED  ] SpatialReferenceTest.test_proj4_roundtrip (16 ms)
```

and one is passing with some kind of soft failure:

```
 (writers.las Error: 0): writers.las: PDAL not built with libGeoTiff.  Can't write valid LAS file.
52: (writers.las Error: 0): writers.las: PDAL not built with libGeoTiff.  Can't write valid LAS file.
52: [       OK ] pc2pcTest.pc2pc_test_switches (338 ms)
```