### PR TITLE
For inspectable Readers, try-catch around SRS init.

### DIFF
--- a/io/bpf/BpfReader.cpp
+++ b/io/bpf/BpfReader.cpp
@@ -120,8 +120,16 @@ void BpfReader::initialize()
         code = "EPSG:326" + Utils::toString(zone);
     else
         code = "EPSG:327" + Utils::toString(zone);
-    SpatialReference srs(code);
-    setSpatialReference(srs);
+
+    try
+    {
+        SpatialReference srs(code);
+        setSpatialReference(srs);
+    }
+    catch (...)
+    {
+        log()->get(LogLevel::Error) << "Could not create an SRS" << std::endl;
+    }
 
     if (m_header.m_version >= 3)
     {

--- a/io/gdal/GDALReader.cpp
+++ b/io/gdal/GDALReader.cpp
@@ -71,7 +71,15 @@ void GDALReader::initialize()
     m_raster.reset(new gdal::Raster(m_filename));
 
     m_raster->open();
-    setSpatialReference(m_raster->getSpatialRef());
+    try
+    {
+        setSpatialReference(m_raster->getSpatialRef());
+    }
+    catch (...)
+    {
+        log()->get(LogLevel::Error) << "Could not create an SRS" << std::endl;
+    }
+
     m_count = m_raster->m_raster_x_size * m_raster->m_raster_y_size;
     m_raster->close();
 }

--- a/io/las/LasHeader.cpp
+++ b/io/las/LasHeader.cpp
@@ -221,7 +221,17 @@ void LasHeader::setSrs()
     else
         useWkt = (m_versionMinor >= 4);
 
-    return useWkt ? setSrsFromWkt() : setSrsFromGeotiff();
+    try
+    {
+        if (useWkt)
+            setSrsFromWkt();
+        else
+            setSrsFromGeotiff();
+    }
+    catch (...)
+    {
+        m_log->get(LogLevel::Error) << "Could not create an SRS" << std::endl;
+    }
 }
 
 
@@ -303,7 +313,9 @@ void LasHeader::setSrsFromGeotiff()
     geotiff.setTags();
     std::string wkt(geotiff.getWkt(false, false));
     if (wkt.size())
-        m_srs.setFromUserInput(geotiff.getWkt(false, false));
+    {
+        m_srs.setFromUserInput(wkt);
+    }
 
     m_log->get(LogLevel::Debug5) << "GeoTIFF keys: " << geotiff.getText() <<
         std::endl;


### PR DESCRIPTION
This allows `inspect` to return information other than SRS even if the file has a bad SRS.  See the latter half of #1188.