### PR TITLE
Move stage creation to pipeline manager

### DIFF
--- a/include/pdal/Options.hpp
+++ b/include/pdal/Options.hpp
@@ -340,8 +340,18 @@ public:
 
     void toMetadata(MetadataNode& parent) const
     {
-        for (auto o : getOptions())
-            o.toMetadata(parent);
+        for (std::string& k : getKeys())
+        {
+            StringList l = getValues(k);
+            std::string vs;
+            for (auto vi = l.begin(); vi != l.end(); ++vi)
+            {
+               if (vi != l.begin())
+                   vs += ", ";
+               vs += *vi;
+            }
+            parent.add(k, vs);
+        }
     }
 
     // add an option (shortcut version, bypass need for an Option object)
@@ -379,6 +389,18 @@ public:
             s.insert(s.end(), t.begin(), t.end());
         }
         return s;
+    }
+
+    StringList getKeys() const
+    {
+        StringList keys;
+
+        for (auto it = m_options.begin(); it != m_options.end();
+            it = m_options.upper_bound(it->first))
+        {
+            keys.push_back(it->first);
+        }
+        return keys;
     }
 
     // get value of an option, or throw not_found if option not present
@@ -450,6 +472,7 @@ public:
 private:
     options::map_t m_options;
 };
+typedef std::map<std::string, Options> OptionsMap;
 
 PDAL_DLL std::ostream& operator<<(std::ostream& ostr, const Options&);
 

--- a/include/pdal/PipelineManager.hpp
+++ b/include/pdal/PipelineManager.hpp
@@ -62,15 +62,21 @@ public:
         {}
     ~PipelineManager();
 
-    void readPipeline(std::istream& input, bool debug=false,
-                   uint32_t verbose = 0);
-    void readPipeline(const std::string& filename, bool debug=false,
-                   uint32_t verbose = 0);
+    void readPipeline(std::istream& input);
+    void readPipeline(const std::string& filename);
 
     // Use these to manually add stages into the pipeline manager.
     Stage& addReader(const std::string& type);
     Stage& addFilter(const std::string& type);
     Stage& addWriter(const std::string& type);
+
+    // These add stages, hook dependencies and set necessary options.
+    // They're preferable to the above as they're more flexible and safer.
+    Stage& makeReader(const std::string& inputFile, std::string driver);
+    Stage& makeFilter(const std::string& driver);
+    Stage& makeFilter(const std::string& driver, Stage& parent);
+    Stage& makeWriter(const std::string& outputFile, Stage& parent,
+        std::string driver);
 
     // returns true if the pipeline endpoint is a writer
     bool isWriterPipeline() const
@@ -93,11 +99,20 @@ public:
         { return m_table; }
 
     MetadataNode getMetadata() const;
+    Options& commonOptions()
+        { return m_commonOptions; }
+    OptionsMap& stageOptions()
+        { return m_stageOptions; }
+    Options& stageOptions(Stage& stage);
+    //ABELL - would like this to be private.
+    void setOptions(Stage& stage, const Options& addOps);
 
 private:
     StageFactory m_factory;
     std::unique_ptr<PointTable> m_tablePtr;
     PointTableRef m_table;
+    Options m_commonOptions;
+    OptionsMap m_stageOptions;
 
     PointViewSet m_viewSet;
 

--- a/include/pdal/PipelineManager.hpp
+++ b/include/pdal/PipelineManager.hpp
@@ -72,11 +72,13 @@ public:
 
     // These add stages, hook dependencies and set necessary options.
     // They're preferable to the above as they're more flexible and safer.
+    Stage& makeReader(const std::string& inputFile);
     Stage& makeReader(const std::string& inputFile, std::string driver);
     Stage& makeFilter(const std::string& driver);
     Stage& makeFilter(const std::string& driver, Stage& parent);
-    Stage& makeWriter(const std::string& outputFile, Stage& parent,
-        std::string driver);
+    Stage& makeWriter(const std::string& outputFile, std::string driver);
+    Stage& makeWriter(const std::string& outputFile, std::string driver,
+        Stage& parent);
 
     // returns true if the pipeline endpoint is a writer
     bool isWriterPipeline() const
@@ -104,18 +106,16 @@ public:
     OptionsMap& stageOptions()
         { return m_stageOptions; }
     Options& stageOptions(Stage& stage);
-    //ABELL - would like this to be private.
-    void setOptions(Stage& stage, const Options& addOps);
 
 private:
+    void setOptions(Stage& stage, const Options& addOps);
+
     StageFactory m_factory;
     std::unique_ptr<PointTable> m_tablePtr;
     PointTableRef m_table;
     Options m_commonOptions;
     OptionsMap m_stageOptions;
-
     PointViewSet m_viewSet;
-
     std::vector<Stage*> m_stages; // stage observer, never owner
     int m_progressFd;
     std::istream *m_input;

--- a/io/derivative/DerivativeWriter.cpp
+++ b/io/derivative/DerivativeWriter.cpp
@@ -79,30 +79,6 @@ void DerivativeWriter::processOptions(const Options& ops)
     m_GRID_DIST_Y = ops.getValueOrDefault<double>("grid_dist_y", 15.0);
     handleFilenameTemplate();
 
-    // maybe we eventually introduce an option to do more than slope
-    //std::vector<Option> types = ops.getOptions("output_type");
-
-    //if (!types.size())
-    //    m_outputTypes = OUTPUT_TYPE_ALL;
-    //else
-    //{
-    //    for (auto i = types.begin(); i != types.end(); ++i)
-    //    {
-    //        if (Utils::iequals(i->getValue<std::string>(), "min"))
-    //            m_outputTypes |= OUTPUT_TYPE_MIN;
-    //        if (Utils::iequals(i->getValue<std::string>(), "max"))
-    //            m_outputTypes |= OUTPUT_TYPE_MAX;
-    //        if (Utils::iequals(i->getValue<std::string>(), "mean"))
-    //            m_outputTypes |= OUTPUT_TYPE_MEAN;
-    //        if (Utils::iequals(i->getValue<std::string>(), "idw"))
-    //            m_outputTypes |= OUTPUT_TYPE_IDW;
-    //        if (Utils::iequals(i->getValue<std::string>(), "den"))
-    //            m_outputTypes |= OUTPUT_TYPE_DEN;
-    //        if (Utils::iequals(i->getValue<std::string>(), "all"))
-    //            m_outputTypes = OUTPUT_TYPE_ALL;
-    //    }
-    //}
-
     std::map<std::string, PrimitiveType> primtypes;
     primtypes["slope_d8"] = SLOPE_D8;
     primtypes["slope_fd"] = SLOPE_FD;

--- a/kernels/info/InfoKernel.hpp
+++ b/kernels/info/InfoKernel.hpp
@@ -79,7 +79,7 @@ private:
     void dumpPipeline() const;
     MetadataNode dumpSummary(const QuickInfo& qi);
     MetadataNode dumpQuery(PointViewPtr inView) const;
-    PipelineManagerPtr makePipeline(const std::string& filename, bool noPoints);
+    void makePipeline(const std::string& filename, bool noPoints);
 
     std::string m_inputFile;
     bool m_showStats;
@@ -100,7 +100,6 @@ private:
     Stage *m_reader;
 
     MetadataNode m_tree;
-    PipelineManagerPtr m_manager;
 };
 
 } // namespace pdal

--- a/kernels/pipeline/PipelineKernel.cpp
+++ b/kernels/pipeline/PipelineKernel.cpp
@@ -93,8 +93,7 @@ int PipelineKernel::execute()
 
     PipelineManager manager(m_progressFd);
 
-    manager.readPipeline(m_inputFile, isDebug(), getVerboseLevel());
-    applyExtraStageOptionsRecursive(manager.getStage());
+    manager.readPipeline(m_inputFile);
     manager.execute();
 
     if (m_pipelineFile.size() > 0)

--- a/kernels/translate/TranslateKernel.cpp
+++ b/kernels/translate/TranslateKernel.cpp
@@ -88,42 +88,10 @@ void TranslateKernel::addSwitches(ProgramArgs& args)
 
 int TranslateKernel::execute()
 {
-    // setting common options for each stage propagates the debug flag and
-    // verbosity level
     Options readerOptions, filterOptions, writerOptions;
-    setCommonOptions(readerOptions);
-    setCommonOptions(filterOptions);
-    setCommonOptions(writerOptions);
 
-    m_manager = std::unique_ptr<PipelineManager>(new PipelineManager);
-
-    if (!m_readerType.empty())
-    {
-        m_manager->addReader(m_readerType);
-    }
-    else
-    {
-        StageFactory factory;
-        std::string driver = factory.inferReaderDriver(m_inputFile);
-
-        if (driver.empty())
-            throw pdal_error("Cannot determine input file type of " +
-                                    m_inputFile);
-        m_manager->addReader(driver);
-    }
-
-    if (m_manager == NULL)
-        throw pdal_error("Error making pipeline\n");
-
-    Stage* reader = m_manager->getStage();
-
-    if (reader == NULL)
-        throw pdal_error("Error getting reader\n");
-
-    readerOptions.add("filename", m_inputFile);
-    reader->setOptions(readerOptions);
-
-    Stage* stage = reader;
+    Stage& reader = m_manager.makeReader(m_inputFile, m_readerType);
+    Stage* stage = &reader;
 
     // add each filter provided on the command-line, updating the stage pointer
     for (auto const f : m_filterType)
@@ -133,55 +101,14 @@ int TranslateKernel::execute()
         if (!Utils::startsWith(f, "filters."))
             filter_name.insert(0, "filters.");
 
-        Stage* filter = &(m_manager->addFilter(filter_name));
-
-        if (filter == NULL)
-        {
-            std::ostringstream oss;
-            oss << "Unable to add filter " << filter_name << ".  Filter "
-              "is invalid or plugin could not be loaded.  Check "
-              "'pdal --drivers'.";
-            throw pdal_error("Error getting filter\n");
-        }
-
-        filter->setOptions(filterOptions);
-        filter->setInput(*stage);
-        stage = filter;
+        Stage& filter = m_manager.makeFilter(filter_name, *stage);
+        stage = &filter;
     }
 
-    if (!m_writerType.empty())
-    {
-        m_manager->addWriter(m_writerType);
-    }
-    else
-    {
-        StageFactory factory;
-        std::string driver = factory.inferWriterDriver(m_outputFile);
-
-        if (driver.empty())
-            throw pdal_error("Cannot determine output file type of " +
-                m_outputFile);
-        Options options = factory.inferWriterOptionsChanges(m_outputFile);
-        writerOptions += options;
-        m_manager->addWriter(driver);
-    }
-
-    Stage* writer = m_manager->getStage();
-
-    if (writer == NULL)
-        throw pdal_error("Error getting writer\n");
-
-    writerOptions.add("filename", m_outputFile);
-    writer->setOptions(writerOptions);
-    writer->setInput(*stage);
-
-    // be sure to recurse through any extra stage options provided by the user
-    applyExtraStageOptionsRecursive(writer);
-
-    m_manager->execute();
-
+    Stage& writer = m_manager.makeWriter(m_outputFile, *stage, m_writerType);
+    m_manager.execute();
     if (m_pipelineOutput.size() > 0)
-        PipelineWriter::writePipeline(m_manager->getStage(), m_pipelineOutput);
+        PipelineWriter::writePipeline(&writer, m_pipelineOutput);
 
     return 0;
 }

--- a/kernels/translate/TranslateKernel.cpp
+++ b/kernels/translate/TranslateKernel.cpp
@@ -105,7 +105,7 @@ int TranslateKernel::execute()
         stage = &filter;
     }
 
-    Stage& writer = m_manager.makeWriter(m_outputFile, *stage, m_writerType);
+    Stage& writer = m_manager.makeWriter(m_outputFile, m_writerType, *stage);
     m_manager.execute();
     if (m_pipelineOutput.size() > 0)
         PipelineWriter::writePipeline(&writer, m_pipelineOutput);

--- a/kernels/translate/TranslateKernel.hpp
+++ b/kernels/translate/TranslateKernel.hpp
@@ -68,8 +68,6 @@ private:
     std::string m_readerType;
     std::vector<std::string> m_filterType;
     std::string m_writerType;
-
-    std::unique_ptr<PipelineManager> m_manager;
 };
 
 } // namespace pdal

--- a/plugins/hexbin/kernel/DensityKernel.hpp
+++ b/plugins/hexbin/kernel/DensityKernel.hpp
@@ -52,16 +52,12 @@ public:
     int execute();
 
 private:
-    PipelineManagerPtr m_manager;
     Stage *m_hexbinStage;
     std::string m_inputFile;
     std::string m_outputFile;
-    std::string m_layerName;
     std::string m_driverName;
-    std::string m_srs;
 
     virtual void addSwitches(ProgramArgs& args);
-    void makePipeline(const std::string& filename);
     void outputDensity(pdal::SpatialReference const& ref);
 };
 

--- a/plugins/pcl/kernel/PCLKernel.cpp
+++ b/plugins/pcl/kernel/PCLKernel.cpp
@@ -109,7 +109,6 @@ int PCLKernel::execute()
     Stage& writer(makeWriter(m_outputFile, pclStage, ""));
     writer.addOptions(writerOptions);
 
-    applyExtraStageOptionsRecursive(&writer);
     writer.prepare(table);
 
     // process the data, grabbing the PointViewSet for visualization of the

--- a/plugins/pcl/kernel/SmoothKernel.cpp
+++ b/plugins/pcl/kernel/SmoothKernel.cpp
@@ -76,11 +76,13 @@ int SmoothKernel::execute()
     // consumed by the processing pipeline
     PointViewPtr input_view = *viewSetIn.begin();
 
-    std::shared_ptr<BufferReader> bufferReader(new BufferReader);
-    Options bufferOptions;
-    setCommonOptions(bufferOptions);
-    bufferReader->setOptions(bufferOptions);
-    bufferReader->addView(input_view);
+    PipelineManager manager;
+    manager.commonOptions() = m_manager.commonOptions();
+    manager.stageOptions() = m_manager.stageOptions();
+
+    BufferReader& bufferReader =
+        static_cast<BufferReader&>(manager.makeReader("", "readers.buffer"));
+    bufferReader.addView(input_view);
 
     std::ostringstream ss;
     ss << "{";
@@ -94,7 +96,7 @@ int SmoothKernel::execute()
     Options smoothOptions;
     smoothOptions.add("json", ss.str());
 
-    Stage& smoothStage = makeFilter("filters.pclblock", *bufferReader);
+    Stage& smoothStage = manager.makeFilter("filters.pclblock", bufferReader);
     smoothStage.addOptions(smoothOptions);
 
     Stage& writer(Kernel::makeWriter(m_outputFile, smoothStage, ""));

--- a/src/Kernel.cpp
+++ b/src/Kernel.cpp
@@ -318,7 +318,7 @@ void Kernel::visualize(PointViewPtr view)
         static_cast<BufferReader&>(manager.makeReader("", "readers.buffer"));
     reader.addView(view);
 
-    Stage& writer = manager.makeWriter("", reader, "writers.pclvisualizer");
+    Stage& writer = manager.makeWriter("", "writers.pclvisualizer", reader);
 
     PointTable table;
     writer.prepare(table);
@@ -519,7 +519,7 @@ Stage& Kernel::makeFilter(const std::string& driver, Stage& parent)
 Stage& Kernel::makeWriter(const std::string& outputFile, Stage& parent,
     std::string driver)
 {
-    return m_manager.makeWriter(outputFile, parent, driver);
+    return m_manager.makeWriter(outputFile, driver, parent);
 }
 
 

--- a/src/PipelineManager.cpp
+++ b/src/PipelineManager.cpp
@@ -214,12 +214,11 @@ Stage& PipelineManager::makeFilter(const std::string& driver, Stage& parent)
 {
     Stage& filter = makeFilter(driver);
     filter.setInput(parent);
-
     return filter;
 }
 
 
-Stage& PipelineManager::makeWriter(const std::string& outputFile, Stage& parent,
+Stage& PipelineManager::makeWriter(const std::string& outputFile,
     std::string driver)
 {
     if (driver.empty())
@@ -235,9 +234,16 @@ Stage& PipelineManager::makeWriter(const std::string& outputFile, Stage& parent,
         options.add("filename", outputFile);
 
     auto& writer = addWriter(driver);
-    writer.setInput(parent);
     setOptions(writer, options);
+    return writer;
+}
 
+
+Stage& PipelineManager::makeWriter(const std::string& outputFile,
+    std::string driver, Stage& parent)
+{
+    Stage& writer = makeWriter(outputFile, driver);
+    writer.setInput(parent);
     return writer;
 }
 

--- a/src/PipelineReaderJSON.hpp
+++ b/src/PipelineReaderJSON.hpp
@@ -56,8 +56,7 @@ class PDAL_DLL PipelineReaderJSON
 private:
     class StageParserContext;
 
-    PipelineReaderJSON(PipelineManager&, bool debug=false,
-                   uint32_t verbose = 0);
+    PipelineReaderJSON(PipelineManager&);
 
     /**
       Read a JSON pipeline file into a PipelineManager.
@@ -78,9 +77,6 @@ private:
     Stage *parseWriterByFilename(const std::string& filename);
 
     PipelineManager& m_manager;
-    bool m_isDebug;
-    uint32_t m_verboseLevel;
-    Options m_baseOptions;
     std::string m_inputJSONFile;
 
     PipelineReaderJSON& operator=(const PipelineReaderJSON&); // not implemented

--- a/src/PipelineReaderJSON.hpp
+++ b/src/PipelineReaderJSON.hpp
@@ -34,19 +34,18 @@
 
 #pragma once
 
-#include <pdal/pdal_internal.hpp>
-#include <pdal/StageFactory.hpp>
-
 #include <json/json-forwards.h>
 
 #include <vector>
 #include <string>
 
+#include <pdal/Options.hpp>
+#include <pdal/StageFactory.hpp>
 
 namespace pdal
 {
 
-class Options;
+class Stage;
 class PipelineManager;
 
 class PDAL_DLL PipelineReaderJSON
@@ -54,27 +53,17 @@ class PDAL_DLL PipelineReaderJSON
     friend class PipelineManager;
 
 private:
-    class StageParserContext;
+    typedef std::map<std::string, Stage *> TagMap;
 
     PipelineReaderJSON(PipelineManager&);
-
-    /**
-      Read a JSON pipeline file into a PipelineManager.
-
-      \param filename  Filename to read.
-    */
     void readPipeline(const std::string& filename);
-
-    /**
-      Read a JSON pipeline file from a stream into a PipelineManager.
-
-      \param input  Stream to read.
-    */
     void readPipeline(std::istream& input);
-
-    void parseElement_Pipeline(const Json::Value&);
-    Stage *parseReaderByFilename(const std::string& filename);
-    Stage *parseWriterByFilename(const std::string& filename);
+    void parsePipeline(Json::Value&);
+    std::string extractType(Json::Value& node);
+    std::string extractFilename(Json::Value& node);
+    std::string extractTag(Json::Value& node, TagMap& tags);
+    std::vector<Stage *> extractInputs(Json::Value& node, TagMap& tags);
+    Options extractOptions(Json::Value& node);
 
     PipelineManager& m_manager;
     std::string m_inputJSONFile;

--- a/src/PipelineReaderXML.cpp
+++ b/src/PipelineReaderXML.cpp
@@ -127,21 +127,9 @@ private:
 };
 
 
-PipelineReaderXML::PipelineReaderXML(PipelineManager& manager, bool isDebug,
-        uint32_t verboseLevel) :
-    m_manager(manager) , m_isDebug(isDebug) , m_verboseLevel(verboseLevel)
-{
-    if (m_isDebug)
-    {
-        Option opt("debug", true);
-        m_baseOptions.add(opt);
-    }
-    if (m_verboseLevel)
-    {
-        Option opt("verbose", m_verboseLevel);
-        m_baseOptions.add(opt);
-    }
-}
+PipelineReaderXML::PipelineReaderXML(PipelineManager& manager) :
+    m_manager(manager)
+{}
 
 
 Option PipelineReaderXML::parseElement_Option(const ptree& tree)
@@ -222,8 +210,7 @@ Stage *PipelineReaderXML::parseElement_anystage(const std::string& name,
 
 Stage *PipelineReaderXML::parseElement_Reader(const ptree& tree)
 {
-    Options options(m_baseOptions);
-
+    Options options;
     StageParserContext context;
     context.setCardinality(StageParserContext::None);
 
@@ -283,14 +270,14 @@ Stage *PipelineReaderXML::parseElement_Reader(const ptree& tree)
     context.validate();
 
     Stage& reader(m_manager.addReader(type));
-    reader.setOptions(options);
+    m_manager.setOptions(reader, options);
     return &reader;
 }
 
 
 Stage *PipelineReaderXML::parseElement_Filter(const ptree& tree)
 {
-    Options options(m_baseOptions);
+    Options options;
 
     StageParserContext context;
 
@@ -335,7 +322,7 @@ Stage *PipelineReaderXML::parseElement_Filter(const ptree& tree)
     }
 
     Stage& filter(m_manager.addFilter(type));
-    filter.setOptions(options);
+    m_manager.setOptions(filter, options);
     for (auto sp : prevStages)
         filter.setInput(*sp);
     context.setCardinality(StageParserContext::Many);
@@ -369,7 +356,7 @@ void PipelineReaderXML::collect_attributes(map_t& attrs, const ptree& tree)
 
 Stage *PipelineReaderXML::parseElement_Writer(const ptree& tree)
 {
-    Options options(m_baseOptions);
+    Options options;
     StageParserContext context;
 
     map_t attrs;
@@ -416,7 +403,7 @@ Stage *PipelineReaderXML::parseElement_Writer(const ptree& tree)
     Stage& writer(m_manager.addWriter(type));
     for (auto sp : prevStages)
         writer.setInput(*sp);
-    writer.setOptions(options);
+    m_manager.setOptions(writer, options);
     return &writer;
 }
 
@@ -425,8 +412,6 @@ void PipelineReaderXML::parseElement_Pipeline(const ptree& tree)
 {
     Stage *stage = NULL;
     Stage *writer = NULL;
-
-    Options o(m_baseOptions);
 
     map_t attrs;
     collect_attributes(attrs, tree);

--- a/src/PipelineReaderXML.hpp
+++ b/src/PipelineReaderXML.hpp
@@ -55,8 +55,7 @@ private:
     class StageParserContext;
 
 public:
-    PipelineReaderXML(PipelineManager&, bool debug=false,
-        uint32_t verbose = 0);
+    PipelineReaderXML(PipelineManager&);
 
     /**
       Read an XML pipeline file into a PipelineManager.
@@ -89,9 +88,6 @@ private:
 
 private:
     PipelineManager& m_manager;
-    bool m_isDebug;
-    uint32_t m_verboseLevel;
-    Options m_baseOptions;
     std::string m_inputXmlFile;
 
     PipelineReaderXML& operator=(const PipelineReaderXML&); // not implemented

--- a/src/Stage.cpp
+++ b/src/Stage.cpp
@@ -85,8 +85,6 @@ void Stage::serialize(MetadataNode root, PipelineWriter::TagMap& tags) const
     m_options.toMetadata(anon);
     for (Stage *s : m_inputs)
         anon.addList("inputs", tagname(s));
-    if (m_metadata.hasChildren())
-        anon.add(m_metadata.clone("execution_metadata"));
     root.addList(anon);
 }
 


### PR DESCRIPTION
Stage creation was in Kernel, which made it difficult to handle things consistently in code that wasn't derived from Kernel.  PipelineManager can be instantiated at will and can handle stage creation and options more consistently.

This also fixes #1221 and removes the passing around of debug/log/verbose flags.