### PR TITLE
ostream << needs to be const to match src

### DIFF
--- a/pdal/util/Bounds.hpp
+++ b/pdal/util/Bounds.hpp
@@ -638,6 +638,6 @@ extern PDAL_DLL std::istream& operator>>(std::istream& istr, BOX2D& bounds);
 extern PDAL_DLL std::istream& operator>>(std::istream& istr, BOX3D& bounds);
 
 PDAL_DLL std::istream& operator >> (std::istream& in, Bounds& bounds);
-PDAL_DLL std::ostream& operator << (std::ostream& in, Bounds& bounds);
+PDAL_DLL std::ostream& operator << (std::ostream& in, const Bounds& bounds);
 
 } // namespace pdal

--- a/test/unit/BoundsTest.cpp
+++ b/test/unit/BoundsTest.cpp
@@ -348,3 +348,11 @@ TEST(BoundsTest, b2)
     EXPECT_EQ(box3.minz, 0.0);
     EXPECT_EQ(box3.maxz, 2.0);
 }
+
+TEST(BoundsTest, bounds_insertion)
+{
+    std::string s;
+    std::ostringstream oss(s);
+    Bounds b;
+    oss << b;
+}


### PR DESCRIPTION
Includes pre-failing test.