### PR TITLE
Stage ops

### DIFF
--- a/doc/apps/pipeline.rst
+++ b/doc/apps/pipeline.rst
@@ -38,4 +38,30 @@ The ``pipeline`` command is used to execute :ref:`pipeline` JSON. See
         $ pdal pipeline translate.json --writers.las.filename=output.laz \
             --readers.las.filename=input.las
 
+    Option substitution can also refer to the tag of an individual stage.
+    This can be done by using the syntax --stage.<tagname>.<option>.  This
+    allows options to be set on individual stages, even if there are multiple
+    stages of the same type.  For example, if a pipeline contained two LAS
+    readers with tags ``las1`` and ``las2`` respectively, the following
+    command would allow assignment of different filenames to each stage:
 
+    ::
+
+        {
+            "pipeline" : [
+                {
+                    "tag" : "las1",
+                    "type" : "readers.las"
+                },
+                {
+                    "tag" : "las2",
+                    "type" : "readers.las"
+                },
+                "placeholder.laz"
+            ]
+        }
+
+        $ pdal pipeline translate.json --writers.las.filename=output.laz \
+            --stage.las1.filename=file1.las --stage.las2.filename=file2.las
+
+    Options specified by tag names override options specified by stage types.

--- a/kernels/PipelineKernel.cpp
+++ b/kernels/PipelineKernel.cpp
@@ -65,6 +65,12 @@ void PipelineKernel::validateSwitches(ProgramArgs& args)
 }
 
 
+bool PipelineKernel::isStagePrefix(const std::string& stage)
+{
+    return Kernel::isStagePrefix(stage) || stage == "stage";
+}
+
+
 void PipelineKernel::addSwitches(ProgramArgs& args)
 {
     args.add("input,i", "input file name", m_inputFile).setOptionalPositional();

--- a/kernels/PipelineKernel.hpp
+++ b/kernels/PipelineKernel.hpp
@@ -58,6 +58,7 @@ private:
     PipelineKernel();
     void addSwitches(ProgramArgs& args);
     void validateSwitches(ProgramArgs& args);
+    virtual bool isStagePrefix(const std::string& stage);
 
     std::string m_inputFile;
     std::string m_pipelineFile;

--- a/pdal/Options.cpp
+++ b/pdal/Options.cpp
@@ -58,7 +58,6 @@ void Option::toMetadata(MetadataNode& parent) const
 
 }
 
-//---------------------------------------------------------------------------
 
 bool Option::nameValid(const std::string& name, bool reportError)
 {
@@ -74,10 +73,19 @@ bool Option::nameValid(const std::string& name, bool reportError)
 }
 
 
+//---------------------------------------------------------------------------
+
+
 void Options::add(const Option& option)
 {
     assert(Option::nameValid(option.getName(), true));
     m_options.insert({ option.getName(), option });
+}
+
+
+void Options::add(const Options& o)
+{
+    m_options.insert(o.m_options.begin(), o.m_options.end());
 }
 
 

--- a/pdal/Options.cpp
+++ b/pdal/Options.cpp
@@ -97,6 +97,13 @@ void Options::addConditional(const Option& option)
 }
 
 
+void Options::addConditional(const Options& options)
+{
+    for (auto& o : options.m_options)
+        addConditional(o.second);
+}
+
+
 void Options::remove(const Option& option)
 {
     m_options.erase(option.getName());

--- a/pdal/Options.hpp
+++ b/pdal/Options.hpp
@@ -131,6 +131,7 @@ public:
     void add(const Option& option);
     void add(const Options& options);
     void addConditional(const Option& option);
+    void addConditional(const Options& option);
 
     // if option name not present, just returns
     void remove(const Option& option);

--- a/pdal/Options.hpp
+++ b/pdal/Options.hpp
@@ -129,6 +129,7 @@ public:
         { add(opt); }
 
     void add(const Option& option);
+    void add(const Options& options);
     void addConditional(const Option& option);
 
     // if option name not present, just returns

--- a/pdal/PipelineManager.cpp
+++ b/pdal/PipelineManager.cpp
@@ -410,9 +410,11 @@ Options PipelineManager::stageOptions(Stage& stage)
         if (oi != m_stageOptions.end())
             opts.add(oi->second);
     }
+    // Tag-based options options override stagename-based options, so
+    // we call addConditional.
     auto oi = m_stageOptions.find(stage.getName());
     if (oi != m_stageOptions.end())
-        opts.add(oi->second);
+        opts.addConditional(oi->second);
     return opts;
 }
 

--- a/pdal/PipelineManager.cpp
+++ b/pdal/PipelineManager.cpp
@@ -39,6 +39,10 @@
 
 #include "private/PipelineReaderXML.hpp"
 
+#if defined(PDAL_COMPILER_CLANG) || defined(PDAL_COMPILER_GCC)
+#  pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+#endif
+
 namespace pdal
 {
 
@@ -93,7 +97,14 @@ void PipelineManager::readPipeline(const std::string& filename)
     {
         Utils::closeFile(m_input);
         m_input = Utils::openFile(filename);
-        readPipeline(*m_input);
+        try
+        {
+            readPipeline(*m_input);
+        }
+        catch (const pdal_error& err)
+        {
+            throw pdal_error(filename + ": " + err.what());
+        }
     }
 }
 
@@ -154,7 +165,8 @@ void PipelineManager::validateStageOptions() const
         const std::string& stageName = si.first;
         auto it = std::find_if(m_stages.begin(), m_stages.end(),
             [stageName](Stage *s)
-            { return (s->getName() == stageName); });
+            { return (s->getName() == stageName ||
+                "stage." + s->tag() == stageName); });
 
         // If the option stage name matches no created stage, then error.
         if (it == m_stages.end())
@@ -230,67 +242,83 @@ MetadataNode PipelineManager::getMetadata() const
     return output;
 }
 
-
 Stage& PipelineManager::makeReader(const std::string& inputFile,
     std::string driver)
 {
-    static Options nullOpts;
+    StageCreationOptions ops { inputFile, driver };
 
-    return makeReader(inputFile, driver, nullOpts);
+    return makeReader(ops);
 }
 
 
 Stage& PipelineManager::makeReader(const std::string& inputFile,
     std::string driver, Options options)
 {
-    if (driver.empty())
-    {
-        driver = StageFactory::inferReaderDriver(inputFile);
-        if (driver.empty())
-            throw pdal_error("Cannot determine reader for input file: " +
-                inputFile);
-    }
-    if (!inputFile.empty())
-        options.replace("filename", inputFile);
+    StageCreationOptions ops { inputFile, driver, nullptr, options };
 
-    Stage& reader = addReader(driver);
-    setOptions(reader, options);
+    return makeReader(ops);
+}
+
+
+Stage& PipelineManager::makeReader(StageCreationOptions& o)
+{
+    if (o.m_driver.empty())
+    {
+        o.m_driver = StageFactory::inferReaderDriver(o.m_filename);
+        if (o.m_driver.empty())
+            throw pdal_error("Cannot determine reader for input file: " +
+                o.m_filename);
+    }
+    if (!o.m_filename.empty())
+        o.m_options.replace("filename", o.m_filename);
+
+    Stage& reader = addReader(o.m_driver);
+    reader.setTag(o.m_tag);
+    setOptions(reader, o.m_options);
     return reader;
 }
 
 
 Stage& PipelineManager::makeFilter(const std::string& driver)
 {
-    static Options nullOps;
+    StageCreationOptions ops { "", driver };
 
-    Stage& filter = addFilter(driver);
-    setOptions(filter, nullOps);
-    return filter;
+    return makeFilter(ops);
 }
 
 
 Stage& PipelineManager::makeFilter(const std::string& driver, Options options)
 {
-    Stage& filter = addFilter(driver);
-    setOptions(filter, options);
-    return filter;
+    StageCreationOptions ops { "", driver, nullptr, options };
+
+    return makeFilter(ops);
 }
 
 
 Stage& PipelineManager::makeFilter(const std::string& driver, Stage& parent)
 {
-    static Options nullOps;
+    StageCreationOptions ops { "", driver, &parent };
 
-    return makeFilter(driver, parent, nullOps);
+    return makeFilter(ops);
 }
 
 
 Stage& PipelineManager::makeFilter(const std::string& driver, Stage& parent,
     Options options)
 {
-    Stage& filter = addFilter(driver);
-    setOptions(filter, options);
-    filter.setInput(parent);
+    StageCreationOptions ops { "", driver, &parent, options };
+
+    return makeFilter(ops);
+}
+
+
+Stage& PipelineManager::makeFilter(StageCreationOptions& o)
+{
+    Stage& filter = addFilter(o.m_driver);
+    filter.setTag(o.m_tag);
+    setOptions(filter, o.m_options);
+    if (o.m_parent)
+        filter.setInput(*o.m_parent);
     return filter;
 }
 
@@ -298,44 +326,57 @@ Stage& PipelineManager::makeFilter(const std::string& driver, Stage& parent,
 Stage& PipelineManager::makeWriter(const std::string& outputFile,
     std::string driver)
 {
-    static Options nullOps;
+    StageCreationOptions ops { outputFile, driver };
 
-    return makeWriter(outputFile, driver, nullOps);
-}
-
-Stage& PipelineManager::makeWriter(const std::string& outputFile,
-    std::string driver, Options options)
-{
-    if (driver.empty())
-    {
-        driver = StageFactory::inferWriterDriver(outputFile);
-        if (driver.empty())
-            throw pdal_error("Cannot determine writer for output file: " +
-                outputFile);
-    }
-
-    if (!outputFile.empty())
-        options.replace("filename", outputFile);
-
-    auto& writer = addWriter(driver);
-    setOptions(writer, options);
-    return writer;
+    return makeWriter(ops);
 }
 
 
 Stage& PipelineManager::makeWriter(const std::string& outputFile,
     std::string driver, Stage& parent)
 {
-    static Options nullOps;
+    StageCreationOptions ops { outputFile, driver, &parent };
 
-    return makeWriter(outputFile, driver, parent, nullOps);
+    return makeWriter(ops);
 }
+
 
 Stage& PipelineManager::makeWriter(const std::string& outputFile,
     std::string driver, Stage& parent, Options options)
 {
-    Stage& writer = makeWriter(outputFile, driver, options);
-    writer.setInput(parent);
+    StageCreationOptions ops { outputFile, driver, &parent, options };
+
+    return makeWriter(ops);
+}
+
+
+Stage& PipelineManager::makeWriter(const std::string& outputFile,
+    std::string driver, Options options)
+{
+    StageCreationOptions ops { outputFile, driver, nullptr, options };
+
+    return makeWriter(ops);
+}
+
+
+Stage& PipelineManager::makeWriter(StageCreationOptions& o)
+{
+    if (o.m_driver.empty())
+    {
+        o.m_driver = StageFactory::inferWriterDriver(o.m_filename);
+        if (o.m_driver.empty())
+            throw pdal_error("Cannot determine writer for output file: " +
+                o.m_filename);
+    }
+
+    if (!o.m_filename.empty())
+        o.m_options.replace("filename", o.m_filename);
+
+    auto& writer = addWriter(o.m_driver);
+    writer.setTag(o.m_tag);
+    setOptions(writer, o.m_options);
+    if (o.m_parent)
+        writer.setInput(*o.m_parent);
     return writer;
 }
 
@@ -351,20 +392,28 @@ void PipelineManager::setOptions(Stage& stage, const Options& addOps)
     stage.addOptions(addOps);
 
     // Apply options provided on the command line, overriding others.
-    Options& ops = stageOptions(stage);
+    Options ops = stageOptions(stage);
     stage.removeOptions(ops);
     stage.addOptions(ops);
 }
 
 
-Options& PipelineManager::stageOptions(Stage& stage)
+Options PipelineManager::stageOptions(Stage& stage)
 {
-    static Options nullOpts;
+    Options opts;
 
+    std::string tag = stage.tag();
+    if (tag.size())
+    {
+        tag = "stage." + tag;
+        auto oi = m_stageOptions.find(tag);
+        if (oi != m_stageOptions.end())
+            opts.add(oi->second);
+    }
     auto oi = m_stageOptions.find(stage.getName());
-    if (oi == m_stageOptions.end())
-        return nullOpts;
-    return oi->second;
+    if (oi != m_stageOptions.end())
+        opts.add(oi->second);
+    return opts;
 }
 
 } // namespace pdal

--- a/pdal/PipelineManager.hpp
+++ b/pdal/PipelineManager.hpp
@@ -45,6 +45,15 @@ namespace pdal
 
 class Options;
 
+struct StageCreationOptions
+{
+    std::string m_filename;
+    std::string m_driver;
+    Stage *m_parent;
+    Options m_options;
+    std::string m_tag;
+};
+
 class PDAL_DLL PipelineManager
 {
     FRIEND_TEST(json, tags);
@@ -76,12 +85,14 @@ public:
     Stage& makeReader(const std::string& inputFile, std::string driver);
     Stage& makeReader(const std::string& inputFile, std::string driver,
         Options options);
+    Stage& makeReader(StageCreationOptions& opts);
 
     Stage& makeFilter(const std::string& driver);
     Stage& makeFilter(const std::string& driver, Options options);
     Stage& makeFilter(const std::string& driver, Stage& parent);
     Stage& makeFilter(const std::string& driver, Stage& parent,
         Options options);
+    Stage& makeFilter(StageCreationOptions& ops);
 
     Stage& makeWriter(const std::string& outputFile, std::string driver);
     Stage& makeWriter(const std::string& outputFile, std::string driver,
@@ -90,6 +101,7 @@ public:
         Stage& parent);
     Stage& makeWriter(const std::string& outputFile, std::string driver,
         Stage& parent, Options options);
+    Stage& makeWriter(StageCreationOptions& ops);
 
     // returns true if the pipeline endpoint is a writer
     bool isWriterPipeline() const
@@ -123,10 +135,10 @@ public:
         { return m_commonOptions; }
     OptionsMap& stageOptions()
         { return m_stageOptions; }
-    Options& stageOptions(Stage& stage);
 
 private:
     void setOptions(Stage& stage, const Options& addOps);
+    Options stageOptions(Stage& stage);
 
     StageFactory m_factory;
     std::unique_ptr<PointTable> m_tablePtr;

--- a/pdal/PipelineReaderJSON.cpp
+++ b/pdal/PipelineReaderJSON.cpp
@@ -99,7 +99,8 @@ void PipelineReaderJSON::parsePipeline(Json::Value& tree)
 
             for (const std::string& path : files)
             {
-                s = &m_manager.makeReader(path, type, options);
+                StageCreationOptions ops { path, type, nullptr, options, tag };
+                s = &m_manager.makeReader(ops);
 
                 if (specifiedInputs.size())
                     throw pdal_error("JSON pipeline: Inputs not permitted for "
@@ -109,7 +110,8 @@ void PipelineReaderJSON::parsePipeline(Json::Value& tree)
         }
         else if (type.empty() || Utils::startsWith(type, "writers."))
         {
-            s = &m_manager.makeWriter(filename, type, options);
+            StageCreationOptions ops { filename, type, nullptr, options, tag };
+            s = &m_manager.makeWriter(ops);
             for (Stage *ts : inputs)
                 s->setInput(*ts);
             inputs.clear();
@@ -118,7 +120,8 @@ void PipelineReaderJSON::parsePipeline(Json::Value& tree)
         {
             if (filename.size())
                 options.add("filename", filename);
-            s = &m_manager.makeFilter(type, options);
+            StageCreationOptions ops { "", type, nullptr, options, tag };
+            s = &m_manager.makeFilter(ops);
             for (Stage *ts : inputs)
                 s->setInput(*ts);
             inputs.clear();

--- a/pdal/PipelineReaderJSON.cpp
+++ b/pdal/PipelineReaderJSON.cpp
@@ -39,6 +39,7 @@
 #include <pdal/PluginManager.hpp>
 #include <pdal/Options.hpp>
 #include <pdal/util/FileUtils.hpp>
+#include <pdal/util/Algorithm.hpp>
 #include <pdal/util/Utils.hpp>
 
 #include <json/json.h>
@@ -244,7 +245,7 @@ std::string PipelineReaderJSON::extractTag(Json::Value& node, TagMap& tags)
                         tag + "'.");
             }
             else
-                throw pdal_error("JSON pipeline: 'tag' must be "
+                throw pdal_error("JSON pipeline: tag must be "
                     "specified as a string.");
         }
         node.removeMember("tag");
@@ -252,6 +253,9 @@ std::string PipelineReaderJSON::extractTag(Json::Value& node, TagMap& tags)
             throw pdal_error("JSON pipeline: found duplicate 'tag' "
                "entry in stage definition.");
     }
+    if (Utils::contains(tag, '.'))
+        throw pdal_error("JSON pipeline: Stage tag name can't contain "
+            "'.' character.");
     return tag;
 }
 

--- a/pdal/PipelineWriter.cpp
+++ b/pdal/PipelineWriter.cpp
@@ -44,7 +44,7 @@ namespace pdal
 namespace
 {
 
-void generateTags(Stage *stage, PipelineWriter::TagMap& tags)
+std::string generateTag(Stage *stage, PipelineWriter::TagMap& tags)
 {
     auto tagExists = [tags](const std::string& tag)
     {
@@ -56,16 +56,24 @@ void generateTags(Stage *stage, PipelineWriter::TagMap& tags)
         return false;
     };
 
+    std::string tag = stage->tag();
+    if (tag.empty())
+    {
+        for (size_t i = 1; ; ++i)
+        {
+            tag = stage->getName() + std::to_string(i);
+            if (!tagExists(tag))
+                break;
+        }
+    }
+    return tag;
+}
+
+void generateTags(Stage *stage, PipelineWriter::TagMap& tags)
+{
     for (Stage *s : stage->getInputs())
         generateTags(s, tags);
-    std::string tag;
-    for (size_t i = 1; ; ++i)
-    {
-        tag = stage->tagName() + std::to_string(i);
-        if (!tagExists(tag))
-            break;
-    }
-    tags[stage] = tag;
+    tags[stage] = generateTag(stage, tags);
 }
 
 } // anonymous namespace

--- a/pdal/Stage.hpp
+++ b/pdal/Stage.hpp
@@ -253,17 +253,18 @@ public:
     virtual std::string getName() const = 0;
 
     /**
+        Set a specific tag name.
+    */
+    void setTag(const std::string& tag)
+        { m_tag = tag; }
+
+    /**
       Return the tag name of a stage.
 
-      The tag name is used when writing a JSON pipeline.  It is generally
-      the same as the stage name, but a number is appended to maintain
-      uniqueness when stages appear more than once in a pipeline.
-      the same as
-
-      \return  The tag's name.
+      \return  The tag name.
     */
-    virtual std::string tagName() const
-        { return getName(); }
+    virtual std::string tag() const
+        { return m_tag; }
 
     /**
       Return a list of the stage's inputs.
@@ -308,7 +309,10 @@ private:
     std::string m_logLeader;
     SpatialReference m_spatialReference;
     std::unique_ptr<ProgramArgs> m_args;
-
+    std::string m_tag;
+    // This is never used after it is set.  It just provides a place to
+    // bind the user_data argument that is essentially a comment in pipeline
+    // files.
     std::string m_userDataJSON;
 
     Stage& operator=(const Stage&); // not implemented

--- a/pdal/private/PipelineReaderXML.hpp
+++ b/pdal/private/PipelineReaderXML.hpp
@@ -66,7 +66,7 @@ public:
 
     /**
       Read an XML pipeline from a stream into a PipelineManager.
-      
+
       \param input  Stream to read from.
     */
     void readPipeline(std::istream& input);
@@ -92,6 +92,8 @@ private:
 
     PipelineReaderXML& operator=(const PipelineReaderXML&); // not implemented
     PipelineReaderXML(const PipelineReaderXML&); // not implemented
+
+    void baseReadPipeline(std::istream& input);
 };
 
 } // namespace pdal

--- a/test/data/pipeline/options.json.in
+++ b/test/data/pipeline/options.json.in
@@ -1,0 +1,12 @@
+{
+  "pipeline":[
+    "@CMAKE_SOURCE_DIR@/test/data/las/1.2-with-color.las",
+    {
+      "type":"filters.assign",
+      "dimension":"Z",
+      "value":"25",
+      "tag":"assigner"
+    },
+    "@CMAKE_SOURCE_DIR@/test/temp/assigned.las"
+  ]
+}

--- a/test/unit/apps/RandomTest.cpp
+++ b/test/unit/apps/RandomTest.cpp
@@ -44,20 +44,12 @@
 
 using namespace pdal;
 
-namespace
-{
-std::string appName()
-{
-    return Support::binpath("pdal random");
-}
-}
-
 TEST(Random, extra_ops)
 {
     std::string outfile(Support::temppath("out.las"));
 
-    const std::string cmd = appName() +
-        " --count=100 --writers.las.minor_version=3 " + outfile;
+    const std::string cmd = Support::binpath("pdal") + " random "
+        "--count=100 --writers.las.minor_version=3 " + outfile;
 
     FileUtils::deleteFile(outfile);
     std::string output;


### PR DESCRIPTION
This allows specification of options for individual stages using the syntax `--stage.<tagname>.<option>`.  Tag-specified options override stagename-specified options.