### PR TITLE
Add multi-thread in crop filter (via new option num_threads)

### DIFF
--- a/doc/stages/filters.crop.rst
+++ b/doc/stages/filters.crop.rst
@@ -42,3 +42,5 @@ polygon
 outside
   Invert the cropping logic and only take points **outside** the cropping bounds or polygon. [Default: **false**]
 
+num_threads
+  Number of threads to use for the crop operation [Default: 1]

--- a/filters/crop/CropFilter.hpp
+++ b/filters/crop/CropFilter.hpp
@@ -64,6 +64,7 @@ private:
     std::vector<Polygon> m_polys;
     SpatialReference m_assignedSrs;
     SpatialReference m_lastSrs;
+    int m_numthreads;
 
     struct GeomPkg
     {
@@ -83,8 +84,10 @@ private:
     virtual PointViewSet run(PointViewPtr view);
     bool crop(PointRef& point, const BOX2D& box);
     void crop(const BOX2D& box, PointView& input, PointView& output);
+    void cropJobBox(unsigned int left, unsigned int right, const BOX2D& box, PointView& input, std::vector<bool>& results);
     bool crop(PointRef& point, const GeomPkg& g);
     void crop(const GeomPkg& g, PointView& input, PointView& output);
+    void cropJobGeom(unsigned int left, unsigned int right, const GeomPkg& g, PointView& input, std::vector<bool>& results);
 
     CropFilter& operator=(const CropFilter&); // not implemented
     CropFilter(const CropFilter&); // not implemented


### PR DESCRIPTION
PDAL tests pass
Default is to use only 1 thread (as before) but now the user may use more threads via the option num_threads