### PR TITLE
Add . and ./bin to default plugin search path list

### DIFF
--- a/src/PluginManager.cpp
+++ b/src/PluginManager.cpp
@@ -90,7 +90,7 @@ StringList pluginSearchPaths()
         searchPaths = Utils::split2(envOverride, ':');
     else
     {
-        StringList standardPaths = { "./lib", "../lib", "../bin" };
+        StringList standardPaths = { ".", "./lib", "../lib", "./bin", "../bin" };
         for (std::string& s : standardPaths)
         {
             if (FileUtils::toAbsolutePath(s) !=


### PR DESCRIPTION
This makes life a little easier (on windows at least) when invoking tests from the root of the build directory. 

The pdal binary is placed in bin/ and so are the plugin dll's. The plugin manager does not look in bin/ when invoked from the build-dir root or from bin. This PR should change that.