### PR TITLE
Close file after creation in glob test

### DIFF
--- a/test/unit/FileUtilsTest.cpp
+++ b/test/unit/FileUtilsTest.cpp
@@ -228,8 +228,10 @@ TEST(FileUtilsTest, glob)
     for (std::string& file : filenames())
         FileUtils::deleteFile(file);
 
-    for (std::string& file : filenames())
-        FileUtils::createFile(file);
+    for (std::string& file : filenames()) {
+        auto f = FileUtils::createFile(file);
+        FileUtils::closeFile(f);
+    }
 
     EXPECT_EQ(FileUtils::glob(TP("*.glob")).size(), 10u);
     EXPECT_EQ(FileUtils::glob(TP("foo1.glob")).size(), 1u);


### PR DESCRIPTION
Otherwise, on subsequent delete, Windoze complains about that file already in use.

*Might* fix AppVeyor. This PR is the way to find out.