### PR TITLE
Log a stacktrace if PDAL segfaults on Unix

### DIFF
--- a/apps/pdal.cpp
+++ b/apps/pdal.cpp
@@ -50,7 +50,6 @@
 #include <execinfo.h>
 #include <unistd.h>
 #include <dlfcn.h>
-#include <cxxabi.h>
 #endif
 
 using namespace pdal;
@@ -241,8 +240,7 @@ int main(int argc, char* argv[])
 
             if (dladdr(buffer[i], &info))
             {
-                char* demangled = abi::__cxa_demangle(info.dli_sname, nullptr,
-                        0, &status);
+                const std::string demangled(Utils::demangle(info.dli_sname));
 
                 const std::size_t offset(
                         static_cast<char*>(buffer[i]) -
@@ -257,11 +255,8 @@ int main(int argc, char* argv[])
                     prefix = symbol.substr(0, pos);
                 }
 
-                lines.push_back(prefix +
-                        (status == 0 ? demangled : info.dli_sname) + " + " +
+                lines.push_back(prefix + demangled + " + " +
                         std::to_string(offset));
-
-                free(demangled);
             }
             else
             {

--- a/apps/pdal.cpp
+++ b/apps/pdal.cpp
@@ -47,6 +47,7 @@
 #include <vector>
 
 #ifndef _WIN32
+#include <csignal>
 #include <execinfo.h>
 #include <unistd.h>
 #include <dlfcn.h>

--- a/filters/stats/StatsFilter.cpp
+++ b/filters/stats/StatsFilter.cpp
@@ -142,7 +142,11 @@ void StatsFilter::prepared(PointTableRef table)
 {
     PointLayoutPtr layout(table.layout());
     std::unordered_map<std::string, Summary::EnumType> dims;
-    std::ostream& out = log()->get(LogLevel::Warning);
+
+    auto getWarn([this]()->std::ostream&
+    {
+        return log()->get(LogLevel::Warning);
+    });
 
     // Add dimensions to the list.
     if (m_dimNames.empty())
@@ -155,7 +159,7 @@ void StatsFilter::prepared(PointTableRef table)
         for (auto& s : m_dimNames)
         {
             if (layout->findDim(s) == Dimension::Id::Unknown)
-                out << "Dimension '" << s << "' listed in --dimensions "
+                getWarn() << "Dimension '" << s << "' listed in --dimensions "
                     "option does not exist.  Ignoring." << std::endl;
             else
                 dims[s] = Summary::NoEnum;
@@ -166,7 +170,7 @@ void StatsFilter::prepared(PointTableRef table)
     for (auto& s : m_enums)
     {
         if (dims.find(s) == dims.end())
-            out << "Dimension '" << s << "' listed in --enumerate option "
+            getWarn() << "Dimension '" << s << "' listed in --enumerate option "
                 "does not exist.  Ignoring." << std::endl;
         else
             dims[s] = Summary::Enumerate;
@@ -176,7 +180,7 @@ void StatsFilter::prepared(PointTableRef table)
     for (auto& s : m_counts)
     {
         if (dims.find(s) == dims.end())
-            out << "Dimension '" << s << "' listed in --count option "
+            getWarn() << "Dimension '" << s << "' listed in --count option "
                 "does not exist.  Ignoring." << std::endl;
         else
             dims[s] = Summary::Count;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -207,6 +207,10 @@ if (WIN32)
     target_link_libraries(${PDAL_BASE_LIB_NAME} PUBLIC ws2_32)
 endif()
 
+if (UNIX)
+    target_link_libraries(${PDAL_BASE_LIB_NAME} PUBLIC dl)
+endif()
+
 ###############################################################################
 # Targets installation
 

--- a/src/util/Utils.cpp
+++ b/src/util/Utils.cpp
@@ -537,10 +537,11 @@ std::string Utils::demangle(const std::string& s)
     int status;
     std::unique_ptr<char[], void (*)(void*)> result(
             abi::__cxa_demangle(s.c_str(), 0, 0, &status), std::free);
-    return std::string(result.get());
-#else
-    return s;
+    if (status == 0)
+        return std::string(result.get());
 #endif
+
+    return s;
 }
 
 


### PR DESCRIPTION
If log-level is Debug, change segfault output to show a demangled stacktrace rather than just `Segmentation fault: 11`.  Sample output shown [here](https://gist.github.com/connormanning/5d1b2444c2eb6e05790d2f1f901970c6).

The StatsFilter tweak here avoids some extraneous logging output at level Debug.  Because `Log::get` produces immediate output even when nothing is streamed in, caching the stream in advance was producing an empty log header.