### PR TITLE
utils: Include sys/wait.h for the WIFEXITED and WEXITSTATUS macros.

### DIFF
--- a/src/util/Utils.cpp
+++ b/src/util/Utils.cpp
@@ -43,6 +43,7 @@
 #ifndef _WIN32
 #include <cxxabi.h>
 #include <sys/ioctl.h>
+#include <sys/wait.h>  // WIFEXITED, WEXITSTATUS
 #endif
 
 #ifdef PDAL_COMPILER_MSVC


### PR DESCRIPTION
These two macros are defined in `sys/wait.h`, which was being included
indirectly by other headers. This did not work on systems such as
FreeBSD, so explicitly include all headers that we actually need.