### PR TITLE
Improve BPF streaming performance for dimension-major format.

### DIFF
--- a/io/BpfReader.hpp
+++ b/io/BpfReader.hpp
@@ -63,7 +63,7 @@ public:
     std::string getName() const;
 
     virtual point_count_t numPoints() const
-        {  return (point_count_t)m_header.m_numPts; }
+        { return (point_count_t)m_header.m_numPts; }
 private:
     ILeStream m_stream;
     BpfHeader m_header;
@@ -81,6 +81,10 @@ private:
     std::vector<char> m_deflateBuf;
     /// Streambuf for deflated data.
     Charbuf m_charbuf;
+
+    // For dimension-major point-at-a-time usage.
+    std::vector<std::unique_ptr<ILeStream>> m_streams;
+    std::vector<std::unique_ptr<Charbuf>> m_charbufs;
 
     virtual QuickInfo inspect();
     virtual void initialize();


### PR DESCRIPTION
The dimension-major streaming interface was quite slow due to seeking `<number of dimensions>` times per point.  This PR removes the seeks by using a separate stream for each dimension.  This method is approximately 16 times faster.