### PR TITLE
Fix spelling errors.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7078,8 +7078,8 @@
 	* Howard Butler <hobu.inc@gmail.com> decruft (14:40:34)
 	* Howard Butler <hobu.inc@gmail.com> decruft (14:40:25)
 	* Howard Butler <hobu.inc@gmail.com> used cached byte positions to avoid per-point map lookup of positions for getField queries (14:40:00)
-	* Howard Butler <hobu.inc@gmail.com> use inplacereprojfilter because the scalingfilter combo doesnt work right now (14:39:03)
-	* Howard Butler <hobu.inc@gmail.com> use inplacereprojfilter because the scalingfilter combo doesnt work right now (14:38:18)
+	* Howard Butler <hobu.inc@gmail.com> use inplacereprojfilter because the scalingfilter combo doesn't work right now (14:39:03)
+	* Howard Butler <hobu.inc@gmail.com> use inplacereprojfilter because the scalingfilter combo doesn't work right now (14:38:18)
 	* Howard Butler <hobu.inc@gmail.com> add getField specialization for fetching based on a pointIndex and Schema::getByteOffset() output (14:36:06)
 	* Howard Butler <hobu.inc@gmail.com> no longer include tuple, not used (14:34:57)
 

--- a/plugins/sqlite/io/SQLiteReader.cpp
+++ b/plugins/sqlite/io/SQLiteReader.cpp
@@ -124,7 +124,7 @@ SQLiteReader::fetchSpatialReference(std::string const& query) const
 void SQLiteReader::addArgs(ProgramArgs& args)
 {
     args.add("spatialreference", "Spatial reference to apply to points if "
-       "one doesnt exist", m_spatialRef);
+       "one doesn't exist", m_spatialRef);
     args.add("query", "SELECT statement that returns point cloud", m_query);
     args.add("connection", "Database connection string", m_connection);
     args.add("module", "Spatialite module name", m_modulename);

--- a/plugins/sqlite/io/SQLiteWriter.cpp
+++ b/plugins/sqlite/io/SQLiteWriter.cpp
@@ -73,7 +73,7 @@ void SQLiteWriter::addArgs(ProgramArgs& args)
         m_block_table).setPositional();
     args.add("cloud_table_name", "Cloud table name",
         m_cloud_table).setPositional();
-    args.add("connection", "SQL conneciton string",
+    args.add("connection", "SQL connection string",
         m_connection).setPositional();
     args.add("cloud_column_name", "Cloud column name", m_cloud_column, "id");
     args.add("module", "Module name", m_modulename);

--- a/vendor/pdalboost/boost/format/detail/compat_workarounds.hpp
+++ b/vendor/pdalboost/boost/format/detail/compat_workarounds.hpp
@@ -17,7 +17,7 @@
 //  and compiler-specific switches)
 
 // Non-conformant Std-libs fail to supply conformant traits (std::char_traits,
-//  std::allocator) and/or  the std::string doesnt support them.
+//  std::allocator) and/or  the std::string doesn't support them.
 // We don't want to have hundreds of #ifdef workarounds, so we define 
 // replacement traits.
 // But both char_traits and allocator traits are visible in the interface, 

--- a/vendor/pdalboost/boost/format/detail/config_macros.hpp
+++ b/vendor/pdalboost/boost/format/detail/config_macros.hpp
@@ -79,7 +79,7 @@ namespace pdalboost {
 #endif
 
 
-// ***  hide std::locale if it doesnt exist. 
+// ***  hide std::locale if it doesn't exist. 
 // this typedef is either std::locale or int, avoids placing ifdefs everywhere
 namespace pdalboost { namespace io { namespace detail {
 #if ! defined(BOOST_NO_STD_LOCALE)

--- a/vendor/pdalboost/boost/format/detail/workarounds_gcc-2_95.hpp
+++ b/vendor/pdalboost/boost/format/detail/workarounds_gcc-2_95.hpp
@@ -29,7 +29,7 @@
 #ifndef BOOST_FORMAT_WORKAROUNDS_GCC295_H
 #define BOOST_FORMAT_WORKAROUNDS_GCC295_H
 
-// SGI STL doesnt have <ostream> and others, so we need iostream.
+// SGI STL doesn't have <ostream> and others, so we need iostream.
 #include <iostream> 
 #define BOOST_FORMAT_OSTREAM_DEFINED
 

--- a/vendor/pdalboost/boost/mpl/for_each.hpp
+++ b/vendor/pdalboost/boost/mpl/for_each.hpp
@@ -113,7 +113,7 @@ BOOST_MPL_CFG_GPU_ENABLED
 inline
 void for_each(F f, Sequence* = 0)
 {
-  // jfalcou: fully qualifying this call so it doesnt clash with pdalboostphoenix::for_each
+  // jfalcou: fully qualifying this call so it doesn't clash with pdalboostphoenix::for_each
   // ons ome compilers -- done on 02/28/2011
   pdalboost::mpl::for_each<Sequence, identity<> >(f);
 }


### PR DESCRIPTION
The lintian QA tool reported a couple of spelling errors for 1.3.0-RC1:

 doesnt     -> doesn't
 conneciton -> connection