### PR TITLE
Add support for kFreeBSD architectures.

### DIFF
--- a/include/pdal/util/portable_endian.hpp
+++ b/include/pdal/util/portable_endian.hpp
@@ -58,6 +58,10 @@
 #   define be64toh betoh64
 #   define le64toh letoh64
                    
+#elif defined(__FreeBSD_kernel__)
+     
+#   include <endian.h>
+      
 #elif defined(__WINDOWS__)
                     
 #   include <winsock2.h>


### PR DESCRIPTION
The Debian package build on the kFreeBSD architecture failed:
```
Building CXX object io/bpf/CMakeFiles/reader_bpf.dir/BpfCompressor.cpp.o
cd /«PKGBUILDDIR»/obj-x86_64-kfreebsd-gnu/io/bpf && /usr/bin/c++    -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -Wdate-time -D_FORTIFY_SOURCE=2  -Wextra -Wall -Wno-unused-parameter -Wno-unused-variable -Wpointer-arith -Wcast-align -Wcast-qual -Wredundant-decls -Wno-long-long -Wno-unknown-pragmas -isystem /usr/local/include -std=c++11 -O2 -g -DNDEBUG -I/«PKGBUILDDIR»/include -I/«PKGBUILDDIR»/src/util -I/«PKGBUILDDIR»/src -I/«PKGBUILDDIR»/io -I/«PKGBUILDDIR»/kernels -I/«PKGBUILDDIR»/filters -I/«PKGBUILDDIR»/obj-x86_64-kfreebsd-gnu/include -I/«PKGBUILDDIR»/vendor/eigen-3.1.91 -I/«PKGBUILDDIR»/vendor/nanoflann-1.1.8 -I/«PKGBUILDDIR»/vendor/rply-1.1.4 -I/usr/include/libxml2 -I/usr/include/gdal -I/usr/include/geotiff    -fPIC -o CMakeFiles/reader_bpf.dir/BpfCompressor.cpp.o -c /«PKGBUILDDIR»/io/bpf/BpfCompressor.cpp
In file included from /«PKGBUILDDIR»/include/pdal/util/OStream.hpp:45:0,
                 from /«PKGBUILDDIR»/io/bpf/BpfCompressor.hpp:41,
                 from /«PKGBUILDDIR»/io/bpf/BpfCompressor.cpp:35:
/«PKGBUILDDIR»/include/pdal/util/portable_endian.hpp:113:5: error: #error platform not supported
 #   error platform not supported
     ^
```
The architecture can generally be treated like Linux because it uses GNU libc with the FreeBSD kernel.