### PR TITLE
Expose hexbin filter options to density kernel

### DIFF
--- a/plugins/hexbin/kernel/DensityKernel.cpp
+++ b/plugins/hexbin/kernel/DensityKernel.cpp
@@ -59,6 +59,13 @@ void DensityKernel::addSwitches(ProgramArgs& args)
     args.add("ogrdriver,f", "OGR driver name to use ", m_driverName,
         "ESRI Shapefile");
     args.add("lyr_name", "OGR layer name to use", m_layerName, "");
+    args.add("sample_size", "Sample size for auto-edge length calculation",
+        m_sampleSize, 5000U);
+    args.add("threshold", "Required cell density", m_density, 15);
+    args.add("edge_length", "Length of hex edge", m_edgeLength);
+    args.add("hole_cull_area_tolerance", "Tolerance area to "
+            "apply to holes before cull", m_cullArea);
+    args.add("smooth", "Smooth boundary output", m_doSmooth, true);
 }
 
 
@@ -91,8 +98,14 @@ int DensityKernel::execute()
     {
         m_manager.makeReader(m_inputFile, "");
     }
+    Options options;
+    options.add("sample_size", m_sampleSize);
+    options.add("threshold", m_density);
+    options.add("edge_length", m_edgeLength);
+    options.add("hole_cull_area_tolerance", m_cullArea);
+    options.add("smooth", m_doSmooth);
     m_hexbinStage = &(m_manager.makeFilter("filters.hexbin",
-        *m_manager.getStage()));
+        *m_manager.getStage(), options));
     m_manager.execute();
     outputDensity(m_manager.pointTable().anySpatialReference());
     return 0;

--- a/plugins/hexbin/kernel/DensityKernel.hpp
+++ b/plugins/hexbin/kernel/DensityKernel.hpp
@@ -57,6 +57,11 @@ private:
     std::string m_outputFile;
     std::string m_driverName;
     std::string m_layerName;
+    uint32_t m_sampleSize;
+    int32_t m_density;
+    double m_edgeLength;
+    double m_cullArea;
+    bool m_doSmooth;
 
     virtual void addSwitches(ProgramArgs& args);
     void outputDensity(pdal::SpatialReference const& ref);


### PR DESCRIPTION
It's nice to be able to tweak the parameters of the density kernel, instead of being locked into the defaults.