### PR TITLE
Move private include out of public crop header

### DIFF
--- a/filters/CropFilter.cpp
+++ b/filters/CropFilter.cpp
@@ -42,6 +42,7 @@
 #include <pdal/pdal_macros.hpp>
 #include <pdal/util/ProgramArgs.hpp>
 #include <pdal/KDIndex.hpp>
+#include "filters/private/crop/Point.hpp"
 
 #include <sstream>
 #include <cstdarg>

--- a/filters/CropFilter.hpp
+++ b/filters/CropFilter.hpp
@@ -37,13 +37,15 @@
 #include <pdal/Filter.hpp>
 #include <pdal/Polygon.hpp>
 #include <pdal/plugin.hpp>
-#include "filters/private/crop/Point.hpp"
 
 extern "C" int32_t CropFilter_ExitFunc();
 extern "C" PF_ExitFunc CropFilter_InitPlugin();
 
 namespace pdal
 {
+namespace cropfilter {
+class Point;
+}
 
 class ProgramArgs;
 


### PR DESCRIPTION
This patch is *broken*, as `CropFilter.hpp` can't be included from a downstream in its current state. I'm not sure if @abellgithub wants to make cropfilter::Point public, or take some other action.