### PR TITLE
Add GDAL_INCLUDE_DIR to interface include dirs

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -198,6 +198,12 @@ target_link_libraries(${PDAL_BASE_LIB_NAME}
     INTERFACE
         ${PDAL_LIBDIR}
 )
+# This allows downstream projects to use GDAL_INCLUDE_DIR simply by linking
+# against PDAL_BASE_LIB_NAME.
+target_include_directories(${PDAL_BASE_LIB_NAME}
+    INTERFACE
+        ${GDAL_INCLUDE_DIR}
+)
 
 if (WITH_GEOTIFF)
     target_link_libraries(${PDAL_BASE_LIB_NAME} PUBLIC ${GEOTIFF_LIBRARY})


### PR DESCRIPTION
If GDAL is installed to a non-standard location, anything that uses
`PDALUtils.hpp` will fail b/c it can't find `cpl_port.h`. Since we use
`include_directories` instead of `target_include_directories`, the CMake
library interface is not populated with upstream include directories.
This patch fixes that *for GDAL only*.

A more comprehensive population of the target include interface is
probably wise. IMO the best way to be to switch all usages of
`include_directories` to `target_include_directories`, which is some
work.