### PR TITLE
Fix various spelling errors.

### DIFF
--- a/include/pdal/Dimension.hpp
+++ b/include/pdal/Dimension.hpp
@@ -260,7 +260,7 @@ inline std::string description(Id::Enum id)
     case Id::GpsTime:
         return "GPS time that the point was acquired";
     case Id::InternalTime:
-        return "Scanner's internal time when the point was aquired, in seconds";
+        return "Scanner's internal time when the point was acquired, in seconds";
     case Id::OffsetTime:
         return "Milliseconds from first acquired point";
     case Id::IsPpsLocked:

--- a/io/las/LasWriter.cpp
+++ b/io/las/LasWriter.cpp
@@ -502,7 +502,7 @@ bool LasWriter::addWktVlr()
     std::vector<uint8_t> wktBytes(wkt.begin(), wkt.end());
     // This tacks a NULL to the end of the data, which is required by the spec.
     wktBytes.resize(wktBytes.size() + 1, 0);
-    addVlr(TRANSFORM_USER_ID, WKT_RECORD_ID, "OGC Tranformation Record",
+    addVlr(TRANSFORM_USER_ID, WKT_RECORD_ID, "OGC Transformation Record",
         wktBytes);
 
     // The data in the vector gets moved to the VLR, so we have to recreate it.

--- a/plugins/pgpointcloud/io/PgReader.cpp
+++ b/plugins/pgpointcloud/io/PgReader.cpp
@@ -46,7 +46,7 @@ namespace pdal
 static PluginInfo const s_info = PluginInfo(
     "readers.pgpointcloud",
     "Read data from pgpointcloud format. \"query\" option needs to be a \n" \
-        "SQL statment selecting the data.",
+        "SQL statement selecting the data.",
     "http://pdal.io/stages/readers.pgpointcloud.html" );
 
 CREATE_SHARED_PLUGIN(1, 0, PgReader, Reader, s_info)


### PR DESCRIPTION
The lintian QA tool reported a couple of spelling errors for the Debian package build:

 * statment      -> statement
 * aquired       -> acquired
 * Tranformation -> Transformation