### PR TITLE
Explicitly assign greyhound prefix, allowing HTTP reads.

### DIFF
--- a/src/StageFactory.cpp
+++ b/src/StageFactory.cpp
@@ -138,7 +138,6 @@ std::string StageFactory::inferReaderDriver(const std::string& filename)
         { "bpf", "readers.bpf" },
         { "csd", "readers.optech" },
         { "greyhound", "readers.greyhound" },
-        { "http", "readers.greyhound" },
         { "icebridge", "readers.icebridge" },
         { "las", "readers.las" },
         { "laz", "readers.las" },
@@ -157,10 +156,12 @@ std::string StageFactory::inferReaderDriver(const std::string& filename)
         { "h5", "readers.icebridge" }
     };
 
+    static const std::string ghPrefix("greyhound://");
+
     std::string ext;
     // filename may actually be a greyhound uri + pipelineId
-    if (Utils::iequals(filename.substr(0, 4), "http"))
-        ext = ".http";      // Make it look like an extension.
+    if (Utils::iequals(filename.substr(0, ghPrefix.size()), ghPrefix))
+        ext = ".greyhound";      // Make it look like an extension.
     else
         ext = FileUtils::extension(filename);
 

--- a/test/unit/StageFactoryTest.cpp
+++ b/test/unit/StageFactoryTest.cpp
@@ -83,7 +83,7 @@ TEST(StageFactoryTest, Load4)
     ASSERT_FALSE(Utils::contains(ns, "readers.las"));
     ASSERT_TRUE(Utils::contains(ns, "writers.bpf"));
 }
-    
+
 TEST(StageFactoryTest, extensionTest)
 {
     EXPECT_EQ(StageFactory::inferWriterDriver("foo.laz"), "writers.las");
@@ -93,7 +93,8 @@ TEST(StageFactoryTest, extensionTest)
 
     EXPECT_EQ(StageFactory::inferReaderDriver("foo.laz"), "readers.las");
     EXPECT_EQ(StageFactory::inferReaderDriver("foo.las"), "readers.las");
-    EXPECT_EQ(StageFactory::inferReaderDriver("http://foo.bar.baz"),
+    EXPECT_EQ(StageFactory::inferReaderDriver("http://foo.laz"), "readers.las");
+    EXPECT_EQ(StageFactory::inferReaderDriver("greyhound://foo.bar.baz"),
         "readers.greyhound");
 
     StringList ext = { "las", "laz" };


### PR DESCRIPTION
Use `greyhound://` to signify the greyhound reader, inferring `http://` paths from their actual file extension.