### PR TITLE
Find Hexer w/ REQUIRED flag

### DIFF
--- a/plugins/hexbin/CMakeLists.txt
+++ b/plugins/hexbin/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 include_directories(${ROOT_DIR}/vendor/pdalboost)
 
-find_package(Hexer)
+find_package(Hexer REQUIRED)
 if (HEXER_FOUND)
     include_directories(${HEXER_INCLUDE_DIR})
     add_definitions(-DHAVE_HEXER=1)


### PR DESCRIPTION
w/o this flag, a user can set `BUILD_PLUGIN_HEXBIN=ON` and successfully
configure, etc without any hexer. IMO that's confusing -- if they ask
for hexer support, CMake should bomb if they don't have it.