### PR TITLE
rxp plugin cleanup (pointers, mostly)

### DIFF
--- a/doc/stages/readers.rxp.rst
+++ b/doc/stages/readers.rxp.rst
@@ -78,33 +78,21 @@ Options
 -------
 
 filename
-  File to read from [Required if rdtp is not provided]
+  File to read from, or rdtp URI for network-accessible scanner. [Required]
 
 rdtp
-  URI for a network-assessable scanner [Required if filename is not provided]
+  Boolean to switch from file-based reading to RDTP-based. [default: false]
 
 sync_to_pps
   If "true", ensure all incoming points have a valid pps timestamp, usually provided by some sort of GPS clock.
   If "false", use the scanner's internal time.
-  Defaults to "true"
+  [default: true]
 
 minimal
   If "true", only write X, Y, Z, and time values to the data stream.
   If "false", write all available values as derived from the rxp file.
   Use this feature to reduce the memory footprint of a PDAL run, if you don't need any values but the points themselves.
-  Defaults to "false".
-
-inclination_fix
-  *EXPERIMENTAL*: If "true", use inclination values in the rxp file to dynamically correct for inclination changes throughout the scan, using a moving average of 2 * ``inclination_fix_window`` inclination readings (see below).
-  This is an experimental feature that will remove some points from the data stream and modify many others.
-  Use with caution.
-  If "false", disable this feature.
-  Defaults to "false".
-
-inclination_fix_window
-  *EXPERIMENTAL*: Sets the half-size of the inclination fix window (see above).
-  Use of this feature should be considered highly experimental.
-
+  [default: false]
 
 .. _RIEGL Laser Measurement Systems: http://www.riegl.com
 .. _RIEGL download pages: http://www.riegl.com/members-area/software-downloads/libraries/

--- a/plugins/rxp/io/RxpReader.cpp
+++ b/plugins/rxp/io/RxpReader.cpp
@@ -83,33 +83,13 @@ Dimension::IdList getRxpDimensions(bool syncToPps, bool minimal)
 
 void RxpReader::addArgs(ProgramArgs& args)
 {
-    m_fileArg = args.add("filename", "Output filename", m_filename);
-    m_rdtpArg = args.add("rdtp", "", m_filename);
+    args.add("rdtp", "", m_isRdtp, DEFAULT_IS_RDTP);
     args.add("sync_to_pps", "Sync to PPS", m_syncToPps, DEFAULT_SYNC_TO_PPS);
 }
 
 void RxpReader::initialize()
 {
-    if (m_fileArg->set() && m_rdtpArg.set())
-    {
-        std::ostringstream oss;
-
-        oss << getName() << "Cannot create URI when both 'filename' "
-            "and 'rdtp' are provided";
-        throw pdal_error(oss.str());
-    }
-    if (!m_fileArg->set() && !m_rdtpArg.set())
-    {
-        std::ostringstream oss;
-
-        oss << getName() << "One of 'rdtp' or 'filename' must be provided.";
-        throw pdal_error(oss.str());
-    }
-
-    if (m_fileArg->set())
-        m_uri = "file: " + m_filename;
-    else
-        m_uri = "rdtp:// + m_filename;
+    m_uri = m_isRdtp ? "rdtp://" + m_filename : "file:" + m_filename;
 }
 
 

--- a/plugins/rxp/io/RxpReader.hpp
+++ b/plugins/rxp/io/RxpReader.hpp
@@ -53,6 +53,7 @@ namespace pdal
 
 
 const bool DEFAULT_SYNC_TO_PPS = true;
+const bool DEFAULT_IS_RDTP = false;
 const bool DEFAULT_MINIMAL = false;
 
 
@@ -87,12 +88,10 @@ private:
     virtual point_count_t read(PointViewPtr view, point_count_t count);
     virtual void done(PointTableRef table);
 
-    Arg *m_fileArg;
-    Arg *m_rdtpArg;
-    std::string m_filename;
     std::string m_uri;
     bool m_syncToPps;
     bool m_minimal;
+    bool m_isRdtp;
     std::unique_ptr<RxpPointcloud> m_pointcloud;
 };
 

--- a/plugins/rxp/test/RxpReaderTest.cpp
+++ b/plugins/rxp/test/RxpReaderTest.cpp
@@ -47,8 +47,7 @@ using namespace pdal;
 Options defaultRxpReaderOptions()
 {
     Options options;
-    Option filename("filename",
-        testDataPath() + "130501_232206_cut.rxp", "");
+    Option filename("filename", testDataPath() + "130501_232206_cut.rxp");
     options.add(filename);
     return options;
 }
@@ -131,7 +130,7 @@ TEST(RxpReaderTest, testRead)
 TEST(RxpReaderTest, testNoPpsSync)
 {
     Options options = defaultRxpReaderOptions();
-    Option syncToPps("sync_to_pps", "false", "");
+    Option syncToPps("sync_to_pps", false);
     options.add(syncToPps);
     RxpReader reader;
     reader.setOptions(options);
@@ -144,23 +143,4 @@ TEST(RxpReaderTest, testNoPpsSync)
 
     checkPoint(view, 0, 0.0705248788, -0.0417557284, 0.0304775704, 31.917255942733149,
             0.14050000667339191, 0.689999998, -14.4898596, 3, false, 1, 1);
-}
-
-TEST(RxpReaderTest, testURILogic)
-{
-    Option fileOption("filename", "foobar", "");
-    Options fileOptions(fileOption);
-    EXPECT_EQ(extractRivlibURI(fileOptions), "file:foobar");
-
-    Option rdtpOption("rdtp", "192.168.0.33", "");
-    Options rdtpOptions(rdtpOption);
-    EXPECT_EQ(extractRivlibURI(rdtpOptions), "rdtp://192.168.0.33");
-
-    Options emptyOptions;
-    EXPECT_THROW(extractRivlibURI(emptyOptions), Option::not_found);
-
-    Options bothOptions;
-    bothOptions.add(fileOption);
-    bothOptions.add(rdtpOption);
-    EXPECT_THROW(extractRivlibURI(bothOptions), pdal_error);
 }


### PR DESCRIPTION
This commit does not bring things up to speed, since PDAL now doesn't
like me providing my own "filename" option (see line 86 of `RxpReader.cpp`). @abellgithub can you advise? I need to store that fileArg for later checking in `initialize`...