### PR TITLE
PMF updates

### DIFF
--- a/filters/PMFFilter.cpp
+++ b/filters/PMFFilter.cpp
@@ -81,8 +81,6 @@ std::vector<double> PMFFilter::morphOpen(PointViewPtr view, float radius)
     QuadIndex idx(*view);
 
     std::vector<double> minZ(np), maxZ(np);
-    typedef std::vector<PointId> PointIdVec;
-    std::map<PointId, PointIdVec> neighborMap;
 
     // erode
     for (PointId i = 0; i < np; ++i)


### PR DESCRIPTION
* Revert back to a 2D box search (vice radius) as in the original PCL
  implementation.
* Do not store map of neighbors, which can grow quite large and blow up
  available memory, just take the hit and redo the search in both the
  erosion and dilation steps.