### PR TITLE
Clean up inclusion of plugin headers

### DIFF
--- a/apps/pdal.cpp
+++ b/apps/pdal.cpp
@@ -34,6 +34,7 @@
 ****************************************************************************/
 
 #include <pdal/KernelFactory.hpp>
+#include <pdal/PluginManager.hpp>
 #include <pdal/StageFactory.hpp>
 #include <pdal/pdal_config.hpp>
 

--- a/examples/writing-reader/MyReader.cpp
+++ b/examples/writing-reader/MyReader.cpp
@@ -1,6 +1,7 @@
 // MyReader.cpp
 
 #include "MyReader.hpp"
+#include <pdal/pdal_macros.hpp>
 
 namespace pdal
 {

--- a/examples/writing-writer/MyWriter.cpp
+++ b/examples/writing-writer/MyWriter.cpp
@@ -1,6 +1,7 @@
 // MyWriter.cpp
 
 #include "MyWriter.hpp"
+#include <pdal/pdal_macros.hpp>
 
 #include <boost/program_options.hpp>
 

--- a/filters/chipper/ChipperFilter.cpp
+++ b/filters/chipper/ChipperFilter.cpp
@@ -66,6 +66,8 @@ from the narrow array so that the approriate extrema of the block can
 be stored.
 **/
 
+#include <pdal/pdal_macros.hpp>
+
 namespace pdal
 {
 

--- a/filters/chipper/ChipperFilter.hpp
+++ b/filters/chipper/ChipperFilter.hpp
@@ -41,9 +41,9 @@
 
 #pragma once
 
+#include <pdal/plugin.hpp>
 #include <pdal/Filter.hpp>
 #include <pdal/PointView.hpp>
-
 #include <vector>
 
 extern "C" int32_t ChipperFilter_ExitFunc();

--- a/filters/colorization/ColorizationFilter.cpp
+++ b/filters/colorization/ColorizationFilter.cpp
@@ -36,6 +36,7 @@
 
 #include <pdal/GlobalEnvironment.hpp>
 #include <pdal/PointView.hpp>
+#include <pdal/pdal_macros.hpp>
 
 #include <gdal.h>
 #include <ogr_spatialref.h>
@@ -206,7 +207,7 @@ bool ColorizationFilter::processOne(PointRef& point)
     double y = point.getFieldAs<double>(Dimension::Id::Y);
 
     if (m_raster->read(x, y, data) == gdal::GDALError::None)
-    { 
+    {
         int i(0);
         for (auto bi = m_bands.begin(); bi != m_bands.end(); ++bi)
         {

--- a/filters/colorization/ColorizationFilter.hpp
+++ b/filters/colorization/ColorizationFilter.hpp
@@ -34,6 +34,7 @@
 
 #pragma once
 
+#include <pdal/plugin.hpp>
 #include <pdal/Filter.hpp>
 
 #include <boost/array.hpp>

--- a/filters/crop/CropFilter.cpp
+++ b/filters/crop/CropFilter.cpp
@@ -39,6 +39,7 @@
 #include <pdal/PointView.hpp>
 #include <pdal/StageFactory.hpp>
 #include <pdal/Polygon.hpp>
+#include <pdal/pdal_macros.hpp>
 
 #include <sstream>
 #include <cstdarg>

--- a/filters/crop/CropFilter.hpp
+++ b/filters/crop/CropFilter.hpp
@@ -36,6 +36,7 @@
 
 #include <pdal/Filter.hpp>
 #include <pdal/Polygon.hpp>
+#include <pdal/plugin.hpp>
 
 extern "C" int32_t CropFilter_ExitFunc();
 extern "C" PF_ExitFunc CropFilter_InitPlugin();

--- a/filters/decimation/DecimationFilter.cpp
+++ b/filters/decimation/DecimationFilter.cpp
@@ -35,6 +35,7 @@
 #include "DecimationFilter.hpp"
 
 #include <pdal/PointView.hpp>
+#include <pdal/pdal_macros.hpp>
 
 namespace pdal
 {

--- a/filters/decimation/DecimationFilter.hpp
+++ b/filters/decimation/DecimationFilter.hpp
@@ -35,6 +35,7 @@
 #pragma once
 
 #include <pdal/Filter.hpp>
+#include <pdal/plugin.hpp>
 
 extern "C" int32_t DecimationFilter_ExitFunc();
 extern "C" PF_ExitFunc DecimationFilter_InitPlugin();

--- a/filters/divider/DividerFilter.cpp
+++ b/filters/divider/DividerFilter.cpp
@@ -32,6 +32,7 @@
  ****************************************************************************/
 
 #include "DividerFilter.hpp"
+#include <pdal/pdal_macros.hpp>
 
 namespace pdal
 {

--- a/filters/divider/DividerFilter.hpp
+++ b/filters/divider/DividerFilter.hpp
@@ -34,6 +34,7 @@
 #pragma once
 
 #include <pdal/Filter.hpp>
+#include <pdal/plugin.hpp>
 
 extern "C" int32_t DividerFilter_ExitFunc();
 extern "C" PF_ExitFunc DividerFilter_InitPlugin();

--- a/filters/ferry/FerryFilter.cpp
+++ b/filters/ferry/FerryFilter.cpp
@@ -35,6 +35,7 @@
 #include "FerryFilter.hpp"
 
 #include <pdal/pdal_export.hpp>
+#include <pdal/pdal_macros.hpp>
 
 namespace pdal
 {

--- a/filters/ferry/FerryFilter.hpp
+++ b/filters/ferry/FerryFilter.hpp
@@ -35,6 +35,7 @@
 #pragma once
 
 #include <pdal/Filter.hpp>
+#include <pdal/plugin.hpp>
 
 #include <map>
 #include <string>

--- a/filters/merge/MergeFilter.cpp
+++ b/filters/merge/MergeFilter.cpp
@@ -33,6 +33,7 @@
  ****************************************************************************/
 
 #include "MergeFilter.hpp"
+#include <pdal/pdal_macros.hpp>
 
 namespace pdal
 {

--- a/filters/merge/MergeFilter.hpp
+++ b/filters/merge/MergeFilter.hpp
@@ -35,6 +35,7 @@
 #pragma once
 
 #include <pdal/Filter.hpp>
+#include <pdal/plugin.hpp>
 
 extern "C" int32_t MergeFilter_ExitFunc();
 extern "C" PF_ExitFunc MergeFilter_InitPlugin();

--- a/filters/mortonorder/MortonOrderFilter.cpp
+++ b/filters/mortonorder/MortonOrderFilter.cpp
@@ -33,6 +33,7 @@
  ****************************************************************************/
 
 #include "MortonOrderFilter.hpp"
+#include <pdal/pdal_macros.hpp>
 
 #include <climits>
 #include <iostream>

--- a/filters/mortonorder/MortonOrderFilter.hpp
+++ b/filters/mortonorder/MortonOrderFilter.hpp
@@ -35,6 +35,7 @@
 #pragma once
 
 #include <pdal/Filter.hpp>
+#include <pdal/plugin.hpp>
 
 extern "C" int32_t MortonOrderFilter_ExitFunc();
 extern "C" PF_ExitFunc MortonOrderFilter_InitPlugin();

--- a/filters/randomize/RandomizeFilter.cpp
+++ b/filters/randomize/RandomizeFilter.cpp
@@ -32,6 +32,7 @@
  ****************************************************************************/
 
 #include "RandomizeFilter.hpp"
+#include <pdal/pdal_macros.hpp>
 
 namespace pdal
 {

--- a/filters/randomize/RandomizeFilter.hpp
+++ b/filters/randomize/RandomizeFilter.hpp
@@ -36,6 +36,7 @@
 
 #include <pdal/Filter.hpp>
 #include <pdal/PointViewIter.hpp>
+#include <pdal/plugin.hpp>
 
 extern "C" int32_t RandomizeFilter_ExitFunc();
 extern "C" PF_ExitFunc RandomizeFilter_InitPlugin();

--- a/filters/range/RangeFilter.cpp
+++ b/filters/range/RangeFilter.cpp
@@ -35,6 +35,7 @@
 #include "RangeFilter.hpp"
 
 #include <pdal/util/Utils.hpp>
+#include <pdal/pdal_macros.hpp>
 
 #include <cctype>
 #include <limits>
@@ -60,7 +61,7 @@ namespace
 {
 
 RangeFilter::Range parseRange(const std::string& r)
-{ 
+{
     std::string::size_type pos, count;
     bool ilb = true;
     bool iub = true;

--- a/filters/range/RangeFilter.hpp
+++ b/filters/range/RangeFilter.hpp
@@ -35,6 +35,7 @@
 #pragma once
 
 #include <pdal/Filter.hpp>
+#include <pdal/plugin.hpp>
 
 #include <memory>
 #include <map>

--- a/filters/reprojection/ReprojectionFilter.cpp
+++ b/filters/reprojection/ReprojectionFilter.cpp
@@ -36,6 +36,7 @@
 
 #include <pdal/PointView.hpp>
 #include <pdal/GlobalEnvironment.hpp>
+#include <pdal/pdal_macros.hpp>
 
 #include <gdal.h>
 #include <ogr_spatialref.h>

--- a/filters/reprojection/ReprojectionFilter.hpp
+++ b/filters/reprojection/ReprojectionFilter.hpp
@@ -34,6 +34,7 @@
 
 #pragma once
 
+#include <pdal/plugin.hpp>
 #include <pdal/Filter.hpp>
 
 #include <memory>

--- a/filters/sort/SortFilter.cpp
+++ b/filters/sort/SortFilter.cpp
@@ -33,6 +33,7 @@
  ****************************************************************************/
 
 #include "SortFilter.hpp"
+#include <pdal/pdal_macros.hpp>
 
 namespace pdal
 {

--- a/filters/sort/SortFilter.hpp
+++ b/filters/sort/SortFilter.hpp
@@ -36,6 +36,7 @@
 
 #include <pdal/Filter.hpp>
 #include <pdal/PointViewIter.hpp>
+#include <pdal/plugin.hpp>
 
 extern "C" int32_t SortFilter_ExitFunc();
 extern "C" PF_ExitFunc SortFilter_InitPlugin();

--- a/filters/splitter/SplitterFilter.hpp
+++ b/filters/splitter/SplitterFilter.hpp
@@ -35,6 +35,7 @@
 #pragma once
 
 #include <pdal/Filter.hpp>
+#include <pdal/plugin.hpp>
 
 extern "C" int32_t SplitterFilter_ExitFunc();
 extern "C" PF_ExitFunc SplitterFilter_InitPlugin();

--- a/filters/stats/StatsFilter.cpp
+++ b/filters/stats/StatsFilter.cpp
@@ -40,6 +40,7 @@
 #include <pdal/Options.hpp>
 #include <pdal/Polygon.hpp>
 #include <pdal/PDALUtils.hpp>
+#include <pdal/pdal_macros.hpp>
 
 namespace pdal
 {

--- a/filters/stats/StatsFilter.hpp
+++ b/filters/stats/StatsFilter.hpp
@@ -35,6 +35,7 @@
 #pragma once
 
 #include <pdal/Filter.hpp>
+#include <pdal/plugin.hpp>
 
 extern "C" int32_t StatsFilter_ExitFunc();
 extern "C" PF_ExitFunc StatsFilter_InitPlugin();

--- a/filters/streamcallback/StreamCallbackFilter.cpp
+++ b/filters/streamcallback/StreamCallbackFilter.cpp
@@ -33,6 +33,7 @@
 ****************************************************************************/
 
 #include "StreamCallbackFilter.hpp"
+#include <pdal/pdal_macros.hpp>
 
 namespace pdal
 {

--- a/filters/streamcallback/StreamCallbackFilter.hpp
+++ b/filters/streamcallback/StreamCallbackFilter.hpp
@@ -35,6 +35,9 @@
 #pragma once
 
 #include <pdal/Filter.hpp>
+#include <pdal/plugin.hpp>
+
+#include <functional>
 
 extern "C" int32_t StreamCallbackFilter_ExitFunc();
 extern "C" PF_ExitFunc StreamCallbackFilter_InitPlugin();

--- a/filters/transformation/TransformationFilter.cpp
+++ b/filters/transformation/TransformationFilter.cpp
@@ -35,6 +35,7 @@
 #include "TransformationFilter.hpp"
 
 #include <pdal/pdal_export.hpp>
+#include <pdal/pdal_macros.hpp>
 
 #include <sstream>
 
@@ -96,7 +97,7 @@ bool TransformationFilter::processOne(PointRef& point)
     double y = point.getFieldAs<double>(Dimension::Id::Y);
     double z = point.getFieldAs<double>(Dimension::Id::Z);
 
-    point.setField(Dimension::Id::X, 
+    point.setField(Dimension::Id::X,
         x * m_matrix[0] + y * m_matrix[1] + z * m_matrix[2] + m_matrix[3]);
 
     point.setField(Dimension::Id::Y,

--- a/filters/transformation/TransformationFilter.hpp
+++ b/filters/transformation/TransformationFilter.hpp
@@ -39,6 +39,7 @@
 
 #include <pdal/Filter.hpp>
 #include <pdal/pdal_export.hpp>
+#include <pdal/plugin.hpp>
 
 extern "C" int32_t TransformationFilter_ExitFunc();
 extern "C" PF_ExitFunc TransformationFilter_InitPlugin();

--- a/include/pdal/GDALUtils.hpp
+++ b/include/pdal/GDALUtils.hpp
@@ -39,9 +39,10 @@
 
 #include <pdal/Log.hpp>
 
+#include <array>
+#include <functional>
 #include <sstream>
 #include <vector>
-#include <array>
 
 #include <cpl_port.h>
 #include <gdal.h>

--- a/include/pdal/Reader.hpp
+++ b/include/pdal/Reader.hpp
@@ -37,6 +37,8 @@
 #include <pdal/Stage.hpp>
 #include <pdal/Options.hpp>
 
+#include <functional>
+
 namespace pdal
 {
 

--- a/include/pdal/Stage.hpp
+++ b/include/pdal/Stage.hpp
@@ -37,7 +37,6 @@
 #include <list>
 
 #include <pdal/pdal_internal.hpp>
-#include <pdal/plugin.hpp>
 
 #include <pdal/Dimension.hpp>
 #include <pdal/Log.hpp>

--- a/include/pdal/pdal_internal.hpp
+++ b/include/pdal/pdal_internal.hpp
@@ -41,7 +41,6 @@
 #include <pdal/pdal_export.hpp>
 #include <pdal/pdal_defines.h>
 #include <pdal/pdal_types.hpp>
-#include <pdal/pdal_macros.hpp>
 
 #include <boost/version.hpp>
 

--- a/include/pdal/util/ProgramArgs.hpp
+++ b/include/pdal/util/ProgramArgs.hpp
@@ -24,6 +24,7 @@
 
 #include <deque>
 #include <map>
+#include <memory>
 
 #include <pdal/util/Utils.hpp>
 

--- a/io/bpf/BpfReader.cpp
+++ b/io/bpf/BpfReader.cpp
@@ -38,6 +38,7 @@
 
 #include <pdal/Options.hpp>
 #include <pdal/pdal_export.hpp>
+#include <pdal/pdal_macros.hpp>
 
 namespace pdal
 {

--- a/io/bpf/BpfReader.hpp
+++ b/io/bpf/BpfReader.hpp
@@ -43,6 +43,7 @@
 #include <pdal/util/Charbuf.hpp>
 #include <pdal/util/IStream.hpp>
 #include <pdal/pdal_export.hpp>
+#include <pdal/plugin.hpp>
 
 #include "BpfHeader.hpp"
 

--- a/io/bpf/BpfWriter.cpp
+++ b/io/bpf/BpfWriter.cpp
@@ -40,6 +40,7 @@
 #include <zlib.h>
 
 #include "BpfCompressor.hpp"
+#include <pdal/pdal_macros.hpp>
 
 namespace pdal
 {

--- a/io/bpf/BpfWriter.hpp
+++ b/io/bpf/BpfWriter.hpp
@@ -42,6 +42,7 @@
 #include <pdal/pdal_export.hpp>
 #include <pdal/FlexWriter.hpp>
 #include <pdal/util/OStream.hpp>
+#include <pdal/plugin.hpp>
 
 #include <vector>
 

--- a/io/derivative/DerivativeWriter.cpp
+++ b/io/derivative/DerivativeWriter.cpp
@@ -36,6 +36,7 @@
 
 #include <pdal/PointView.hpp>
 #include <pdal/util/Utils.hpp>
+#include <pdal/pdal_macros.hpp>
 
 #include <algorithm>
 #include <cfloat>

--- a/io/derivative/DerivativeWriter.hpp
+++ b/io/derivative/DerivativeWriter.hpp
@@ -35,6 +35,7 @@
 #pragma once
 
 #include <pdal/Writer.hpp>
+#include <pdal/plugin.hpp>
 
 #include <Eigen/Core>
 

--- a/io/faux/FauxReader.cpp
+++ b/io/faux/FauxReader.cpp
@@ -36,6 +36,7 @@
 
 #include <pdal/Options.hpp>
 #include <pdal/PointView.hpp>
+#include <pdal/pdal_macros.hpp>
 
 #include <ctime>
 

--- a/io/faux/FauxReader.hpp
+++ b/io/faux/FauxReader.hpp
@@ -34,6 +34,7 @@
 
 #pragma once
 
+#include <pdal/plugin.hpp>
 #include <pdal/Reader.hpp>
 
 extern "C" int32_t FauxReader_ExitFunc();

--- a/io/gdal/GDALReader.cpp
+++ b/io/gdal/GDALReader.cpp
@@ -40,6 +40,7 @@
 
 #include <pdal/PointView.hpp>
 #include <pdal/GlobalEnvironment.hpp>
+#include <pdal/pdal_macros.hpp>
 
 namespace pdal
 {

--- a/io/gdal/GDALReader.hpp
+++ b/io/gdal/GDALReader.hpp
@@ -40,8 +40,8 @@
 #include <pdal/Dimension.hpp>
 #include <pdal/Reader.hpp>
 #include <pdal/StageFactory.hpp>
-
 #include <pdal/GDALUtils.hpp>
+#include <pdal/plugin.hpp>
 
 extern "C" int32_t GDALReader_ExitFunc();
 extern "C" PF_ExitFunc GDALReader_InitPlugin();

--- a/io/ilvis2/Ilvis2Reader.cpp
+++ b/io/ilvis2/Ilvis2Reader.cpp
@@ -34,6 +34,7 @@
 
 #include "Ilvis2Reader.hpp"
 #include <pdal/util/FileUtils.hpp>
+#include <pdal/pdal_macros.hpp>
 
 #include <algorithm>
 #include <cmath>

--- a/io/ilvis2/Ilvis2Reader.hpp
+++ b/io/ilvis2/Ilvis2Reader.hpp
@@ -35,6 +35,7 @@
 #include <pdal/PointView.hpp>
 #include <pdal/Reader.hpp>
 #include <pdal/util/IStream.hpp>
+#include <pdal/plugin.hpp>
 #include <map>
 
 #ifndef PDAL_HAVE_LIBXML2

--- a/io/las/LasReader.cpp
+++ b/io/las/LasReader.cpp
@@ -44,6 +44,7 @@
 #include <pdal/util/Extractor.hpp>
 #include <pdal/util/FileUtils.hpp>
 #include <pdal/util/IStream.hpp>
+#include <pdal/pdal_macros.hpp>
 
 #include "GeotiffSupport.hpp"
 #include "LasHeader.hpp"

--- a/io/las/LasReader.hpp
+++ b/io/las/LasReader.hpp
@@ -35,6 +35,7 @@
 #pragma once
 
 #include <pdal/pdal_export.hpp>
+#include <pdal/plugin.hpp>
 #include <pdal/Compression.hpp>
 #include <pdal/Reader.hpp>
 

--- a/io/las/LasWriter.cpp
+++ b/io/las/LasWriter.cpp
@@ -43,6 +43,7 @@
 #include <pdal/util/Inserter.hpp>
 #include <pdal/util/OStream.hpp>
 #include <pdal/util/Utils.hpp>
+#include <pdal/pdal_macros.hpp>
 
 #include "GeotiffSupport.hpp"
 #include "ZipPoint.hpp"

--- a/io/las/LasWriter.hpp
+++ b/io/las/LasWriter.hpp
@@ -36,6 +36,7 @@
 
 #include <pdal/Compression.hpp>
 #include <pdal/FlexWriter.hpp>
+#include <pdal/plugin.hpp>
 
 #include "HeaderVal.hpp"
 #include "LasError.hpp"

--- a/io/null/NullWriter.cpp
+++ b/io/null/NullWriter.cpp
@@ -1,4 +1,5 @@
 #include "NullWriter.hpp"
+#include <pdal/pdal_macros.hpp>
 
 namespace pdal
 {

--- a/io/null/NullWriter.hpp
+++ b/io/null/NullWriter.hpp
@@ -35,7 +35,7 @@
 #pragma once
 
 #include <pdal/pdal_export.hpp>
-
+#include <pdal/plugin.hpp>
 #include <pdal/Writer.hpp>
 
 extern "C" int32_t NullWriter_ExitFunc();

--- a/io/optech/OptechReader.cpp
+++ b/io/optech/OptechReader.cpp
@@ -41,6 +41,7 @@
 
 #include <pdal/SpatialReference.hpp>
 #include <pdal/StageFactory.hpp>
+#include <pdal/pdal_macros.hpp>
 
 namespace pdal
 {

--- a/io/optech/OptechReader.hpp
+++ b/io/optech/OptechReader.hpp
@@ -42,6 +42,7 @@
 #include <pdal/util/Georeference.hpp>
 #include <pdal/util/IStream.hpp>
 #include <pdal/pdal_export.hpp>
+#include <pdal/plugin.hpp>
 
 #include "OptechCommon.hpp"
 

--- a/io/ply/PlyReader.cpp
+++ b/io/ply/PlyReader.cpp
@@ -37,6 +37,7 @@
 #include <sstream>
 
 #include <pdal/PointView.hpp>
+#include <pdal/pdal_macros.hpp>
 
 namespace pdal
 {

--- a/io/ply/PlyReader.hpp
+++ b/io/ply/PlyReader.hpp
@@ -41,7 +41,7 @@
 #include <pdal/Dimension.hpp>
 #include <pdal/Reader.hpp>
 #include <pdal/StageFactory.hpp>
-
+#include <pdal/plugin.hpp>
 
 extern "C" int32_t PlyReader_ExitFunc();
 extern "C" PF_ExitFunc PlyReader_InitPlugin();

--- a/io/ply/PlyWriter.cpp
+++ b/io/ply/PlyWriter.cpp
@@ -36,6 +36,7 @@
 
 #include <sstream>
 
+#include <pdal/pdal_macros.hpp>
 
 namespace pdal
 {

--- a/io/ply/PlyWriter.hpp
+++ b/io/ply/PlyWriter.hpp
@@ -36,7 +36,7 @@
 
 #include <pdal/PointView.hpp>
 #include <pdal/Writer.hpp>
-
+#include <pdal/plugin.hpp>
 
 extern "C" int32_t PlyWriter_ExitFunc();
 extern "C" PF_ExitFunc PlyWriter_InitPlugin();

--- a/io/qfit/QfitReader.cpp
+++ b/io/qfit/QfitReader.cpp
@@ -169,6 +169,7 @@ Word #       Content
 #include <pdal/PointView.hpp>
 #include <pdal/util/Extractor.hpp>
 #include <pdal/util/portable_endian.hpp>
+#include <pdal/pdal_macros.hpp>
 
 #include <algorithm>
 #include <map>

--- a/io/qfit/QfitReader.hpp
+++ b/io/qfit/QfitReader.hpp
@@ -40,6 +40,7 @@
 #include <pdal/Reader.hpp>
 #include <pdal/Options.hpp>
 #include <pdal/util/IStream.hpp>
+#include <pdal/plugin.hpp>
 
 
 extern "C" int32_t QfitReader_ExitFunc();

--- a/io/sbet/SbetReader.cpp
+++ b/io/sbet/SbetReader.cpp
@@ -36,6 +36,8 @@
 
 #include "SbetReader.hpp"
 
+#include <pdal/pdal_macros.hpp>
+
 namespace pdal
 {
 

--- a/io/sbet/SbetReader.hpp
+++ b/io/sbet/SbetReader.hpp
@@ -37,6 +37,7 @@
 #include <pdal/PointView.hpp>
 #include <pdal/Reader.hpp>
 #include <pdal/util/IStream.hpp>
+#include <pdal/plugin.hpp>
 
 #include "SbetCommon.hpp"
 

--- a/io/sbet/SbetWriter.cpp
+++ b/io/sbet/SbetWriter.cpp
@@ -35,6 +35,7 @@
 #include "SbetWriter.hpp"
 
 #include <pdal/PointView.hpp>
+#include <pdal/pdal_macros.hpp>
 
 namespace pdal
 {

--- a/io/sbet/SbetWriter.hpp
+++ b/io/sbet/SbetWriter.hpp
@@ -34,6 +34,7 @@
 
 #pragma once
 
+#include <pdal/plugin.hpp>
 #include <pdal/util/OStream.hpp>
 #include <pdal/Writer.hpp>
 

--- a/io/terrasolid/TerrasolidReader.cpp
+++ b/io/terrasolid/TerrasolidReader.cpp
@@ -36,6 +36,7 @@
 
 #include <pdal/PointView.hpp>
 #include <pdal/util/Extractor.hpp>
+#include <pdal/pdal_macros.hpp>
 
 #include <map>
 

--- a/io/terrasolid/TerrasolidReader.hpp
+++ b/io/terrasolid/TerrasolidReader.hpp
@@ -37,6 +37,7 @@
 #include <pdal/Options.hpp>
 #include <pdal/Reader.hpp>
 #include <pdal/util/IStream.hpp>
+#include <pdal/plugin.hpp>
 
 #include <memory>
 #include <vector>

--- a/io/text/TextReader.cpp
+++ b/io/text/TextReader.cpp
@@ -37,6 +37,8 @@
 
 #include "TextReader.hpp"
 
+#include <pdal/pdal_macros.hpp>
+
 namespace pdal
 {
 

--- a/io/text/TextReader.hpp
+++ b/io/text/TextReader.hpp
@@ -37,6 +37,7 @@
 #include <istream>
 
 #include <pdal/Reader.hpp>
+#include <pdal/plugin.hpp>
 
 extern "C" int32_t TextReader_ExitFunc();
 extern "C" PF_ExitFunc TextReader_InitPlugin();

--- a/io/text/TextWriter.cpp
+++ b/io/text/TextWriter.cpp
@@ -37,6 +37,7 @@
 #include <pdal/pdal_export.hpp>
 #include <pdal/PointView.hpp>
 #include <pdal/util/Algorithm.hpp>
+#include <pdal/pdal_macros.hpp>
 
 #include <algorithm>
 #include <iostream>

--- a/io/text/TextWriter.hpp
+++ b/io/text/TextWriter.hpp
@@ -38,6 +38,7 @@
 #include <pdal/StageFactory.hpp>
 #include <pdal/util/FileUtils.hpp>
 #include <pdal/Writer.hpp>
+#include <pdal/plugin.hpp>
 
 #include <memory>
 #include <vector>

--- a/io/tindex/TIndexReader.cpp
+++ b/io/tindex/TIndexReader.cpp
@@ -34,8 +34,7 @@
 
 #include "TIndexReader.hpp"
 #include <pdal/GDALUtils.hpp>
-
-
+#include <pdal/pdal_macros.hpp>
 
 namespace pdal
 {

--- a/io/tindex/TIndexReader.hpp
+++ b/io/tindex/TIndexReader.hpp
@@ -40,6 +40,7 @@
 #include <merge/MergeFilter.hpp>
 #include <pdal/StageFactory.hpp>
 #include <pdal/GDALUtils.hpp>
+#include <pdal/plugin.hpp>
 
 extern "C" int32_t TIndexReader_ExitFunc();
 extern "C" PF_ExitFunc TIndexReader_InitPlugin();

--- a/kernels/delta/DeltaKernel.cpp
+++ b/kernels/delta/DeltaKernel.cpp
@@ -35,6 +35,7 @@
 #include "DeltaKernel.hpp"
 
 #include <pdal/PDALUtils.hpp>
+#include <pdal/pdal_macros.hpp>
 
 namespace pdal
 {

--- a/kernels/delta/DeltaKernel.hpp
+++ b/kernels/delta/DeltaKernel.hpp
@@ -39,6 +39,7 @@
 #include <pdal/KDIndex.hpp>
 #include <pdal/Kernel.hpp>
 #include <pdal/PointView.hpp>
+#include <pdal/plugin.hpp>
 
 extern "C" int32_t DeltaKernel_ExitFunc();
 extern "C" PF_ExitFunc DeltaKernel_InitPlugin();

--- a/kernels/diff/DiffKernel.cpp
+++ b/kernels/diff/DiffKernel.cpp
@@ -38,6 +38,7 @@
 
 #include <pdal/PDALUtils.hpp>
 #include <pdal/PointView.hpp>
+#include <pdal/pdal_macros.hpp>
 
 
 namespace pdal

--- a/kernels/diff/DiffKernel.hpp
+++ b/kernels/diff/DiffKernel.hpp
@@ -37,6 +37,7 @@
 #include <pdal/Kernel.hpp>
 #include <pdal/Stage.hpp>
 #include <pdal/util/FileUtils.hpp>
+#include <pdal/plugin.hpp>
 
 extern "C" int32_t DiffKernel_ExitFunc();
 extern "C" PF_ExitFunc DiffKernel_InitPlugin();

--- a/kernels/info/InfoKernel.cpp
+++ b/kernels/info/InfoKernel.cpp
@@ -44,6 +44,7 @@
 #ifdef PDAL_HAVE_LIBXML2
 #include <pdal/XMLSchema.hpp>
 #endif
+#include <pdal/pdal_macros.hpp>
 
 namespace pdal
 {

--- a/kernels/info/InfoKernel.hpp
+++ b/kernels/info/InfoKernel.hpp
@@ -39,6 +39,7 @@
 #include <pdal/PointView.hpp>
 #include <pdal/Stage.hpp>
 #include <pdal/util/FileUtils.hpp>
+#include <pdal/plugin.hpp>
 
 #ifdef __clang__
 #pragma GCC diagnostic ignored "-Wtautological-constant-out-of-range-compare"

--- a/kernels/merge/MergeKernel.cpp
+++ b/kernels/merge/MergeKernel.cpp
@@ -36,6 +36,7 @@
 
 #include <merge/MergeFilter.hpp>
 #include <pdal/StageFactory.hpp>
+#include <pdal/pdal_macros.hpp>
 
 namespace pdal
 {

--- a/kernels/merge/MergeKernel.hpp
+++ b/kernels/merge/MergeKernel.hpp
@@ -35,6 +35,7 @@
 #pragma once
 
 #include <pdal/Kernel.hpp>
+#include <pdal/plugin.hpp>
 
 extern "C" int32_t MergeKernel_ExitFunc();
 extern "C" PF_ExitFunc MergeKernel_InitPlugin();

--- a/kernels/pipeline/PipelineKernel.cpp
+++ b/kernels/pipeline/PipelineKernel.cpp
@@ -37,8 +37,8 @@
 #ifdef PDAL_HAVE_LIBXML2
 #include <pdal/XMLSchema.hpp>
 #endif
-
 #include <pdal/PDALUtils.hpp>
+#include <pdal/pdal_macros.hpp>
 
 namespace pdal
 {
@@ -105,7 +105,7 @@ int PipelineKernel::execute()
     {
 #ifdef PDAL_HAVE_LIBXML2
         XMLSchema schema(manager.pointTable().layout());
-        
+
         std::ostream *out = FileUtils::createFile(m_PointCloudSchemaOutput);
         std::string xml(schema.xml());
         out->write(xml.c_str(), xml.size());

--- a/kernels/pipeline/PipelineKernel.hpp
+++ b/kernels/pipeline/PipelineKernel.hpp
@@ -38,6 +38,7 @@
 #include <pdal/PipelineManager.hpp>
 #include <pdal/PipelineWriter.hpp>
 #include <pdal/util/FileUtils.hpp>
+#include <pdal/plugin.hpp>
 
 extern "C" int32_t PipelineKernel_ExitFunc();
 extern "C" PF_ExitFunc PipelineKernel_InitPlugin();

--- a/kernels/random/RandomKernel.cpp
+++ b/kernels/random/RandomKernel.cpp
@@ -35,6 +35,7 @@
 #include "RandomKernel.hpp"
 
 #include <pdal/StageFactory.hpp>
+#include <pdal/pdal_macros.hpp>
 
 namespace pdal
 {

--- a/kernels/random/RandomKernel.hpp
+++ b/kernels/random/RandomKernel.hpp
@@ -36,6 +36,7 @@
 
 #include <pdal/Kernel.hpp>
 #include <pdal/util/FileUtils.hpp>
+#include <pdal/plugin.hpp>
 
 extern "C" int32_t RandomKernel_ExitFunc();
 extern "C" PF_ExitFunc RandomKernel_InitPlugin();

--- a/kernels/sort/SortKernel.cpp
+++ b/kernels/sort/SortKernel.cpp
@@ -36,6 +36,7 @@
 
 #include <buffer/BufferReader.hpp>
 #include <pdal/StageFactory.hpp>
+#include <pdal/pdal_macros.hpp>
 
 namespace pdal
 {

--- a/kernels/sort/SortKernel.hpp
+++ b/kernels/sort/SortKernel.hpp
@@ -35,6 +35,7 @@
 #pragma once
 
 #include <pdal/Kernel.hpp>
+#include <pdal/plugin.hpp>
 
 extern "C" int32_t SortKernel_ExitFunc();
 extern "C" PF_ExitFunc SortKernel_InitPlugin();

--- a/kernels/split/SplitKernel.cpp
+++ b/kernels/split/SplitKernel.cpp
@@ -36,6 +36,7 @@
 
 #include <buffer/BufferReader.hpp>
 #include <pdal/StageFactory.hpp>
+#include <pdal/pdal_macros.hpp>
 
 namespace pdal
 {

--- a/kernels/split/SplitKernel.hpp
+++ b/kernels/split/SplitKernel.hpp
@@ -35,6 +35,7 @@
 #pragma once
 
 #include <pdal/Kernel.hpp>
+#include <pdal/plugin.hpp>
 
 extern "C" int32_t SplitKernel_ExitFunc();
 extern "C" PF_ExitFunc SplitKernel_InitPlugin();

--- a/kernels/tindex/TIndexKernel.cpp
+++ b/kernels/tindex/TIndexKernel.cpp
@@ -48,6 +48,7 @@
 #include <merge/MergeFilter.hpp>
 #include <pdal/PDALUtils.hpp>
 #include <pdal/StageFactory.hpp>
+#include <pdal/pdal_macros.hpp>
 
 #include <cpl_string.h>
 

--- a/kernels/tindex/TIndexKernel.hpp
+++ b/kernels/tindex/TIndexKernel.hpp
@@ -38,6 +38,7 @@
 #include <pdal/Kernel.hpp>
 #include <pdal/Stage.hpp>
 #include <pdal/util/FileUtils.hpp>
+#include <pdal/plugin.hpp>
 
 
 extern "C" int32_t TIndexKernel_ExitFunc();

--- a/kernels/translate/TranslateKernel.hpp
+++ b/kernels/translate/TranslateKernel.hpp
@@ -38,6 +38,7 @@
 #include <pdal/Kernel.hpp>
 #include <pdal/PipelineManager.hpp>
 #include <pdal/pdal_export.hpp>
+#include <pdal/plugin.hpp>
 
 #include <memory>
 #include <string>

--- a/plugins/attribute/filters/AttributeFilter.cpp
+++ b/plugins/attribute/filters/AttributeFilter.cpp
@@ -38,11 +38,10 @@
 #include <vector>
 
 #include <pdal/GlobalEnvironment.hpp>
-
 #include <pdal/StageFactory.hpp>
 #include <pdal/QuadIndex.hpp>
 #include <pdal/Polygon.hpp>
-
+#include <pdal/pdal_macros.hpp>
 
 namespace pdal
 {

--- a/plugins/geowave/io/GeoWaveReader.cpp
+++ b/plugins/geowave/io/GeoWaveReader.cpp
@@ -33,6 +33,7 @@
 ****************************************************************************/
 
 #include "GeoWaveReader.hpp"
+#include <pdal/pdal_macros.hpp>
 
 #include <jace/Jace.h>
 using jace::java_cast;
@@ -200,7 +201,7 @@ namespace pdal
         layout->registerDims(getDefaultDimensions());
 
         BasicAccumuloOperations accumuloOperations;
-        try 
+        try
         {
             accumuloOperations = java_new<BasicAccumuloOperations>(
                 java_new<String>(m_zookeeperUrl),
@@ -219,7 +220,7 @@ namespace pdal
             log()->get(LogLevel::Error) << "The credentials passed are invalid. " << e;
             return;
         }
-        
+
         AccumuloAdapterStore accumuloAdapterStore = java_new<AccumuloAdapterStore>(accumuloOperations);
 
         List attribs;
@@ -249,7 +250,7 @@ namespace pdal
             return;
 
         BasicAccumuloOperations accumuloOperations;
-        try 
+        try
         {
             accumuloOperations = java_new<BasicAccumuloOperations>(
                 java_new<String>(m_zookeeperUrl),
@@ -268,7 +269,7 @@ namespace pdal
             log()->get(LogLevel::Error) << "The credentials passed are invalid. " << e;
             return;
         }
-        
+
         AccumuloDataStore accumuloDataStore = java_new<AccumuloDataStore>(
             accumuloOperations);
 

--- a/plugins/geowave/io/GeoWaveReader.hpp
+++ b/plugins/geowave/io/GeoWaveReader.hpp
@@ -37,6 +37,7 @@
 #include <pdal/Reader.hpp>
 #include <pdal/StageFactory.hpp>
 #include <pdal/util/Bounds.hpp>
+#include <pdal/plugin.hpp>
 
 #include <geos_c.h>
 

--- a/plugins/greyhound/io/GreyhoundReader.cpp
+++ b/plugins/greyhound/io/GreyhoundReader.cpp
@@ -33,8 +33,8 @@
 ****************************************************************************/
 
 #include "GreyhoundReader.hpp"
-
 #include "Exchanges.hpp"
+#include <pdal/pdal_macros.hpp>
 
 namespace pdal
 {

--- a/plugins/hexbin/filters/HexBin.cpp
+++ b/plugins/hexbin/filters/HexBin.cpp
@@ -37,6 +37,7 @@
 #include <hexer/HexIter.hpp>
 #include <pdal/Polygon.hpp>
 #include <pdal/StageFactory.hpp>
+#include <pdal/pdal_macros.hpp>
 
 using namespace hexer;
 

--- a/plugins/icebridge/io/IcebridgeReader.cpp
+++ b/plugins/icebridge/io/IcebridgeReader.cpp
@@ -35,6 +35,7 @@
 #include "IcebridgeReader.hpp"
 #include <pdal/util/FileUtils.hpp>
 #include <pdal/PointView.hpp>
+#include <pdal/pdal_macros.hpp>
 
 #include <map>
 

--- a/plugins/matlab/io/MatlabWriter.cpp
+++ b/plugins/matlab/io/MatlabWriter.cpp
@@ -33,7 +33,7 @@
  ****************************************************************************/
 
 #include "MatlabWriter.hpp"
-
+#include <pdal/pdal_macros.hpp>
 
 namespace pdal
 {

--- a/plugins/matlab/io/MatlabWriter.hpp
+++ b/plugins/matlab/io/MatlabWriter.hpp
@@ -39,7 +39,7 @@
 #include <mat.h>
 
 #include <pdal/Writer.hpp>
-
+#include <pdal/plugin.hpp>
 
 extern "C" int32_t MatlabWriter_ExitFunc();
 extern "C" PF_ExitFunc MatlabWriter_InitPlugin();

--- a/plugins/mrsid/io/MrsidReader.cpp
+++ b/plugins/mrsid/io/MrsidReader.cpp
@@ -36,6 +36,7 @@
 
 #include <lidar/MG4PointReader.h>
 #include <lidar/FileIO.h>
+#include <pdal/pdal_macros.hpp>
 
 namespace pdal
 {

--- a/plugins/mrsid/io/MrsidReader.hpp
+++ b/plugins/mrsid/io/MrsidReader.hpp
@@ -35,8 +35,8 @@
 #pragma once
 
 #include <pdal/Reader.hpp>
-
 #include <pdal/util/Bounds.hpp>
+#include <pdal/plugin.hpp>
 
 #include <lidar/PointSource.h>
 #include <lidar/PointData.h>

--- a/plugins/nitf/io/NitfReader.cpp
+++ b/plugins/nitf/io/NitfReader.cpp
@@ -34,6 +34,7 @@
 
 #include "NitfFile.hpp"
 #include "NitfReader.hpp"
+#include <pdal/pdal_macros.hpp>
 
 namespace pdal
 {

--- a/plugins/oci/io/OciReader.cpp
+++ b/plugins/oci/io/OciReader.cpp
@@ -35,6 +35,7 @@
 #include <pdal/Compression.hpp>
 #include <pdal/GDALUtils.hpp>
 #include <pdal/GlobalEnvironment.hpp>
+#include <pdal/pdal_macros.hpp>
 
 #include "OciReader.hpp"
 

--- a/plugins/oci/io/OciWriter.cpp
+++ b/plugins/oci/io/OciWriter.cpp
@@ -38,6 +38,7 @@
 #include <pdal/PointView.hpp>
 #include <pdal/StageFactory.hpp>
 #include <pdal/GlobalEnvironment.hpp>
+#include <pdal/pdal_macros.hpp>
 
 #include "OciWriter.hpp"
 

--- a/plugins/p2g/io/P2gWriter.cpp
+++ b/plugins/p2g/io/P2gWriter.cpp
@@ -34,6 +34,7 @@
 
 #include "P2gWriter.hpp"
 #include <pdal/PointView.hpp>
+#include <pdal/pdal_macros.hpp>
 
 #include <iostream>
 #include <algorithm>

--- a/plugins/pcl/filters/DartSampleFilter.cpp
+++ b/plugins/pcl/filters/DartSampleFilter.cpp
@@ -42,6 +42,8 @@
 #include <pcl/point_types.h>
 #include <pcl/io/pcd_io.h>
 
+#include <pdal/pdal_macros.hpp>
+
 namespace pdal
 {
 

--- a/plugins/pcl/filters/GreedyProjectionFilter.cpp
+++ b/plugins/pcl/filters/GreedyProjectionFilter.cpp
@@ -43,6 +43,8 @@
 #include <pcl/io/pcd_io.h>
 #include <pcl/surface/gp3.h>
 
+#include <pdal/pdal_macros.hpp>
+
 namespace pdal
 {
 

--- a/plugins/pcl/filters/GridProjectionFilter.cpp
+++ b/plugins/pcl/filters/GridProjectionFilter.cpp
@@ -43,6 +43,8 @@
 #include <pcl/io/pcd_io.h>
 #include <pcl/surface/grid_projection.h>
 
+#include <pdal/pdal_macros.hpp>
+
 namespace pdal
 {
 

--- a/plugins/pcl/filters/GroundFilter.cpp
+++ b/plugins/pcl/filters/GroundFilter.cpp
@@ -40,6 +40,7 @@
 #include <pdal/PointTable.hpp>
 #include <pdal/PointView.hpp>
 #include <pdal/StageFactory.hpp>
+#include <pdal/pdal_macros.hpp>
 
 #include <pcl/point_types.h>
 #include <pcl/console/print.h>

--- a/plugins/pcl/filters/HeightFilter.cpp
+++ b/plugins/pcl/filters/HeightFilter.cpp
@@ -47,6 +47,7 @@
 #include <pdal/PointTable.hpp>
 #include <pdal/PointView.hpp>
 #include <pdal/StageFactory.hpp>
+#include <pdal/pdal_macros.hpp>
 
 // other
 #include <pcl/console/print.h>

--- a/plugins/pcl/filters/MovingLeastSquaresFilter.cpp
+++ b/plugins/pcl/filters/MovingLeastSquaresFilter.cpp
@@ -42,6 +42,8 @@
 #include <pcl/io/pcd_io.h>
 #include <pcl/surface/mls.h>
 
+#include <pdal/pdal_macros.hpp>
+
 namespace pdal
 {
 

--- a/plugins/pcl/filters/PCLBlock.cpp
+++ b/plugins/pcl/filters/PCLBlock.cpp
@@ -41,6 +41,8 @@
 #include <pcl/point_types.h>
 #include <pcl/io/pcd_io.h>
 
+#include <pdal/pdal_macros.hpp>
+
 namespace pdal
 {
 

--- a/plugins/pcl/filters/PoissonFilter.cpp
+++ b/plugins/pcl/filters/PoissonFilter.cpp
@@ -43,6 +43,8 @@
 #include <pcl/io/pcd_io.h>
 #include <pcl/surface/poisson.h>
 
+#include <pdal/pdal_macros.hpp>
+
 namespace pdal
 {
 

--- a/plugins/pcl/filters/RadiusOutlierFilter.cpp
+++ b/plugins/pcl/filters/RadiusOutlierFilter.cpp
@@ -40,6 +40,7 @@
 #include <pdal/PointTable.hpp>
 #include <pdal/PointView.hpp>
 #include <pdal/StageFactory.hpp>
+#include <pdal/pdal_macros.hpp>
 
 #include <pcl/point_types.h>
 #include <pcl/console/print.h>

--- a/plugins/pcl/filters/StatisticalOutlierFilter.cpp
+++ b/plugins/pcl/filters/StatisticalOutlierFilter.cpp
@@ -40,6 +40,7 @@
 #include <pdal/PointTable.hpp>
 #include <pdal/PointView.hpp>
 #include <pdal/StageFactory.hpp>
+#include <pdal/pdal_macros.hpp>
 
 #include <pcl/point_types.h>
 #include <pcl/console/print.h>

--- a/plugins/pcl/filters/VoxelGridFilter.cpp
+++ b/plugins/pcl/filters/VoxelGridFilter.cpp
@@ -42,6 +42,8 @@
 #include <pcl/io/pcd_io.h>
 #include <pcl/filters/voxel_grid.h>
 
+#include <pdal/pdal_macros.hpp>
+
 namespace pdal
 {
 

--- a/plugins/pcl/io/PCLVisualizer.cpp
+++ b/plugins/pcl/io/PCLVisualizer.cpp
@@ -44,6 +44,7 @@
 
 #include <pdal/PointView.hpp>
 #include <pdal/StageFactory.hpp>
+#include <pdal/pdal_macros.hpp>
 
 #include "PCLConversions.hpp"
 #include "point_types.hpp"

--- a/plugins/pcl/io/PcdReader.cpp
+++ b/plugins/pcl/io/PcdReader.cpp
@@ -43,6 +43,8 @@
 #include <pdal/PointView.hpp>
 #include "PCLConversions.hpp"
 
+#include <pdal/pdal_macros.hpp>
+
 namespace pdal
 {
 

--- a/plugins/pcl/kernel/PCLKernel.cpp
+++ b/plugins/pcl/kernel/PCLKernel.cpp
@@ -38,6 +38,7 @@
 
 #include <buffer/BufferReader.hpp>
 #include <pdal/KernelFactory.hpp>
+#include <pdal/pdal_macros.hpp>
 
 namespace pdal
 {

--- a/plugins/pcl/kernel/SmoothKernel.cpp
+++ b/plugins/pcl/kernel/SmoothKernel.cpp
@@ -39,6 +39,7 @@
 
 #include <buffer/BufferReader.hpp>
 #include <pdal/KernelFactory.hpp>
+#include <pdal/pdal_macros.hpp>
 
 namespace pdal
 {

--- a/plugins/pcl/kernel/ViewKernel.cpp
+++ b/plugins/pcl/kernel/ViewKernel.cpp
@@ -35,6 +35,7 @@
 #include "ViewKernel.hpp"
 
 #include <pdal/KernelFactory.hpp>
+#include <pdal/pdal_macros.hpp>
 
 namespace pdal
 {

--- a/plugins/pgpointcloud/io/PgReader.cpp
+++ b/plugins/pgpointcloud/io/PgReader.cpp
@@ -36,6 +36,7 @@
 #include "PgReader.hpp"
 #include <pdal/PointView.hpp>
 #include <pdal/XMLSchema.hpp>
+#include <pdal/pdal_macros.hpp>
 
 #include <iostream>
 

--- a/plugins/pgpointcloud/io/PgWriter.cpp
+++ b/plugins/pgpointcloud/io/PgWriter.cpp
@@ -40,6 +40,7 @@
 #include <pdal/util/FileUtils.hpp>
 #include <pdal/util/portable_endian.hpp>
 #include <pdal/XMLSchema.hpp>
+#include <pdal/pdal_macros.hpp>
 
 namespace pdal
 {

--- a/plugins/python/filters/PredicateFilter.cpp
+++ b/plugins/python/filters/PredicateFilter.cpp
@@ -37,6 +37,7 @@
 #include "PredicateFilter.hpp"
 #include <pdal/PointView.hpp>
 #include <pdal/StageFactory.hpp>
+#include <pdal/pdal_macros.hpp>
 
 namespace pdal
 {

--- a/plugins/python/filters/ProgrammableFilter.cpp
+++ b/plugins/python/filters/ProgrammableFilter.cpp
@@ -37,6 +37,7 @@
 #include "ProgrammableFilter.hpp"
 #include <pdal/PointView.hpp>
 #include <pdal/StageFactory.hpp>
+#include <pdal/pdal_macros.hpp>
 
 namespace pdal
 {

--- a/plugins/rxp/io/RxpReader.cpp
+++ b/plugins/rxp/io/RxpReader.cpp
@@ -41,6 +41,7 @@
 #include "RxpReader.hpp"
 
 #include <pdal/StageFactory.hpp>
+#include <pdal/pdal_macros.hpp>
 
 namespace pdal
 {

--- a/plugins/sqlite/io/SQLiteReader.cpp
+++ b/plugins/sqlite/io/SQLiteReader.cpp
@@ -34,6 +34,7 @@
 
 #include "SQLiteReader.hpp"
 #include <pdal/PointView.hpp>
+#include <pdal/pdal_macros.hpp>
 
 namespace pdal
 {
@@ -56,7 +57,7 @@ void SQLiteReader::initialize()
         m_session = std::unique_ptr<SQLite>(new SQLite(m_connection, log()));
         m_session->connect(false); // don't connect in write mode
         log()->get(LogLevel::Debug) << "Connected to database" << std::endl;
-        
+
         bool bHaveSpatialite = m_session->haveSpatialite();
         log()->get(LogLevel::Debug) << "Have spatialite?: " <<
             bHaveSpatialite << std::endl;

--- a/plugins/sqlite/io/SQLiteWriter.cpp
+++ b/plugins/sqlite/io/SQLiteWriter.cpp
@@ -37,6 +37,7 @@
 #include <pdal/StageFactory.hpp>
 #include <pdal/pdal_internal.hpp>
 #include <pdal/util/FileUtils.hpp>
+#include <pdal/pdal_macros.hpp>
 
 #include <iomanip>
 #include <sstream>
@@ -106,7 +107,7 @@ void SQLiteWriter::initialize()
         m_session = std::unique_ptr<SQLite>(new SQLite(m_connection, log()));
         m_session->connect(true);
         log()->get(LogLevel::Debug) << "Connected to database" << std::endl;
-        
+
         bool bHaveSpatialite = m_session->haveSpatialite();
         log()->get(LogLevel::Debug) << "Have spatialite?: " <<
             bHaveSpatialite << std::endl;

--- a/src/KernelFactory.cpp
+++ b/src/KernelFactory.cpp
@@ -33,6 +33,7 @@
 ****************************************************************************/
 
 #include <pdal/KernelFactory.hpp>
+#include <pdal/PluginManager.hpp>
 
 #include <delta/DeltaKernel.hpp>
 #include <diff/DiffKernel.hpp>

--- a/src/PipelineReader.cpp
+++ b/src/PipelineReader.cpp
@@ -36,6 +36,7 @@
 
 #include <pdal/Filter.hpp>
 #include <pdal/PipelineManager.hpp>
+#include <pdal/PluginManager.hpp>
 #include <pdal/Options.hpp>
 #include <pdal/util/FileUtils.hpp>
 


### PR DESCRIPTION
Remove pdal_macros.hpp from pdal_internal.hpp.
Include pdal_macros.hpp only where it is required (.cpp of plugins).
Include plugin.hpp is included where required (.hpp of plugins).
Include some other missing headers.