### PR TITLE
Fix 'specificiation' typo, replace with 'specification'.

### DIFF
--- a/kernels/info/InfoKernel.cpp
+++ b/kernels/info/InfoKernel.cpp
@@ -406,7 +406,7 @@ MetadataNode InfoKernel::dumpQuery(PointViewPtr inView) const
     else
         count = 0;
     if (count == 0)
-        throw pdal_error("Invalid location specificiation. "
+        throw pdal_error("Invalid location specification. "
             "--query=\"X,Y[/count]\"");
 
     auto seps = [](char c){ return (c == ',' || c == '|' || c == ' '); };


### PR DESCRIPTION
The spelling error was reported by the lintian QA tool for the most recent Debian package build.