### PR TITLE
Fix PcdWriter compression option for 1.3

### DIFF
--- a/plugins/pcl/io/PcdWriter.cpp
+++ b/plugins/pcl/io/PcdWriter.cpp
@@ -1,5 +1,6 @@
 /******************************************************************************
 * Copyright (c) 2011, Brad Chambers (brad.chambers@gmail.com)
+* Copytight (c) 2016, Logan Byers (logan.c.byers@gmail.com)
 *
 * All rights reserved.
 *
@@ -63,9 +64,8 @@ std::string PcdWriter::getName() const { return s_info.name; }
 void PcdWriter::addArgs(ProgramArgs& args)
 {
 
-    std::string compression;
     args.add("filename", "Filename to write PCD file to", m_filename);
-    args.add("compression","Level of PCD compression to use (ascii, binary, compressed)", compression, "ascii");
+    args.add("compression", "Level of PCD compression to use (ascii, binary, compressed)", m_compression_string);
     args.add("xyz", "Write only XYZ dimensions?", m_xyz, false);
     args.add("subtract_minimum", "Set origin to minimum of XYZ dimension", m_subtract_minimum, true);
     args.add("offset_x", "Offset to be subtracted from XYZ position", m_offset_x, 0.0);
@@ -74,19 +74,6 @@ void PcdWriter::addArgs(ProgramArgs& args)
     args.add("scale_x", "Scale to divide from XYZ dimension", m_scale_x, 1.0);
     args.add("scale_y", "Scale to divide from XYZ dimension", m_scale_y, 1.0);
     args.add("scale_z", "Scale to divide from XYZ dimension", m_scale_z, 1.0);
-
-    if (compression == "binary")
-    {
-      m_compression = 1;
-    }
-    else if (compression == "compressed")
-    {
-      m_compression = 2;
-    }
-    else  // including "ascii"
-    {
-      m_compression = 0;
-    }
 
 }
 

--- a/plugins/pcl/io/PcdWriter.hpp
+++ b/plugins/pcl/io/PcdWriter.hpp
@@ -1,5 +1,6 @@
 /******************************************************************************
 * Copyright (c) 2014, Brad Chambers (brad.chambers@gmail.com)
+* Copytight (c) 2016, Logan Byers (logan.c.byers@gmail.com)
 *
 * All rights reserved.
 *
@@ -67,6 +68,7 @@ private:
     inline void writeView(const PointViewPtr view); // implemented in header
 
     std::string m_filename;
+    std::string m_compression_string;
     uint8_t m_compression;
     bool m_xyz;
     bool m_subtract_minimum;
@@ -101,6 +103,20 @@ void PcdWriter::writeView(const PointViewPtr view)
     }
     pclsupport::PDALtoPCD(view, *cloud, bounds, m_scale_x, m_scale_y, m_scale_z);
     pcl::PCDWriter w;
+
+    if (m_compression_string == "binary")
+    {
+      m_compression = 1;
+    }
+    else if (m_compression_string == "compressed")
+    {
+      m_compression = 2;
+    }
+    else  // including "ascii"
+    {
+      m_compression = 0;
+    }
+
     switch (m_compression)
     {
         case 0 : w.writeASCII<PointT>(m_filename, *cloud); break;


### PR DESCRIPTION

Upgrades to PcdWriter had problems once integrated with the rest of 1.3 changes.
This fixes problems with the compression option.

The main failures were loss of the variable to hold the option due to scope changes.
The compression enum also was set before the variables were set from the options.
This resulted in always-default behavior of ascii compression.

---
Rearrange workflow for determining compression level
for option writers.pcd.compression. Previous version
set write method before the program arguments were
set! This resulted in always ascii compression.

This also fixes a potential free() error that can occur
when this writer is ran within a pipeline.