### PR TITLE
Link to system libjsoncpp if available.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -101,8 +101,17 @@ set(PDAL_BASE_CPP
   ${PDAL_XML_SRC}
   ${PDAL_LAZPERF_SRC}
   ${DB_DRIVER_SRCS}
-  ${PROJECT_SOURCE_DIR}/vendor/jsoncpp-1.6.2/dist/jsoncpp.cpp
 )
+
+find_package(JSONCPP)
+if(JSONCPP_FOUND)
+  include_directories(${JSONCPP_INCLUDE_DIR})
+else(JSONCPP_FOUND)
+  set(PDAL_BASE_CPP
+    ${PDAL_BASE_CPP}
+    ${PROJECT_SOURCE_DIR}/vendor/jsoncpp-1.6.2/dist/jsoncpp.cpp
+  )
+endif(JSONCPP_FOUND)
 
 list (APPEND PDAL_CPP ${PDAL_BASE_CPP} )
 list (APPEND PDAL_HPP ${PDAL_BASE_HPP} )
@@ -166,6 +175,10 @@ endif()
 if (PDAL_HAVE_LIBXML2)
     target_link_libraries(${PDAL_BASE_LIB_NAME} ${LIBXML2_LIBRARIES})
 endif()
+
+if(JSONCPP_FOUND)
+    target_link_libraries(${PDAL_BASE_LIB_NAME} ${JSONCPP_LIBRARY})
+endif(JSONCPP_FOUND)
 
 #
 # On OSX we reexport the symbols in libpdal_util.dylib into libpdalcpp.dylib

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -103,7 +103,9 @@ set(PDAL_BASE_CPP
   ${DB_DRIVER_SRCS}
 )
 
-find_package(JSONCPP)
+include(FindPkgConfig)
+
+pkg_search_module(JSONCPP jsoncpp>=1.6.2)
 if(JSONCPP_FOUND)
   include_directories(${JSONCPP_INCLUDE_DIR})
 else(JSONCPP_FOUND)


### PR DESCRIPTION
The static linking of libjsoncpp triggered a [lintian embedded-library error](https://lintian.debian.org/tags/embedded-library.html) for the PDAL 1.2.0 Debian package build.

The system libjsoncpp should be used when its available, the greyhound plugin already uses it too.