### PR TITLE
Make StageFactory a sole owner of any created stages.

### DIFF
--- a/apps/pdal.cpp
+++ b/apps/pdal.cpp
@@ -132,7 +132,7 @@ void outputOptions(std::string const& n)
     // Force plugin loading.
     StageFactory f(false);
 
-    std::unique_ptr<Stage> s(f.createStage(n));
+    Stage* s = f.createStage(n);
     if (!s)
     {
         std::cerr << "Unable to create stage " << n << "\n";

--- a/examples/writing/tutorial.cpp
+++ b/examples/writing/tutorial.cpp
@@ -54,7 +54,7 @@ int main(int argc, char* argv[])
 
     // Set second argument to 'true' to let factory take ownership of
     // stage and facilitate clean up.
-    Stage *writer = factory.createStage("writers.las", true);
+    Stage *writer = factory.createStage("writers.las");
 
     writer->setInput(reader);
     writer->setOptions(options);

--- a/include/pdal/Kernel.hpp
+++ b/include/pdal/Kernel.hpp
@@ -41,7 +41,7 @@
 #include <string>
 #include <vector>
 
-#include <pdal/Stage.hpp>
+#include <pdal/StageFactory.hpp>
 #include <pdal/util/ProgramArgs.hpp>
 
 namespace pdal
@@ -78,6 +78,7 @@ public:
 protected:
     // this is protected; your derived class ctor will be the public entry point
     Kernel();
+    Stage& createStage(const std::string& name);
     Stage& makeReader(const std::string& inputFile);
     Stage& makeWriter(const std::string& outputFile, Stage& parent);
 
@@ -120,11 +121,6 @@ public:
     }
 
 protected:
-    Stage& ownStage(Stage *s)
-    {
-        m_stages.push_back(std::unique_ptr<Stage>(s));
-        return *s;
-    }
 
     bool m_usestdin;
     Log m_log;
@@ -160,7 +156,7 @@ private:
 
     std::vector<std::string> m_extra_options;
     std::map<std::string, Options> m_extraStageOptions;
-    std::vector<std::unique_ptr<Stage>> m_stages;
+    StageFactory m_factory;
 
     Kernel& operator=(const Kernel&); // not implemented
     Kernel(const Kernel&); // not implemented

--- a/include/pdal/PipelineManager.hpp
+++ b/include/pdal/PipelineManager.hpp
@@ -72,9 +72,9 @@ public:
     bool isWriterPipeline() const
         { return (bool)getStage(); }
 
-    // return the pipeline reader endpoint (or NULL, if not a reader pipeline)
+    // return the pipeline reader endpoint (or nullptr, if not a reader pipeline)
     Stage* getStage() const
-        { return m_stages.empty() ? NULL : m_stages.back().get(); }
+        { return m_stages.empty() ? nullptr : m_stages.back(); }
 
     void prepare() const;
     point_count_t execute();
@@ -96,8 +96,7 @@ private:
 
     PointViewSet m_viewSet;
 
-    typedef std::vector<std::unique_ptr<Stage> > StagePtrList;
-    StagePtrList m_stages;
+    std::vector<Stage*> m_stages; // stage observer, never owner
     int m_progressFd;
 
     PipelineManager& operator=(const PipelineManager&); // not implemented

--- a/include/pdal/StageFactory.hpp
+++ b/include/pdal/StageFactory.hpp
@@ -78,7 +78,7 @@ public:
     // e.g. output files ending in .laz should be compressed
     static pdal::Options inferWriterOptionsChanges(const std::string& filename);
 
-    Stage *createStage(const std::string& type, bool ownStage = false);
+    Stage *createStage(const std::string& type);
 
 private:
     StageFactory& operator=(const StageFactory&); // not implemented

--- a/include/pdal/StageWrapper.hpp
+++ b/include/pdal/StageWrapper.hpp
@@ -11,10 +11,10 @@ namespace pdal
 class StageWrapper
 {
 public:
-    static void initialize(std::shared_ptr<Stage> s, PointTableRef table)
+    static void initialize(Stage& s, PointTableRef table)
     {
-        s->l_initialize(table);
-        s->initialize();
+        s.l_initialize(table);
+        s.initialize();
     }
     static void processOptions(Stage& s, const Options& options)
         { s.processOptions(options); }

--- a/io/tindex/TIndexReader.cpp
+++ b/io/tindex/TIndexReader.cpp
@@ -260,7 +260,7 @@ void TIndexReader::initialize()
                                     << " to merge filter" <<std::endl;
 
         std::string driver = m_factory.inferReaderDriver(f.m_filename);
-        Stage *reader = m_factory.createStage(driver, true);
+        Stage *reader = m_factory.createStage(driver);
         if (!reader)
         {
             std::stringstream out;
@@ -276,7 +276,7 @@ void TIndexReader::initialize()
         if (m_tgtSrsString != f.m_srs &&
             (m_tgtSrsString.size() && f.m_srs.size()))
         {
-            Stage *repro = m_factory.createStage("filters.reprojection", true);
+            Stage *repro = m_factory.createStage("filters.reprojection");
             repro->setInput(*reader);
             Options reproOptions;
             reproOptions.add("out_srs", m_tgtSrsString);
@@ -292,7 +292,7 @@ void TIndexReader::initialize()
         // can be used as a test here.
         if (!m_wkt.empty())
         {
-            Stage *crop = m_factory.createStage("filters.crop", true);
+            Stage *crop = m_factory.createStage("filters.crop");
             crop->setOptions(cropOptions);
             crop->setInput(*premerge);
             log()->get(LogLevel::Debug3) << "Cropping data with wkt '"

--- a/kernels/random/RandomKernel.cpp
+++ b/kernels/random/RandomKernel.cpp
@@ -87,11 +87,9 @@ Stage& RandomKernel::makeReader(Options readerOptions)
         readerOptions.add<std::string>("log", "STDERR");
     }
 
-    StageFactory factory;
-    Stage& readerStage = ownStage(factory.createStage("readers.faux"));
-    readerStage.setOptions(readerOptions);
-
-    return readerStage;
+    auto& reader = createStage("readers.faux");
+    reader.setOptions(readerOptions);
+    return reader;
 }
 
 

--- a/kernels/sort/SortKernel.cpp
+++ b/kernels/sort/SortKernel.cpp
@@ -118,8 +118,7 @@ int SortKernel::execute()
     sortOptions.add<bool>("debug", isDebug());
     sortOptions.add<uint32_t>("verbose", getVerboseLevel());
 
-    StageFactory f;
-    Stage& sortStage = ownStage(f.createStage("filters.mortonorder"));
+    auto& sortStage = createStage("filters.mortonorder");
     sortStage.setInput(bufferReader);
     sortStage.setOptions(sortOptions);
 

--- a/kernels/split/SplitKernel.cpp
+++ b/kernels/split/SplitKernel.cpp
@@ -109,26 +109,22 @@ int SplitKernel::execute()
     Stage& reader = makeReader(m_inputFile);
     reader.setOptions(readerOpts);
 
-    std::unique_ptr<Stage> f;
-    StageFactory factory;
     Options filterOpts;
+    Stage& f = (m_length ? createStage("filters.splitter") : createStage("filters.chipper"));
     if (m_length)
     {
-        f.reset(factory.createStage("filters.splitter"));
         filterOpts.add("length", m_length);
         filterOpts.add("origin_x", m_xOrigin);
         filterOpts.add("origin_y", m_yOrigin);
     }
     else
     {
-        f.reset(factory.createStage("filters.chipper"));
         filterOpts.add("capacity", m_capacity);
     }
-    f->setInput(reader);
-    f->setOptions(filterOpts);
-
-    f->prepare(table);
-    PointViewSet pvSet = f->execute(table);
+    f.setInput(reader);
+    f.setOptions(filterOpts);
+    f.prepare(table);
+    PointViewSet pvSet = f.execute(table);
 
     int filenum = 1;
     for (auto& pvp : pvSet)

--- a/kernels/tindex/TIndexKernel.cpp
+++ b/kernels/tindex/TIndexKernel.cpp
@@ -369,7 +369,7 @@ void TIndexKernel::mergeFile()
     {
         Stage *premerge = NULL;
         std::string driver = factory.inferReaderDriver(f.m_filename);
-        Stage *reader = factory.createStage(driver, true);
+        Stage *reader = factory.createStage(driver);
         if (!reader)
         {
             out << "Unable to create reader for file '" << f.m_filename << "'.";
@@ -382,7 +382,7 @@ void TIndexKernel::mergeFile()
 
         if (m_tgtSrsString != f.m_srs)
         {
-            Stage *repro = factory.createStage("filters.reprojection", true);
+            Stage *repro = factory.createStage("filters.reprojection");
             repro->setInput(*reader);
             Options reproOptions;
             reproOptions.add("out_srs", m_tgtSrsString);
@@ -395,7 +395,7 @@ void TIndexKernel::mergeFile()
         // can be used as a test here.
         if (!m_wkt.empty())
         {
-            Stage *crop = factory.createStage("filters.crop", true);
+            Stage *crop = factory.createStage("filters.crop");
             crop->setOptions(cropOptions);
             crop->setInput(*premerge);
             premerge = crop;
@@ -406,7 +406,7 @@ void TIndexKernel::mergeFile()
 
     std::string driver = factory.inferWriterDriver(m_filespec);
     Options factoryOptions = factory.inferWriterOptionsChanges(m_filespec);
-    Stage *writer = factory.createStage(driver, true);
+    Stage *writer = factory.createStage(driver);
     if (!writer)
     {
         out << "Unable to create reader for file '" << m_filespec << "'.";
@@ -520,7 +520,7 @@ TIndexKernel::FileInfo TIndexKernel::getFileInfo(KernelFactory& factory,
     StageFactory f;
 
     std::string driverName = f.inferReaderDriver(filename);
-    Stage *s = f.createStage(driverName, true);
+    Stage *s = f.createStage(driverName);
     Options ops;
     ops.add("filename", filename);
     setCommonOptions(ops);
@@ -547,7 +547,7 @@ TIndexKernel::FileInfo TIndexKernel::getFileInfo(KernelFactory& factory,
     {
         PointTable table;
 
-        Stage *hexer = f.createStage("filters.hexbin", true);
+        Stage *hexer = f.createStage("filters.hexbin");
         if (! hexer)
         {
 

--- a/plugins/attribute/test/AttributeFilterTest.cpp
+++ b/plugins/attribute/test/AttributeFilterTest.cpp
@@ -47,14 +47,14 @@ TEST(AttributeFilterTest, value)
     ro.add("filename", Support::datapath("autzen/autzen-dd.las"));
 
     StageFactory factory;
-    Stage& r = *(factory.createStage("readers.las", true));
+    Stage& r = *(factory.createStage("readers.las"));
     r.setOptions(ro);
 
     Options fo;
     fo.add("dimension", "X");
     fo.add("value", 27.5);
 
-    Stage& f = *(factory.createStage("filters.attribute", true));
+    Stage& f = *(factory.createStage("filters.attribute"));
     f.setInput(r);
     f.setOptions(fo);
 
@@ -62,19 +62,19 @@ TEST(AttributeFilterTest, value)
 
     Options wo;
     wo.add("filename", tempfile);
-    Stage& w = *(factory.createStage("writers.las", true));
+    Stage& w = *(factory.createStage("writers.las"));
     w.setInput(f);
     w.setOptions(wo);
 
     FileUtils::deleteFile(tempfile);
     PointTable t1;
-    w.prepare(t1); 
+    w.prepare(t1);
     w.execute(t1);
 
     Options testOptions;
     testOptions.add("filename", tempfile);
 
-    Stage& test = *(factory.createStage("readers.las", true)); 
+    Stage& test = *(factory.createStage("readers.las"));
     test.setOptions(testOptions);
 
     PointTable t2;
@@ -91,7 +91,7 @@ TEST(AttributeFilterTest, datasource)
     ro.add("filename", Support::datapath("autzen/autzen-dd.las"));
 
     StageFactory factory;
-    Stage& r = *(factory.createStage("readers.las", true));
+    Stage& r = *(factory.createStage("readers.las"));
     r.setOptions(ro);
 
     Options fo;
@@ -99,7 +99,7 @@ TEST(AttributeFilterTest, datasource)
     fo.add("column", "cls");
     fo.add("datasource", Support::datapath("autzen/attributes.shp"));
 
-    Stage& f = *(factory.createStage("filters.attribute", true));
+    Stage& f = *(factory.createStage("filters.attribute"));
     f.setInput(r);
     f.setOptions(fo);
 
@@ -108,24 +108,24 @@ TEST(AttributeFilterTest, datasource)
     Options wo;
     wo.add("filename", tempfile);
     wo.add("forward", "all");
-    Stage& w = *(factory.createStage("writers.las", true));
+    Stage& w = *(factory.createStage("writers.las"));
     w.setInput(f);
     w.setOptions(wo);
 
     FileUtils::deleteFile(tempfile);
     PointTable t;
-    w.prepare(t); 
+    w.prepare(t);
     w.execute(t);
 
-// 
+//
 //
     Options testOptions;
     testOptions.add("filename", tempfile);
 
-    Stage& test = *(factory.createStage("readers.las", true)); 
+    Stage& test = *(factory.createStage("readers.las"));
     test.setOptions(testOptions);
 
-    Stage& c = *(factory.createStage("filters.crop", true));
+    Stage& c = *(factory.createStage("filters.crop"));
     c.setInput(test);
 
     Options o1;

--- a/plugins/hexbin/test/HexbinFilterTest.cpp
+++ b/plugins/hexbin/test/HexbinFilterTest.cpp
@@ -71,12 +71,12 @@ TEST(HexbinFilterTest, HexbinFilterTest_test_1)
         "use in situations where you do not want to estimate based on "
         "a sample");
 
-    std::unique_ptr<Stage> reader(f.createStage("readers.las"));
-    EXPECT_TRUE(reader.get());
+    Stage* reader(f.createStage("readers.las"));
+    EXPECT_TRUE(reader);
     reader->setOptions(options);
 
-    std::unique_ptr<Stage> hexbin(f.createStage("filters.hexbin"));
-    EXPECT_TRUE(hexbin.get());
+    Stage* hexbin(f.createStage("filters.hexbin"));
+    EXPECT_TRUE(hexbin);
     hexbin->setOptions(options);
     hexbin->setInput(*reader);
 

--- a/plugins/icebridge/test/IcebridgeReaderTest.cpp
+++ b/plugins/icebridge/test/IcebridgeReaderTest.cpp
@@ -90,8 +90,8 @@ std::string getFilePath()
 TEST(IcebridgeReaderTest, testRead)
 {
     StageFactory f;
-    std::unique_ptr<Stage> reader(f.createStage("readers.icebridge"));
-    EXPECT_TRUE(reader.get());
+    Stage* reader(f.createStage("readers.icebridge"));
+    EXPECT_TRUE(reader);
 
     Option filename("filename", getFilePath(), "");
     Options options(filename);

--- a/plugins/matlab/test/MatlabWriterTest.cpp
+++ b/plugins/matlab/test/MatlabWriterTest.cpp
@@ -70,8 +70,8 @@ TEST_F(MatlabWriterTest, constructor)
 TEST_F(MatlabWriterTest, findStage)
 {
     StageFactory factory;
-    std::unique_ptr<Stage> stage(factory.createStage("writers.matlab"));
-    EXPECT_TRUE(stage.get());
+    Stage* stage(factory.createStage("writers.matlab"));
+    EXPECT_TRUE(stage);
 }
 
 

--- a/plugins/mrsid/test/MrsidTest.cpp
+++ b/plugins/mrsid/test/MrsidTest.cpp
@@ -61,8 +61,8 @@ TEST(MrsidReaderTest, test_one)
 
     PointTable table;
 
-    std::shared_ptr<Stage> sid_reader(f.createStage("readers.mrsid"));
-    EXPECT_TRUE(sid_reader.get());
+    Stage* sid_reader(f.createStage("readers.mrsid"));
+    EXPECT_TRUE(sid_reader);
     sid_reader->setOptions(sid_opts);
     sid_reader->prepare(table);
     PointViewSet pbSet = sid_reader->execute(table);

--- a/plugins/nitf/test/NitfReaderTest.cpp
+++ b/plugins/nitf/test/NitfReaderTest.cpp
@@ -60,8 +60,8 @@ TEST(NitfReaderTest, test_one)
 
     PointTable table;
 
-    std::shared_ptr<Stage> nitf_reader(f.createStage("readers.nitf"));
-    EXPECT_TRUE(nitf_reader.get());
+    Stage* nitf_reader(f.createStage("readers.nitf"));
+    EXPECT_TRUE(nitf_reader);
     nitf_reader->setOptions(nitf_opts);
     nitf_reader->prepare(table);
     PointViewSet pbSet = nitf_reader->execute(table);
@@ -87,8 +87,8 @@ TEST(NitfReaderTest, test_one)
 
     PointTable table2;
 
-    std::shared_ptr<Stage> las_reader(f.createStage("readers.las"));
-    EXPECT_TRUE(las_reader.get());
+    Stage* las_reader(f.createStage("readers.las"));
+    EXPECT_TRUE(las_reader);
     las_reader->setOptions(las_opts);
     las_reader->prepare(table2);
     PointViewSet pbSet2 = las_reader->execute(table2);
@@ -151,8 +151,8 @@ TEST(NitfReaderTest, optionSrs)
 
     PointTable table;
 
-    std::shared_ptr<Stage> nitfReader(f.createStage("readers.nitf"));
-    EXPECT_TRUE(nitfReader.get());
+    Stage* nitfReader(f.createStage("readers.nitf"));
+    EXPECT_TRUE(nitfReader);
     nitfReader->setOptions(nitfOpts);
 
     Options lasOpts;

--- a/plugins/nitf/test/NitfWriterTest.cpp
+++ b/plugins/nitf/test/NitfWriterTest.cpp
@@ -59,7 +59,8 @@ void compare_contents(const std::string& las_file, const std::string& ntf_file)
 
     StageFactory f;
 
-    std::unique_ptr<Stage> las_reader(f.createStage("readers.las"));
+    Stage* las_reader(f.createStage("readers.las"));
+    EXPECT_TRUE(las_reader);
     las_reader->setOptions(las_opts);
     las_reader->prepare(lasPoints);
     PointViewSet lasViews = las_reader->execute(lasPoints);
@@ -74,7 +75,8 @@ void compare_contents(const std::string& las_file, const std::string& ntf_file)
     ntf_opts.add(ntf_opt);
 
     PointTable ntfPoints;
-    std::unique_ptr<Stage> ntf_reader(f.createStage("readers.nitf"));
+    Stage* ntf_reader(f.createStage("readers.nitf"));
+    EXPECT_TRUE(ntf_reader);
     ntf_reader->setOptions(ntf_opts);
     ntf_reader->prepare(ntfPoints);
     PointViewSet ntfViews = ntf_reader->execute(ntfPoints);
@@ -142,12 +144,12 @@ TEST(NitfWriterTest, test1)
         // writer_opts.add(verbose);
         writer_opts.add(writer_opt1);
 
-        std::unique_ptr<Stage> reader(f.createStage("readers.las"));
-        EXPECT_TRUE(reader.get());
+        Stage* reader(f.createStage("readers.las"));
+        EXPECT_TRUE(reader);
         reader->setOptions(reader_opts);
 
-        std::unique_ptr<Stage> writer(f.createStage("writers.nitf"));
-        EXPECT_TRUE(writer.get());
+        Stage* writer(f.createStage("writers.nitf"));
+        EXPECT_TRUE(writer);
         writer->setOptions(writer_opts);
         writer->setInput(*reader);
         {
@@ -198,7 +200,7 @@ TEST(NitfWriterTest, flex)
 
     PointTable table;
 
-    std::unique_ptr<Stage> reader(f.createStage("readers.nitf"));
+    Stage* reader(f.createStage("readers.nitf"));
     reader->setOptions(readerOps);
 
     reader->prepare(table);
@@ -228,7 +230,7 @@ TEST(NitfWriterTest, flex)
     Options writerOps;
     writerOps.add("filename", Support::temppath("test_#.ntf"));
 
-    std::unique_ptr<Stage> writer(f.createStage("writers.nitf"));
+    Stage* writer(f.createStage("writers.nitf"));
     writer->setOptions(writerOps);
     writer->setInput(reader2);
 
@@ -243,7 +245,7 @@ TEST(NitfWriterTest, flex)
         Options ops;
         ops.add("filename", filename);
 
-        std::unique_ptr<Stage> r(f.createStage("readers.nitf"));
+        Stage* r(f.createStage("readers.nitf"));
         r->setOptions(ops);
         EXPECT_EQ(r->preview().m_pointCount, vs[i]->size());
     }
@@ -260,7 +262,7 @@ TEST(NitfWriterTest, flex2)
 
     PointTable table;
 
-    std::unique_ptr<Stage> reader(f.createStage("readers.nitf"));
+    Stage* reader(f.createStage("readers.nitf"));
     reader->setOptions(readerOps);
 
     reader->prepare(table);
@@ -290,7 +292,7 @@ TEST(NitfWriterTest, flex2)
     Options writerOps;
     writerOps.add("filename", outfile);
 
-    std::unique_ptr<Stage> writer(f.createStage("writers.nitf"));
+    Stage* writer(f.createStage("writers.nitf"));
     writer->setOptions(writerOps);
     writer->setInput(reader2);
 
@@ -302,7 +304,7 @@ TEST(NitfWriterTest, flex2)
     Options ops;
     ops.add("filename", outfile);
 
-    std::unique_ptr<Stage> r(f.createStage("readers.nitf"));
+    Stage* r(f.createStage("readers.nitf"));
     r->setOptions(ops);
     EXPECT_EQ(r->preview().m_pointCount, v->size());
 }

--- a/plugins/oci/test/OCITest.cpp
+++ b/plugins/oci/test/OCITest.cpp
@@ -216,13 +216,13 @@ TEST_F(OCITest, throughput)
     PointTable table;
 
     StageFactory f;
-    std::unique_ptr<Stage> reader(f.createStage("readers.nitf"));
+    Stage* reader(f.createStage("readers.nitf"));
     reader->setOptions(options);
 
     SplitFilter split(10000);
     split.setInput(*reader);
 
-    std::unique_ptr<Stage> writer(f.createStage("writers.oci"));
+    Stage* writer(f.createStage("writers.oci"));
     EXPECT_TRUE(writer.get());
     writer->setOptions(options);
     writer->setInput(split);
@@ -271,7 +271,7 @@ void writeData(Orientation::Enum orient, bool scaling, bool compression = false)
     SplitFilter split;
     split.setInput(reader);
 
-    std::unique_ptr<Stage> writer(f.createStage("writers.oci"));
+    Stage* writer(f.createStage("writers.oci"));
     EXPECT_TRUE(writer.get());
     writer->setOptions(options);
     writer->setInput(split);
@@ -302,7 +302,7 @@ void compare(const PointViewPtr candidate, std::string filename)
 
     EXPECT_EQ(source->size(), candidate->size());
     PointId limit = std::min(source->size(), candidate->size());
-    
+
     for (PointId i = 0; i < limit; ++i)
     {
         using namespace Dimension;
@@ -349,7 +349,7 @@ void readData()
     options.add("query", oss.str());
 
     StageFactory f;
-    std::unique_ptr<Stage> reader(f.createStage("readers.oci"));
+    Stage* reader(f.createStage("readers.oci"));
     EXPECT_TRUE(reader.get());
 
     reader->setOptions(options);

--- a/plugins/pcl/kernel/GroundKernel.cpp
+++ b/plugins/pcl/kernel/GroundKernel.cpp
@@ -112,7 +112,7 @@ int GroundKernel::execute()
     groundOptions.add<uint32_t>("verbose", getVerboseLevel());
 
     StageFactory f;
-    std::unique_ptr<Stage> groundStage(f.createStage("filters.ground"));
+    Stage* groundStage(f.createStage("filters.ground"));
     groundStage->setOptions(groundOptions);
     groundStage->setInput(readerStage);
 

--- a/plugins/pcl/kernel/GroundKernel.hpp
+++ b/plugins/pcl/kernel/GroundKernel.hpp
@@ -60,8 +60,6 @@ private:
     GroundKernel();
     virtual void addSwitches(ProgramArgs& args);
 
-    std::shared_ptr<Stage> makeReader(Options readerOptions);
-
     std::string m_inputFile;
     std::string m_outputFile;
     double m_maxWindowSize;

--- a/plugins/pcl/kernel/PCLKernel.cpp
+++ b/plugins/pcl/kernel/PCLKernel.cpp
@@ -100,9 +100,9 @@ int PCLKernel::execute()
     pclOptions.add<bool>("debug", isDebug());
     pclOptions.add<uint32_t>("verbose", getVerboseLevel());
 
-    std::shared_ptr<Stage> pclStage(new PCLBlock());
-    pclStage->setInput(*bufferReader);
-    pclStage->setOptions(pclOptions);
+    auto& pclStage = createStage("filters.pclblock");
+    pclStage.setInput(*bufferReader);
+    pclStage.setOptions(pclOptions);
 
     // the PCLBlock stage consumes the BufferReader rather than the
     // readerStage
@@ -116,7 +116,7 @@ int PCLKernel::execute()
     if (m_bForwardMetadata)
         writerOptions.add("forward_metadata", true);
 
-    Stage& writer(Kernel::makeWriter(m_outputFile, *pclStage));
+    Stage& writer(Kernel::makeWriter(m_outputFile, pclStage));
 
     // Some options are inferred by makeWriter based on filename
     // (compression, driver type, etc).

--- a/plugins/pcl/kernel/PCLKernel.hpp
+++ b/plugins/pcl/kernel/PCLKernel.hpp
@@ -53,7 +53,6 @@ private:
     virtual void addSwitches(ProgramArgs& args);
 
     std::unique_ptr<PipelineManager> m_manager;
-    std::shared_ptr<Stage> makeReader(Options readerOptions);
 
     std::string m_inputFile;
     std::string m_outputFile;

--- a/plugins/pcl/kernel/SmoothKernel.cpp
+++ b/plugins/pcl/kernel/SmoothKernel.cpp
@@ -97,15 +97,15 @@ int SmoothKernel::execute()
     smoothOptions.add("debug", isDebug());
     smoothOptions.add("verbose", getVerboseLevel());
 
-    std::shared_ptr<Stage> smoothStage(new PCLBlock());
-    smoothStage->setOptions(smoothOptions);
-    smoothStage->setInput(*bufferReader);
+    auto& smoothStage = createStage("filters.pclblock");
+    smoothStage.setOptions(smoothOptions);
+    smoothStage.setInput(*bufferReader);
 
     Options writerOptions;
     writerOptions.add("filename", m_outputFile);
     setCommonOptions(writerOptions);
 
-    Stage& writer(Kernel::makeWriter(m_outputFile, *smoothStage));
+    Stage& writer(Kernel::makeWriter(m_outputFile, smoothStage));
     writer.setOptions(writerOptions);
 
     writer.prepare(table);

--- a/plugins/pcl/kernel/SmoothKernel.hpp
+++ b/plugins/pcl/kernel/SmoothKernel.hpp
@@ -54,8 +54,6 @@ private:
     SmoothKernel() {};
     virtual void addSwitches(ProgramArgs& args);
 
-    std::shared_ptr<Stage> makeReader(Options readerOptions);
-
     std::string m_inputFile;
     std::string m_outputFile;
 };

--- a/plugins/pcl/kernel/ViewKernel.hpp
+++ b/plugins/pcl/kernel/ViewKernel.hpp
@@ -53,8 +53,6 @@ public:
 private:
     virtual void addSwitches(ProgramArgs& args);
 
-    std::shared_ptr<Stage> makeReader(Options readerOptions);
-
     std::string m_inputFile;
     std::string m_pointIndexes;
 };

--- a/plugins/pcl/test/PCLBlockFilterTest.cpp
+++ b/plugins/pcl/test/PCLBlockFilterTest.cpp
@@ -47,8 +47,8 @@ using namespace pdal;
 TEST(PCLBlockFilterTest, PCLBlockFilterTest_example_passthrough_xml)
 {
     StageFactory f;
-    std::unique_ptr<Stage> filter(f.createStage("filters.pclblock"));
-    EXPECT_TRUE(filter.get());
+    Stage* filter(f.createStage("filters.pclblock"));
+    EXPECT_TRUE(filter);
 
     PipelineManager pipeline;
     pipeline.readPipeline(Support::datapath("filters/pcl/passthrough.xml"));
@@ -80,16 +80,16 @@ static void test_filter(const std::string& jsonFile,
     options.add(debug);
     options.add(verbose);
 
-    std::unique_ptr<Stage> reader(f.createStage("readers.las"));
-    EXPECT_TRUE(reader.get());
+    Stage* reader(f.createStage("readers.las"));
+    EXPECT_TRUE(reader);
     reader->setOptions(options);
 
     Option fname("filename", Support::datapath(jsonFile));
     Options filter_options;
     filter_options.add(fname);
 
-    std::shared_ptr<Stage> pcl_block(f.createStage("filters.pclblock"));
-    EXPECT_TRUE(pcl_block.get());
+    Stage* pcl_block(f.createStage("filters.pclblock"));
+    EXPECT_TRUE(pcl_block);
     pcl_block->setOptions(filter_options);
     pcl_block->setInput(*reader);
 

--- a/plugins/pgpointcloud/test/PgpointcloudWriterTest.cpp
+++ b/plugins/pgpointcloud/test/PgpointcloudWriterTest.cpp
@@ -184,12 +184,12 @@ namespace
 void optionsWrite(const Options& writerOps)
 {
     StageFactory f;
-    std::unique_ptr<Stage> writer(f.createStage("writers.pgpointcloud"));
-    std::unique_ptr<Stage> reader(f.createStage("readers.las"));
+    Stage* writer(f.createStage("writers.pgpointcloud"));
+    Stage* reader(f.createStage("readers.las"));
 
-    EXPECT_TRUE(writer.get());
-    EXPECT_TRUE(reader.get());
-    if (!writer.get() || !reader.get())
+    EXPECT_TRUE(writer);
+    EXPECT_TRUE(reader);
+    if (!writer || !reader)
         return;
 
     const std::string file(Support::datapath("las/1.2-with-color.las"));
@@ -251,8 +251,8 @@ TEST_F(PgpointcloudWriterTest, writeXYZ)
     optionsWrite(ops);
 
     PointTable table;
-    std::unique_ptr<Stage> reader(
-        StageFactory().createStage("readers.pgpointcloud"));
+    StageFactory factory;
+    Stage* reader(factory.createStage("readers.pgpointcloud"));
     reader->setOptions(getDbOptions());
 
     reader->prepare(table);
@@ -271,8 +271,8 @@ TEST_F(PgpointcloudWriterTest, writetNoPointcloudExtension)
     }
 
     StageFactory f;
-    std::unique_ptr<Stage> writer(f.createStage("writers.pgpointcloud"));
-    EXPECT_TRUE(writer.get());
+    Stage* writer(f.createStage("writers.pgpointcloud"));
+    EXPECT_TRUE(writer);
 
     executeOnTestDb("DROP EXTENSION pointcloud");
 
@@ -280,8 +280,8 @@ TEST_F(PgpointcloudWriterTest, writetNoPointcloudExtension)
 
     const Option opt_filename("filename", file);
 
-    std::unique_ptr<Stage> reader(f.createStage("readers.las"));
-    EXPECT_TRUE(reader.get());
+    Stage* reader(f.createStage("readers.las"));
+    EXPECT_TRUE(reader);
     Options options;
     options.add(opt_filename);
     reader->setOptions(options);

--- a/plugins/python/test/PLangTest.cpp
+++ b/plugins/python/test/PLangTest.cpp
@@ -383,7 +383,7 @@ TEST(PLangTest, log)
 
         reader.setOptions(reader_opts);
 
-        std::unique_ptr<Stage> xfilter(f.createStage("filters.programmable"));
+        Stage* xfilter(f.createStage("filters.programmable"));
         xfilter->setOptions(xfilter_opts);
         xfilter->setInput(reader);
 

--- a/plugins/python/test/PredicateFilterTest.cpp
+++ b/plugins/python/test/PredicateFilterTest.cpp
@@ -91,7 +91,7 @@ TEST_F(PredicateFilterTest, PredicateFilterTest_test1)
     opts.add(module);
     opts.add(function);
 
-    std::unique_ptr<Stage> filter(f.createStage("filters.predicate"));
+    Stage* filter(f.createStage("filters.predicate"));
     filter->setOptions(opts);
     filter->setInput(reader);
 
@@ -149,7 +149,7 @@ TEST_F(PredicateFilterTest, PredicateFilterTest_test2)
     opts.add(module);
     opts.add(function);
 
-    std::unique_ptr<Stage> filter(f.createStage("filters.predicate"));
+    Stage* filter(f.createStage("filters.predicate"));
     filter->setOptions(opts);
     filter->setInput(reader);
 
@@ -209,7 +209,7 @@ TEST_F(PredicateFilterTest, PredicateFilterTest_test3)
     opts1.add(module1);
     opts1.add(function1);
 
-    std::unique_ptr<Stage> filter1(f.createStage("filters.predicate"));
+    Stage* filter1(f.createStage("filters.predicate"));
     filter1->setOptions(opts1);
     filter1->setInput(reader);
 
@@ -232,7 +232,7 @@ TEST_F(PredicateFilterTest, PredicateFilterTest_test3)
     opts2.add(module2);
     opts2.add(function2);
 
-    std::unique_ptr<Stage> filter2(f.createStage("filters.predicate"));
+    Stage* filter2(f.createStage("filters.predicate"));
     filter2->setOptions(opts2);
     filter2->setInput(*filter1);
 
@@ -288,7 +288,7 @@ TEST_F(PredicateFilterTest, PredicateFilterTest_test4)
     opts.add(module);
     opts.add(function);
 
-    std::unique_ptr<Stage> filter(f.createStage("filters.predicate"));
+    Stage* filter(f.createStage("filters.predicate"));
     filter->setOptions(opts);
     filter->setInput(reader);
 
@@ -343,7 +343,7 @@ TEST_F(PredicateFilterTest, PredicateFilterTest_test5)
     opts.add(module);
     opts.add(function);
 
-    std::unique_ptr<Stage> filter(f.createStage("filters.predicate"));
+    Stage* filter(f.createStage("filters.predicate"));
     filter->setOptions(opts);
     filter->setInput(reader);
 

--- a/plugins/python/test/ProgrammableFilterTest.cpp
+++ b/plugins/python/test/ProgrammableFilterTest.cpp
@@ -89,7 +89,7 @@ TEST_F(ProgrammableFilterTest, ProgrammableFilterTest_test1)
     opts.add(module);
     opts.add(function);
 
-    std::unique_ptr<Stage> filter(f.createStage("filters.programmable"));
+    Stage* filter(f.createStage("filters.programmable"));
     filter->setOptions(opts);
     filter->setInput(reader);
 
@@ -167,7 +167,7 @@ TEST_F(ProgrammableFilterTest, add_dimension)
     opts.add(intensity);
     opts.add(scanDirection);
 
-    std::unique_ptr<Stage> filter(f.createStage("filters.programmable"));
+    Stage* filter(f.createStage("filters.programmable"));
     filter->setOptions(opts);
     filter->setInput(reader);
 
@@ -217,7 +217,7 @@ TEST_F(ProgrammableFilterTest, metadata)
     opts.add(module);
     opts.add(function);
 
-    std::unique_ptr<Stage> filter(f.createStage("filters.programmable"));
+    Stage* filter(f.createStage("filters.programmable"));
     filter->setOptions(opts);
     filter->setInput(reader);
 

--- a/plugins/sqlite/test/SQLiteTest.cpp
+++ b/plugins/sqlite/test/SQLiteTest.cpp
@@ -105,7 +105,7 @@ void testReadWrite(bool compression, bool scaling)
         reader.setOptions(lasReadOpts);
 
         StageFactory f;
-        std::unique_ptr<Stage> sqliteWriter(f.createStage("writers.sqlite"));
+        Stage* sqliteWriter(f.createStage("writers.sqlite"));
         sqliteWriter->setOptions(sqliteOptions);
         sqliteWriter->setInput(reader);
 
@@ -113,11 +113,11 @@ void testReadWrite(bool compression, bool scaling)
         sqliteWriter->prepare(table);
         sqliteWriter->execute(table);
     }
-    
+
     {
         // Done - now read back.
         StageFactory f;
-        std::unique_ptr<Stage> sqliteReader(f.createStage("readers.sqlite"));
+        Stage* sqliteReader(f.createStage("readers.sqlite"));
         sqliteReader->setOptions(sqliteOptions);
 
         PointTable table2;

--- a/src/PipelineManager.cpp
+++ b/src/PipelineManager.cpp
@@ -41,7 +41,7 @@ namespace pdal
 bool PipelineManager::readPipeline(std::istream& input)
 {
     PipelineReader reader(*this);
-    
+
     return reader.readPipeline(input);
 }
 
@@ -49,38 +49,38 @@ bool PipelineManager::readPipeline(std::istream& input)
 bool PipelineManager::readPipeline(const std::string& filename)
 {
     PipelineReader reader(*this);
-    
+
     return reader.readPipeline(filename);
 }
 
 
 Stage& PipelineManager::addReader(const std::string& type)
 {
-    Stage *r = m_factory.createStage(type);
-    if (!r)
+    Stage *reader = m_factory.createStage(type);
+    if (!reader)
     {
         std::ostringstream ss;
         ss << "Couldn't create reader stage of type '" << type << "'.";
         throw pdal_error(ss.str());
     }
-    r->setProgressFd(m_progressFd);
-    m_stages.push_back(std::unique_ptr<Stage>(r));
-    return *r;
+    reader->setProgressFd(m_progressFd);
+    m_stages.push_back(reader);
+    return *reader;
 }
 
 
 Stage& PipelineManager::addFilter(const std::string& type)
 {
-    Stage *stage = m_factory.createStage(type);
-    if (!stage)
+    Stage *filter = m_factory.createStage(type);
+    if (!filter)
     {
         std::ostringstream ss;
         ss << "Couldn't create filter stage of type '" << type << "'.";
         throw pdal_error(ss.str());
     }
-    stage->setProgressFd(m_progressFd);
-    m_stages.push_back(std::unique_ptr<Stage>(stage));
-    return *stage;
+    filter->setProgressFd(m_progressFd);
+    m_stages.push_back(filter);
+    return *filter;
 }
 
 
@@ -94,7 +94,7 @@ Stage& PipelineManager::addWriter(const std::string& type)
         throw pdal_error(ss.str());
     }
     writer->setProgressFd(m_progressFd);
-    m_stages.push_back(std::unique_ptr<Stage>(writer));
+    m_stages.push_back(writer);
     return *writer;
 }
 
@@ -129,9 +129,8 @@ MetadataNode PipelineManager::getMetadata() const
 {
     MetadataNode output("stages");
 
-    for (auto si = m_stages.begin(); si != m_stages.end(); ++si)
+    for (auto s : m_stages)
     {
-        Stage *s = si->get();
         output.add(s->getMetadata());
     }
     return output;

--- a/src/StageFactory.cpp
+++ b/src/StageFactory.cpp
@@ -230,19 +230,17 @@ StageFactory::StageFactory(bool no_plugins)
     PluginManager::initializePlugin(NullWriter_InitPlugin);
 }
 
-
-/// Create a stage and return a pointer to the created stage.  Caller takes
-/// ownership unless the ownStage argument is true.
+/// Create a stage and return a pointer to the created stage.
+/// The factory takes ownership of any successfully created stage.
 ///
 /// \param[in] stage_name  Type of stage to by created.
-/// \param[in] ownStage    Whether the factory should own the stage.
 /// \return  Pointer to created stage.
 ///
-Stage *StageFactory::createStage(std::string const& stage_name,
-    bool ownStage)
+Stage *StageFactory::createStage(std::string const& stage_name)
 {
+    static_assert(0 < sizeof(Stage), "");
     Stage *s = static_cast<Stage*>(PluginManager::createObject(stage_name));
-    if (s && ownStage)
+    if (s)
     {
         std::lock_guard<std::mutex> lock(m_mutex);
         m_ownedStages.push_back(std::unique_ptr<Stage>(s));

--- a/test/unit/filters/CropFilterTest.cpp
+++ b/test/unit/filters/CropFilterTest.cpp
@@ -51,8 +51,8 @@ using namespace pdal;
 TEST(CropFilterTest, create)
 {
     StageFactory f;
-    std::unique_ptr<Stage> filter(f.createStage("filters.crop"));
-    EXPECT_TRUE(filter.get());
+    Stage* filter(f.createStage("filters.crop"));
+    EXPECT_TRUE(filter);
 }
 
 TEST(CropFilterTest, test_crop)

--- a/test/unit/filters/DecimationFilterTest.cpp
+++ b/test/unit/filters/DecimationFilterTest.cpp
@@ -45,8 +45,8 @@ using namespace pdal;
 TEST(DecimationFilterTest, create)
 {
     StageFactory f;
-    std::unique_ptr<Stage> filter(f.createStage("filters.decimation"));
-    EXPECT_TRUE(filter.get());
+    Stage* filter(f.createStage("filters.decimation"));
+    EXPECT_TRUE(filter);
 }
 
 TEST(DecimationFilterTest, DecimationFilterTest_test1)
@@ -105,7 +105,7 @@ TEST(DecimationFilterTest, stream)
     dec.setInput(reader);
 
     StreamCallbackFilter filter;
-    
+
     auto cb = [](PointRef& point)
     {
         static int i = 0;

--- a/test/unit/filters/FerryFilterTest.cpp
+++ b/test/unit/filters/FerryFilterTest.cpp
@@ -48,8 +48,8 @@ using namespace pdal;
 TEST(FerryFilterTest, create)
 {
     StageFactory f;
-    std::unique_ptr<Stage> filter(f.createStage("filters.ferry"));
-    EXPECT_TRUE(filter.get());
+    Stage* filter(f.createStage("filters.ferry"));
+    EXPECT_TRUE(filter);
 }
 
 TEST(FerryFilterTest, test_ferry_copy)
@@ -131,7 +131,7 @@ TEST(FerryFilterTest, test_ferry_invalid)
     reader.setOptions(ops1);
 
     Options op1;
-    
+
     op1.add("dimensions", "X=X");
 
     FerryFilter f1;

--- a/test/unit/filters/RangeFilterTest.cpp
+++ b/test/unit/filters/RangeFilterTest.cpp
@@ -45,8 +45,8 @@ using namespace pdal;
 TEST(RangeFilterTest, createStage)
 {
     StageFactory f;
-    std::shared_ptr<Stage> filter(f.createStage("filters.range"));
-    EXPECT_TRUE(filter.get());
+    Stage* filter(f.createStage("filters.range"));
+    EXPECT_TRUE(filter);
 }
 
 TEST(RangeFilterTest, noLimits)

--- a/test/unit/filters/StatsFilterTest.cpp
+++ b/test/unit/filters/StatsFilterTest.cpp
@@ -53,8 +53,8 @@ TEST(Stats, simple)
 
     StageFactory f;
 
-    std::unique_ptr<Stage> reader(f.createStage("readers.faux"));
-    EXPECT_TRUE(reader.get());
+    Stage* reader(f.createStage("readers.faux"));
+    EXPECT_TRUE(reader);
     reader->setOptions(ops);
 
     StatsFilter filter;
@@ -97,8 +97,8 @@ TEST(Stats, stream)
 
     StageFactory f;
 
-    std::unique_ptr<Stage> reader(f.createStage("readers.faux"));
-    EXPECT_TRUE(reader.get());
+    Stage* reader(f.createStage("readers.faux"));
+    EXPECT_TRUE(reader);
     reader->setOptions(ops);
 
     StatsFilter filter;
@@ -140,8 +140,8 @@ TEST(Stats, dimset)
     ops.add("mode", "constant");
 
     StageFactory f;
-    std::unique_ptr<Stage> reader(f.createStage("readers.faux"));
-    EXPECT_TRUE(reader.get());
+    Stage* reader(f.createStage("readers.faux"));
+    EXPECT_TRUE(reader);
     reader->setOptions(ops);
 
     Options filterOps;
@@ -182,8 +182,8 @@ TEST(Stats, metadata)
     ops.add("mode", "constant");
 
     StageFactory f;
-    std::unique_ptr<Stage> reader(f.createStage("readers.faux"));
-    EXPECT_TRUE(reader.get());
+    Stage* reader(f.createStage("readers.faux"));
+    EXPECT_TRUE(reader);
     reader->setOptions(ops);
 
     Options filterOps;

--- a/test/unit/filters/TransformationFilterTest.cpp
+++ b/test/unit/filters/TransformationFilterTest.cpp
@@ -67,8 +67,8 @@ public:
 TEST(TransformationMatrix, create)
 {
     StageFactory f;
-    std::unique_ptr<Stage> filter(f.createStage("filters.transformation"));
-    EXPECT_TRUE(filter.get());
+    Stage* filter(f.createStage("filters.transformation"));
+    EXPECT_TRUE(filter);
 }
 
 

--- a/test/unit/io/las/LasReaderTest.cpp
+++ b/test/unit/io/las/LasReaderTest.cpp
@@ -72,8 +72,8 @@ TEST(LasReaderTest, create)
 {
     StageFactory f;
 
-    std::unique_ptr<Stage> s(f.createStage("readers.las"));
-    EXPECT_TRUE(s.get());
+    auto s = f.createStage("readers.las");
+    EXPECT_TRUE(s);
 }
 
 TEST(LasReaderTest, test_base_options)

--- a/test/unit/io/optech/OptechReaderTest.cpp
+++ b/test/unit/io/optech/OptechReaderTest.cpp
@@ -76,8 +76,8 @@ TEST(OptechReader, Constructor)
     OptechReader reader1;
 
     StageFactory f;
-    std::unique_ptr<Stage> reader2(f.createStage("readers.optech"));
-    EXPECT_TRUE(reader2.get());
+    Stage* reader2 = f.createStage("readers.optech");
+    EXPECT_TRUE(reader2);
 }
 
 

--- a/test/unit/io/ply/PlyReaderTest.cpp
+++ b/test/unit/io/ply/PlyReaderTest.cpp
@@ -56,8 +56,8 @@ TEST(PlyReader, Constructor)
     PlyReader reader1;
 
     StageFactory f;
-    std::unique_ptr<Stage> reader2(f.createStage("readers.ply"));
-    EXPECT_TRUE(reader2.get());
+    Stage* reader2(f.createStage("readers.ply"));
+    EXPECT_TRUE(reader2);
 }
 
 

--- a/test/unit/io/ply/PlyWriterTest.cpp
+++ b/test/unit/io/ply/PlyWriterTest.cpp
@@ -49,8 +49,8 @@ TEST(PlyWriter, Constructor)
     PlyWriter writer1;
 
     StageFactory f;
-    std::unique_ptr<Stage> writer2(f.createStage("writers.ply"));
-    EXPECT_TRUE(writer2.get());
+    Stage* writer2(f.createStage("writers.ply"));
+    EXPECT_TRUE(writer2);
 }
 
 

--- a/test/unit/io/terrasolid/TerrasolidReaderTest.cpp
+++ b/test/unit/io/terrasolid/TerrasolidReaderTest.cpp
@@ -76,7 +76,7 @@ TEST(TerrasolidReader, Constructor)
     TerrasolidReader reader1;
 
     StageFactory f;
-    std::unique_ptr<Stage> reader2(f.createStage("readers.terrasolid"));
+    Stage* reader2(f.createStage("readers.terrasolid"));
 }
 
 


### PR DESCRIPTION
Remove `Kernel::ownStage` and `m_stages`, cache factory as stage owner.
Remove uses of smart pointers capturing `StageFactory::createStage` result.
Make `StageFactory` the only place where `std::xxx_ptr<Stage>` is allowed.

This introduces a very simple contract:
* always create stage with `StageFactory::createStage`
* interact with stages as an observer
* never become an owner of any stages
* if you need to extend lifetime stages, just extend lifetime of `StageFactory`.

Since there is no point in controlling lifetime of individual stages, especially if used with pipeline, this change should simplify PDAL interface.