### PR TITLE
Use SOURCE_DATE_EPOCH instead of current date for reproducible builds.

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -12,8 +12,13 @@
 # serve to show the default.
 
 import sys, os, re
+import time
 import datetime
-year = datetime.datetime.now().year
+if os.environ.get('SOURCE_DATE_EPOCH'):
+    year  = datetime.datetime.utcfromtimestamp(int(os.environ.get('SOURCE_DATE_EPOCH', time.gmtime()))).year
+    today = datetime.datetime.utcfromtimestamp(int(os.environ.get('SOURCE_DATE_EPOCH', time.gmtime()))).strftime('%B %d, %Y')
+else:
+    year  = datetime.datetime.now().year
 
 
 # If extensions (or modules to document with autodoc) are in another directory,


### PR DESCRIPTION
In the effort the support [Reproducible Builds](https://reproducible-builds.org/) of the PDAL Debian package, support for the [SOURCE_DATE_EPOCH specification](https://reproducible-builds.org/specs/source-date-epoch/) has been added to the Sphinx configuration.

When the `SOURCE_DATE_EPOCH` environment variable is set, its value is used to set the `today` and `year` variables in `doc/conf.py` instead of `datetime.now()`.

See also: https://tests.reproducible-builds.org/rb-pkg/unstable/amd64/pdal.html