### PR TITLE
Deduce plugin type from base class

### DIFF
--- a/examples/writing-filter/MyFilter.cpp
+++ b/examples/writing-filter/MyFilter.cpp
@@ -15,7 +15,7 @@ static PluginInfo const s_info =
     PluginInfo("filters.name", "My awesome filter",
                "http://link/to/documentation");
 
-CREATE_STATIC_PLUGIN(1, 0, MyFilter, Filter, s_info)
+CREATE_STATIC_PLUGIN(1, 0, MyFilter, s_info)
 
 std::string MyFilter::getName() const
 {

--- a/examples/writing-kernel/MyKernel.cpp
+++ b/examples/writing-kernel/MyKernel.cpp
@@ -23,7 +23,7 @@ namespace pdal {
     "http://link/to/documentation"
   };
 
-  CREATE_SHARED_PLUGIN(1, 0, MyKernel, Kernel, s_info);
+  CREATE_SHARED_PLUGIN(1, 0, MyKernel, s_info);
 
   std::string MyKernel::getName() const { return s_info.name; }
 

--- a/examples/writing-reader/MyReader.cpp
+++ b/examples/writing-reader/MyReader.cpp
@@ -10,7 +10,7 @@ namespace pdal
     "My Awesome Reader",
     "http://link/to/documentation" );
 
-  CREATE_SHARED_PLUGIN(1, 0, MyReader, Reader, s_info)
+  CREATE_SHARED_PLUGIN(1, 0, MyReader, s_info)
 
   std::string MyReader::getName() const { return s_info.name; }
 

--- a/examples/writing-writer/MyWriter.cpp
+++ b/examples/writing-writer/MyWriter.cpp
@@ -14,7 +14,7 @@ namespace pdal
     "My Awesome Writer",
     "http://path/to/documentation" );
 
-  CREATE_SHARED_PLUGIN(1, 0, MyWriter, Writer, s_info);
+  CREATE_SHARED_PLUGIN(1, 0, MyWriter, s_info);
 
   std::string MyWriter::getName() const { return s_info.name; }
 

--- a/filters/chipper/ChipperFilter.cpp
+++ b/filters/chipper/ChipperFilter.cpp
@@ -76,7 +76,7 @@ static PluginInfo const s_info = PluginInfo(
     "Organize points into spatially contiguous, squarish, and non-overlapping chips.",
     "http://pdal.io/stages/filters.chipper.html" );
 
-CREATE_STATIC_PLUGIN(1, 0, ChipperFilter, Filter, s_info)
+CREATE_STATIC_PLUGIN(1, 0, ChipperFilter, s_info)
 
 std::string ChipperFilter::getName() const { return s_info.name; }
 

--- a/filters/colorization/ColorizationFilter.cpp
+++ b/filters/colorization/ColorizationFilter.cpp
@@ -51,7 +51,7 @@ static PluginInfo const s_info = PluginInfo(
     "Fetch and assign RGB color information from a GDAL-readable datasource.",
     "http://pdal.io/stages/filters.colorization.html" );
 
-CREATE_STATIC_PLUGIN(1, 0, ColorizationFilter, Filter, s_info)
+CREATE_STATIC_PLUGIN(1, 0, ColorizationFilter, s_info)
 
 std::string ColorizationFilter::getName() const { return s_info.name; }
 

--- a/filters/crop/CropFilter.cpp
+++ b/filters/crop/CropFilter.cpp
@@ -52,7 +52,7 @@ static PluginInfo const s_info = PluginInfo(
     "Filter points inside or outside a bounding box or a polygon if PDAL was built with GEOS support.",
     "http://pdal.io/stages/filters.crop.html" );
 
-CREATE_STATIC_PLUGIN(1, 0, CropFilter, Filter, s_info)
+CREATE_STATIC_PLUGIN(1, 0, CropFilter, s_info)
 
 std::string CropFilter::getName() const { return s_info.name; }
 

--- a/filters/decimation/DecimationFilter.cpp
+++ b/filters/decimation/DecimationFilter.cpp
@@ -45,7 +45,7 @@ static PluginInfo const s_info = PluginInfo(
     "Rank decimation filter. Keep every Nth point",
     "http://pdal.io/stages/filters.decimation.html" );
 
-CREATE_STATIC_PLUGIN(1, 0, DecimationFilter, Filter,  s_info)
+CREATE_STATIC_PLUGIN(1, 0, DecimationFilter,  s_info)
 
 std::string DecimationFilter::getName() const { return s_info.name; }
 

--- a/filters/divider/DividerFilter.cpp
+++ b/filters/divider/DividerFilter.cpp
@@ -43,7 +43,7 @@ static PluginInfo const s_info = PluginInfo(
       "scheme",
     "http://pdal.io/stages/filters.divider.html" );
 
-CREATE_STATIC_PLUGIN(1, 0, DividerFilter, Filter, s_info)
+CREATE_STATIC_PLUGIN(1, 0, DividerFilter, s_info)
 
 std::string DividerFilter::getName() const { return s_info.name; }
 

--- a/filters/ferry/FerryFilter.cpp
+++ b/filters/ferry/FerryFilter.cpp
@@ -45,7 +45,7 @@ static PluginInfo const s_info = PluginInfo(
     "Copy date from one dimension to another.",
     "http://pdal.io/stages/filters.ferry.html" );
 
-CREATE_STATIC_PLUGIN(1, 0, FerryFilter, Filter, s_info)
+CREATE_STATIC_PLUGIN(1, 0, FerryFilter, s_info)
 
 std::string FerryFilter::getName() const { return s_info.name; }
 

--- a/filters/merge/MergeFilter.cpp
+++ b/filters/merge/MergeFilter.cpp
@@ -43,7 +43,7 @@ static PluginInfo const s_info = PluginInfo(
     "Merge data from two different readers into a single stream.",
     "http://pdal.io/stages/filters.merge.html" );
 
-CREATE_STATIC_PLUGIN(1, 0, MergeFilter, Filter, s_info)
+CREATE_STATIC_PLUGIN(1, 0, MergeFilter, s_info)
 
 std::string MergeFilter::getName() const { return s_info.name; }
 

--- a/filters/mortonorder/MortonOrderFilter.cpp
+++ b/filters/mortonorder/MortonOrderFilter.cpp
@@ -48,7 +48,7 @@ static PluginInfo const s_info = PluginInfo(
     "Morton or z-order sorting of points. See http://en.wikipedia.org/wiki/Z-order_curve for more detail.",
     "http://pdal.io/stages/filters.mortonorder.html" );
 
-CREATE_STATIC_PLUGIN(1, 0, MortonOrderFilter, Filter, s_info)
+CREATE_STATIC_PLUGIN(1, 0, MortonOrderFilter, s_info)
 
 std::string MortonOrderFilter::getName() const { return s_info.name; }
 

--- a/filters/randomize/RandomizeFilter.cpp
+++ b/filters/randomize/RandomizeFilter.cpp
@@ -42,7 +42,7 @@ static PluginInfo const s_info = PluginInfo(
     "Randomize points in a view.",
     "http://pdal.io/stages/filters.randomize.html" );
 
-CREATE_STATIC_PLUGIN(1, 0, RandomizeFilter, Filter, s_info)
+CREATE_STATIC_PLUGIN(1, 0, RandomizeFilter, s_info)
 
 std::string RandomizeFilter::getName() const { return s_info.name; }
 

--- a/filters/range/RangeFilter.cpp
+++ b/filters/range/RangeFilter.cpp
@@ -50,7 +50,7 @@ static PluginInfo const s_info =
     PluginInfo("filters.range", "Pass only points given a dimension/range.",
                "http://pdal.io/stages/filters.range.html");
 
-CREATE_STATIC_PLUGIN(1, 0, RangeFilter, Filter, s_info)
+CREATE_STATIC_PLUGIN(1, 0, RangeFilter, s_info)
 
 std::string RangeFilter::getName() const
 {

--- a/filters/reprojection/ReprojectionFilter.cpp
+++ b/filters/reprojection/ReprojectionFilter.cpp
@@ -51,7 +51,7 @@ static PluginInfo const s_info = PluginInfo(
     "Reproject data using GDAL from one coordinate system to another.",
     "http://pdal.io/stages/filters.reprojection.html" );
 
-CREATE_STATIC_PLUGIN(1, 0, ReprojectionFilter, Filter, s_info)
+CREATE_STATIC_PLUGIN(1, 0, ReprojectionFilter, s_info)
 
 std::string ReprojectionFilter::getName() const { return s_info.name; }
 

--- a/filters/sort/SortFilter.cpp
+++ b/filters/sort/SortFilter.cpp
@@ -43,7 +43,7 @@ static PluginInfo const s_info = PluginInfo(
     "Sort data based on a given dimension.",
     "http://pdal.io/stages/filters.sort.html" );
 
-CREATE_STATIC_PLUGIN(1, 0, SortFilter, Filter, s_info)
+CREATE_STATIC_PLUGIN(1, 0, SortFilter, s_info)
 
 std::string SortFilter::getName() const { return s_info.name; }
 

--- a/filters/splitter/SplitterFilter.cpp
+++ b/filters/splitter/SplitterFilter.cpp
@@ -48,7 +48,7 @@ static PluginInfo const s_info = PluginInfo(
     "Split data based on a X/Y box length.",
     "http://pdal.io/stages/filters.splitter.html" );
 
-CREATE_STATIC_PLUGIN(1, 0, SplitterFilter, Filter, s_info)
+CREATE_STATIC_PLUGIN(1, 0, SplitterFilter, s_info)
 
 std::string SplitterFilter::getName() const { return s_info.name; }
 

--- a/filters/stats/StatsFilter.cpp
+++ b/filters/stats/StatsFilter.cpp
@@ -50,7 +50,7 @@ static PluginInfo const s_info = PluginInfo(
     "Compute statistics about each dimension (mean, min, max, etc.)",
     "http://pdal.io/stages/filters.stats.html" );
 
-CREATE_STATIC_PLUGIN(1, 0, StatsFilter, Filter, s_info)
+CREATE_STATIC_PLUGIN(1, 0, StatsFilter, s_info)
 
 std::string StatsFilter::getName() const { return s_info.name; }
 

--- a/filters/streamcallback/StreamCallbackFilter.cpp
+++ b/filters/streamcallback/StreamCallbackFilter.cpp
@@ -43,6 +43,6 @@ static PluginInfo const s_info = PluginInfo(
     "Provide a hook for a simple point-by-point callback.",
     "" );
 
-CREATE_STATIC_PLUGIN(1, 0, StreamCallbackFilter, Filter, s_info)
+CREATE_STATIC_PLUGIN(1, 0, StreamCallbackFilter, s_info)
 
 } // namespace pdal

--- a/filters/transformation/TransformationFilter.cpp
+++ b/filters/transformation/TransformationFilter.cpp
@@ -47,7 +47,7 @@ static PluginInfo const s_info = PluginInfo(
     "Transform each point using a 4x4 transformation matrix",
     "http://pdal.io/stages/filters.transformation.html" );
 
-CREATE_STATIC_PLUGIN(1, 0, TransformationFilter, Filter, s_info)
+CREATE_STATIC_PLUGIN(1, 0, TransformationFilter, s_info)
 
 std::string TransformationFilter::getName() const { return s_info.name; }
 

--- a/io/bpf/BpfReader.cpp
+++ b/io/bpf/BpfReader.cpp
@@ -50,7 +50,7 @@ static PluginInfo const s_info = PluginInfo(
         "processing chains.",
     "http://pdal.io/stages/readers.bpf.html" );
 
-CREATE_STATIC_PLUGIN(1, 0, BpfReader, Reader, s_info)
+CREATE_STATIC_PLUGIN(1, 0, BpfReader, s_info)
 
 std::string BpfReader::getName() const { return s_info.name; }
 

--- a/io/bpf/BpfWriter.cpp
+++ b/io/bpf/BpfWriter.cpp
@@ -52,7 +52,7 @@ static PluginInfo const s_info = PluginInfo(
         "processing chains.",
     "http://pdal.io/stages/writers.bpf.html" );
 
-CREATE_STATIC_PLUGIN(1, 0, BpfWriter, Writer, s_info)
+CREATE_STATIC_PLUGIN(1, 0, BpfWriter, s_info)
 
 std::string BpfWriter::getName() const { return s_info.name; }
 

--- a/io/derivative/DerivativeWriter.cpp
+++ b/io/derivative/DerivativeWriter.cpp
@@ -57,7 +57,7 @@ static PluginInfo const s_info = PluginInfo(
                                      "Derivative writer",
                                      "http://pdal.io/stages/writers.derivative.html");
 
-CREATE_STATIC_PLUGIN(1, 0, DerivativeWriter, Writer, s_info)
+CREATE_STATIC_PLUGIN(1, 0, DerivativeWriter, s_info)
 
 std::string DerivativeWriter::getName() const
 {

--- a/io/faux/FauxReader.cpp
+++ b/io/faux/FauxReader.cpp
@@ -48,7 +48,7 @@ static PluginInfo const s_info = PluginInfo(
     "Faux Reader",
     "http://pdal.io/stages/readers.faux.html" );
 
-CREATE_STATIC_PLUGIN(1, 0, FauxReader, Reader, s_info)
+CREATE_STATIC_PLUGIN(1, 0, FauxReader, s_info)
 
 std::string FauxReader::getName() const { return s_info.name; }
 

--- a/io/gdal/GDALReader.cpp
+++ b/io/gdal/GDALReader.cpp
@@ -51,7 +51,7 @@ static PluginInfo const s_info = PluginInfo(
         "http://pdal.io/stages/reader.gdal.html");
 
 
-CREATE_STATIC_PLUGIN(1, 0, GDALReader, Reader, s_info);
+CREATE_STATIC_PLUGIN(1, 0, GDALReader, s_info);
 
 
 std::string GDALReader::getName() const

--- a/io/ilvis2/Ilvis2Reader.cpp
+++ b/io/ilvis2/Ilvis2Reader.cpp
@@ -47,7 +47,7 @@ static PluginInfo const s_info = PluginInfo(
     "ILVIS2 Reader",
     "http://pdal.io/stages/readers.ilvis2.html" );
 
-CREATE_STATIC_PLUGIN(1, 0, Ilvis2Reader, Reader, s_info)
+CREATE_STATIC_PLUGIN(1, 0, Ilvis2Reader, s_info)
 
 std::string Ilvis2Reader::getName() const { return s_info.name; }
 

--- a/io/las/LasReader.cpp
+++ b/io/las/LasReader.cpp
@@ -101,7 +101,7 @@ static PluginInfo const s_info = PluginInfo(
         "compilation.",
     "http://pdal.io/stages/readers.las.html" );
 
-CREATE_STATIC_PLUGIN(1, 0, LasReader, Reader, s_info)
+CREATE_STATIC_PLUGIN(1, 0, LasReader, s_info)
 
 std::string LasReader::getName() const { return s_info.name; }
 

--- a/io/las/LasWriter.cpp
+++ b/io/las/LasWriter.cpp
@@ -58,7 +58,7 @@ static PluginInfo const s_info = PluginInfo(
         "does not provide LAS 1.4 support at this time.",
     "http://pdal.io/stages/writers.las.html" );
 
-CREATE_STATIC_PLUGIN(1, 0, LasWriter, Writer, s_info)
+CREATE_STATIC_PLUGIN(1, 0, LasWriter, s_info)
 
 std::string LasWriter::getName() const { return s_info.name; }
 

--- a/io/null/NullWriter.cpp
+++ b/io/null/NullWriter.cpp
@@ -10,7 +10,7 @@ static PluginInfo const s_info = PluginInfo(
         "It's the same as sending pipeline output to /dev/null.",
     "http://pdal.io/stages/writers.null.html" );
 
-CREATE_STATIC_PLUGIN(1, 0, NullWriter, Writer, s_info)
+CREATE_STATIC_PLUGIN(1, 0, NullWriter, s_info)
 
 std::string NullWriter::getName() const { return s_info.name; }
 

--- a/io/optech/OptechReader.cpp
+++ b/io/optech/OptechReader.cpp
@@ -51,7 +51,7 @@ static PluginInfo const s_info = PluginInfo(
     "Optech reader support.",
     "http://pdal.io/stages/readers.optech.html" );
 
-CREATE_STATIC_PLUGIN(1, 0, OptechReader, Reader, s_info);
+CREATE_STATIC_PLUGIN(1, 0, OptechReader, s_info);
 
 std::string OptechReader::getName() const
 {

--- a/io/ply/PlyReader.cpp
+++ b/io/ply/PlyReader.cpp
@@ -137,7 +137,7 @@ static PluginInfo const s_info = PluginInfo(
         "http://pdal.io/stages/reader.ply.html");
 
 
-CREATE_STATIC_PLUGIN(1, 0, PlyReader, Reader, s_info);
+CREATE_STATIC_PLUGIN(1, 0, PlyReader, s_info);
 
 
 std::string PlyReader::getName() const

--- a/io/ply/PlyWriter.cpp
+++ b/io/ply/PlyWriter.cpp
@@ -93,7 +93,7 @@ static PluginInfo const s_info = PluginInfo(
         "http://pdal.io/stages/writers.ply.html"
         );
 
-CREATE_STATIC_PLUGIN(1, 0, PlyWriter, Writer, s_info)
+CREATE_STATIC_PLUGIN(1, 0, PlyWriter, s_info)
 
 std::string PlyWriter::getName() const { return s_info.name; }
 

--- a/io/qfit/QfitReader.cpp
+++ b/io/qfit/QfitReader.cpp
@@ -187,7 +187,7 @@ static PluginInfo const s_info = PluginInfo(
     "QFIT Reader",
     "http://pdal.io/stages/readers.qfit.html" );
 
-CREATE_STATIC_PLUGIN(1, 0, QfitReader, Reader, s_info)
+CREATE_STATIC_PLUGIN(1, 0, QfitReader, s_info)
 
 std::string QfitReader::getName() const { return s_info.name; }
 

--- a/io/sbet/SbetReader.cpp
+++ b/io/sbet/SbetReader.cpp
@@ -46,7 +46,7 @@ static PluginInfo const s_info = PluginInfo(
     "SBET Reader",
     "http://pdal.io/stages/readers.sbet.html" );
 
-CREATE_STATIC_PLUGIN(1, 0, SbetReader, Reader, s_info)
+CREATE_STATIC_PLUGIN(1, 0, SbetReader, s_info)
 
 std::string SbetReader::getName() const { return s_info.name; }
 

--- a/io/sbet/SbetWriter.cpp
+++ b/io/sbet/SbetWriter.cpp
@@ -45,7 +45,7 @@ static PluginInfo const s_info = PluginInfo(
     "SBET Writer",
     "http://pdal.io/stages/writers.sbet.html" );
 
-CREATE_STATIC_PLUGIN(1, 0, SbetWriter, Writer, s_info)
+CREATE_STATIC_PLUGIN(1, 0, SbetWriter, s_info)
 
 std::string SbetWriter::getName() const { return s_info.name; }
 

--- a/io/terrasolid/TerrasolidReader.cpp
+++ b/io/terrasolid/TerrasolidReader.cpp
@@ -48,7 +48,7 @@ static PluginInfo const s_info = PluginInfo(
     "TerraSolid Reader",
     "http://pdal.io/stages/readers.terrasolid.html" );
 
-CREATE_STATIC_PLUGIN(1, 0, TerrasolidReader, Reader, s_info)
+CREATE_STATIC_PLUGIN(1, 0, TerrasolidReader, s_info)
 
 std::string TerrasolidReader::getName() const { return s_info.name; }
 

--- a/io/text/TextReader.cpp
+++ b/io/text/TextReader.cpp
@@ -47,7 +47,7 @@ static PluginInfo const s_info = PluginInfo(
     "Text Reader",
     "http://pdal.io/stages/readers.text.html" );
 
-CREATE_STATIC_PLUGIN(1, 0, TextReader, Reader, s_info)
+CREATE_STATIC_PLUGIN(1, 0, TextReader, s_info)
 
 std::string TextReader::getName() const { return s_info.name; }
 

--- a/io/text/TextWriter.cpp
+++ b/io/text/TextWriter.cpp
@@ -51,7 +51,7 @@ static PluginInfo const s_info = PluginInfo(
     "Text Writer",
     "http://pdal.io/stages/writers.text.html" );
 
-CREATE_STATIC_PLUGIN(1, 0, TextWriter, Writer, s_info)
+CREATE_STATIC_PLUGIN(1, 0, TextWriter, s_info)
 
 std::string TextWriter::getName() const { return s_info.name; }
 

--- a/io/tindex/TIndexReader.cpp
+++ b/io/tindex/TIndexReader.cpp
@@ -44,7 +44,7 @@ static PluginInfo const s_info = PluginInfo(
     "TileIndex Reader",
     "http://pdal.io/stages/readers.tindex.html" );
 
-CREATE_STATIC_PLUGIN(1, 0, TIndexReader, Reader, s_info)
+CREATE_STATIC_PLUGIN(1, 0, TIndexReader, s_info)
 
 std::string TIndexReader::getName() const { return s_info.name; }
 

--- a/kernels/delta/DeltaKernel.cpp
+++ b/kernels/delta/DeltaKernel.cpp
@@ -45,7 +45,7 @@ static PluginInfo const s_info = PluginInfo(
     "Delta Kernel",
     "http://pdal.io/kernels/kernels.delta.html" );
 
-CREATE_STATIC_PLUGIN(1, 0, DeltaKernel, Kernel, s_info)
+CREATE_STATIC_PLUGIN(1, 0, DeltaKernel, s_info)
 
 std::string DeltaKernel::getName() const { return s_info.name; }
 

--- a/kernels/diff/DiffKernel.cpp
+++ b/kernels/diff/DiffKernel.cpp
@@ -49,7 +49,7 @@ static PluginInfo const s_info = PluginInfo(
     "Diff Kernel",
     "http://pdal.io/kernels/kernels.diff.html" );
 
-CREATE_STATIC_PLUGIN(1, 0, DiffKernel, Kernel, s_info)
+CREATE_STATIC_PLUGIN(1, 0, DiffKernel, s_info)
 
 std::string DiffKernel::getName() const { return s_info.name; }
 

--- a/kernels/info/InfoKernel.cpp
+++ b/kernels/info/InfoKernel.cpp
@@ -54,7 +54,7 @@ static PluginInfo const s_info = PluginInfo(
     "Info Kernel",
     "http://pdal.io/kernels/kernels.info.html" );
 
-CREATE_STATIC_PLUGIN(1, 0, InfoKernel, Kernel, s_info)
+CREATE_STATIC_PLUGIN(1, 0, InfoKernel, s_info)
 
 std::string InfoKernel::getName() const { return s_info.name; }
 

--- a/kernels/merge/MergeKernel.cpp
+++ b/kernels/merge/MergeKernel.cpp
@@ -46,7 +46,7 @@ static PluginInfo const s_info = PluginInfo(
     "Merge Kernel",
     "http://pdal.io/kernels/kernels.merge.html" );
 
-CREATE_STATIC_PLUGIN(1, 0, MergeKernel, Kernel, s_info)
+CREATE_STATIC_PLUGIN(1, 0, MergeKernel, s_info)
 
 std::string MergeKernel::getName() const
 {

--- a/kernels/pipeline/PipelineKernel.cpp
+++ b/kernels/pipeline/PipelineKernel.cpp
@@ -48,7 +48,7 @@ static PluginInfo const s_info = PluginInfo(
     "Pipeline Kernel",
     "http://pdal.io/kernels/kernels.pipeline.html" );
 
-CREATE_STATIC_PLUGIN(1, 0, PipelineKernel, Kernel, s_info)
+CREATE_STATIC_PLUGIN(1, 0, PipelineKernel, s_info)
 
 std::string PipelineKernel::getName() const { return s_info.name; }
 

--- a/kernels/random/RandomKernel.cpp
+++ b/kernels/random/RandomKernel.cpp
@@ -45,7 +45,7 @@ static PluginInfo const s_info = PluginInfo(
     "Random Kernel",
     "http://pdal.io/kernels/kernels.random.html" );
 
-CREATE_STATIC_PLUGIN(1, 0, RandomKernel, Kernel, s_info)
+CREATE_STATIC_PLUGIN(1, 0, RandomKernel, s_info)
 
 std::string RandomKernel::getName() const { return s_info.name; }
 

--- a/kernels/sort/SortKernel.cpp
+++ b/kernels/sort/SortKernel.cpp
@@ -46,7 +46,7 @@ static PluginInfo const s_info = PluginInfo(
     "Sort Kernel",
     "http://pdal.io/kernels/kernels.sort.html" );
 
-CREATE_STATIC_PLUGIN(1, 0, SortKernel, Kernel, s_info)
+CREATE_STATIC_PLUGIN(1, 0, SortKernel, s_info)
 
 std::string SortKernel::getName() const
 {

--- a/kernels/split/SplitKernel.cpp
+++ b/kernels/split/SplitKernel.cpp
@@ -46,7 +46,7 @@ static PluginInfo const s_info = PluginInfo(
     "Split Kernel",
     "http://pdal.io/kernels/kernels.split.html" );
 
-CREATE_STATIC_PLUGIN(1, 0, SplitKernel, Kernel, s_info)
+CREATE_STATIC_PLUGIN(1, 0, SplitKernel, s_info)
 
 std::string SplitKernel::getName() const
 {

--- a/kernels/tindex/TIndexKernel.cpp
+++ b/kernels/tindex/TIndexKernel.cpp
@@ -74,7 +74,7 @@ static PluginInfo const s_info = PluginInfo(
     "TIndex Kernel",
     "http://pdal.io/kernels/kernels.tindex.html" );
 
-CREATE_STATIC_PLUGIN(1, 0, TIndexKernel, Kernel, s_info)
+CREATE_STATIC_PLUGIN(1, 0, TIndexKernel, s_info)
 
 std::string TIndexKernel::getName() const { return s_info.name; }
 

--- a/kernels/translate/TranslateKernel.cpp
+++ b/kernels/translate/TranslateKernel.cpp
@@ -60,7 +60,7 @@ static PluginInfo const s_info =
                "combination.",
                "http://pdal.io/kernels/kernels.translate.html");
 
-CREATE_STATIC_PLUGIN(1, 0, TranslateKernel, Kernel, s_info)
+CREATE_STATIC_PLUGIN(1, 0, TranslateKernel, s_info)
 
 std::string TranslateKernel::getName() const
 {

--- a/plugins/attribute/filters/AttributeFilter.cpp
+++ b/plugins/attribute/filters/AttributeFilter.cpp
@@ -52,7 +52,7 @@ static PluginInfo const s_info = PluginInfo(
         "an OGR-readable data source, or an OGR SQL query.",
     "http://pdal.io/stages/filters.attribute.html" );
 
-CREATE_SHARED_PLUGIN(1, 0, AttributeFilter, Filter, s_info)
+CREATE_SHARED_PLUGIN(1, 0, AttributeFilter, s_info)
 
 struct OGRDataSourceDeleter
 {

--- a/plugins/cpd/kernel/Cpd.cpp
+++ b/plugins/cpd/kernel/Cpd.cpp
@@ -49,7 +49,7 @@ static PluginInfo const s_info = PluginInfo(
     "CPD Kernel",
     "http://pdal.io/kernels/kernels.cpd.html" );
 
-CREATE_SHARED_PLUGIN(1, 0, CpdKernel, Kernel, s_info)
+CREATE_SHARED_PLUGIN(1, 0, CpdKernel, s_info)
 
 std::string CpdKernel::getName() const { return s_info.name; }
 
@@ -88,7 +88,7 @@ void CpdKernel::addSwitches(ProgramArgs& args)
         "Use the domain of the XY dimensions to automatically "
         "exaggerate the Z dimensions",
         m_auto_z_exaggeration);
-    args.add("auto-z-exaggeration-ratio", 
+    args.add("auto-z-exaggeration-ratio",
         "The scaling ratio for the Z-exaggeration. Z's range will "
         "be scaled to this ratio of the extent of the smallest XY extent.",
         m_auto_z_exaggeration_ratio, (float)(5.0 / 8.0));

--- a/plugins/geowave/io/GeoWaveReader.cpp
+++ b/plugins/geowave/io/GeoWaveReader.cpp
@@ -133,7 +133,7 @@ static PluginInfo const s_info = PluginInfo(
     "\"GeoWave\"  reader support. ",
     "http://pdal.io/stages/drivers.geowave.reader.html" );
 
-CREATE_SHARED_PLUGIN(1, 0, GeoWaveReader, Reader, s_info)
+CREATE_SHARED_PLUGIN(1, 0, GeoWaveReader, s_info)
 
 std::string pdal::GeoWaveReader::getName() const { return s_info.name; }
 

--- a/plugins/geowave/io/GeoWaveWriter.cpp
+++ b/plugins/geowave/io/GeoWaveWriter.cpp
@@ -139,7 +139,7 @@ static PluginInfo const s_info = PluginInfo(
     "Write data using GeoWave.",
     "http://pdal.io/stages/drivers.geowave.writer.html" );
 
-CREATE_SHARED_PLUGIN(1, 0, GeoWaveWriter, Writer, s_info)
+CREATE_SHARED_PLUGIN(1, 0, GeoWaveWriter, s_info)
 
 std::string pdal::GeoWaveWriter::getName() const { return s_info.name; }
 
@@ -216,7 +216,7 @@ namespace pdal
         std::ostringstream os;
 
         BasicAccumuloOperations accumuloOperations;
-        try 
+        try
         {
             accumuloOperations = java_new<BasicAccumuloOperations>(
                 java_new<String>(m_zookeeperUrl),

--- a/plugins/greyhound/io/GreyhoundReader.cpp
+++ b/plugins/greyhound/io/GreyhoundReader.cpp
@@ -44,7 +44,7 @@ static PluginInfo const s_info = PluginInfo(
     "Greyhound Reader",
     "http://pdal.io/stages/readers.greyhound.html" );
 
-CREATE_SHARED_PLUGIN(1, 0, GreyhoundReader, Reader, s_info)
+CREATE_SHARED_PLUGIN(1, 0, GreyhoundReader, s_info)
 
 std::string GreyhoundReader::getName() const { return s_info.name; }
 

--- a/plugins/hexbin/filters/HexBin.cpp
+++ b/plugins/hexbin/filters/HexBin.cpp
@@ -49,7 +49,7 @@ static PluginInfo const s_info = PluginInfo(
     "Tessellate the point's X/Y domain and determine point density and/or point boundary.",
     "http://pdal.io/stages/filters.hexbin.html" );
 
-CREATE_SHARED_PLUGIN(1, 0, HexBin, Filter, s_info)
+CREATE_SHARED_PLUGIN(1, 0, HexBin, s_info)
 
 void HexBin::processOptions(const Options& options)
 {

--- a/plugins/icebridge/io/IcebridgeReader.cpp
+++ b/plugins/icebridge/io/IcebridgeReader.cpp
@@ -68,7 +68,7 @@ static PluginInfo const s_info = PluginInfo(
         "for more information.",
     "http://pdal.io/stages/readers.icebridge.html" );
 
-CREATE_SHARED_PLUGIN(1, 0, IcebridgeReader, Reader, s_info)
+CREATE_SHARED_PLUGIN(1, 0, IcebridgeReader, s_info)
 
 std::string IcebridgeReader::getName() const { return s_info.name; }
 

--- a/plugins/matlab/io/MatlabWriter.cpp
+++ b/plugins/matlab/io/MatlabWriter.cpp
@@ -45,7 +45,7 @@ static PluginInfo const s_info = PluginInfo(
     "http://pdal.io/stages/writers.matlab.html");
 
 
-CREATE_SHARED_PLUGIN(1, 0, MatlabWriter, Writer, s_info)
+CREATE_SHARED_PLUGIN(1, 0, MatlabWriter, s_info)
 std::string MatlabWriter::getName() const { return s_info.name; }
 
 

--- a/plugins/mrsid/io/MrsidReader.cpp
+++ b/plugins/mrsid/io/MrsidReader.cpp
@@ -46,7 +46,7 @@ static PluginInfo const s_info = PluginInfo(
     "MrSID Reader",
     "http://www.pdal.io/stages/readers.mrsid.html" );
 
-CREATE_SHARED_PLUGIN(1, 0, MrsidReader, Reader, s_info)
+CREATE_SHARED_PLUGIN(1, 0, MrsidReader, s_info)
 
 std::string MrsidReader::getName() const { return s_info.name; }
 

--- a/plugins/nitf/io/NitfReader.cpp
+++ b/plugins/nitf/io/NitfReader.cpp
@@ -44,7 +44,7 @@ static PluginInfo const s_info = PluginInfo(
     "NITF Reader",
     "http://pdal.io/stages/readers.nitf.html" );
 
-CREATE_SHARED_PLUGIN(1, 0, NitfReader, Reader, s_info)
+CREATE_SHARED_PLUGIN(1, 0, NitfReader, s_info)
 
 std::string NitfReader::getName() const { return s_info.name; }
 

--- a/plugins/nitf/io/NitfWriter.cpp
+++ b/plugins/nitf/io/NitfWriter.cpp
@@ -83,7 +83,7 @@ static PluginInfo const s_info = PluginInfo(
     "NITF Writer",
     "http://pdal.io/stages/writers.nitf.html" );
 
-CREATE_SHARED_PLUGIN(1, 0, NitfWriter, Writer, s_info)
+CREATE_SHARED_PLUGIN(1, 0, NitfWriter, s_info)
 
 std::string NitfWriter::getName() const { return s_info.name; }
 

--- a/plugins/oci/io/OciReader.cpp
+++ b/plugins/oci/io/OciReader.cpp
@@ -47,7 +47,7 @@ static PluginInfo const s_info = PluginInfo(
     "Read point cloud data from Oracle SDO_POINTCLOUD.",
     "http://pdal.io/stages/readers.oci.html" );
 
-CREATE_SHARED_PLUGIN(1, 0, OciReader, Reader, s_info)
+CREATE_SHARED_PLUGIN(1, 0, OciReader, s_info)
 
 std::string OciReader::getName() const { return s_info.name; }
 

--- a/plugins/oci/io/OciWriter.cpp
+++ b/plugins/oci/io/OciWriter.cpp
@@ -54,7 +54,7 @@ static PluginInfo const s_info = PluginInfo(
     "Write data using SDO_PC objects to Oracle.",
     "http://pdal.io/stages/writers.oci.html" );
 
-CREATE_SHARED_PLUGIN(1, 0, OciWriter, Writer, s_info)
+CREATE_SHARED_PLUGIN(1, 0, OciWriter, s_info)
 
 std::string OciWriter::getName() const { return s_info.name; }
 

--- a/plugins/p2g/io/P2gWriter.cpp
+++ b/plugins/p2g/io/P2gWriter.cpp
@@ -49,7 +49,7 @@ static PluginInfo const s_info = PluginInfo(
     "Points2Grid Writer",
     "http://pdal.io/stages/writers.p2g.html" );
 
-CREATE_SHARED_PLUGIN(1, 0, P2gWriter, Writer, s_info)
+CREATE_SHARED_PLUGIN(1, 0, P2gWriter, s_info)
 
 std::string P2gWriter::getName() const { return s_info.name; }
 

--- a/plugins/pcl/filters/DartSampleFilter.cpp
+++ b/plugins/pcl/filters/DartSampleFilter.cpp
@@ -51,7 +51,7 @@ static PluginInfo const s_info =
     PluginInfo("filters.dartsample", "Dart sample filter",
                "http://pdal.io/stages/filters.dartsample.html");
 
-CREATE_SHARED_PLUGIN(1, 0, DartSampleFilter, Filter, s_info)
+CREATE_SHARED_PLUGIN(1, 0, DartSampleFilter, s_info)
 
 std::string DartSampleFilter::getName() const
 {

--- a/plugins/pcl/filters/GreedyProjectionFilter.cpp
+++ b/plugins/pcl/filters/GreedyProjectionFilter.cpp
@@ -52,7 +52,7 @@ static PluginInfo const s_info =
     PluginInfo("filters.greedyprojection", "Grid Projection filter",
                "http://pdal.io/stages/filters.greedyprojection.html");
 
-CREATE_SHARED_PLUGIN(1, 0, GreedyProjectionFilter, Filter, s_info)
+CREATE_SHARED_PLUGIN(1, 0, GreedyProjectionFilter, s_info)
 
 std::string GreedyProjectionFilter::getName() const
 {

--- a/plugins/pcl/filters/GridProjectionFilter.cpp
+++ b/plugins/pcl/filters/GridProjectionFilter.cpp
@@ -52,7 +52,7 @@ static PluginInfo const s_info =
     PluginInfo("filters.gridprojection", "Grid Projection filter",
                "http://pdal.io/stages/filters.gridprojection.html");
 
-CREATE_SHARED_PLUGIN(1, 0, GridProjectionFilter, Filter, s_info)
+CREATE_SHARED_PLUGIN(1, 0, GridProjectionFilter, s_info)
 
 std::string GridProjectionFilter::getName() const
 {

--- a/plugins/pcl/filters/GroundFilter.cpp
+++ b/plugins/pcl/filters/GroundFilter.cpp
@@ -56,7 +56,7 @@ static PluginInfo const s_info =
     PluginInfo("filters.ground", "Progressive morphological filter",
                "http://pdal.io/stages/filters.ground.html");
 
-CREATE_SHARED_PLUGIN(1, 0, GroundFilter, Filter, s_info)
+CREATE_SHARED_PLUGIN(1, 0, GroundFilter, s_info)
 
 std::string GroundFilter::getName() const
 {

--- a/plugins/pcl/filters/HeightFilter.cpp
+++ b/plugins/pcl/filters/HeightFilter.cpp
@@ -68,7 +68,7 @@ typedef pcl::PointCloud<pcl::PointXYZ> Cloud;
 static PluginInfo const s_info =
     PluginInfo("filters.height", "Height Filter", "");
 
-CREATE_SHARED_PLUGIN(1, 0, HeightFilter, Filter, s_info)
+CREATE_SHARED_PLUGIN(1, 0, HeightFilter, s_info)
 
 std::string HeightFilter::getName() const
 {

--- a/plugins/pcl/filters/MovingLeastSquaresFilter.cpp
+++ b/plugins/pcl/filters/MovingLeastSquaresFilter.cpp
@@ -51,7 +51,7 @@ static PluginInfo const s_info =
     PluginInfo("filters.movingleastsquares", "Moving Least Squares filter",
                "http://pdal.io/stages/filters.movingleastsquares.html");
 
-CREATE_SHARED_PLUGIN(1, 0, MovingLeastSquaresFilter, Filter, s_info)
+CREATE_SHARED_PLUGIN(1, 0, MovingLeastSquaresFilter, s_info)
 
 std::string MovingLeastSquaresFilter::getName() const
 {

--- a/plugins/pcl/filters/PCLBlock.cpp
+++ b/plugins/pcl/filters/PCLBlock.cpp
@@ -50,7 +50,7 @@ static PluginInfo const s_info =
     PluginInfo("filters.pclblock", "PCL Block implementation",
                "http://pdal.io/stages/filters.pclblock.html");
 
-CREATE_SHARED_PLUGIN(1, 0, PCLBlock, Filter, s_info)
+CREATE_SHARED_PLUGIN(1, 0, PCLBlock, s_info)
 
 std::string PCLBlock::getName() const
 {

--- a/plugins/pcl/filters/PoissonFilter.cpp
+++ b/plugins/pcl/filters/PoissonFilter.cpp
@@ -52,7 +52,7 @@ static PluginInfo const s_info =
     PluginInfo("filters.poisson", "Poisson filter",
                "http://pdal.io/stages/filters.poisson.html");
 
-CREATE_SHARED_PLUGIN(1, 0, PoissonFilter, Filter, s_info)
+CREATE_SHARED_PLUGIN(1, 0, PoissonFilter, s_info)
 
 std::string PoissonFilter::getName() const
 {

--- a/plugins/pcl/filters/RadiusOutlierFilter.cpp
+++ b/plugins/pcl/filters/RadiusOutlierFilter.cpp
@@ -55,7 +55,7 @@ static PluginInfo const s_info =
     PluginInfo("filters.radiusoutlier", "Radius outlier removal",
                "http://pdal.io/stages/filters.radiusoutlier.html");
 
-CREATE_SHARED_PLUGIN(1, 0, RadiusOutlierFilter, Filter, s_info)
+CREATE_SHARED_PLUGIN(1, 0, RadiusOutlierFilter, s_info)
 
 std::string RadiusOutlierFilter::getName() const
 {

--- a/plugins/pcl/filters/StatisticalOutlierFilter.cpp
+++ b/plugins/pcl/filters/StatisticalOutlierFilter.cpp
@@ -55,7 +55,7 @@ static PluginInfo const s_info =
     PluginInfo("filters.statisticaloutlier", "Statistical outlier removal",
                "http://pdal.io/stages/filters.statisticaloutlier.html");
 
-CREATE_SHARED_PLUGIN(1, 0, StatisticalOutlierFilter, Filter, s_info)
+CREATE_SHARED_PLUGIN(1, 0, StatisticalOutlierFilter, s_info)
 
 std::string StatisticalOutlierFilter::getName() const
 {

--- a/plugins/pcl/filters/VoxelGridFilter.cpp
+++ b/plugins/pcl/filters/VoxelGridFilter.cpp
@@ -51,7 +51,7 @@ static PluginInfo const s_info =
     PluginInfo("filters.voxelgrid", "Voxel grid filter",
                "http://pdal.io/stages/filters.voxelgrid.html");
 
-CREATE_SHARED_PLUGIN(1, 0, VoxelGridFilter, Filter, s_info)
+CREATE_SHARED_PLUGIN(1, 0, VoxelGridFilter, s_info)
 
 std::string VoxelGridFilter::getName() const
 {

--- a/plugins/pcl/io/PCLVisualizer.cpp
+++ b/plugins/pcl/io/PCLVisualizer.cpp
@@ -137,7 +137,7 @@ static PluginInfo const s_info = PluginInfo(
     "PCL Visualizer",
     "http://pdal.io/stages/writers.pclvisualizer.html" );
 
-CREATE_SHARED_PLUGIN(1, 0, PclVisualizer, Writer, s_info)
+CREATE_SHARED_PLUGIN(1, 0, PclVisualizer, s_info)
 
 std::string PclVisualizer::getName() const { return s_info.name; }
 

--- a/plugins/pcl/io/PcdReader.cpp
+++ b/plugins/pcl/io/PcdReader.cpp
@@ -53,7 +53,7 @@ static PluginInfo const s_info = PluginInfo(
     "Read data in the Point Cloud Library (PCL) format.",
     "http://pdal.io/stages/readers.pclvisualizer.html" );
 
-CREATE_SHARED_PLUGIN(1, 0, PcdReader, Reader, s_info)
+CREATE_SHARED_PLUGIN(1, 0, PcdReader, s_info)
 
 std::string PcdReader::getName() const { return s_info.name; }
 

--- a/plugins/pcl/io/PcdWriter.cpp
+++ b/plugins/pcl/io/PcdWriter.cpp
@@ -54,7 +54,7 @@ static PluginInfo const s_info = PluginInfo(
     "Write data in the Point Cloud Library (PCL) format.",
     "http://pdal.io/stages/writers.pclvisualizer.html" );
 
-CREATE_SHARED_PLUGIN(1, 0, PcdWriter, Writer, s_info)
+CREATE_SHARED_PLUGIN(1, 0, PcdWriter, s_info)
 
 std::string PcdWriter::getName() const { return s_info.name; }
 

--- a/plugins/pcl/kernel/GroundKernel.cpp
+++ b/plugins/pcl/kernel/GroundKernel.cpp
@@ -55,7 +55,7 @@ static PluginInfo const s_info = PluginInfo(
     "Ground Kernel",
     "http://pdal.io/kernels/kernels.ground.html" );
 
-CREATE_SHARED_PLUGIN(1, 0, GroundKernel, Kernel, s_info)
+CREATE_SHARED_PLUGIN(1, 0, GroundKernel, s_info)
 
 std::string GroundKernel::getName() const { return s_info.name; }
 

--- a/plugins/pcl/kernel/PCLKernel.cpp
+++ b/plugins/pcl/kernel/PCLKernel.cpp
@@ -48,7 +48,7 @@ static PluginInfo const s_info = PluginInfo(
     "PCL Kernel",
     "http://pdal.io/kernels/kernels.pcl.html" );
 
-CREATE_SHARED_PLUGIN(1, 0, PCLKernel, Kernel, s_info)
+CREATE_SHARED_PLUGIN(1, 0, PCLKernel, s_info)
 
 std::string PCLKernel::getName() const { return s_info.name; }
 

--- a/plugins/pcl/kernel/SmoothKernel.cpp
+++ b/plugins/pcl/kernel/SmoothKernel.cpp
@@ -49,7 +49,7 @@ static PluginInfo const s_info = PluginInfo(
     "Smooth Kernel",
     "http://pdal.io/kernels/kernels.smooth.html" );
 
-CREATE_SHARED_PLUGIN(1, 0, SmoothKernel, Kernel, s_info)
+CREATE_SHARED_PLUGIN(1, 0, SmoothKernel, s_info)
 
 std::string SmoothKernel::getName() const { return s_info.name; }
 

--- a/plugins/pcl/kernel/ViewKernel.cpp
+++ b/plugins/pcl/kernel/ViewKernel.cpp
@@ -45,7 +45,7 @@ static PluginInfo const s_info = PluginInfo(
     "View Kernel",
     "http://pdal.io/kernels/kernels.view.html" );
 
-CREATE_SHARED_PLUGIN(1, 0, ViewKernel, Kernel, s_info)
+CREATE_SHARED_PLUGIN(1, 0, ViewKernel, s_info)
 
 std::string ViewKernel::getName() const { return s_info.name; }
 

--- a/plugins/pgpointcloud/io/PgReader.cpp
+++ b/plugins/pgpointcloud/io/PgReader.cpp
@@ -49,7 +49,7 @@ static PluginInfo const s_info = PluginInfo(
         "SQL statment selecting the data.",
     "http://pdal.io/stages/readers.pgpointcloud.html" );
 
-CREATE_SHARED_PLUGIN(1, 0, PgReader, Reader, s_info)
+CREATE_SHARED_PLUGIN(1, 0, PgReader, s_info)
 
 std::string PgReader::getName() const { return s_info.name; }
 

--- a/plugins/pgpointcloud/io/PgWriter.cpp
+++ b/plugins/pgpointcloud/io/PgWriter.cpp
@@ -50,7 +50,7 @@ static PluginInfo const s_info = PluginInfo(
     "Write points to PostgreSQL pgpointcloud output",
     "http://pdal.io/stages/writers.pgpointcloud.html" );
 
-CREATE_SHARED_PLUGIN(1, 0, PgWriter, Writer, s_info)
+CREATE_SHARED_PLUGIN(1, 0, PgWriter, s_info)
 
 std::string PgWriter::getName() const { return s_info.name; }
 

--- a/plugins/python/filters/PredicateFilter.cpp
+++ b/plugins/python/filters/PredicateFilter.cpp
@@ -47,7 +47,7 @@ static PluginInfo const s_info = PluginInfo(
     "Filter data using inline Python expressions.",
     "http://pdal.io/stages/filters.predicate.html" );
 
-CREATE_SHARED_PLUGIN(1, 0, PredicateFilter, Filter, s_info)
+CREATE_SHARED_PLUGIN(1, 0, PredicateFilter, s_info)
 
 std::string PredicateFilter::getName() const { return s_info.name; }
 

--- a/plugins/python/filters/ProgrammableFilter.cpp
+++ b/plugins/python/filters/ProgrammableFilter.cpp
@@ -47,7 +47,7 @@ static PluginInfo const s_info = PluginInfo(
     "Manipulate data using inline Python",
     "http://pdal.io/stages/filters.programmable.html" );
 
-CREATE_SHARED_PLUGIN(1, 0, ProgrammableFilter, Filter, s_info)
+CREATE_SHARED_PLUGIN(1, 0, ProgrammableFilter, s_info)
 
 std::string ProgrammableFilter::getName() const { return s_info.name; }
 

--- a/plugins/rxp/io/RxpReader.cpp
+++ b/plugins/rxp/io/RxpReader.cpp
@@ -51,7 +51,7 @@ static PluginInfo const s_info = PluginInfo(
     "RXP Reader",
     "http://pdal.io/stages/readers.rxp.html" );
 
-CREATE_SHARED_PLUGIN(1, 0, RxpReader, Reader, s_info)
+CREATE_SHARED_PLUGIN(1, 0, RxpReader, s_info)
 
 std::string RxpReader::getName() const { return s_info.name; }
 

--- a/plugins/sqlite/io/SQLiteReader.cpp
+++ b/plugins/sqlite/io/SQLiteReader.cpp
@@ -44,7 +44,7 @@ static PluginInfo const s_info = PluginInfo(
     "Read data from SQLite3 database files.",
     "" );
 
-CREATE_SHARED_PLUGIN(1, 0, SQLiteReader, Reader, s_info)
+CREATE_SHARED_PLUGIN(1, 0, SQLiteReader, s_info)
 
 std::string SQLiteReader::getName() const { return s_info.name; }
 

--- a/plugins/sqlite/io/SQLiteWriter.cpp
+++ b/plugins/sqlite/io/SQLiteWriter.cpp
@@ -53,7 +53,7 @@ static PluginInfo const s_info = PluginInfo(
     "Write data to SQLite3 database files.",
     "" );
 
-CREATE_SHARED_PLUGIN(1, 0, SQLiteWriter, Writer, s_info)
+CREATE_SHARED_PLUGIN(1, 0, SQLiteWriter, s_info)
 
 std::string SQLiteWriter::getName() const { return s_info.name; }
 


### PR DESCRIPTION
Add PluginType metafunction that allows to deduce plugin type enumerator from base class of the plugin class.
Remove superfluous base class parameter from macros `CREATE_SHARED_PLUGIN` and `CREATE_STATIC_PLUGIN`.
The PluginType makes also a compile-time check if a plugin class is derived from one of the required bases.