### PR TITLE
The TPS interpolation in filters.mongus is generic enough to move to EigenUtils

### DIFF
--- a/filters/MongusFilter.hpp
+++ b/filters/MongusFilter.hpp
@@ -78,11 +78,6 @@ private:
     virtual void addArgs(ProgramArgs& args);
     int getColIndex(double x, double cell_size);
     int getRowIndex(double y, double cell_size);
-    Eigen::MatrixXd computeSpline(Eigen::MatrixXd x_prev,
-                                  Eigen::MatrixXd y_prev,
-                                  Eigen::MatrixXd z_prev,
-                                  Eigen::MatrixXd x_samp,
-                                  Eigen::MatrixXd y_samp);
     void writeControl(Eigen::MatrixXd cx, Eigen::MatrixXd cy, Eigen::MatrixXd cz, std::string filename);
     void downsampleMin(Eigen::MatrixXd *cx, Eigen::MatrixXd *cy,
                        Eigen::MatrixXd* cz, Eigen::MatrixXd *dcx,

--- a/pdal/EigenUtils.hpp
+++ b/pdal/EigenUtils.hpp
@@ -760,6 +760,21 @@ PDAL_DLL double computeSlopeFD(const Eigen::MatrixBase<Derived>& data,
     return 100.0 * std::sqrt(p);
 }
 
+/**
+  Thin Plate Spline interpolation.
+
+  \param x the x coordinate of the input data.
+  \param y the y coordinate of the input data.
+  \param z the z coordinate of the input data.
+  \param xx the x coordinate of the points to be interpolated.
+  \param yy the y coordinate of the points to be interpolated.
+  \return the values of the interpolated data at xx and yy.
+*/
+PDAL_DLL Eigen::MatrixXd computeSpline(Eigen::MatrixXd x, Eigen::MatrixXd y,
+                                       Eigen::MatrixXd z, Eigen::MatrixXd xx,
+                                       Eigen::MatrixXd yy);
+
+
 } // namespace eigen
 
 } // namespace pdal


### PR DESCRIPTION
A number of other ground segmentation routines (yet to be implemented) use a
similar approach for estimating the ground surface. Our modified version of
SMRF even uses TPS to fill holes, although we have yet to port that over to
this EigenUtils function, as it differs slightly.