### PR TITLE
How to use of proj strings in filters.reprojection

### DIFF
--- a/doc/stages/filters.reprojection.rst
+++ b/doc/stages/filters.reprojection.rst
@@ -21,8 +21,12 @@ if you want to preserve the old coordinates for future processing, use a
     for storing the data.
 
 
-Example
+Example 1
 -------
+This pipeline reprojecs terrain points with Z-values between 0 and 100 by first
+applying a range filter and then specifing both the input and output spatial
+reference as EPSG-codes. The X and Y dimensions are scaled to allow enough
+precision in the output coordinates. 
 
 .. code-block:: json
 
@@ -55,15 +59,47 @@ Example
       ]
     }
 
+Examle 2
+-------
+In some cases it is not possible to use a EPSG-code as a spatial reference. 
+Instead `Proj.4 <http:/proj4.org>`_ parameters can be used to define a spatial reference. 
+In this example the vertical component of points in a laz file is converted from
+geometric (ellipsoidal) heights to orthometric heights by using the ``geoidgrids``
+parameter from Proj.4.
+Here we change the vertical datum from the GRS80 ellipsoid to DVR90,
+the vertical datum in Denmark. In the writing stage of the pipeline the spatial 
+reference of the file is set to EPSG:7416. The last step is needed since PDAL will
+otherwise reference the vertical datum as "Unnamed Vertical Datum" in the spatial
+reference VLR.
+
+
+.. code-block:: json
+
+    {
+      "pipeline":[
+        "./1km_6135_632.laz",
+        {
+            "type":"filters.reprojection",
+            "in_srs":"EPSG:25832",
+            "out_srs":"+init=epsg:25832 +geoidgrids=C:/data/geoids/dvr90.gtx"
+        },
+        {
+          "type":"writers.las",
+          "a_srs":"EPSG:7416",
+          "filename":"1km_6135_632_DVR90.laz"
+        }
+      ]
+    }
+
 Options
 -------
 
 in_srs
   Spatial reference system of the input data. Express as an EPSG string (eg
-  "EPSG:4326" for WGS86 geographic) or a well-known text string. [Required if
+  "EPSG:4326" for WGS84 geographic), Proj.4 string or a well-known text string. [Required if
   input reader does not supply SRS information]
 
 out_srs
   Spatial reference system of the output data. Express as an EPSG string (eg
-  "EPSG:4326" for WGS86 geographic) or a well-known text string. [Required]
+  "EPSG:4326" for WGS84 geographic), Proj.4 string or a well-known text string. [Required]
 


### PR DESCRIPTION
Using Proj.4 to do coordinate transformation was previously undocumented. I have added an example that explains how to do a vertical gridshift with Proj.4.