### PR TITLE
Update PCL pipeline spec/implementation

### DIFF
--- a/doc/stages/filters.pclblock.rst
+++ b/doc/stages/filters.pclblock.rst
@@ -10,22 +10,23 @@ between PDAL and PCL point cloud representations.
 
 This filter is under active development. The current implementation serves as a
 proof of concept for linking PCL into PDAL and converting data. The PCL Block
-filter creates a PCL ``Pipeline`` object and passes it a single argument, the JSON
-file containing the PCL block definition. After filtering, the resulting indices
-can be retrieved and used to create a new PDAL ``PointView`` containing only
-those points that passed the filtering stages.
+filter creates a PCL ``Pipeline`` object and passes it a single argument, the
+JSON file containing the PCL block definition. After filtering, the resulting
+indices can be retrieved and used to create a new PDAL ``PointView`` containing
+only those points that passed the filtering stages.
 
 At this stage in its development, the PCL ``Pipeline`` does not allow complex
-operations that may change the point type (e.g., ``PointXYZ`` to ``PointNormal``) or
-alter points.  We will continue to look into use cases that are of value and
-feasible, but for now are limited primarily to PCL functions that filter or
-segment the point cloud, returning a list of indices of the filtered points
-(e.g., ground or object, noise or signal). The main reason for this design
-decision is that we want to avoid converting all ``PointView`` dimensions to the
-PCL ``PointCloud``. In the case of an LAS reader, we may very well not want to
-operate on fields such as return number, but we do not want to lose this
-information post PCL filtering. The easy solution is to simply retain the index
-between the ``PointView`` and ``PointCloud`` objects and update as necessary.
+operations that may change the point type (e.g., ``PointXYZ`` to
+``PointNormal``) or alter points.  We will continue to look into use cases that
+are of value and feasible, but for now are limited primarily to PCL functions
+that filter or segment the point cloud, returning a list of indices of the
+filtered points (e.g., ground or object, noise or signal). The main reason for
+this design decision is that we want to avoid converting all ``PointView``
+dimensions to the PCL ``PointCloud``. In the case of an LAS reader, we may very
+well not want to operate on fields such as return number, but we do not want to
+lose this information post PCL filtering. The easy solution is to simply retain
+the index between the ``PointView`` and ``PointCloud`` objects and update as
+necessary.
 
 .. seealso::
 
@@ -43,7 +44,10 @@ Options
 -------------------------------------------------------------------------------
 
 filename
-  JSON file to read [Required]
+  Path to external PCL JSON file describing the pipeline
+  
+methods
+  Raw PCL JSON array describing the pipeline
 
 
 
@@ -55,30 +59,21 @@ PCL. Here is an example:
 
 .. code-block:: json
 
-    {
-        "pipeline":
+    [
         {
-            "name": "PCL-Block-Name",
-            "help": "This is an example pipeline with two filters.",
-            "author": "mpg",
-            "filters":
-            [
-                {
-                    "name": "FilterOne",
-                    "setFooParameter": "value"
-                },
-                {
-                    "name": "FilterTwo",
-                    "setBarParameter": false,
-                    "setBounds":
-                    {
-                        "upper": 42,
-                        "lower": 17
-                    }
-                }
-            ]
+            "name": "FilterOne",
+            "setFooParameter": "value"
+        },
+        {
+            "name": "FilterTwo",
+            "setBarParameter": false,
+            "setBounds":
+            {
+                "upper": 42,
+                "lower": 17
+            }
         }
-    }
+    ]
 
 
 
@@ -98,14 +93,8 @@ ApproximateProgressiveMorphologicalFilter
     faster (and potentially less accurate) version of the
     **ProgressiveMorphologicalFilter**
 
-ConditionalRemoval
-    filters the data to remove normals outside of a given Z range
-
 GridMinimum
     assembles a local 2D grid over a given PointCloud, then downsamples the data
-
-NormalEstimation
-    computes the surfaces normals of the points in the input
 
 PassThrough
     allows the user to set min/max bounds on one dimension of the data

--- a/doc/tutorial/pcl_block_tutorial.rst
+++ b/doc/tutorial/pcl_block_tutorial.rst
@@ -180,24 +180,17 @@ returning only those points with z values in the range 100 to 200.
 
 .. code-block:: json
 
-    {
-        "pipeline":
+    [
         {
-            "name": "PassThroughExample",
-            "filters":
-            [
-                {
-                    "name": "PassThrough",
-                    "setFilterFieldName": "z",
-                    "setFilterLimits":
-                    {
-                        "min": 410.0,
-                        "max": 440.0
-                    }
-                }
-            ]
+            "name": "PassThrough",
+            "setFilterFieldName": "z",
+            "setFilterLimits":
+            {
+                "min": 410.0,
+                "max": 440.0
+            }
         }
-    }
+    ]
 
 (This example is taken from the unit test
 `PCLBlockFilterTest_example_PassThrough_1`.)
@@ -216,34 +209,24 @@ their public member functions by name.
 
 .. code-block:: json
 
-    {
-        "pipeline":
+    [
         {
-            "name": "CombinedExample",
-            "help": "Apply passthrough filter followed by statistical outlier removal",
-            "version": 1.0,
-            "author": "Bradley J Chambers",
-            "filters":
-            [
-                {
-                    "name": "PassThrough",
-                    "help": "filter z values to the range [410,440]",
-                    "setFilterFieldName": "z",
-                    "setFilterLimits":
-                    {
-                        "min": 410.0,
-                        "max": 440.0
-                    }
-                },
-                {
-                    "name": "StatisticalOutlierRemoval",
-                    "help": "apply outlier removal",
-                    "setMeanK": 8,
-                    "setStddevMulThresh": 0.2
-                }
-            ]
+            "name": "PassThrough",
+            "help": "filter z values to the range [410,440]",
+            "setFilterFieldName": "z",
+            "setFilterLimits":
+            {
+                "min": 410.0,
+                "max": 440.0
+            }
+        },
+        {
+            "name": "StatisticalOutlierRemoval",
+            "help": "apply outlier removal",
+            "setMeanK": 8,
+            "setStddevMulThresh": 0.2
         }
-    }
+    ]
 
 (This example is taken from the unit test
 `PCLBlockFilterTest_example_PassThrough_2`.)
@@ -265,42 +248,28 @@ To run the PMF with default settings, the PCL Block JSON is simply:
 
 .. code-block:: json
 
-    {
-        "pipeline":
+    [
         {
-            "name": "ProgressiveMorphologicalFilterExample",
-            "filters":
-            [
-                {
-                    "name": "ProgressiveMorphologicalFilter"
-                    "setMaxWindowSize": 200,
-                }
-            ]
+            "name": "ProgressiveMorphologicalFilter"
+            "setMaxWindowSize": 200,
         }
-    }
+    ]
 
 Additional parameters can be set by advanced users:
 
 .. code-block:: json
 
-    {
-        "pipeline":
+    [
         {
-            "name": "ProgressiveMorphologicalFilterAdvancedExample",
-            "filters":
-            [
-                {
-                    "name": "ProgressiveMorphologicalFilter",
-                    "setCellSize": 1.0,
-                    "setMaxWindowSize": 200,
-                    "setSlope": 1.0,
-                    "setInitialDistance": 0.5,
-                    "setMaxDistance": 3.0,
-                    "setExponential": true
-                }
-            ]
+            "name": "ProgressiveMorphologicalFilter",
+            "setCellSize": 1.0,
+            "setMaxWindowSize": 200,
+            "setSlope": 1.0,
+            "setInitialDistance": 0.5,
+            "setMaxDistance": 3.0,
+            "setExponential": true
         }
-    }
+    ]
 
 (These examples are taken from the unit tests
 `PCLBlockFilterTest_example_PMF_1` and `PCLBlockFilterTest_example_PMF_2`.)

--- a/doc/tutorial/pcl_spec.rst
+++ b/doc/tutorial/pcl_spec.rst
@@ -5,9 +5,9 @@ Draft PCL JSON Specification
 ============================
 
 :Author: Bradley J. Chambers (RadiantBlue Technologies, Inc.)
-:Revision: 0.1
-:Date: 28 February 2014
-:Copyright: Copyright (c) 2014, RadiantBlue Technologies, Inc. This work is licensed under a Creative Commons Attribution 3.0 United States License.
+:Revision: 0.2
+:Date: 13 December 2016
+:Copyright: Copyright (c) 2014-2016, RadiantBlue Technologies, Inc. This work is licensed under a Creative Commons Attribution 3.0 United States License.
 
 The PCL JSON specification is a point cloud processing pipeline interchange
 format based on JavaScript Object Notation (JSON), drawing inspiration from
@@ -24,14 +24,14 @@ both GeoJSON and TopoJSON.
 Introduction
 ============
 
-A PCL JSON object represents a processing pipeline.
+A PCL JSON array represents a processing pipeline.
 
-A complete PCL JSON data structure is always an object (in JSON terms). In PCL
-JSON, an object consists of a collection of name/value pairs -- also called
-members. For each member, the name is always a string. Member values are either
-a string, number, object, array or one of the literals: "true", "false", and
-"null". An array consists of elements where each element is a value as
-described above.
+A complete PCL JSON data structure is always an array of objects (in JSON
+terms). In PCL JSON, an object consists of a collection of name/value pairs --
+also called members. For each member, the name is always a string. Member values
+are either a string, number, object, array or one of the literals: "true",
+"false", and "null". An array consists of elements where each element is a value
+as described above.
 
 
 
@@ -42,56 +42,62 @@ A very simple PCL JSON pipeline:
 
 .. code-block:: json
 
-    {
-        "pipeline":
+    [
         {
-            "name": "My cool pipeline",
-            "filters":
-            [
-                {
-                    "name": "VoxelGrid",
-                    "setLeafSize":
-                    {
-                        "x": 1.0,
-                        "y": 1.0,
-                        "z": 1.0
-                    }
-                }
-            ]
+            "name": "VoxelGrid",
+            "setLeafSize":
+            {
+                "x": 1.0,
+                "y": 1.0,
+                "z": 1.0
+            }
         }
-    }
+    ]
 
 A more complex pipeline, containing two filters:
 
 .. code-block:: json
 
-    {
-        "pipeline":
+    [
         {
-            "name": "CombinedExample",
-            "help": "Apply passthrough filter followed by statistical outlier removal",
-            "version": 1.0,
-            "author": "Bradley J Chambers",
-            "filters":
-            [
-                {
-                    "name": "PassThrough",
-                    "help": "filter z values to the range [410,440]",
-                    "setFilterFieldName": "z",
-                    "setFilterLimits":
-                    {
-                        "min": 410.0,
-                        "max": 440.0
-                    }
-                },
-                {
-                    "name": "StatisticalOutlierRemoval",
-                    "help": "apply outlier removal",
-                    "setMeanK": 8,
-                    "setStddevMulThresh": 0.2
-                }
-            ]
+            "name": "PassThrough",
+            "setFilterFieldName": "z",
+            "setFilterLimits":
+            {
+                "min": 410.0,
+                "max": 440.0
+            }
+        },
+        {
+            "name": "StatisticalOutlierRemoval",
+            "setMeanK": 8,
+            "setStddevMulThresh": 0.2
         }
+    ]
+    
+A PCL pipeline is embedded within a PDAL pipeline as the "methods" option to :ref:`filters.pclblock` as shown below:
+
+.. code-block:: json
+
+    {
+        "pipeline": [
+            "input.las",
+            {
+                "type": "filters.pclblock",
+                "methods": [
+                    {
+                        "name": "VoxelGrid",
+                        "setLeafSize":
+                        {
+                            "x": 1.0,
+                            "y": 1.0,
+                            "z": 1.0
+                        }
+                    }
+                ]
+            },
+            "output.las"
+        ]
     }
 
 
@@ -114,34 +120,20 @@ Definitions
 PCL JSON Objects
 ================
 
-PCL JSON always consists of a single object. This object (referred to as the
-PCL JSON object below) represents a processing pipeline.
+PCL JSON always consists of a single array of PCL JSON objects. This array
+(referred to as the PCL JSON array below) represents a processing pipeline.
 
-* The PCL JSON object may have any number of members (name/value pairs).
+* The PCL JSON array may have any number of PCL JSON objects.
 
-* The PCL JSON object must have a "pipeline" object.
+* A PCL JSON object shall have a "name" member that identifies a supported PCL
+  filter (as documented below).
 
-
-
-Pipeline Objects
-----------------
-
-* A pipeline may have a member with the name "name" whose value is a string.
-
-* A pipeline may have a member with the name "help" whose value is a string.
-
-* A pipeline may have a member with the name "version" whose value is a number.
-
-* A pipeline must have a member with the name "filters" whose value is an array
-  of filters.
+* A PCL JSON object may have any number of members (name/value pairs).
 
 
 
 Filters
 .......
-
-A pipeline must have a "filters" member whose value is an array of zero or more
-filters.
 
 A filter is any of the PCL filters that has been exposed through the PCL
 pipeline class.
@@ -171,25 +163,19 @@ Example:
 
 .. code-block:: json
 
-    {
-        "pipeline":
+    [
         {
-            "filters":
-            [
-                {
-                    "name": "ApproximateProgressiveMorphologicalFilter",
-                    "setMaxWindowSize": 65,
-                    "setSlope": 0.7,
-                    "setMaxDistance": 10,
-                    "setInitialDistance": 0.3,
-                    "setCellSize": 1,
-                    "setBase": 2,
-                    "setExponential": false,
-                    "setNegative": false
-                }
-            ]
+            "name": "ApproximateProgressiveMorphologicalFilter",
+            "setMaxWindowSize": 65,
+            "setSlope": 0.7,
+            "setMaxDistance": 10,
+            "setInitialDistance": 0.3,
+            "setCellSize": 1,
+            "setBase": 2,
+            "setExponential": false,
+            "setNegative": false
         }
-    }
+    ]
 
 **Parameters**
 
@@ -225,47 +211,6 @@ setNegative: bool
 
 
 
-ConditionalRemoval
-``````````````````
-
-.. seealso::
-
-    :ref:`filters.range` implements support for this PCL operation as a
-    PDAL filter
-
-This filter removes normals outside of a given Z range.
-
-PCL details: http://docs.pointclouds.org/trunk/classpcl_1_1_conditional_removal.html
-
-Example:
-
-.. code-block:: json
-
-    {
-        "pipeline":
-        {
-            "filters":
-            [
-                {
-                    "name": "ConditionalRemoval",
-                    "normalZ":
-                    {
-                        "min": 0,
-                        "max": 0.95
-                    }
-                }
-            ]
-        }
-    }
-
-**Parameters**
-
-normalZ: object `{"min": float, "max": float}`
-  Set the numerical limits for filtering points based on the z component of
-  their normal. [default: `{"min": 0.0, "max": FLT_MAX}`]
-
-
-
 GridMinimum
 ```````````
 
@@ -278,62 +223,17 @@ Example:
 
 .. code-block:: json
 
-    {
-        "pipeline":
+    [
         {
-            "filters":
-            [
-                {
-                    "name": "GridMinimum",
-                    "setResolution": 2.0
-                }
-            ]
+            "name": "GridMinimum",
+            "setResolution": 2.0
         }
-    }
+    ]
 
 **Parameters**
 
 setResolution: float
   Set the grid resolution. [default: 1.0]
-
-
-
-NormalEstimation
-````````````````
-
-
-**Description**
-
-This filter computes the surfaces normals of the points in the input.
-
-PCL details: http://docs.pointclouds.org/1.7.1/classpcl_1_1_normal_estimation.html
-
-Example:
-
-.. code-block:: json
-
-    {
-        "pipeline":
-        {
-            "filters":
-            [
-                {
-                    "name": "NormalEstimation",
-                    "setRadiusSearch": 2
-                }
-            ]
-        }
-    }
-
-**Parameters**
-
-setKSearch: float
-    Set the number of k nearest neighbors to use for the feature estimation.
-    [default: 0.0]
-
-setRadiusSearch: float
-    Set the sphere radius that is to be used for determining the nearest
-    neighbors used for the feature estimation. [default: 1.0]
 
 
 
@@ -350,23 +250,17 @@ Example:
 
 .. code-block:: json
 
-    {
-        "pipeline":
+    [
         {
-            "filters":
-            [
-                {
-                    "name": "PassThrough",
-                    "setFilterFieldName": "z",
-                    "setFilterLimits":
-                    {
-                        "min": 3850100,
-                        "max": 3850200
-                    }
-                }
-            ]
+            "name": "PassThrough",
+            "setFilterFieldName": "z",
+            "setFilterLimits":
+            {
+                "min": 3850100,
+                "max": 3850200
+            }
         }
-    }
+    ]
 
 **Parameters**
 
@@ -408,25 +302,19 @@ Example:
 
 .. code-block:: json
 
-    {
-        "pipeline":
+    [
         {
-            "filters":
-            [
-                {
-                    "name": "ProgressiveMorphologicalFilter",
-                    "setMaxWindowSize": 65,
-                    "setSlope": 0.7,
-                    "setMaxDistance": 10,
-                    "setInitialDistance": 0.3,
-                    "setCellSize": 1,
-                    "setBase": 2,
-                    "setExponential": false,
-                    "setNegative": true
-                }
-            ]
+            "name": "ProgressiveMorphologicalFilter",
+            "setMaxWindowSize": 65,
+            "setSlope": 0.7,
+            "setMaxDistance": 10,
+            "setInitialDistance": 0.3,
+            "setCellSize": 1,
+            "setBase": 2,
+            "setExponential": false,
+            "setNegative": true
         }
-    }
+    ]
 
 **Parameters**
 
@@ -482,19 +370,13 @@ Example:
 
 .. code-block:: json
 
-    {
-        "pipeline":
+    [
         {
-            "filters":
-            [
-                {
-                    "name": "RadiusOutlierRemoval",
-                    "setMinNeighborsInRadius": 8,
-                    "setRadiusSearch": 1.0
-                }
-            ]
+            "name": "RadiusOutlierRemoval",
+            "setMinNeighborsInRadius": 8,
+            "setRadiusSearch": 1.0
         }
-    }
+    ]
 
 **Parameters**
 
@@ -526,19 +408,13 @@ Example:
 
 .. code-block:: json
 
-    {
-        "pipeline":
+    [
         {
-            "filters":
-            [
-                {
-                    "name": "StatisticalOutlierRemoval",
-                    "setMeanK": 8,
-                    "setStddevMulThresh": 1.17
-                }
-            ]
+            "name": "StatisticalOutlierRemoval",
+            "setMeanK": 8,
+            "setStddevMulThresh": 1.17
         }
-    }
+    ]
 
 **Parameters**
 
@@ -570,23 +446,17 @@ Example:
 
 .. code-block:: json
 
-    {
-        "pipeline":
+    [
         {
-            "filters":
-            [
-                {
-                    "name": "VoxelGrid",
-                    "setLeafSize":
-                    {
-                        "x": 1.0,
-                        "y": 1.0,
-                        "z": 1.0
-                    }
-                }
-            ]
+            "name": "VoxelGrid",
+            "setLeafSize":
+            {
+                "x": 1.0,
+                "y": 1.0,
+                "z": 1.0
+            }
         }
-    }
+    ]
 
 **Parameters**
 

--- a/plugins/pcl/CMakeLists.txt
+++ b/plugins/pcl/CMakeLists.txt
@@ -75,9 +75,15 @@ PDAL_ADD_PLUGIN(pclblock_libname filter pclblock
     FILES
         pipeline/PCLPipeline.cpp
         filters/PCLBlock.cpp
-    LINK_WITH ${PCL_LIBRARIES})
-target_include_directories(${pclblock_libname} PRIVATE
-    ${INCLUDE_DIRS})
+    LINK_WITH
+        ${PCL_LIBRARIES}
+        ${PDAL_JSONCPP_LIB_NAME}
+)
+target_include_directories(${pclblock_libname}
+    PRIVATE
+      ${INCLUDE_DIRS}
+      ${PDAL_JSONCPP_INCLUDE_DIR}
+)
 
 PDAL_ADD_PLUGIN(voxelgrid_filter_libname filter voxelgrid
     FILES

--- a/plugins/pcl/filters/PCLBlock.hpp
+++ b/plugins/pcl/filters/PCLBlock.hpp
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (c) 2013, Bradley J Chambers (brad.chambers@gmail.com)
+* Copyright (c) 2013-2016, Bradley J Chambers (brad.chambers@gmail.com)
 *
 * All rights reserved.
 *
@@ -35,10 +35,14 @@
 #pragma once
 
 #include <pdal/Filter.hpp>
-#include <pdal/StageFactory.hpp>
+
+#include <string>
 
 namespace pdal
 {
+  
+class PointView;
+class ProgramArgs;
 
 class PDAL_DLL PCLBlock : public Filter
 {
@@ -52,7 +56,7 @@ public:
 
 private:
     std::string m_filename;
-    std::string m_json;
+    std::string m_methods;
 
     virtual void addArgs(ProgramArgs& args);
     virtual PointViewSet run(PointViewPtr view);
@@ -62,4 +66,3 @@ private:
 };
 
 } // namespace pdal
-

--- a/plugins/pcl/pipeline/PCLPipeline.hpp
+++ b/plugins/pcl/pipeline/PCLPipeline.hpp
@@ -4,7 +4,7 @@
  *  Point Cloud Library (PCL) - www.pointclouds.org
  *  Copyright (c) 2009-2012, Willow Garage, Inc.
  *  Copyright (c) 2012-, Open Perception, Inc.
- *  Copyright (c) 2014, RadiantBlue Technologies, Inc.
+ *  Copyright (c) 2014-2016, RadiantBlue Technologies, Inc.
  *
  *  All rights reserved.
  *
@@ -43,11 +43,6 @@
 
 #include <exception>
 
-#include <boost/algorithm/string.hpp>
-#include <boost/property_tree/ptree.hpp>
-#include <boost/property_tree/json_parser.hpp>
-#include <boost/foreach.hpp>
-
 #include <pcl/for_each_type.h>
 #include <pcl/point_traits.h>
 #include <pcl/common/common.h>
@@ -66,201 +61,56 @@
 
 #include "PCLPipeline.h"
 
+#include <pdal/util/Utils.hpp>
 
-namespace pdal
-{
-namespace pclsupport
-{
+#include <json/json.h>
 
-
-struct tile_point_idx
-{
-    unsigned int tile_idx;
-    unsigned int point_idx;
-
-    tile_point_idx(unsigned int tile_idx_, unsigned int point_idx_) : tile_idx(tile_idx_), point_idx(point_idx_) {}
-    bool operator < (const tile_point_idx &p) const
-    {
-        return (tile_idx < p.tile_idx);
-    }
-};
-
-
-} // namespace pclsupport
-} // namespace pdal
+using namespace pdal;
 
 
 template <typename PointT> void
-pcl::Pipeline<PointT>::dumper(PointCloud &cloud)
-{
-    for (size_t i = 0; i < cloud.points.size(); ++i)
-    {
-        if (pcl::traits::has_xyz<PointT>::value)
-        {
-            std::cout << cloud.points[i].x << " "
-                      << cloud.points[i].y << " "
-                      << cloud.points[i].z << " ";
-        }
-        //if (pcl::traits::has_normal<PointT>::value)
-        //{
-        //    std::cout << cloud.points[i].normal[0] << " "
-        //              << cloud.points[i].normal[1] << " "
-        //              << cloud.points[i].normal[2] << " ";
-        //}
-        std::cout << std::endl;
-    }
-}
-
-
-template <typename PointT> void
-pcl::Pipeline<PointT>::generateTileIndices(PointCloudConstPtr cloud, const float& resolution, std::vector<PointIndices> &tile_indices)
-{
-    Eigen::Vector4f leaf_size;
-    Eigen::Array4f inverse_leaf_size;
-    Eigen::Vector4i min_b, max_b, div_b, divb_mul;
-
-    leaf_size[0] = resolution;
-    leaf_size[1] = resolution;
-    leaf_size[2] = resolution;
-    leaf_size[3] = resolution;
-
-    inverse_leaf_size = Eigen::Array4f::Ones() / leaf_size.array();
-
-    PCL_DEBUG("experimental, tiling with leaf size %f\n", resolution);
-
-    Eigen::Vector4f min_p, max_p;
-    // Get the minimum and maximum dimensions
-    pcl::getMinMax3D<PointT> (*cloud, *indices_, min_p, max_p);
-
-    // Check that the leaf size is not too small, given the size of the data
-    int64_t dx = static_cast<int64_t>((max_p[0] - min_p[0]) * inverse_leaf_size[0])+1;
-    int64_t dy = static_cast<int64_t>((max_p[1] - min_p[1]) * inverse_leaf_size[1])+1;
-
-    if ((dx*dy) > static_cast<int64_t>(std::numeric_limits<int32_t>::max()))
-    {
-        PCL_WARN("[pcl::%s::applyFilter] Leaf size is too small for the input dataset. Integer indices would overflow.", getClassName().c_str());
-        // is this really relevant anymore? don't think so, but maybe something like it
-        //output = *input_;
-        return;
-    }
-
-    // Compute the minimum and maximum bounding box values
-    min_b[0] = static_cast<int>(floor(min_p[0] * inverse_leaf_size[0]));
-    max_b[0] = static_cast<int>(floor(max_p[0] * inverse_leaf_size[0]));
-    min_b[1] = static_cast<int>(floor(min_p[1] * inverse_leaf_size[1]));
-    max_b[1] = static_cast<int>(floor(max_p[1] * inverse_leaf_size[1]));
-
-    // Compute the number of divisions needed along all axis
-    div_b = max_b - min_b + Eigen::Vector4i::Ones();
-    div_b[3] = 0;
-
-    PCL_DEBUG("%d and %d divisions in x and y\n", div_b[0], div_b[1]);
-
-    // Set up the division multiplier
-    divb_mul = Eigen::Vector4i(1, div_b[0], div_b[0] * div_b[1], 0);
-
-    std::vector<pdal::pclsupport::tile_point_idx> index_vector;
-    index_vector.reserve(indices_->size());
-
-    // First pass: go over all points and insert them into the index_vector vector
-    // with calculated idx. Points with the same idx value will contribute to the
-    // same point of resulting CloudPoint
-    for (std::vector<int>::const_iterator it = indices_->begin(); it != indices_->end(); ++it)
-    {
-        if (!input_->is_dense)
-            // Check if the point is invalid
-            if (!pcl_isfinite(input_->points[*it].x) ||
-                    !pcl_isfinite(input_->points[*it].y) ||
-                    !pcl_isfinite(input_->points[*it].z))
-                continue;
-
-        int ijk0 = static_cast<int>(floor(input_->points[*it].x * inverse_leaf_size[0]) - static_cast<float>(min_b[0]));
-        int ijk1 = static_cast<int>(floor(input_->points[*it].y * inverse_leaf_size[1]) - static_cast<float>(min_b[1]));
-
-        // Compute the centroid leaf index
-        int idx = ijk0 * divb_mul[0] + ijk1 * divb_mul[1];
-        index_vector.push_back(pdal::pclsupport::tile_point_idx(static_cast<unsigned int>(idx), *it));
-    }
-
-    // Second pass: sort the index_vector vector using value representing target cell as index
-    // in effect all points belonging to the same output cell will be next to each other
-    std::sort(index_vector.begin(), index_vector.end(), std::less<pdal::pclsupport::tile_point_idx> ());
-
-    // Third pass: count output cells
-    // we need to skip all the same, adjacenent idx values
-    unsigned int index = 0;
-    // first_and_last_indices_vector[i] represents the index in index_vector of the first point in
-    // index_vector belonging to the voxel which corresponds to the i-th output point,
-    // and of the first point not belonging to.
-    std::vector<std::pair<unsigned int, unsigned int> > first_and_last_indices_vector;
-    // Worst case size
-    first_and_last_indices_vector.reserve(index_vector.size());
-    while (index < index_vector.size())
-    {
-        unsigned int i = index + 1;
-        while (i < index_vector.size() && index_vector[i].tile_idx == index_vector[index].tile_idx)
-            ++i;
-        first_and_last_indices_vector.push_back(std::pair<unsigned int, unsigned int> (index, i));
-        index = i;
-    }
-
-    tile_indices.resize(first_and_last_indices_vector.size());
-
-    for (unsigned int cp = 0; cp < first_and_last_indices_vector.size(); ++cp)
-    {
-        // calculate centroid - sum values from all input points, that have the same idx value in index_vector array
-        unsigned int first_index = first_and_last_indices_vector[cp].first;
-        unsigned int last_index = first_and_last_indices_vector[cp].second;
-
-        tile_indices[cp].indices.resize(last_index - first_index);
-
-        PCL_DEBUG("tile %d will have %d points\n", cp, last_index - first_index);
-
-        index = 0;
-
-        for (unsigned int i = first_index + 1; i < last_index; ++i)
-        {
-            tile_indices[cp].indices[index] = index_vector[i].point_idx;
-            ++index;
-        }
-    }
-
-    return;
-}
-
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointT> void
-pcl::Pipeline<PointT>::applyPassThrough(PointCloudConstPtr cloud, PointCloud &output, boost::property_tree::ptree::value_type &vt)
+pcl::Pipeline<PointT>::applyPassThrough(PointCloudConstPtr cloud,
+    PointCloud &output, Json::Value const& vt)
 {
     // initial setup
     pcl::PassThrough<PointT> pass;
     pass.setInputCloud(cloud);
 
     // parse params
-    std::string field = vt.second.get<std::string> ("setFilterFieldName");
-    float m1 = vt.second.get<float> ("setFilterLimits.min", -std::numeric_limits<float>::max());
-    float m2 = vt.second.get<float> ("setFilterLimits.max", std::numeric_limits<float>::max());
+    std::string field = vt["setFilterFieldName"].asString();
+    float m1 = vt["setFilterLimits"]
+        .get("min", -std::numeric_limits<float>::max())
+        .asFloat();
+    float m2 = vt["setFilterLimits"]
+        .get("max", std::numeric_limits<float>::max())
+        .asFloat();
 
     // summarize settings
-    PCL_DEBUG("      Field name: %s\n", field.c_str());
-    PCL_DEBUG("      Limits: %f, %f\n", m1, m2);
+    PCL_DEBUG("\tField name: %s\n", field.c_str());
+    PCL_DEBUG("\tLimits: %f, %f\n", m1, m2);
 
     if (field.compare("x") == 0)
     {
-        if (m1 != -std::numeric_limits<float>::max()) m1 -= x_offset_;
-        if (m2 != std::numeric_limits<float>::max()) m2 -= x_offset_;
+        if (m1 != -std::numeric_limits<float>::max())
+            m1 -= x_offset_;
+        if (m2 != std::numeric_limits<float>::max())
+            m2 -= x_offset_;
     }
 
     if (field.compare("y") == 0)
     {
-        if (m1 != -std::numeric_limits<float>::max()) m1 -= y_offset_;
-        if (m2 != std::numeric_limits<float>::max()) m2 -= y_offset_;
+        if (m1 != -std::numeric_limits<float>::max())
+            m1 -= y_offset_;
+        if (m2 != std::numeric_limits<float>::max())
+            m2 -= y_offset_;
     }
 
     if (field.compare("z") == 0)
     {
-        if (m1 != -std::numeric_limits<float>::max()) m1 -= z_offset_;
-        if (m2 != std::numeric_limits<float>::max()) m2 -= z_offset_;
+        if (m1 != -std::numeric_limits<float>::max())
+            m1 -= z_offset_;
+        if (m2 != std::numeric_limits<float>::max())
+            m2 -= z_offset_;
     }
 
     // set params and apply filter
@@ -268,76 +118,79 @@ pcl::Pipeline<PointT>::applyPassThrough(PointCloudConstPtr cloud, PointCloud &ou
     pass.setFilterLimits(m1, m2);
     pass.filter(output);
 
-    PCL_DEBUG("%d filtered to %d in passthrough\n", cloud->points.size(), output.points.size());
+    PCL_DEBUG("\t%d filtered to %d in passthrough\n", cloud->points.size(),
+        output.points.size());
 
     return;
 }
 
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT> void
-pcl::Pipeline<PointT>::applyStatisticalOutlierRemoval(PointCloudConstPtr cloud, PointCloud &output, boost::property_tree::ptree::value_type &vt)
+pcl::Pipeline<PointT>::applyStatisticalOutlierRemoval(PointCloudConstPtr cloud,
+    PointCloud &output, Json::Value const& vt)
 {
     // initial setup
     pcl::StatisticalOutlierRemoval<PointT> sor;
     sor.setInputCloud(cloud);
 
     // parse params
-    int nr_k = vt.second.get<int> ("setMeanK", 2);
-    double stddev_mult = vt.second.get<double> ("setStddevMulThresh", 0.0);
+    int nr_k = vt.get("setMeanK", 2).asInt();
+    double stddev_mult = vt.get("setStddevMulThresh", 0.0).asDouble();
 
     // summarize settings
-    PCL_DEBUG("      %d neighbors and %f multiplier\n", nr_k, stddev_mult);
+    PCL_DEBUG("\t%d neighbors and %f multiplier\n", nr_k, stddev_mult);
 
     // set params and apply filter
     sor.setMeanK(nr_k);
     sor.setStddevMulThresh(stddev_mult);
     sor.filter(output);
 
-    PCL_DEBUG("      %d points filtered to %d following outlier removal\n", cloud->points.size(), output.points.size());
+    PCL_DEBUG("\t%d points filtered to %d following outlier removal\n",
+        cloud->points.size(), output.points.size());
 
     return;
 }
 
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT> void
-pcl::Pipeline<PointT>::applyRadiusOutlierRemoval(PointCloudConstPtr cloud, PointCloud &output, boost::property_tree::ptree::value_type &vt)
+pcl::Pipeline<PointT>::applyRadiusOutlierRemoval(PointCloudConstPtr cloud,
+    PointCloud &output, Json::Value const& vt)
 {
     // initial setup
     pcl::RadiusOutlierRemoval<PointT> ror;
     ror.setInputCloud(cloud);
 
     // parse params
-    int min_neighbors = vt.second.get<int> ("setMinNeighborsInRadius", 2);
-    double radius = vt.second.get<double> ("setRadiusSearch", 1.0);
+    int min_neighbors = vt.get("setMinNeighborsInRadius", 2).asInt();
+    double radius = vt.get("setRadiusSearch", 1.0).asDouble();
 
     // summarize settings
-    PCL_DEBUG("      %d neighbors and %f radius\n", min_neighbors, radius);
+    PCL_DEBUG("\t%d neighbors and %f radius\n", min_neighbors, radius);
 
     // set params and apply filter
     ror.setMinNeighborsInRadius(min_neighbors);
     ror.setRadiusSearch(radius);
     ror.filter(output);
 
-    PCL_DEBUG("      %d points filtered to %d following outlier removal\n", cloud->points.size(), output.points.size());
+    PCL_DEBUG("\t%d points filtered to %d following outlier removal\n",
+        cloud->points.size(), output.points.size());
 
     return;
 }
 
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT> void
-pcl::Pipeline<PointT>::applyVoxelGrid(PointCloudConstPtr cloud, PointCloud &output, boost::property_tree::ptree::value_type &vt)
+pcl::Pipeline<PointT>::applyVoxelGrid(PointCloudConstPtr cloud,
+    PointCloud &output, Json::Value const& vt)
 {
     // initial setup
     pcl::VoxelGrid<PointT> vg;
     vg.setInputCloud(cloud);
 
     // parse params
-    float x = vt.second.get<float> ("setLeafSize.x", 1.0);
-    float y = vt.second.get<float> ("setLeafSize.y", 1.0);
-    float z = vt.second.get<float> ("setLeafSize.z", 1.0);
+    float x = vt["setLeafSize"].get("x", 1.0).asFloat();
+    float y = vt["setLeafSize"].get("y", 1.0).asFloat();
+    float z = vt["setLeafSize"].get("z", 1.0).asFloat();
 
     // summarize settings
-    PCL_DEBUG("      leaf size: %f, %f, %f\n", x, y, z);
+    PCL_DEBUG("\tleaf size: %f, %f, %f\n", x, y, z);
 
     // set params and apply filter
     vg.setLeafSize(x, y, z);
@@ -346,15 +199,15 @@ pcl::Pipeline<PointT>::applyVoxelGrid(PointCloudConstPtr cloud, PointCloud &outp
     return;
 }
 
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT> void
-pcl::Pipeline<PointT>::applyGridMinimum(PointCloudConstPtr cloud, PointCloud &output, boost::property_tree::ptree::value_type &vt)
+pcl::Pipeline<PointT>::applyGridMinimum(PointCloudConstPtr cloud,
+    PointCloud &output, Json::Value const& vt)
 {
     // parse params
-    float r = vt.second.get<float> ("setResolution", 1.0);
+    float r = vt.get("setResolution", 1.0).asFloat();
 
     // summarize settings
-    PCL_DEBUG("      resolution: %f\n", r);
+    PCL_DEBUG("\tresolution: %f\n", r);
 
     // initial setup
     pcl::GridMinimum<PointT> vgm(r);
@@ -366,31 +219,31 @@ pcl::Pipeline<PointT>::applyGridMinimum(PointCloudConstPtr cloud, PointCloud &ou
     return;
 }
 
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT> void
-pcl::Pipeline<PointT>::applyApproximateProgressiveMorphologicalFilter(PointCloudConstPtr cloud, PointCloud &output, boost::property_tree::ptree::value_type &vt)
+pcl::Pipeline<PointT>::applyApproximateProgressiveMorphologicalFilter(
+    PointCloudConstPtr cloud, PointCloud &output, Json::Value const& vt)
 {
     pcl::ApproximateProgressiveMorphologicalFilter<PointT> pmf;
 
     // parse params
-    int w = vt.second.get<int> ("setMaxWindowSize", 33);
-    float s = vt.second.get<float> ("setSlope", 1.0);
-    float md = vt.second.get<float> ("setMaxDistance", 2.5);
-    float id = vt.second.get<float> ("setInitialDistance", 0.15);
-    float c = vt.second.get<float> ("setCellSize", 1.0);
-    float b = vt.second.get<float> ("setBase", 2.0);
-    bool e = vt.second.get<bool> ("setExponential", true);
-    bool n = vt.second.get<bool> ("setNegative", false);
+    int w = vt.get("setMaxWindowSize", 33).asInt();
+    float s = vt.get("setSlope", 1.0).asFloat();
+    float md = vt.get("setMaxDistance", 2.5).asFloat();
+    float id = vt.get("setInitialDistance", 0.15).asFloat();
+    float c = vt.get("setCellSize", 1.0).asFloat();
+    float b = vt.get("setBase", 2.0).asFloat();
+    bool e = vt.get("setExponential", true).asBool();
+    bool n = vt.get("setNegative", false).asBool();
 
     // summarize settings
-    PCL_DEBUG("      max window size: %d\n", w);
-    PCL_DEBUG("      slope: %f\n", s);
-    PCL_DEBUG("      max distance: %f\n", md);
-    PCL_DEBUG("      initial distance: %f\n", id);
-    PCL_DEBUG("      cell size: %f\n", c);
-    PCL_DEBUG("      base: %f\n", b);
-    PCL_DEBUG("      exponential: %s\n", e?"true":"false");
-    PCL_DEBUG("      negative: %s\n", n?"true":"false");
+    PCL_DEBUG("\tmax window size: %d\n", w);
+    PCL_DEBUG("\tslope: %f\n", s);
+    PCL_DEBUG("\tmax distance: %f\n", md);
+    PCL_DEBUG("\tinitial distance: %f\n", id);
+    PCL_DEBUG("\tcell size: %f\n", c);
+    PCL_DEBUG("\tbase: %f\n", b);
+    PCL_DEBUG("\texponential: %s\n", e?"true":"false");
+    PCL_DEBUG("\tnegative: %s\n", n?"true":"false");
 
     pmf.setInputCloud(cloud);
     pmf.setMaxWindowSize(w);
@@ -410,36 +263,37 @@ pcl::Pipeline<PointT>::applyApproximateProgressiveMorphologicalFilter(PointCloud
     extract.setNegative(n);
     extract.filter(output);
 
-    PCL_DEBUG("      %d points filtered to %d following approximate progressive morphological filter\n", cloud->points.size(), output.points.size());
+    PCL_DEBUG("\t%d points filtered to %d following approximate PMF\n",
+        cloud->points.size(), output.points.size());
 
     return;
 }
 
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT> void
-pcl::Pipeline<PointT>::applyProgressiveMorphologicalFilter(PointCloudConstPtr cloud, PointCloud &output, boost::property_tree::ptree::value_type &vt)
+pcl::Pipeline<PointT>::applyProgressiveMorphologicalFilter(
+    PointCloudConstPtr cloud, PointCloud &output, Json::Value const& vt)
 {
     pcl::ProgressiveMorphologicalFilter<PointT> pmf;
 
     // parse params
-    int w = vt.second.get<int> ("setMaxWindowSize", 33);
-    float s = vt.second.get<float> ("setSlope", 1.0);
-    float md = vt.second.get<float> ("setMaxDistance", 2.5);
-    float id = vt.second.get<float> ("setInitialDistance", 0.15);
-    float c = vt.second.get<float> ("setCellSize", 1.0);
-    float b = vt.second.get<float> ("setBase", 2.0);
-    bool e = vt.second.get<bool> ("setExponential", true);
-    bool n = vt.second.get<bool> ("setNegative", false);
+    int w = vt.get("setMaxWindowSize", 33).asInt();
+    float s = vt.get("setSlope", 1.0).asFloat();
+    float md = vt.get("setMaxDistance", 2.5).asFloat();
+    float id = vt.get("setInitialDistance", 0.15).asFloat();
+    float c = vt.get("setCellSize", 1.0).asFloat();
+    float b = vt.get("setBase", 2.0).asFloat();
+    bool e = vt.get("setExponential", true).asBool();
+    bool n = vt.get("setNegative", false).asBool();
 
     // summarize settings
-    PCL_DEBUG("      max window size: %d\n", w);
-    PCL_DEBUG("      slope: %f\n", s);
-    PCL_DEBUG("      max distance: %f\n", md);
-    PCL_DEBUG("      initial distance: %f\n", id);
-    PCL_DEBUG("      cell size: %f\n", c);
-    PCL_DEBUG("      base: %f\n", b);
-    PCL_DEBUG("      exponential: %s\n", e?"true":"false");
-    PCL_DEBUG("      negative: %s\n", n?"true":"false");
+    PCL_DEBUG("\tmax window size: %d\n", w);
+    PCL_DEBUG("\tslope: %f\n", s);
+    PCL_DEBUG("\tmax distance: %f\n", md);
+    PCL_DEBUG("\tinitial distance: %f\n", id);
+    PCL_DEBUG("\tcell size: %f\n", c);
+    PCL_DEBUG("\tbase: %f\n", b);
+    PCL_DEBUG("\texponential: %s\n", e?"true":"false");
+    PCL_DEBUG("\tnegative: %s\n", n?"true":"false");
 
     pmf.setInputCloud(cloud);
     pmf.setMaxWindowSize(w);
@@ -459,134 +313,20 @@ pcl::Pipeline<PointT>::applyProgressiveMorphologicalFilter(PointCloudConstPtr cl
     extract.setNegative(n);
     extract.filter(output);
 
-    PCL_DEBUG("      %d points filtered to %d following progressive morphological filter\n", cloud->points.size(), output.points.size());
+    PCL_DEBUG("\t%d points filtered to %d following PMF\n",
+        cloud->points.size(), output.points.size());
 
     return;
 }
 
-/*
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointT> void
-pcl::Pipeline<PointT>::applyNormalEstimation(PointCloudConstPtr cloud, PointCloud &output, boost::property_tree::ptree::value_type &vt)
-{
-    if (pcl::traits::has_normal<PointT>::value && pcl::traits::has_curvature<PointT>::value)
-    {
-        // parse params
-        float r = vt.second.get<float> ("setRadiusSearch", 1.0);
-        float k = vt.second.get<float> ("setKSearch", 0);
-
-        PCL_DEBUG("      radius: %f\n", r);
-
-        pcl::PointCloud<pcl::Normal>::Ptr normals(new pcl::PointCloud<pcl::Normal>);
-
-        typename pcl::search::KdTree<PointT>::Ptr tree(new pcl::search::KdTree<PointT> ());
-        pcl::NormalEstimation<PointT, pcl::Normal> ne;
-        ne.setInputCloud(cloud);
-        //ne.setSearchSurface (cloud); // or maybe not
-        ne.setViewPoint(0.0f, 0.0f, std::numeric_limits<float>::max());
-        ne.setSearchMethod(tree);
-        ne.setRadiusSearch(r);
-        ne.setKSearch(k);
-        ne.compute(*normals);
-
-        pcl::concatenateFields(*cloud, *normals, output);
-    }
-    else
-    {
-        PCL_ERROR("Requested point type does not support NormalEstimation...\n");
-    }
-
-    return;
-}
-
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointT> void
-pcl::Pipeline<PointT>::applyConditionalRemoval(PointCloudConstPtr cloud, PointCloud &output, boost::property_tree::ptree::value_type &vt)
-{
-    typename pcl::ConditionAnd<PointT>::Ptr cond(new pcl::ConditionAnd<PointT> ());
-
-    if (pcl::traits::has_normal<PointT>::value)
-    {
-        // parse params
-        float m1 = vt.second.get<float> ("normalZ.min", 0);
-        float m2 = vt.second.get<float> ("normalZ.max", std::numeric_limits<float>::max());
-
-        // summarize settings
-        PCL_DEBUG("      Limits: %f, %f\n", m1, m2);
-
-        typedef typename pcl::traits::fieldList<PointT>::type FieldList;
-        float min_normal_z = std::numeric_limits<float>::max();
-        float max_normal_z = -std::numeric_limits<float>::max();
-        for (size_t ii = 0; ii < cloud->points.size(); ++ii)
-        {
-            bool has_normal_z = false;
-            float normal_z_val = 0.0f;
-            pcl::for_each_type<FieldList> (pcl::CopyIfFieldExists<PointT, float> (cloud->points[ii], "normal_z", has_normal_z, normal_z_val));
-            if (has_normal_z)
-            {
-                if (normal_z_val < min_normal_z) min_normal_z = normal_z_val;
-                if (normal_z_val > max_normal_z) max_normal_z = normal_z_val;
-            }
-        }
-        PCL_DEBUG("min/max normal_z [%f, %f]\n", min_normal_z, max_normal_z);
-
-        cond->addComparison(typename pcl::FieldComparison<PointT>::ConstPtr(new pcl::FieldComparison<PointT> ("normal_z", pcl::ComparisonOps::GT, m1)));
-        cond->addComparison(typename pcl::FieldComparison<PointT>::ConstPtr(new pcl::FieldComparison<PointT> ("normal_z", pcl::ComparisonOps::LT, m2)));
-    }
-    else
-    {
-        PCL_WARN("Requested point type does not support ConditionalRemoval by normals...\n");
-    }
-
-    pcl::ConditionalRemoval<PointT> condrem;
-    condrem.setCondition(cond);
-    condrem.setInputCloud(cloud);
-    condrem.filter(output);
-
-    return;
-}
-*/
-
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointT> void
-pcl::Pipeline<PointT>::applyMovingLeastSquares(PointCloudConstPtr cloud, PointCloud &output, boost::property_tree::ptree::value_type &vt)
-{
-        // parse params
-//        float r = vt.second.get<float> ("setRadiusSearch", 1.0);
-//        float k = vt.second.get<float> ("setKSearch", 0);
-
-//        PCL_DEBUG("      radius: %f\n", r);
-
-//        typename pcl::search::KdTree<PointT>::Ptr tree(new pcl::search::KdTree<PointT> ());
-        pcl::MovingLeastSquares<PointT, PointT> mls;
-        mls.setInputCloud(cloud);
-        //mls.setSearchMethod(tree);
-        mls.setSearchRadius(1);
-        mls.setPolynomialFit(true);
-        mls.setPolynomialOrder(2);
-        mls.setUpsamplingMethod(pcl::MovingLeastSquares<PointT, PointT>::NONE);
-        //mls.setDilationIterations(1);
-        //mls.setDilationVoxelSize(0.5);
-        //mls.setPointDensity(20);
-        //mls.setUpsamplingRadius(2);
-        //mls.setUpsamplingStepSize(1);
-        //PCL_DEBUG("%f radius \n", mls.getUpsamplingRadius());
-        //PCL_DEBUG("%f step\n", mls.getUpsamplingStepSize());
-        mls.process(output);
-
-    PCL_DEBUG("%d filtered to %d in moving least squares\n", cloud->points.size(), output.points.size());
-
-    return;
-}
-
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT> void
 pcl::Pipeline<PointT>::applyFilter(PointCloud &output)
 {
     // Has the input dataset been set already?
     if (!input_)
     {
-        PCL_WARN("[pcl::%s::applyFilter] No input dataset given!\n", getClassName().c_str());
+        PCL_WARN("[pcl::%s::applyFilter] No input dataset given!\n",
+            getClassName().c_str());
         output.width = output.height = 0;
         output.points.clear();
         return;
@@ -595,7 +335,8 @@ pcl::Pipeline<PointT>::applyFilter(PointCloud &output)
     // Do we have a JSON string to process?
     if (!json_set_)
     {
-        PCL_WARN("[pcl::%s::applyFilter] No input JSON given!\n", getClassName().c_str());
+        PCL_WARN("[pcl::%s::applyFilter] No input JSON given!\n",
+            getClassName().c_str());
         output = *input_;
         return;
     }
@@ -604,89 +345,52 @@ pcl::Pipeline<PointT>::applyFilter(PointCloud &output)
 
     try
     {
-        PCL_DEBUG("\n");
-        PCL_DEBUG("--------------------------------------------------------------------------------\n");
-        PCL_DEBUG("NAME:   %s (%s)\n", pt_.get<std::string> ("pipeline.name","").c_str(), pt_.get<std::string> ("pipeline.version","").c_str());
-        PCL_DEBUG("HELP:   %s\n", pt_.get<std::string> ("pipeline.help","").c_str());
-        PCL_DEBUG("AUTHOR: %s\n", pt_.get<std::string> ("pipeline.author","").c_str());
-        PCL_DEBUG("--------------------------------------------------------------------------------\n");
+        typedef pcl::PointCloud<PointT> Cloud;
+        typename Cloud::Ptr cloud(new Cloud);
+        typename Cloud::Ptr cloud_f(new Cloud);
 
-        // generate tile indices, can use vector of PointIndices (itself a vector of indices belonging to each tile)
-        std::vector<PointIndices> tile_indices;
-        PointIndices foo; // okay, this is totally ugly. i just want to make sure we have a single tile of all indices if no tile_size is specified.
-        foo.indices = *indices_;
-        tile_indices.push_back(foo);
-        float ts = pt_.get<float> ("pipeline.tile_size", 0.0f);
-        if (ts > 0.0f)
-            generateTileIndices(input_, ts, tile_indices);
+        pcl::copyPointCloud<PointT> (*input_, *cloud);
 
-        // loop over each tile (each PointIndices)
-        #pragma omp parallel for shared(output) num_threads(4)
-        for (size_t tile = 0; tile < tile_indices.size(); ++tile)
+        for (auto const& vt : pt_)
         {
-            typename pcl::PointCloud<PointT>::Ptr cloud(new pcl::PointCloud<PointT>);
-            typename pcl::PointCloud<PointT>::Ptr cloud_f(new pcl::PointCloud<PointT>);
+            std::string name(vt.get("name", "").asString());
+            
+            using namespace Utils;
 
-            // move the copyPointCloud at line 84 here, and only copy the indices belonging to the current tile (and somehow marry that with the *indices_)
-            pcl::copyPointCloud<PointT> (*input_, tile_indices[tile].indices, *cloud);
+            if (iequals(name, "PassThrough"))
+                applyPassThrough(cloud, *cloud_f, vt);
+            else if (iequals(name, "StatisticalOutlierRemoval"))
+                applyStatisticalOutlierRemoval(cloud, *cloud_f, vt);
+            else if (iequals(name, "RadiusOutlierRemoval"))
+                applyRadiusOutlierRemoval(cloud, *cloud_f, vt);
+            else if (iequals(name, "VoxelGrid"))
+                applyVoxelGrid(cloud, *cloud_f, vt);
+            else if (iequals(name, "GridMinimum"))
+                applyGridMinimum(cloud, *cloud_f, vt);
+            else if (iequals(name, "ApproximateProgressiveMorphologicalFilter"))
+                applyApproximateProgressiveMorphologicalFilter(cloud, *cloud_f,
+                    vt);
+            else if (iequals(name, "ProgressiveMorphologicalFilter"))
+                applyProgressiveMorphologicalFilter(cloud, *cloud_f, vt);
+            else
+                PCL_WARN("Requested filter `%s` not implemented! Skipping...\n",
+                    name.c_str());
 
-            PCL_DEBUG("process tile %d through the pipeline\n", tile);
+            cloud.swap(cloud_f);
 
-            int step = 1;
-
-            BOOST_FOREACH(boost::property_tree::ptree::value_type &vt, pt_.get_child("pipeline.filters"))
+            if (cloud->points.size() == 0)
             {
-                std::string name = vt.second.get<std::string> ("name", "");
-                std::string help = vt.second.get<std::string> ("help", "");
-
-                PCL_DEBUG("\n");
-                PCL_DEBUG("   Step %d) %s\n", step++, name.c_str());
-                PCL_DEBUG("      %s\n", help.c_str());
-
-                if (boost::iequals(name, "PassThrough"))
-                    applyPassThrough(cloud, *cloud_f, vt);
-                else if (boost::iequals(name, "StatisticalOutlierRemoval"))
-                    applyStatisticalOutlierRemoval(cloud, *cloud_f, vt);
-                else if (boost::iequals(name, "RadiusOutlierRemoval"))
-                    applyRadiusOutlierRemoval(cloud, *cloud_f, vt);
-                else if (boost::iequals(name, "VoxelGrid"))
-                    applyVoxelGrid(cloud, *cloud_f, vt);
-                else if (boost::iequals(name, "GridMinimum"))
-                    applyGridMinimum(cloud, *cloud_f, vt);
-                else if (boost::iequals(name, "ApproximateProgressiveMorphologicalFilter"))
-                    applyApproximateProgressiveMorphologicalFilter(cloud, *cloud_f, vt);
-                else if (boost::iequals(name, "ProgressiveMorphologicalFilter"))
-                    applyProgressiveMorphologicalFilter(cloud, *cloud_f, vt);
-                //else if (boost::iequals(name, "NormalEstimation"))
-                //    applyNormalEstimation(cloud, *cloud_f, vt);
-                //else if (boost::iequals(name, "ConditionalRemoval"))
-                //    applyConditionalRemoval(cloud, *cloud_f, vt);
-                else if (boost::iequals(name, "MovingLeastSquares"))
-                    applyMovingLeastSquares(cloud, *cloud_f, vt);
-                else
-                    PCL_WARN("Requested filter `%s` not implemented! Skipping...\n", name.c_str());
-
-                cloud.swap(cloud_f);
-
-                if (cloud->points.size() == 0)
-                {
-                    PCL_WARN("No points in filtered cloud. Skipping remaining filters...\n");
-                    break;
-                }
+                PCL_WARN("No points in filtered cloud. Aborting!\n");
+                break;
             }
-
-            // after processing each tile, we need to merge them back together into output
-            #pragma omp critical
-            output += *cloud;
-
-            PCL_DEBUG("tile %d filtered to %d points, adding to output, which now has %d points\n", tile, cloud->points.size(), output.points.size());
         }
 
-        PCL_DEBUG("\n");
+        output += *cloud;
     }
     catch (std::exception const& e)
     {
-        PCL_WARN("[pcl::%s::applyFilterIndices] Error parsing JSON and creating pipeline! %s\n", getClassName().c_str(), e.what());
+        PCL_WARN("[pcl::%s] Error parsing JSON and creating pipeline! %s\n",
+            getClassName().c_str(), e.what());
     }
 
     // Resize the output arrays

--- a/plugins/pcl/test/PCLBlockFilterTest.cpp
+++ b/plugins/pcl/test/PCLBlockFilterTest.cpp
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (c) 2013, Bradley J Chambers (brad.chambers@gmail.com)
+* Copyright (c) 2013-2016, Bradley J Chambers (brad.chambers@gmail.com)
 *
 * All rights reserved.
 *
@@ -35,7 +35,6 @@
 #include <pdal/pdal_test_main.hpp>
 
 #include <pdal/PipelineManager.hpp>
-#include <pdal/PluginManager.hpp>
 #include <pdal/StageFactory.hpp>
 
 #include "Support.hpp"
@@ -55,9 +54,9 @@ TEST(PCLBlockFilterTest, PCLBlockFilterTest_example_passthrough_json)
     pipeline.execute();
 
     PointViewSet viewSet = pipeline.views();
-    EXPECT_EQ(viewSet.size(), 1u);
+    EXPECT_EQ(1u, viewSet.size());
     PointViewPtr view = *viewSet.begin();
-    EXPECT_EQ(view->size(), 795u);
+    EXPECT_EQ(795u, view->size());
 }
 
 static void test_filter(const std::string& jsonFile,
@@ -85,9 +84,9 @@ static void test_filter(const std::string& jsonFile,
     pcl_block->prepare(table);
     PointViewSet viewSet = pcl_block->execute(table);
 
-    EXPECT_EQ(viewSet.size(), 1u);
+    EXPECT_EQ(1u, viewSet.size());
     PointViewPtr view = *viewSet.begin();
-    EXPECT_EQ(view->size(), expectedPointCount);
+    EXPECT_EQ(expectedPointCount, view->size());
 }
 
 

--- a/test/data/filters/pcl/example_PassThrough_1.json
+++ b/test/data/filters/pcl/example_PassThrough_1.json
@@ -1,18 +1,11 @@
-{
-    "pipeline":
+[
     {
-        "name": "PassThroughExample",
-        "filters":
-        [
-            {
-                "name": "PassThrough",
-                "setFilterFieldName": "z",
-                "setFilterLimits":
-                {
-                    "min": 410.0,
-                    "max": 440.0
-                }
-            }
-        ]
+        "name": "PassThrough",
+        "setFilterFieldName": "z",
+        "setFilterLimits":
+        {
+            "min": 410.0,
+            "max": 440.0
+        }
     }
-}
+]

--- a/test/data/filters/pcl/example_PassThrough_2.json
+++ b/test/data/filters/pcl/example_PassThrough_2.json
@@ -1,28 +1,18 @@
-{
-    "pipeline":
+[
     {
-        "name": "CombinedExample",
-        "help": "Apply passthrough filter followed by statistical outlier removal",
-        "version": 1.0,
-        "author": "Bradley J Chambers",
-        "filters":
-        [
-            {
-                "name": "PassThrough",
-                "help": "filter z values to the range [410,440]",
-                "setFilterFieldName": "z",
-                "setFilterLimits":
-                {
-                    "min": 410.0,
-                    "max": 440.0
-                }
-            },
-            {
-                "name": "StatisticalOutlierRemoval",
-                "help": "apply outlier removal",
-                "setMeanK": 8,
-                "setStddevMulThresh": 0.2
-            }
-        ]
+        "name": "PassThrough",
+        "help": "filter z values to the range [410,440]",
+        "setFilterFieldName": "z",
+        "setFilterLimits":
+        {
+            "min": 410.0,
+            "max": 440.0
+        }
+    },
+    {
+        "name": "StatisticalOutlierRemoval",
+        "help": "apply outlier removal",
+        "setMeanK": 8,
+        "setStddevMulThresh": 0.2
     }
-}
+]

--- a/test/data/filters/pcl/filter_ConditionalRemoval_1.json
+++ b/test/data/filters/pcl/filter_ConditionalRemoval_1.json
@@ -1,21 +1,15 @@
-{
-    "pipeline":
+[
     {
-        "filters":
-        [
-            {
-                "name": "NormalEstimation",
-                "setKSearch": 0.0,
-                "setRadiusSearch": 50.0
-            },
-            {
-                "name": "ConditionalRemoval",
-                "normalZ":
-                {
-                    "min": 0.0,
-                    "max": 0.087156
-                }
-            }
-        ]
+        "name": "NormalEstimation",
+        "setKSearch": 0.0,
+        "setRadiusSearch": 50.0
+    },
+    {
+        "name": "ConditionalRemoval",
+        "normalZ":
+        {
+            "min": 0.0,
+            "max": 0.087156
+        }
     }
-}
+]

--- a/test/data/filters/pcl/filter_ConditionalRemoval_2.json
+++ b/test/data/filters/pcl/filter_ConditionalRemoval_2.json
@@ -1,21 +1,15 @@
-{
-    "pipeline":
+[
     {
-        "filters":
-        [
-            {
-                "name": "NormalEstimation",
-                "setKSearch": 0.0,
-                "setRadiusSearch": 50.0
-            },
-            {
-                "name": "ConditionalRemoval",
-                "normalZ":
-                {
-                    "min": 0.01,
-                    "max": 0.10
-                }
-            }
-        ]
+        "name": "NormalEstimation",
+        "setKSearch": 0.0,
+        "setRadiusSearch": 50.0
+    },
+    {
+        "name": "ConditionalRemoval",
+        "normalZ":
+        {
+            "min": 0.01,
+            "max": 0.10
+        }
     }
-}
+]

--- a/test/data/filters/pcl/filter_GridMinimum.json
+++ b/test/data/filters/pcl/filter_GridMinimum.json
@@ -1,12 +1,6 @@
-{
-    "pipeline":
+[
     {
-        "filters":
-        [
-            {
-                "name": "GridMinimum",
-                "setResolution": 1000.0
-            }
-        ]
+        "name": "GridMinimum",
+        "setResolution": 1000.0
     }
-}
+]

--- a/test/data/filters/pcl/filter_NormalEstimation_1.json
+++ b/test/data/filters/pcl/filter_NormalEstimation_1.json
@@ -1,21 +1,15 @@
-{
-    "pipeline":
+[
     {
-        "filters":
-        [
-            {
-                "name": "NormalEstimation",
-                "setKSearch": 0.0,
-                "setRadiusSearch": 50.0
-            },
-            {
-                "name": "ConditionalRemoval",
-                "normalZ":
-                {
-                    "min": 0.0,
-                    "max": 0.087156
-                }
-            }
-        ]
+        "name": "NormalEstimation",
+        "setKSearch": 0.0,
+        "setRadiusSearch": 50.0
+    },
+    {
+        "name": "ConditionalRemoval",
+        "normalZ":
+        {
+            "min": 0.0,
+            "max": 0.087156
+        }
     }
-}
+]

--- a/test/data/filters/pcl/filter_NormalEstimation_2.json
+++ b/test/data/filters/pcl/filter_NormalEstimation_2.json
@@ -1,21 +1,15 @@
-{
-    "pipeline":
+[
     {
-        "filters":
-        [
-            {
-                "name": "NormalEstimation",
-                "setKSearch": 0.0,
-                "setRadiusSearch": 51.0
-            },
-            {
-                "name": "ConditionalRemoval",
-                "normalZ":
-                {
-                    "min": 0.0,
-                    "max": 0.087156
-                }
-            }
-        ]
+        "name": "NormalEstimation",
+        "setKSearch": 0.0,
+        "setRadiusSearch": 51.0
+    },
+    {
+        "name": "ConditionalRemoval",
+        "normalZ":
+        {
+            "min": 0.0,
+            "max": 0.087156
+        }
     }
-}
+]

--- a/test/data/filters/pcl/filter_PassThrough_1.json
+++ b/test/data/filters/pcl/filter_PassThrough_1.json
@@ -1,17 +1,11 @@
-{
-    "pipeline":
+[
     {
-        "filters":
-        [
-            {
-                "name": "PassThrough",
-                "setFilterFieldName": "z",
-                "setFilterLimits":
-                {
-                    "min": 410.0,
-                    "max": 440.0
-                }
-            }
-        ]
+        "name": "PassThrough",
+        "setFilterFieldName": "z",
+        "setFilterLimits":
+        {
+            "min": 410.0,
+            "max": 440.0
+        }
     }
-}
+]

--- a/test/data/filters/pcl/filter_PassThrough_2.json
+++ b/test/data/filters/pcl/filter_PassThrough_2.json
@@ -1,17 +1,11 @@
-{
-    "pipeline":
+[
     {
-        "filters":
-        [
-            {
-                "name": "PassThrough",
-                "setFilterFieldName": "x",
-                "setFilterLimits":
-                {
-                    "min": 636000,
-                    "max": 637000
-                }
-            }
-        ]
+        "name": "PassThrough",
+        "setFilterFieldName": "x",
+        "setFilterLimits":
+        {
+            "min": 636000,
+            "max": 637000
+        }
     }
-}
+]

--- a/test/data/filters/pcl/filter_VoxelGrid.json
+++ b/test/data/filters/pcl/filter_VoxelGrid.json
@@ -1,17 +1,11 @@
-{
-    "pipeline":
+[
     {
-        "filters":
-        [
-            {
-                "name": "VoxelGrid",
-                "setLeafSize":
-                {
-                    "x": 500.0,
-                    "y": 500.0,
-                    "z": 10.0
-                }
-            }
-        ]
+        "name": "VoxelGrid",
+        "setLeafSize":
+        {
+            "x": 500.0,
+            "y": 500.0,
+            "z": 10.0
+        }
     }
-}
+]


### PR DESCRIPTION
* PCL JSON specification is simplified - the heart of the former pipeline, the
  "filters" array is now THE pipeline

* PCL pipeline can be embedded directly in a PDAL pipeline by providing PCL
  JSON as "methods" option to filters.pclblock (avoiding "filters" to avoid
  confusion with PDAL filters)

* PCL pipeline can still be provided as a separate file

* PCL JSON no longer accepted as escaped string passed via the "json" option to
  filters.pclblock

* PCL filters ConditionalRemoval and NormalEstimation had been disabled for
  some time - remove them

* Remove ability to tile the data in filters.pclblock, which was untested, and
  can be done in the PDAL pipeline

* Update documentation throughout

* Missed this in the commit message, but this portion of the plugin no longer
  uses Boost (though it does now use our vendored jsoncpp)