### PR TITLE
Add tests for native JSON options.  Convert GreyhoundReader.

### DIFF
--- a/plugins/greyhound/io/GreyhoundReader.hpp
+++ b/plugins/greyhound/io/GreyhoundReader.hpp
@@ -77,7 +77,6 @@ private:
     std::size_t m_sparseDepth;
     Json::Value m_info;
     Json::Value m_schema;
-    std::string m_filterString;
     std::unique_ptr<greyhound::Point> m_scale;
     std::unique_ptr<greyhound::Point> m_offset;
 
@@ -100,7 +99,7 @@ private:
     uint32_t m_depthBeginArg;
     uint32_t m_depthEndArg;
     std::vector<std::string> m_pathsArg;
-    std::string m_filterArg;
+    Json::Value m_filter;
     int32_t m_threadsArg;
 
     virtual void initialize(PointTableRef table) override;

--- a/plugins/greyhound/test/GreyhoundReaderTest.cpp
+++ b/plugins/greyhound/test/GreyhoundReaderTest.cpp
@@ -164,27 +164,57 @@ TEST_F(GreyhoundReaderTest, filter)
 {
     if (!doTests()) return;
 
-    pdal::GreyhoundReader reader;
-    auto options(greyhoundOptions(&stadiumBounds, 0, 12));
-    options.add("filter", "{ \"Z\": { \"$gte\": 500 } }");
-
-    reader.setOptions(options);
-
-    pdal::PointTable table;
-    reader.prepare(table);
-    PointViewSet viewSet = reader.execute(table);
-    PointViewPtr view = *viewSet.begin();
-    ASSERT_LT(view->size(), 188260u);
-
-    greyhound::Point p;
-    for (std::size_t i(0); i < view->size(); ++i)
     {
-        p.x = view->getFieldAs<double>(Dimension::Id::X, i);
-        p.y = view->getFieldAs<double>(Dimension::Id::Y, i);
-        p.z = view->getFieldAs<double>(Dimension::Id::Z, i);
+        pdal::GreyhoundReader reader;
+        auto options(greyhoundOptions(&stadiumBounds, 0, 12));
+        options.add("filter", "{ \"Z\": { \"$gte\": 500 } }");
 
-        ASSERT_TRUE(stadiumBounds.contains(p));
-        ASSERT_GE(p.z, 500);
+        reader.setOptions(options);
+
+        pdal::PointTable table;
+        reader.prepare(table);
+        PointViewSet viewSet = reader.execute(table);
+        PointViewPtr view = *viewSet.begin();
+        ASSERT_LT(view->size(), 188260u);
+
+        greyhound::Point p;
+        for (std::size_t i(0); i < view->size(); ++i)
+        {
+            p.x = view->getFieldAs<double>(Dimension::Id::X, i);
+            p.y = view->getFieldAs<double>(Dimension::Id::Y, i);
+            p.z = view->getFieldAs<double>(Dimension::Id::Z, i);
+
+            ASSERT_TRUE(stadiumBounds.contains(p));
+            ASSERT_GE(p.z, 500);
+        }
+    }
+
+    {
+        pdal::GreyhoundReader reader;
+        auto options(greyhoundOptions(&stadiumBounds, 0, 12));
+
+        Json::Value filter;
+        filter["Z"]["$gte"] = 500;
+        options.add("filter", filter);
+
+        reader.setOptions(options);
+
+        pdal::PointTable table;
+        reader.prepare(table);
+        PointViewSet viewSet = reader.execute(table);
+        PointViewPtr view = *viewSet.begin();
+        ASSERT_LT(view->size(), 188260u);
+
+        greyhound::Point p;
+        for (std::size_t i(0); i < view->size(); ++i)
+        {
+            p.x = view->getFieldAs<double>(Dimension::Id::X, i);
+            p.y = view->getFieldAs<double>(Dimension::Id::Y, i);
+            p.z = view->getFieldAs<double>(Dimension::Id::Z, i);
+
+            ASSERT_TRUE(stadiumBounds.contains(p));
+            ASSERT_GE(p.z, 500);
+        }
     }
 }
 

--- a/test/unit/OptionsTest.cpp
+++ b/test/unit/OptionsTest.cpp
@@ -34,6 +34,8 @@
 
 #include <pdal/pdal_test_main.hpp>
 
+#include <json/json.h>
+
 #include <pdal/Options.hpp>
 #include <pdal/PDALUtils.hpp>
 #include <io/FauxReader.hpp>
@@ -53,11 +55,6 @@ namespace pdal
 
 TEST(OptionsTest, test_option_writing)
 {
-    std::ostringstream ostr_i;
-    const std::string ref_i = xml_header + xml_int_ref;
-    std::ostringstream ostr_s;
-    const std::string ref_s = xml_header + xml_str_ref;
-
     const Option option_i("my_int", (uint16_t)17);
     EXPECT_TRUE(option_i.getName() == "my_int");
     EXPECT_TRUE(option_i.getValue() == "17");
@@ -66,6 +63,24 @@ TEST(OptionsTest, test_option_writing)
     EXPECT_TRUE(option_s.getName() == "my_string");
     EXPECT_TRUE(option_s.getValue() == "Yow.");
     EXPECT_TRUE(option_s.getValue() == "Yow.");
+}
+
+
+TEST(OptionsTest, json)
+{
+    // Test that a JSON option will be stringified into the option's underlying
+    // value.
+    Json::Value inJson;
+    inJson["key"] = 42;
+    const Option option_j("my_json", inJson);
+    EXPECT_TRUE(option_j.getName() == "my_json");
+
+    // Don't string-compare, test JSON-equality, since we don't care exactly
+    // how it's stringified.
+    Json::Value outJson;
+    Json::Reader().parse(option_j.getValue(), outJson);
+
+    EXPECT_EQ(inJson, outJson) << inJson << " != " << outJson;
 }
 
 


### PR DESCRIPTION
#1435 added the capability to parse JSON that was nested as a pipeline option into a string.  This also inadvertently added the ability to natively back a `pdal::Option` with a reference to an underlying `Json::Value`, and it would "just work" even though we weren't really trying to support it.  This removes the need for manual parsing within the Stage, which was the original aim of #1435.  It also makes the Stage code more clear, since you can semantically convey an option as being JSON by its type.

I propose that we standardize this behavior since it is a more natural way for a Stage to accept JSON options.  I've added some tests for the behavior and converted the GreyhoundReader's `filter` option, which previously used the stringified method.  There's no PDAL code change here, so that method still works as well.

For reviewers, it ends up working because the `<<` and `>>` stream operators, which are used for type coercion by ProgramArgs (see the unspecialized versions of `Utils::fromString` and `Utils::toString`), are implemented to serialize/deserialize `Json::Value` objects.