### PR TITLE
Blanket include libxml2 include dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,6 +225,7 @@ target_include_directories(${PDAL_BASE_LIB_NAME}
         ${PDAL_VENDOR_DIR}/eigen
         ${PDAL_VENDOR_DIR}/pdalboost
         ${PDAL_JSONCPP_INCLUDE_DIR}
+        ${LIBXML2_INCLUDE_DIR}
     INTERFACE
         ${GDAL_INCLUDE_DIR}
 )


### PR DESCRIPTION
We blanket link against the library a few lines below, so I follow that
lead. IMO it might be more explicit to check against PDAL_HAVE_LIBXML2
first?

cc @abellgithub 