### PR TITLE
Use FLAGS set in the environment.

### DIFF
--- a/cmake/unix_compiler_options.cmake
+++ b/cmake/unix_compiler_options.cmake
@@ -19,4 +19,4 @@ else()
     message(FATAL_ERROR "Unsupported C++ compiler")
 endif()
 
-set (CMAKE_CXX_FLAGS "${PDAL_COMMON_CXX_FLAGS} ${CXX_STANDARD}")
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${PDAL_COMMON_CXX_FLAGS} ${CXX_STANDARD}")


### PR DESCRIPTION
The CXX FLAGS set in the environment are used to enable [hardening](https://wiki.debian.org/Hardening) build flags.