### PR TITLE
Allow setting of bounds on p2g writer

### DIFF
--- a/doc/stages/writers.p2g.rst
+++ b/doc/stages/writers.p2g.rst
@@ -70,3 +70,8 @@ output_format
 
 z
   Name of the 'z' dimension to use. [Default: 'Z']
+
+bounds
+  Custom bounds for output raster(s).
+  If not provided, bounds will be calculated from the bounds of the input data.
+  [Default: **none**]

--- a/plugins/p2g/io/P2gWriter.cpp
+++ b/plugins/p2g/io/P2gWriter.cpp
@@ -62,6 +62,7 @@ void P2gWriter::addArgs(ProgramArgs& args)
     args.add("fill_window_size", "Fill window size", m_fill_window_size, 3U);
     args.add("output_type", "Output type", m_outputTypeSpec);
     args.add("output_format", "Output format", m_outputFormatSpec, "grid");
+    args.add("bounds", "Output raster bounds", m_bounds);
 
 }
 
@@ -138,7 +139,9 @@ void P2gWriter::write(const PointViewPtr view)
         m_coordinates.push_back(Coordinate{x, y, z});
     }
 
-    view->calculateBounds(m_bounds);
+    if (m_bounds.empty()) {
+        view->calculateBounds(m_bounds);
+    }
 }
 
 void P2gWriter::done(PointTableRef table)


### PR DESCRIPTION
This is useful if you're creating rasters for a bunch of files and they all need to have the same spatial extent.