### PR TITLE
Add support for modern bash-completion path.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,7 +209,9 @@ export(PACKAGE PDAL)
 
 # TODO: move under scripts/bash-completion ?
 if (WITH_COMPLETION)
-    if (IS_DIRECTORY /etc/bash_completion.d)
+    if (IS_DIRECTORY ${CMAKE_INSTALL_PREFIX}/share/bash-completion/completions)
+        install(FILES "${PROJECT_SOURCE_DIR}/scripts/bash-completion/pdal" DESTINATION "${CMAKE_INSTALL_PREFIX}/share/bash-completion/completions")
+    elseif (IS_DIRECTORY /etc/bash_completion.d)
         install(FILES "${PROJECT_SOURCE_DIR}/scripts/bash-completion/pdal" DESTINATION "${CMAKE_INSTALL_PREFIX}/etc/bash_completion.d")
     endif()
 endif()


### PR DESCRIPTION
`/etc/bash_completion.d` is deprecated, and `/usr/share/bash-completion/completions` should be used instead.

Better would be to use `pkg-config --variable=completionsdir bash-completion` to get the appropriate directory (the `bash-completion` Debian package doesn't include the CMake files), as documented in the [bash-completion FAQ](https://github.com/scop/bash-completion#faq).

The recent upload of the PDAL 1.2.0 Debian package fixing the HDF5 include dir (see #1292) failed to build because the Debian build daemons don't have the `/etc/bash_completion.d` directory by default any more.