### PR TITLE
Fix out-of-bounds access in program args

### DIFF
--- a/include/pdal/util/ProgramArgs.hpp
+++ b/include/pdal/util/ProgramArgs.hpp
@@ -80,7 +80,7 @@ public:
     {
         m_vals[i].m_consumed = true;
         if (i == m_unconsumedStart)
-            while (i < m_vals.size() && consumed(++i))
+            while (i < m_vals.size() - 1 && consumed(++i))
                 m_unconsumedStart++;
     }
 


### PR DESCRIPTION
If `i == m_vals.size() - 1`, `consumed` is passed `m_vals.size()`, which is out-of-bounds. Bug discovered by a combination of MSVC compilation in Debug mode and http://clang.llvm.org/docs/AddressSanitizer.html.