### PR TITLE
CMake 2.8.12 and target_link_libraries keyword signature

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 #
 # (based originally on the libLAS files copyright Mateusz Loskot)
 
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 2.8.12)
 
 project(PDAL CXX C)
 string(TOLOWER ${PROJECT_NAME} PROJECT_NAME_LOWER)

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -50,7 +50,7 @@ if(PDAL_UTILITY)
     else (APPLE AND PDAL_BUNDLE)
         add_executable(${PDAL_UTILITY} ${srcs})
     endif(APPLE AND PDAL_BUNDLE)
-    target_link_libraries(${PDAL_UTILITY} ${PDAL_BASE_LIB_NAME}
+    target_link_libraries(${PDAL_UTILITY} PRIVATE ${PDAL_BASE_LIB_NAME}
         ${PDAL_UTIL_LIB_NAME})
 endif()
 

--- a/cmake/macros.cmake
+++ b/cmake/macros.cmake
@@ -127,7 +127,7 @@ macro(PDAL_ADD_PLUGIN _name _type _shortname)
     endif()
 
     add_library(${${_name}} SHARED ${PDAL_ADD_PLUGIN_FILES})
-    target_link_libraries(${${_name}}
+    target_link_libraries(${${_name}} PUBLIC
         ${PDAL_BASE_LIB_NAME}
         ${PDAL_UTIL_LIB_NAME}
         ${PDAL_ADD_PLUGIN_LINK_WITH})
@@ -170,7 +170,7 @@ macro(PDAL_ADD_TEST _name)
     add_executable(${_name} ${PDAL_ADD_TEST_FILES} ${common_srcs})
     set_target_properties(${_name} PROPERTIES COMPILE_DEFINITIONS PDAL_DLL_IMPORT)
     set_property(TARGET ${_name} PROPERTY FOLDER "Tests")
-    target_link_libraries(${_name}
+    target_link_libraries(${_name} PRIVATE
         ${PDAL_BASE_LIB_NAME} ${PDAL_UTIL_LIB_NAME} gtest
         ${PDAL_ADD_TEST_LINK_WITH})
     add_test(NAME ${_name} COMMAND "${PROJECT_BINARY_DIR}/bin/${_name}" WORKING_DIRECTORY "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/..")

--- a/dimbuilder/CMakeLists.txt
+++ b/dimbuilder/CMakeLists.txt
@@ -23,5 +23,5 @@ set (SOURCES
 add_executable(dimbuilder ${SOURCES})
 target_link_libraries(dimbuilder PRIVATE ${PDAL_UTIL_LIB_NAME})
 if (PDAL_HAVE_JSONCPP)
-    target_link_libraries(dimbuilder ${PDAL_JSONCPP_LIB_NAME})
+    target_link_libraries(dimbuilder PRIVATE ${PDAL_JSONCPP_LIB_NAME})
 endif()

--- a/doc/tutorial/using.rst
+++ b/doc/tutorial/using.rst
@@ -30,7 +30,7 @@ Begin by creating a file named CMakeLists.txt that contains:
   add_definitions(${PDAL_DEFINITIONS})
   set(CMAKE_CXX_FLAGS "-std=c++11")
   add_executable(tutorial tutorial.cpp)
-  target_link_libraries(tutorial ${PDAL_LIBRARIES})
+  target_link_libraries(tutorial PRIVATE ${PDAL_LIBRARIES})
 
 CMakeLists explained
 -------------------------------------------------------------------------------
@@ -88,7 +88,7 @@ We use the `add_executable` command to tell CMake to create an executable named
 
 .. code-block:: cmake
 
-  target_link_libraries(tutorial ${PDAL_LIBRARIES})
+  target_link_libraries(tutorial PRIVATE ${PDAL_LIBRARIES})
 
 We assume that the tutorial executable makes calls to PDAL functions. To make
 the linker aware of the PDAL libraries, we use `target_link_libraries` to link

--- a/examples/writing-filter/CMakeLists.txt
+++ b/examples/writing-filter/CMakeLists.txt
@@ -8,4 +8,4 @@ include_directories(/Users/chambbj/loki/pdal/repo/filters)
 
 set(CMAKE_CXX_FLAGS "-std=c++11")
 add_library(pdal_plugin_filter_myfilter SHARED MyFilter.cpp)
-target_link_libraries(pdal_plugin_filter_myfilter ${PDAL_LIBRARIES})
+target_link_libraries(pdal_plugin_filter_myfilter PRIVATE ${PDAL_LIBRARIES})

--- a/examples/writing-kernel/CMakeLists.txt
+++ b/examples/writing-kernel/CMakeLists.txt
@@ -8,4 +8,4 @@ include_directories(/Users/chambbj/loki/pdal/repo/kernels)
 
 set(CMAKE_CXX_FLAGS "-std=c++11")
 add_library(pdal_plugin_kernel_mykernel SHARED MyKernel.cpp)
-target_link_libraries(pdal_plugin_kernel_mykernel ${PDAL_LIBRARIES})
+target_link_libraries(pdal_plugin_kernel_mykernel PRIVATE ${PDAL_LIBRARIES})

--- a/examples/writing-reader/CMakeLists.txt
+++ b/examples/writing-reader/CMakeLists.txt
@@ -8,4 +8,4 @@ include_directories(/Users/chambbj/loki/pdal/repo/readers)
 
 set(CMAKE_CXX_FLAGS "-std=c++11")
 add_library(pdal_plugin_reader_myreader SHARED MyReader.cpp)
-target_link_libraries(pdal_plugin_reader_myreader ${PDAL_LIBRARIES})
+target_link_libraries(pdal_plugin_reader_myreader PRIVATE ${PDAL_LIBRARIES})

--- a/examples/writing-writer/CMakeLists.txt
+++ b/examples/writing-writer/CMakeLists.txt
@@ -6,4 +6,4 @@ include_directories(${PDAL_INCLUDE_DIRS})
 
 set(CMAKE_CXX_FLAGS "-std=c++11")
 add_library(pdal_plugin_writer_mywriter SHARED MyWriter.cpp)
-target_link_libraries(pdal_plugin_writer_mywriter ${PDAL_LIBRARIES})
+target_link_libraries(pdal_plugin_writer_mywriter PRIVATE ${PDAL_LIBRARIES})

--- a/examples/writing/CMakeLists.txt
+++ b/examples/writing/CMakeLists.txt
@@ -6,4 +6,4 @@ include_directories(${PDAL_INCLUDE_DIRS})
 
 set(CMAKE_CXX_FLAGS "-std=c++11")
 add_executable(tutorial tutorial.cpp)
-target_link_libraries(tutorial ${PDAL_LIBRARIES})
+target_link_libraries(tutorial PRIVATE ${PDAL_LIBRARIES})

--- a/src/plang/CMakeLists.txt
+++ b/src/plang/CMakeLists.txt
@@ -26,7 +26,7 @@ set_target_properties(${PDAL_PLANG_LIB_NAME} PROPERTIES
     SOVERSION "${PDAL_API_VERSION}"
     CLEAN_DIRECT_OUTPUT 1)
 
-target_link_libraries(${PDAL_PLANG_LIB_NAME}
+target_link_libraries(${PDAL_PLANG_LIB_NAME} PUBLIC
     ${PDAL_BASE_LIB_NAME}
     ${PDAL_UTIL_LIB_NAME}
     ${PYTHON_LIBRARY})

--- a/tools/lasdump/CMakeLists.txt
+++ b/tools/lasdump/CMakeLists.txt
@@ -37,12 +37,12 @@ if (LASZIP_FOUND)
     )
 
     add_executable(lasdump ${SOURCES} ${HEADERS})
-    target_link_libraries(lasdump
+    target_link_libraries(lasdump PRIVATE
         ${PDAL_UTIL_LIB_NAME}
         ${LASZIP_LIBRARIES}
     )
     if (WIN32)
-        target_link_libraries(lasdump wsock32 ws2_32)
+        target_link_libraries(lasdump PRIVATE wsock32 ws2_32)
     endif()
 endif()
 

--- a/tools/nitfwrap/CMakeLists.txt
+++ b/tools/nitfwrap/CMakeLists.txt
@@ -21,7 +21,7 @@ set (HEADERS
 
 add_executable(nitfwrap ${SOURCES} ${HEADERS})
 add_dependencies(nitfwrap generate_dimension_hpp)
-target_link_libraries(nitfwrap
+target_link_libraries(nitfwrap PRIVATE
     ${PDAL_BASE_LIB_NAME}
     ${PDAL_UTIL_LIB_NAME}
     ${NITRO_LIBRARIES}


### PR DESCRIPTION
Two patches for our CMake setup. First one just bumps our minimum required CMake version to 2.8.12, which allows us to use the `target_link_libraries(target <PUBLIC|INTERFACE|PRIVATE>...` signature. The second patch updates all `target_link_libraries` to use the keyword signature, per policy CMP0023.