### PR TITLE
Add two include guards for libgeotiff

### DIFF
--- a/io/las/LasReader.cpp
+++ b/io/las/LasReader.cpp
@@ -46,7 +46,9 @@
 #include <pdal/util/IStream.hpp>
 #include <pdal/pdal_macros.hpp>
 
+#ifdef PDAL_HAVE_LIBGEOTIFF
 #include "GeotiffSupport.hpp"
+#endif
 #include "LasHeader.hpp"
 #include "VariableLengthRecord.hpp"
 #include "ZipPoint.hpp"

--- a/io/las/LasWriter.cpp
+++ b/io/las/LasWriter.cpp
@@ -45,7 +45,9 @@
 #include <pdal/util/Utils.hpp>
 #include <pdal/pdal_macros.hpp>
 
+#ifdef PDAL_HAVE_LIBGEOTIFF
 #include "GeotiffSupport.hpp"
+#endif
 #include "ZipPoint.hpp"
 
 namespace pdal


### PR DESCRIPTION
If installing w/o libgeotiff, can't build w/o these two guards. I'm not
sure how to fix the "no optional components" test to run w/o geotiff,
since this Docker stuff is a bit opaque to me ATM.