### PR TITLE
Improve quality of derivative writer outputs

### DIFF
--- a/io/DerivativeWriter.cpp
+++ b/io/DerivativeWriter.cpp
@@ -163,13 +163,13 @@ void DerivativeWriter::write(const PointViewPtr data)
                 {
                     out(r-1, c-1) = computeSlopeD8(block, m_edgeLength);
                     if (Utils::iequals(m_slopeUnit, "degrees"))
-                        out(r-1, c-1) = std::atan(out(r-1, c-1) / 100.0) * 180.0 / 3.14159;
+                        out(r-1, c-1) = percentSlopeToDegrees(out(r-1, c-1));
                 }
                 if (to.m_type == SLOPE_FD)
                 {
                     out(r-1, c-1) = computeSlopeFD(block, m_edgeLength);
                     if (Utils::iequals(m_slopeUnit, "degrees"))
-                        out(r-1, c-1) = std::atan(out(r-1, c-1) / 100.0) * 180.0 / 3.14159;
+                        out(r-1, c-1) = percentSlopeToDegrees(out(r-1, c-1));
                 }
                 if (to.m_type == ASPECT_D8)
                     out(r-1, c-1) = computeAspectD8(block, m_edgeLength);

--- a/io/DerivativeWriter.cpp
+++ b/io/DerivativeWriter.cpp
@@ -57,6 +57,8 @@ void DerivativeWriter::addArgs(ProgramArgs& args)
     args.add("filename", "Output filename", m_filename).setPositional();
     args.add("edge_length", "Edge length", m_edgeLength, 15.0);
     args.add("primitive_type", "Primitive type", m_primTypesSpec, {"slope_d8"});
+    args.add("slope_units", "Slope units (degrees/percent)", m_slopeUnit,
+             "percent");
     args.add("altitude", "Illumination altitude (degrees)", m_illumAltDeg,
              45.0);
     args.add("azimuth", "Illumination azimuth (degrees)", m_illumAzDeg, 315.0);
@@ -135,19 +137,16 @@ void DerivativeWriter::write(const PointViewPtr data)
     size_t rows = ((bounds.maxy - bounds.miny) / m_edgeLength) + 1;
 
     // Begin by creating a DSM of max elevations per XY cell.
-    MatrixXd DSM = createMaxMatrix(*data.get(), rows, cols, m_edgeLength,
-                                   bounds);
-
-    // Continue by cleaning the DSM.
-    MatrixXd cleanedDSM = cleanDSM(DSM);
+    MatrixXd DSM = createMaxMatrix2(*data.get(), rows, cols, m_edgeLength,
+                                    bounds);
 
     // We will pad the edges by 1 cell, though according to some texts we should
     // simply compute forward- or backward-difference as opposed to centered
     // difference at these points.
-    MatrixXd paddedDSM = padMatrix(cleanedDSM, 1);
+    MatrixXd paddedDSM = padMatrix(DSM, 1);
 
     // Prepare the out matrix.
-    MatrixXd out(cleanedDSM.rows(), cleanedDSM.cols());
+    MatrixXd out(DSM.rows(), DSM.cols());
     out.setConstant(std::numeric_limits<double>::quiet_NaN());
 
     for (TypeOutput& to : m_primitiveTypes)
@@ -161,9 +160,17 @@ void DerivativeWriter::write(const PointViewPtr data)
                     continue;
                 Matrix3d block = paddedDSM.block(r-1, c-1, 3, 3);
                 if (to.m_type == SLOPE_D8)
+                {
                     out(r-1, c-1) = computeSlopeD8(block, m_edgeLength);
+                    if (Utils::iequals(m_slopeUnit, "degrees"))
+                        out(r-1, c-1) = std::atan(out(r-1, c-1) / 100.0) * 180.0 / 3.14159;
+                }
                 if (to.m_type == SLOPE_FD)
+                {
                     out(r-1, c-1) = computeSlopeFD(block, m_edgeLength);
+                    if (Utils::iequals(m_slopeUnit, "degrees"))
+                        out(r-1, c-1) = std::atan(out(r-1, c-1) / 100.0) * 180.0 / 3.14159;
+                }
                 if (to.m_type == ASPECT_D8)
                     out(r-1, c-1) = computeAspectD8(block, m_edgeLength);
                 if (to.m_type == ASPECT_FD)

--- a/io/DerivativeWriter.hpp
+++ b/io/DerivativeWriter.hpp
@@ -90,6 +90,7 @@ private:
 
     std::string m_filename;
     std::string m_driver;
+    std::string m_slopeUnit;
     double m_edgeLength;
     double m_illumAltDeg;
     double m_illumAzDeg;

--- a/io/DerivativeWriter.hpp
+++ b/io/DerivativeWriter.hpp
@@ -97,6 +97,13 @@ private:
     StringList m_primTypesSpec;
     std::vector<TypeOutput> m_primitiveTypes;
 
+    const double c_PI = std::acos(-1.0);
+    const double c_rad2deg = 180.0 / c_PI;
+    double percentSlopeToDegrees(double slope)
+    {
+        return std::atan(slope / 100.0) * c_rad2deg;
+    }
+
     DerivativeWriter& operator=(const DerivativeWriter&); // not implemented
     DerivativeWriter(const DerivativeWriter&); // not implemented
 };

--- a/pdal/EigenUtils.hpp
+++ b/pdal/EigenUtils.hpp
@@ -250,6 +250,9 @@ PDAL_DLL uint8_t computeRank(PointView& view, std::vector<PointId> ids,
 PDAL_DLL Eigen::MatrixXd createMaxMatrix(PointView& view, int rows, int cols,
         double cell_size, BOX2D bounds);
 
+PDAL_DLL Eigen::MatrixXd createMaxMatrix2(PointView& view, int rows, int cols,
+        double cell_size, BOX2D bounds);
+
 /**
   Create matrix of minimum Z values.
 
@@ -738,12 +741,14 @@ PDAL_DLL double computeSlopeD8(const Eigen::MatrixBase<Derived>& data,
     submatrix.setConstant(data(1, 1));
     submatrix -= data;
     submatrix /= spacing;
-    submatrix(0, 1) /= std::sqrt(2.0);
-    submatrix(1, 0) /= std::sqrt(2.0);
-    submatrix(1, 2) /= std::sqrt(2.0);
-    submatrix(2, 1) /= std::sqrt(2.0);
+    submatrix(0, 0) /= std::sqrt(2.0);
+    submatrix(0, 2) /= std::sqrt(2.0);
+    submatrix(2, 0) /= std::sqrt(2.0);
+    submatrix(2, 2) /= std::sqrt(2.0);
 
-    // find max and convert to degrees
+    // Why not just use Eigen's maxCoeff reduction to find the max? Well, as it
+    // turns out, if there is a chance that we will have NaN's then maxCoeff
+    // has no way to ignore the NaN.
     double maxval = std::numeric_limits<double>::lowest();
     for (int i = 0; i < submatrix.size(); ++i)
     {
@@ -791,7 +796,7 @@ template <typename Derived>
 PDAL_DLL Derived dilate(const Eigen::MatrixBase<Derived>& A, int radius)
 {
     Derived B = Derived::Constant(A.rows(), A.cols(), 0);
-    
+
     int length = 2 * radius + 1;
     bool match_flag;
     for (int c = 0; c < A.cols(); ++c)
@@ -826,7 +831,7 @@ PDAL_DLL Derived dilate(const Eigen::MatrixBase<Derived>& A, int radius)
             B(r, c) = (match_flag) ? 1 : 0;
         }
     }
-    
+
     return B;
 }
 
@@ -844,7 +849,7 @@ template <typename Derived>
 PDAL_DLL Derived erode(const Eigen::MatrixBase<Derived>& A, int radius)
 {
     Derived B = Derived::Constant(A.rows(), A.cols(), 1);
-    
+
     int length = 2 * radius + 1;
     bool mismatch_flag;
     for (int c = 0; c < A.cols(); ++c)
@@ -885,7 +890,7 @@ PDAL_DLL Derived erode(const Eigen::MatrixBase<Derived>& A, int radius)
             B(r, c) = (mismatch_flag) ? 0 : 1;
         }
     }
-    
+
     return B;
 }
 

--- a/test/unit/EigenTest.cpp
+++ b/test/unit/EigenTest.cpp
@@ -115,7 +115,7 @@ TEST(EigenTest, ComputeValues)
     EXPECT_NEAR(0.8236099869, slope, 0.0001);
 
     double sd8 = eigen::computeSlopeD8(A, spacing);
-    EXPECT_NEAR(48.0378, sd8, 0.0001);
+    EXPECT_NEAR(67.9357, sd8, 0.0001);
 
     double sfd = eigen::computeSlopeFD(A, spacing);
     EXPECT_NEAR(210.1961, sfd, 0.0001);


### PR DESCRIPTION
First, we had a bug in how we computed slope for the D8 method. We were
dividing the slope in the cardinal directions by sqrt(2) instead of the
diagonals.

Second, we offer a switch to output slopes in degrees, not just percent. Note,
this is really just a convenience as analysts should have been able to convert
in the GIS tool of their choice.

Finally, our DSM generation approach had a tendency to leave voids in the max
elevation matrix. We switched to something very similar to what the GDAL writer
does, that is, specifying a radius and considering all points within the
cylinder centered at the current grid cell. At the same time, we remove the DSM
cleaning step.

Future work should consider unifying the behavior of GDALGrid/GDALWriter with
DerivativeWriter such that we can leverage the existing implementation and hole
filling capabilities. We may also be able to convert this to support streaming.