### PR TITLE
Add test case for transformation starting with -

### DIFF
--- a/test/data/pipeline/transformation.json.in
+++ b/test/data/pipeline/transformation.json.in
@@ -1,0 +1,14 @@
+{
+  "pipeline":[
+    {
+      "filename":"@CMAKE_SOURCE_DIR@/test/data/las/1.2-with-color.las",
+      "debug":true,
+      "verbose":6
+    },
+    {
+      "type":"filters.transformation",
+      "matrix": "-1 0 0 1 0 1 0 2 0 0 1 3 0 0 0 1"
+    },
+    "@CMAKE_SOURCE_DIR@/test/temp/out2.las"
+  ]
+}

--- a/test/unit/apps/pcpipelineTestJSON.cpp
+++ b/test/unit/apps/pcpipelineTestJSON.cpp
@@ -148,7 +148,8 @@ INSTANTIATE_TEST_CASE_P(base, json,
                             "pipeline/sbet2txt.json",
                             "pipeline/sort.json",
                             "pipeline/splitter.json",
-                            "pipeline/stats.json"
+                            "pipeline/stats.json",
+                            "pipeline/transformation.json"
                         ));
 
 class jsonWithNITF : public testing::TestWithParam<const char*> {};


### PR DESCRIPTION
This breaks new option parsing (the leading `-` causes `pdal pipeline` to think that there's no value provided to the `matrix` argument).

cc @abellgithub 