### PR TITLE
g++-5 cleanup

### DIFF
--- a/cmake/unix_compiler_options.cmake
+++ b/cmake/unix_compiler_options.cmake
@@ -1,4 +1,4 @@
-set(PDAL_COMMON_CXX_FLAGS "-Wextra -Wall -Wno-unused-parameter -Wno-unused-variable -Wpointer-arith -Wcast-align -Wcast-qual -Wredundant-decls -Wno-long-long -Wno-unknown-pragmas -isystem /usr/local/include"
+set(PDAL_COMMON_CXX_FLAGS "-Wextra -Wall -Wno-unused-parameter -Wno-unused-variable -Wpointer-arith -Wcast-align -Wcast-qual -Wredundant-decls -Wno-long-long -Wno-unknown-pragmas -Wno-deprecated-declarations -isystem /usr/local/include"
 )
 
 if (${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")

--- a/filters/colorization/ColorizationFilter.cpp
+++ b/filters/colorization/ColorizationFilter.cpp
@@ -83,7 +83,6 @@ ColorizationFilter::BandInfo parseDim(const std::string& dim,
     std::string name;
     uint32_t band = defaultBand;
     double scale = 1.0;
-    bool foundBand = false;
 
     try
     {
@@ -109,7 +108,6 @@ ColorizationFilter::BandInfo parseDim(const std::string& dim,
             if (start == end)
                 band = defaultBand;
             pos += (end - start);
-            foundBand = true;
 
             count = Utils::extract(dim, pos, (int(*)(int))std::isspace);
             pos += count;

--- a/io/bpf/BpfReader.cpp
+++ b/io/bpf/BpfReader.cpp
@@ -34,6 +34,8 @@
 
 #include "BpfReader.hpp"
 
+#include <climits>
+
 #include <zlib.h>
 
 #include <pdal/Options.hpp>

--- a/io/bpf/BpfWriter.cpp
+++ b/io/bpf/BpfWriter.cpp
@@ -34,6 +34,8 @@
 
 #include "BpfWriter.hpp"
 
+#include <climits>
+
 #include <pdal/Options.hpp>
 #include <pdal/pdal_export.hpp>
 

--- a/io/derivative/DerivativeWriter.cpp
+++ b/io/derivative/DerivativeWriter.cpp
@@ -1525,15 +1525,25 @@ void DerivativeWriter::writeCurvature(Eigen::MatrixXd* tDemData,
     tBand->SetNoDataValue((double)c_background);
 
     if (m_GRID_SIZE_X > 0 && m_GRID_SIZE_Y > 0)
+    {
+        int ret;
 #if GDAL_VERSION_MAJOR <= 1
-        tBand->RasterIO(GF_Write, 0, 0, m_GRID_SIZE_X, m_GRID_SIZE_Y,
+        ret = tBand->RasterIO(GF_Write, 0, 0, m_GRID_SIZE_X, m_GRID_SIZE_Y,
                 poRasterData.data(), m_GRID_SIZE_X, m_GRID_SIZE_Y,
                 GDT_Float32, 0, 0);
 #else
-        tBand->RasterIO(GF_Write, 0, 0, m_GRID_SIZE_X, m_GRID_SIZE_Y,
+        ret = tBand->RasterIO(GF_Write, 0, 0, m_GRID_SIZE_X, m_GRID_SIZE_Y,
             poRasterData.data(), m_GRID_SIZE_X, m_GRID_SIZE_Y,
             GDT_Float32, 0, 0, 0);
 #endif
+        if (ret != CE_None)
+        {
+            std::ostringstream oss;
+
+            oss << getName() << ": Error reading raster IO.";
+            throw pdal_error(oss.str());
+        }
+    }
     GDALClose((GDALDatasetH) mpDstDS);
 }
 

--- a/io/derivative/DerivativeWriter.cpp
+++ b/io/derivative/DerivativeWriter.cpp
@@ -1524,14 +1524,13 @@ void DerivativeWriter::writeCurvature(Eigen::MatrixXd* tDemData,
 
     tBand->SetNoDataValue((double)c_background);
 
-    int ret;
     if (m_GRID_SIZE_X > 0 && m_GRID_SIZE_Y > 0)
 #if GDAL_VERSION_MAJOR <= 1
-        ret = tBand->RasterIO(GF_Write, 0, 0, m_GRID_SIZE_X, m_GRID_SIZE_Y,
+        tBand->RasterIO(GF_Write, 0, 0, m_GRID_SIZE_X, m_GRID_SIZE_Y,
                 poRasterData.data(), m_GRID_SIZE_X, m_GRID_SIZE_Y,
                 GDT_Float32, 0, 0);
 #else
-        ret = tBand->RasterIO(GF_Write, 0, 0, m_GRID_SIZE_X, m_GRID_SIZE_Y,
+        tBand->RasterIO(GF_Write, 0, 0, m_GRID_SIZE_X, m_GRID_SIZE_Y,
             poRasterData.data(), m_GRID_SIZE_X, m_GRID_SIZE_Y,
             GDT_Float32, 0, 0, 0);
 #endif


### PR DESCRIPTION
I just built out PDAL with g++-5 (Homebrew gcc 5.3.0 --without-multilib) on my mac, and a couple of errors and warnings popped up. This pull request fixes all of them.

99a60df fixes errors so is critical; the other two fix warnings and could be kept or left depending on your preferences.