### PR TITLE
Move boost/property_tree/ptree.hpp where it is actually needed

### DIFF
--- a/include/pdal/Stage.hpp
+++ b/include/pdal/Stage.hpp
@@ -50,8 +50,6 @@
 #include <pdal/QuickInfo.hpp>
 #include <pdal/SpatialReference.hpp>
 
-#include <boost/property_tree/ptree.hpp>
-
 namespace pdal
 {
 

--- a/src/PipelineReader.hpp
+++ b/src/PipelineReader.hpp
@@ -40,6 +40,7 @@
 #include <vector>
 #include <string>
 
+#include <boost/property_tree/ptree.hpp>
 
 namespace pdal
 {

--- a/src/PipelineWriter.cpp
+++ b/src/PipelineWriter.cpp
@@ -39,6 +39,8 @@
 #include <pdal/Stage.hpp>
 #include <pdal/util/FileUtils.hpp>
 
+#include <boost/property_tree/ptree.hpp>
+
 using namespace pdalboost::property_tree;
 
 namespace pdal

--- a/src/Stage.cpp
+++ b/src/Stage.cpp
@@ -40,6 +40,7 @@
 
 #include "StageRunner.hpp"
 
+#include <iterator>
 #include <memory>
 
 namespace pdal


### PR DESCRIPTION
Add missing <iterator> for std::back_inserter.