### PR TITLE
portable_endian: Fix BSD->Linux macro translations.

### DIFF
--- a/include/pdal/util/portable_endian.hpp
+++ b/include/pdal/util/portable_endian.hpp
@@ -49,14 +49,14 @@
                
 #   include <sys/endian.h>
                 
-#   define be16toh betoh16
-#   define le16toh letoh16
+#   define betoh16 be16toh
+#   define letoh16 le16toh
                  
-#   define be32toh betoh32
-#   define le32toh letoh32
+#   define betoh32 be32toh
+#   define letoh32 le32toh
                   
-#   define be64toh betoh64
-#   define le64toh letoh64
+#   define betoh64 be64toh
+#   define letoh64 le64toh
                    
 #elif defined(__FreeBSD_kernel__)
      


### PR DESCRIPTION
The definitions for `{b,l}etoh{16,32}` were inverted: PDAL uses the Linux
names, but it was the BSD function names that were being redefined.