### PR TITLE
Prefer std::experimental::filesystem if available.

### DIFF
--- a/include/pdal/util/FileUtils.hpp
+++ b/include/pdal/util/FileUtils.hpp
@@ -106,12 +106,15 @@ namespace FileUtils
     // toAbsolutePath(base)
     PDAL_DLL std::string toAbsolutePath(const std::string& filename,
         const std::string base);
-    
+
     PDAL_DLL void fileTimes(const std::string& filename, struct tm *createTime,
         struct tm *modTime);
 
     /// Return the extension of the filename, including the separator (.).
     PDAL_DLL std::string extension(const std::string& path);
+
+    /// Replaces the extension of the filename with replacement or removes it if the default value is used.
+    PDAL_DLL std::string replaceExtension(std::string const& path, std::string const& replacement = {});
 
     /// Return the filename stripped of the extension.  . and .. are returned
     /// unchanged.

--- a/io/derivative/DerivativeWriter.cpp
+++ b/io/derivative/DerivativeWriter.cpp
@@ -44,8 +44,6 @@
 #include <iostream>
 #include <limits>
 
-#include <boost/filesystem.hpp>
-
 #include "gdal_priv.h" // For File I/O
 #include "gdal_version.h" // For version info
 #include "ogr_spatialref.h"  //For Geographic Information/Transformations
@@ -1003,10 +1001,9 @@ GDALDataset* DerivativeWriter::createFloat32GTIFF(std::string filename,
         {
             char **papszOptions = NULL;
 
-            pdalboost::filesystem::path p(filename);
-            p.replace_extension(".tif");
+            auto const p = FileUtils::replaceExtension(filename, ".tif");
             GDALDataset *dataset;
-            dataset = tpDriver->Create(p.string().c_str(), cols, rows, 1,
+            dataset = tpDriver->Create(p.c_str(), cols, rows, 1,
                 GDT_Float32, papszOptions);
 
             BOX2D& extent = getBounds();


### PR DESCRIPTION
Add `FileUtils::replaceExtension`, thin wrapper for `filesystem::replace_extension`.
Remove remaining uses of `pdalboost::filesystem` and make `FileUtils.cpp` the sole place where `xxx::filesystem` is used.