### PR TITLE
portable_endian: Remove wrong byte-order macro definitions for the BSDs.

### DIFF
--- a/include/pdal/util/portable_endian.hpp
+++ b/include/pdal/util/portable_endian.hpp
@@ -41,23 +41,10 @@
 #   define __PDP_ENDIAN    PDP_ENDIAN
 **/
             
-#elif defined(__OpenBSD__)
-             
+#elif defined(__OpenBSD__) || defined(__NetBSD__) || defined(__FreeBSD__) || defined(__DragonFly__)
+
 #   include <sys/endian.h>
-              
-#elif defined(__NetBSD__) || defined(__FreeBSD__) || defined(__DragonFly__)
-               
-#   include <sys/endian.h>
-                
-#   define be16toh betoh16
-#   define le16toh letoh16
-                 
-#   define be32toh betoh32
-#   define le32toh letoh32
-                  
-#   define be64toh betoh64
-#   define le64toh letoh64
-                   
+
 #elif defined(__FreeBSD_kernel__)
      
 #   include <endian.h>


### PR DESCRIPTION
Only OpenBSD has `{b,l}etoh{16,32,64}` in addition to `{b,l}e{16,32,64}toh`,
so the macro definitions were breaking the build on all those OSes.