### PR TITLE
nanoflann: Include <cstdlib> for ::malloc().

### DIFF
--- a/vendor/nanoflann-1.1.8/nanoflann.hpp
+++ b/vendor/nanoflann-1.1.8/nanoflann.hpp
@@ -38,6 +38,7 @@
 #include <algorithm>
 #include <stdexcept>
 #include <cstdio>  // for fwrite()
+#include <cstdlib> // for malloc()
 #include <cmath>   // for fabs(),...
 #include <limits>
 


### PR DESCRIPTION
`malloc()` is defined in `stdlib.h`, which was being included indirectly by
other on Linux. On systems such as FreeBSD, the code was just failing to
build because of the missing symbol.