### PR TITLE
Protect IStream::get from invalid vector address

### DIFF
--- a/include/pdal/util/IStream.hpp
+++ b/include/pdal/util/IStream.hpp
@@ -37,6 +37,7 @@
 #include <sys/types.h>
 #include <stdint.h>
 
+#include <cassert>
 #include <fstream>
 #include <memory>
 #include <stack>
@@ -216,16 +217,20 @@ public:
 
       \param buf  Buffer to fill.
     */
-    PDAL_DLL void get(std::vector<char>& buf)
-        { m_stream->read(&buf[0], buf.size()); }
+    PDAL_DLL void get(std::vector<char>& buf) {
+        assert(buf.size() != 0);
+        m_stream->read((char *)&buf[0], buf.size());
+    }
 
     /**
       Fetch data from the stream into a vector of unsigned char.
 
       \param buf  Buffer to fill.
     */
-    PDAL_DLL void get(std::vector<unsigned char>& buf)
-        { m_stream->read((char *)&buf[0], buf.size()); }
+    PDAL_DLL void get(std::vector<unsigned char>& buf) {
+        assert(buf.size() != 0);
+        m_stream->read((char *)&buf[0], buf.size());
+    }
 
     /**
       Fetch data from the stream into the specified buffer of char.

--- a/io/las/VariableLengthRecord.cpp
+++ b/io/las/VariableLengthRecord.cpp
@@ -50,7 +50,9 @@ ILeStream& operator>>(ILeStream& in, VariableLengthRecord& v)
     in >> v.m_recordId >> dataLen;
     in.get(v.m_description, 32);
     v.m_data.resize(dataLen);
-    in.get(v.m_data);
+    if (v.m_data.size() > 0) {
+        in.get(v.m_data);
+    }
 
     return in;
 }
@@ -77,7 +79,9 @@ ILeStream& operator>>(ILeStream& in, ExtVariableLengthRecord& v)
     in >> v.m_recordId >> dataLen;
     in.get(v.m_description, 32);
     v.m_data.resize(dataLen);
-    in.get(v.m_data);
+    if (v.m_data.size() > 0) {
+        in.get(v.m_data);
+    }
 
     return in;
 }


### PR DESCRIPTION
Empty buffers are not read into at all.