### PR TITLE
Fixes for compiling with Visual Studio 2013.  This addresses

### DIFF
--- a/include/pdal/DimUtil.hpp
+++ b/include/pdal/DimUtil.hpp
@@ -81,16 +81,16 @@ inline std::string toName(BaseType b)
 enum class Type
 {
     None = 0,
-    Unsigned8 = Utils::toNative(BaseType::Unsigned) | 1,
-    Signed8 = Utils::toNative(BaseType::Signed) | 1,
-    Unsigned16 = Utils::toNative(BaseType::Unsigned) | 2,
-    Signed16 = Utils::toNative(BaseType::Signed) | 2,
-    Unsigned32 = Utils::toNative(BaseType::Unsigned) | 4,
-    Signed32 = Utils::toNative(BaseType::Signed) | 4,
-    Unsigned64 = Utils::toNative(BaseType::Unsigned )| 8,
-    Signed64 = Utils::toNative(BaseType::Signed) | 8,
-    Float = Utils::toNative(BaseType::Floating) | 4,
-    Double = Utils::toNative(BaseType::Floating) | 8
+    Unsigned8 = unsigned(BaseType::Unsigned) | 1,
+    Signed8 = unsigned(BaseType::Signed) | 1,
+    Unsigned16 = unsigned(BaseType::Unsigned) | 2,
+    Signed16 = unsigned(BaseType::Signed) | 2,
+    Unsigned32 = unsigned(BaseType::Unsigned) | 4,
+    Signed32 = unsigned(BaseType::Signed) | 4,
+    Unsigned64 = unsigned(BaseType::Unsigned )| 8,
+    Signed64 = unsigned(BaseType::Signed) | 8,
+    Float = unsigned(BaseType::Floating) | 4,
+    Double = unsigned(BaseType::Floating) | 8
 };
 
 inline std::size_t size(Type t)

--- a/include/pdal/util/Utils.hpp
+++ b/include/pdal/util/Utils.hpp
@@ -948,7 +948,7 @@ namespace Utils
       \return  Converted variable.
     */
     template<typename E>
-    constexpr typename std::underlying_type<E>::type toNative(E e)
+    typename std::underlying_type<E>::type toNative(E e)
     {
         return static_cast<typename std::underlying_type<E>::type>(e);
     }

--- a/src/PipelineManager.cpp
+++ b/src/PipelineManager.cpp
@@ -50,8 +50,9 @@ PipelineManager::~PipelineManager()
 
 void PipelineManager::readPipeline(std::istream& input)
 {
+    std::istreambuf_iterator<char> eos;
     // Read stream into string.
-    std::string s(std::istreambuf_iterator<char>(input), {});
+    std::string s(std::istreambuf_iterator<char>(input), eos);
 
     std::istringstream ss(s);
     if (s.find("?xml") != std::string::npos)

--- a/vendor/arbiter/arbiter.cpp
+++ b/vendor/arbiter/arbiter.cpp
@@ -1419,7 +1419,7 @@ namespace
                         std::isspace(c) &&
                         (out.empty() || std::isspace(out.back())))
                     {
-                        return out;
+                        return out + "";
                     }
                     else
                     {


### PR DESCRIPTION
(1) lack of support for constexpr
(2) absence of {} as an initializer
(3) need to have consistent return types

Fixing these doesn't detract too much from the expressive power of
C++11.  I recommend adding Visual Studio 2013 and Visusal Studio 2015
compilers to the continuous integration suite!