### PR TITLE
Don't require Nitro dependency.

### DIFF
--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -88,6 +88,8 @@ option(BUILD_PLUGIN_PYTHON
 add_feature_info("Python plugin" BUILD_PLUGIN_PYTHON
     "add features that depend on python")
 
+option(BUILD_TOOLS_NITFWRAP "Choose if nitfwrap tool should be built" FALSE)
+
 option(WITH_TESTS
     "Choose if PDAL unit tests should be built" TRUE)
 add_feature_info("Unit tests" WITH_TESTS "PDAL unit tests")

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,2 +1,4 @@
 add_subdirectory(lasdump)
-add_subdirectory(nitfwrap)
+if (BUILD_TOOLS_NITFWRAP)
+    add_subdirectory(nitfwrap)
+endif()


### PR DESCRIPTION
Like the NITF plugin, the tool should not be built by default.

The Nitro dependency is not available for the Debian package builds.