### PR TITLE
Load mod_spatialite.so on Linux too.

### DIFF
--- a/cmake/spatialite.cmake
+++ b/cmake/spatialite.cmake
@@ -1,0 +1,10 @@
+#
+# SpatiaLite cmake configuration
+#
+
+include(FindPkgConfig)
+
+pkg_search_module(SPATIALITE spatialite>=4.2.0)
+if(SPATIALITE_FOUND)
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DMOD_SPATIALITE")
+endif(SPATIALITE_FOUND)

--- a/plugins/sqlite/CMakeLists.txt
+++ b/plugins/sqlite/CMakeLists.txt
@@ -3,6 +3,7 @@
 #
 
 include (${PDAL_CMAKE_DIR}/sqlite.cmake)
+include (${PDAL_CMAKE_DIR}/spatialite.cmake)
 include_directories(${ROOT_DIR}/vendor/pdalboost)
 
 # SQLite Reader

--- a/plugins/sqlite/io/SQLiteCommon.hpp
+++ b/plugins/sqlite/io/SQLiteCommon.hpp
@@ -459,7 +459,11 @@ public:
 
 #ifdef __linux__
         so_extension = "so";
+#ifdef MOD_SPATIALITE
         lib_extension = "mod_";
+#else
+        lib_extension = "lib";
+#endif
 #endif
 
 #ifdef _WIN32

--- a/plugins/sqlite/io/SQLiteCommon.hpp
+++ b/plugins/sqlite/io/SQLiteCommon.hpp
@@ -459,7 +459,7 @@ public:
 
 #ifdef __linux__
         so_extension = "so";
-        lib_extension = "lib";
+        lib_extension = "mod_";
 #endif
 
 #ifdef _WIN32


### PR DESCRIPTION
The loadable SQLite3 module is named `mod_spatialite` since 4.2.0, see the related discussion in the [SpatiaLite 4.2.1 RC0 release announcement](https://groups.google.com/d/msg/spatialite-users/jknlgTY9zgU/3p_ESVIeyoIJ).

This change allows the SQLite plugin to build with `libsqlite3-dev` & `libsqlite3-mod-spatialite` on Debian unstable.