### PR TITLE
Add support for GNU/Hurd

### DIFF
--- a/include/pdal/util/portable_endian.hpp
+++ b/include/pdal/util/portable_endian.hpp
@@ -10,7 +10,7 @@
    
 #endif
     
-#if defined(__linux__) || defined(__CYGWIN__)
+#if defined(__linux__) || defined(__CYGWIN__) || defined(__GNU__)
      
 #   include <endian.h>
       

--- a/src/PluginManager.cpp
+++ b/src/PluginManager.cpp
@@ -61,7 +61,7 @@ static PluginManager s_instance;
 
 #if defined(__APPLE__) && defined(__MACH__)
     const std::string dynamicLibraryExtension(".dylib");
-#elif defined(__linux__) || defined(__FreeBSD_kernel__)
+#elif defined(__linux__) || defined(__FreeBSD_kernel__) || defined(__GNU__)
     const std::string dynamicLibraryExtension(".so");
 #elif defined _WIN32
     const std::string dynamicLibraryExtension(".dll");


### PR DESCRIPTION
The Hurd porting guidelines document the following:

> Missing linux/types.h, asm/types.h, linux/limits.h, asm/byteorder.h, sys/endian.h, asm/ioctl.h, asm/ioctls.h, linux/soundcard.h
> 
> These are often used (from lame rgrep results) instead of their standard equivalents: sys/types.h (or stdint.h for fixed-size types), limits.h, endian.h, sys/ioctl.h, sys/soundcard.h

https://www.gnu.org/software/hurd/hurd/porting/guidelines.html#linux_headers

Hurd also uses the .so extension for dynamic libraries like Linux & kFreeBSD.