### PR TITLE
Add support for kFreeBSD to PluginManager & SQLiteCommon.

### DIFF
--- a/plugins/sqlite/io/SQLiteCommon.hpp
+++ b/plugins/sqlite/io/SQLiteCommon.hpp
@@ -457,7 +457,7 @@ public:
         lib_extension = "mod_";
 #endif
 
-#ifdef __linux__
+#if defined(__linux__) || defined(__FreeBSD_kernel__)
         so_extension = "so";
 #ifdef MOD_SPATIALITE
         lib_extension = "mod_";

--- a/src/PluginManager.cpp
+++ b/src/PluginManager.cpp
@@ -61,7 +61,7 @@ static PluginManager s_instance;
 
 #if defined(__APPLE__) && defined(__MACH__)
     const std::string dynamicLibraryExtension(".dylib");
-#elif defined __linux__
+#elif defined(__linux__) || defined(__FreeBSD_kernel__)
     const std::string dynamicLibraryExtension(".so");
 #elif defined _WIN32
     const std::string dynamicLibraryExtension(".dll");


### PR DESCRIPTION
The initial patch from #1187 was not sufficient to support the kFreeBSD architecture.

This PR also adapts the PluginManager & SQLiteCommon.