### PR TITLE
Attempt to shrink the size of the Docker image by removing development packages once we're done with them. The pdal/dependencies package also no longer installs all of the grid files (350+mb).

### DIFF
--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -56,6 +56,7 @@ RUN git clone https://github.com/PDAL/PRC.git \
     && cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DPDAL_DIR=/usr/lib/pdal/cmake \
+        -DCMAKE_BUILD_PREFIX=/usr \
         .. \
     && make \
     && make install \

--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -6,8 +6,6 @@ ENV CC clang
 ENV CXX clang++
 
 RUN apt-get update && apt-get install -y --fix-missing --no-install-recommends \
-        cython \
-        python-pip \
         libhpdf-dev \
     && rm -rf /var/lib/apt/lists/*
 

--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -141,6 +141,8 @@ RUN apt-get update && apt-get install -y \
     libpq5 \
     libdapclient6v5 \
     libspatialite7 \
+    libsqlite3-mod-spatialite \
+    spatialite-bin \
     libmysqlclient20 \
     libtiff5 \
     libboost-system1.58.0 \

--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -61,3 +61,94 @@ RUN git clone https://github.com/PDAL/PRC.git \
     && make install \
     && rm -rf /PRC
 
+# Remove all our dev junk and then we'll put back only
+# runtime stuff
+RUN apt-get purge -y \
+    build-essential \
+    ca-certificates \
+    cmake \
+    curl \
+    gfortran \
+    git \
+    libarmadillo-dev \
+    libarpack2-dev \
+    libflann-dev \
+    libhdf5-serial-dev \
+    liblapack-dev \
+    libtiff5-dev \
+    openssh-client \
+    python-dev \
+    python-numpy \
+    python-software-properties \
+    software-properties-common \
+    wget \
+    automake \
+    libtool \
+    libspatialite-dev \
+    libhdf5-dev \
+    subversion \
+    libjsoncpp-dev \
+    libboost-filesystem1.58-dev \
+    libboost-iostreams1.58-dev \
+    libboost-program-options1.58-dev \
+    libboost-system1.58-dev \
+    libboost-thread1.58-dev \
+    subversion \
+    clang \
+    libproj-dev \
+    libc6-dev \
+    libnetcdf-dev \
+    libjasper-dev \
+    libpng-dev \
+    libjpeg-dev \
+    libgif-dev \
+    libwebp-dev \
+    libhdf4-alt-dev \
+    libhdf5-dev \
+    libpq-dev \
+    libxerces-c-dev \
+    unixodbc-dev \
+    libsqlite3-dev \
+    libgeos-dev \
+    libmysqlclient-dev \
+    libltdl-dev \
+    libcurl4-openssl-dev \
+    libspatialite-dev \
+    libdap-dev\
+    ninja \
+    cython \
+    python-pip
+
+RUN apt-get autoremove -y
+
+RUN apt-get update && apt-get install -y \
+    libexpat1 \
+    libgomp1 \
+    libxml2 \
+    libgeos-c1v5 \
+    libjsoncpp1 \
+    libcurl3 \
+    libarmadillo6 \
+    libwebp5 \
+    libodbc1 \
+    odbcinst1debian2 \
+    libxerces-c3.1 \
+    libjasper1 \
+    netcdf-bin \
+    libhdf4-0-alt \
+    libgif7 \
+    libpq5 \
+    libdapclient6v5 \
+    libspatialite7 \
+    libmysqlclient20 \
+    libtiff5 \
+    libboost-system1.58.0 \
+    libboost-filesystem1.58.0 \
+    libboost-thread1.58.0 \
+    libboost-program-options1.58.0 \
+    libboost-iostreams1.58.0 \
+    libboost-date-time1.58.0 \
+    libboost-serialization1.58.0 \
+    libboost-chrono1.58.0 \
+    libboost-atomic1.58.0 \
+    libboost-regex1.58.0

--- a/scripts/docker/dependencies/Dockerfile
+++ b/scripts/docker/dependencies/Dockerfile
@@ -173,9 +173,9 @@ RUN wget http://bitbucket.org/eigen/eigen/get/3.2.7.tar.gz \
         && rm -rf /3.2.7.tar.gz \
         && rm -rf /eigen-eigen-b30b87236a1b
 
-RUN git clone https://github.com/chambbj/pcl.git \
+RUN git clone https://github.com/PointCloudLibrary/pcl.git \
         && cd pcl \
-        && git checkout pcl-1.7.2-sans-opengl \
+        && git checkout pcl-1.8.0 \
         && mkdir build \
         && cd build \
         && CXXFLAGS="-std=c++11"  cmake \
@@ -218,6 +218,14 @@ RUN git clone https://github.com/chambbj/pcl.git \
                 -DWITH_QT=OFF \
                 -DWITH_VTK=OFF \
                 -DWITH_PCAP=OFF \
+                -DWITH_OPENNI=OFF \
+                -DWITH_OPENNI2=OFF \
+                -DWITH_FZAPI=OFF \
+                -DWITH_ENSENSO=OFF \
+                -DWITH_DAVIDSDK=OFF \
+                -DWITH_DSSDK=OFF \
+                -DWITH_RSSDK=OFF \
+                -DWITH_OPENGL=OFF \
                 -DCMAKE_INSTALL_PREFIX=/usr \
                 -DCMAKE_BUILD_TYPE="Release" \
                 .. \

--- a/scripts/docker/dependencies/Dockerfile
+++ b/scripts/docker/dependencies/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:15.04
+FROM ubuntu:16.04
 MAINTAINER Howard Butler <howard@hobu.co>
 
 RUN apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 16126D3A3E5C1192
@@ -30,11 +30,11 @@ RUN apt-get update && apt-get install -y --fix-missing --no-install-recommends \
         libhdf5-dev \
         subversion \
         libjsoncpp-dev \
-        libboost-filesystem1.55-dev \
-        libboost-iostreams1.55-dev \
-        libboost-program-options1.55-dev \
-        libboost-system1.55-dev \
-        libboost-thread1.55-dev \
+        libboost-filesystem1.58-dev \
+        libboost-iostreams1.58-dev \
+        libboost-program-options1.58-dev \
+        libboost-system1.58-dev \
+        libboost-thread1.58-dev \
         subversion \
         clang \
         libproj-dev \
@@ -240,18 +240,18 @@ RUN apt-get update && apt-get install -y --fix-missing --no-install-recommends \
         unzip \
     && rm -rf /var/lib/apt/lists/*
 
-RUN mkdir /vdatum \
-    && cd /vdatum \
-    && wget http://download.osgeo.org/proj/vdatum/usa_geoid2012.zip && unzip -j -u usa_geoid2012.zip -d /usr/share/proj \
-    && wget http://download.osgeo.org/proj/vdatum/usa_geoid2009.zip && unzip -j -u usa_geoid2009.zip -d /usr/share/proj \
-    && wget http://download.osgeo.org/proj/vdatum/usa_geoid2003.zip && unzip -j -u usa_geoid2003.zip -d /usr/share/proj \
-    && wget http://download.osgeo.org/proj/vdatum/usa_geoid1999.zip && unzip -j -u usa_geoid1999.zip -d /usr/share/proj \
-    && wget http://download.osgeo.org/proj/vdatum/vertcon/vertconc.gtx && mv vertconc.gtx /usr/share/proj \
-    && wget http://download.osgeo.org/proj/vdatum/vertcon/vertcone.gtx && mv vertcone.gtx /usr/share/proj \
-    && wget http://download.osgeo.org/proj/vdatum/vertcon/vertconw.gtx && mv vertconw.gtx /usr/share/proj \
-    && wget http://download.osgeo.org/proj/vdatum/egm96_15/egm96_15.gtx && mv egm96_15.gtx /usr/share/proj \
-    && wget http://download.osgeo.org/proj/vdatum/egm08_25/egm08_25.gtx && mv egm08_25.gtx /usr/share/proj \
-    && rm -rf /vdatum
+#RUN mkdir /vdatum \
+#    && cd /vdatum \
+#    && wget http://download.osgeo.org/proj/vdatum/usa_geoid2012.zip && unzip -j -u usa_geoid2012.zip -d /usr/share/proj \
+#    && wget http://download.osgeo.org/proj/vdatum/usa_geoid2009.zip && unzip -j -u usa_geoid2009.zip -d /usr/share/proj \
+#    && wget http://download.osgeo.org/proj/vdatum/usa_geoid2003.zip && unzip -j -u usa_geoid2003.zip -d /usr/share/proj \
+#    && wget http://download.osgeo.org/proj/vdatum/usa_geoid1999.zip && unzip -j -u usa_geoid1999.zip -d /usr/share/proj \
+#    && wget http://download.osgeo.org/proj/vdatum/vertcon/vertconc.gtx && mv vertconc.gtx /usr/share/proj \
+#    && wget http://download.osgeo.org/proj/vdatum/vertcon/vertcone.gtx && mv vertcone.gtx /usr/share/proj \
+#    && wget http://download.osgeo.org/proj/vdatum/vertcon/vertconw.gtx && mv vertconw.gtx /usr/share/proj \
+#    && wget http://download.osgeo.org/proj/vdatum/egm96_15/egm96_15.gtx && mv egm96_15.gtx /usr/share/proj \
+#    && wget http://download.osgeo.org/proj/vdatum/egm08_25/egm08_25.gtx && mv egm08_25.gtx /usr/share/proj \
+#    && rm -rf /vdatum
 
 RUN git clone https://github.com/gadomski/fgt.git \
     && cd fgt \
@@ -269,5 +269,6 @@ RUN git clone https://github.com/gadomski/cpd.git \
     && make install \
     && rm -rf /cpd
 
-RUN apt-get clean
+
+
 

--- a/scripts/docker/dependencies/Dockerfile
+++ b/scripts/docker/dependencies/Dockerfile
@@ -60,49 +60,50 @@ RUN apt-get update && apt-get install -y --fix-missing --no-install-recommends \
         ninja \
         cython \
         python-pip \
+        libgdal1-dev \
     && rm -rf /var/lib/apt/lists/*
 
 
-RUN git clone --depth=1 https://github.com/OSGeo/gdal.git \
-    &&    cd gdal/gdal \
-    && ./configure --prefix=/usr \
-            --mandir=/usr/share/man \
-            --includedir=/usr/include/gdal \
-            --with-threads \
-            --with-grass=no \
-            --with-hide-internal-symbols=yes \
-            --with-rename-internal-libtiff-symbols=yes \
-            --with-rename-internal-libgeotiff-symbols=yes \
-            --with-libtiff=internal \
-            --with-geotiff=internal \
-            --with-webp \
-            --with-jasper \
-            --with-netcdf \
-            --with-hdf5=/usr/lib/x86_64-linux-gnu/hdf5/serial/ \
-            --with-xerces \
-            --with-geos \
-            --with-sqlite3 \
-            --with-curl \
-            --with-pg \
-            --with-mysql \
-            --with-python \
-            --with-odbc \
-            --with-ogdi \
-            --with-dods-root=/usr \
-            --with-spatialite=/usr \
-            --with-cfitsio=no \
-            --with-ecw=no \
-            --with-mrsid=no \
-            --with-poppler=yes \
-            --with-openjpeg=yes \
-            --with-freexl=yes \
-            --with-libkml=yes \
-            --with-armadillo=yes \
-            --with-liblzma=yes \
-            --with-epsilon=/usr \
-    && make -j 4 \
-    && make install \
-    && rm -rf /gdal
+#RUN git clone --depth=1 https://github.com/OSGeo/gdal.git \
+#    &&    cd gdal/gdal \
+#    && ./configure --prefix=/usr \
+#            --mandir=/usr/share/man \
+#            --includedir=/usr/include/gdal \
+#            --with-threads \
+#            --with-grass=no \
+#            --with-hide-internal-symbols=yes \
+#            --with-rename-internal-libtiff-symbols=yes \
+#            --with-rename-internal-libgeotiff-symbols=yes \
+#            --with-libtiff=internal \
+#            --with-geotiff=internal \
+#            --with-webp \
+#            --with-jasper \
+#            --with-netcdf \
+#            --with-hdf5=/usr/lib/x86_64-linux-gnu/hdf5/serial/ \
+#            --with-xerces \
+#            --with-geos \
+#            --with-sqlite3 \
+#            --with-curl \
+#            --with-pg \
+#            --with-mysql \
+#            --with-python \
+#            --with-odbc \
+#            --with-ogdi \
+#            --with-dods-root=/usr \
+#            --with-spatialite=/usr \
+#            --with-cfitsio=no \
+#            --with-ecw=no \
+#            --with-mrsid=no \
+#            --with-poppler=yes \
+#            --with-openjpeg=yes \
+#            --with-freexl=yes \
+#            --with-libkml=yes \
+#            --with-armadillo=yes \
+#            --with-liblzma=yes \
+#            --with-epsilon=/usr \
+#    && make -j 4 \
+#    && make install \
+#    && rm -rf /gdal
 
 RUN git clone https://github.com/hobu/nitro \
     && cd nitro \

--- a/scripts/docker/dependencies/Dockerfile
+++ b/scripts/docker/dependencies/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update && apt-get install -y --fix-missing --no-install-recommends \
         libboost-thread1.58-dev \
         subversion \
         clang \
+        clang-3.6 \
         libproj-dev \
         libc6-dev \
         libnetcdf-dev \
@@ -62,6 +63,7 @@ RUN apt-get update && apt-get install -y --fix-missing --no-install-recommends \
         python-pip \
         libgdal1-dev \
     && rm -rf /var/lib/apt/lists/*
+
 
 
 #RUN git clone --depth=1 https://github.com/OSGeo/gdal.git \
@@ -178,7 +180,7 @@ RUN git clone https://github.com/PointCloudLibrary/pcl.git \
         && git checkout pcl-1.8.0 \
         && mkdir build \
         && cd build \
-        && CXXFLAGS="-std=c++11"  cmake \
+        && CC="clang" CXX="clang++" CXXFLAGS="-std=c++11"  cmake \
                 -DBUILD_2d=ON \
                 -DBUILD_CUDA=OFF \
                 -DBUILD_GPU=OFF \
@@ -229,7 +231,7 @@ RUN git clone https://github.com/PointCloudLibrary/pcl.git \
                 -DCMAKE_INSTALL_PREFIX=/usr \
                 -DCMAKE_BUILD_TYPE="Release" \
                 .. \
-        && make \
+        && make -j 4\
         && make install \
         && rm -rf /pcl
 
@@ -280,4 +282,6 @@ RUN git clone https://github.com/gadomski/cpd.git \
 
 
 
+
+#RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-3.6 20 && update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-3.6 20
 


### PR DESCRIPTION
We also upgrade to Xenial in this patch. #1278 #1269