### PR TITLE
[WIP] Plugins params description expansion

### DIFF
--- a/pdal/Reader.cpp
+++ b/pdal/Reader.cpp
@@ -40,7 +40,7 @@ namespace pdal
 
 void Reader::readerAddArgs(ProgramArgs& args)
 {
-    m_filenameArg = &args.add("filename", "Name of file to read", m_filename);
+    m_filenameArg = &args.addRequired("filename", "Name of file to read", m_filename);
     m_countArg = &args.add("count", "Maximum number of points read", m_count,
         std::numeric_limits<point_count_t>::max());
 }

--- a/pdal/util/ProgramArgs.hpp
+++ b/pdal/util/ProgramArgs.hpp
@@ -25,8 +25,10 @@
 #include <map>
 #include <memory>
 #include <vector>
+#include <typeinfo>
 
 #include <pdal/util/Utils.hpp>
+#include <pdal/util/TypeName.hpp>
 
 namespace pdal
 {
@@ -152,9 +154,15 @@ protected:
       \param description  Argument description.
     */
     Arg(const std::string& longname, const std::string& shortname,
-        const std::string& description) : m_longname(longname),
+        const std::string& description, const bool required) : m_longname(longname),
         m_shortname(shortname), m_description(description), m_set(false),
-        m_hidden(false), m_positional(PosType::None)
+        m_hidden(false), m_positional(PosType::None), m_required(required), m_valType(TypeName<std::string>::get())
+    {}
+
+    Arg(const std::string& longname, const std::string& shortname,
+        const std::string& description, const bool required, const std::string& valType) : m_longname(longname),
+        m_shortname(shortname), m_description(description), m_set(false),
+        m_hidden(false), m_positional(PosType::None), m_required(required), m_valType(valType)
     {}
 
 public:
@@ -299,6 +307,22 @@ public:
         { return m_longname; }
 
     /**
+      Return whether argument is required.
+
+      \return  By default arguments are not required.
+    */
+    bool isRequired() const
+        { return m_required; }
+
+    /**
+      Return whether argument type in a string.
+
+      \return  By default returns string.
+    */
+    std::string valType() const
+        { return m_valType; }
+
+    /**
       Returns text indicating the longname and shortname of the option
       suitable for displaying in help information.
       \note  Not intended to be called from user code.
@@ -334,6 +358,8 @@ protected:
     bool m_set;
     bool m_hidden;
     PosType m_positional;
+    bool m_required;
+    std::string m_valType;
     std::string m_error;
 };
 
@@ -356,10 +382,11 @@ public:
       \param variable  Variable to which the value of the argument should
         be bound.
       \param def  Default value to be assigned to the bound variable.
+      \param required  Is field required or not.
     */
     TArg(const std::string& longname, const std::string& shortname,
-        const std::string& description, T& variable, T def) :
-        Arg(longname, shortname, description), m_var(variable),
+         const std::string& description, T& variable, T def, const bool required) :
+        Arg(longname, shortname, description, required, TypeName<T>::get()), m_var(variable),
         m_defaultVal(def), m_defaultProvided(true)
     { m_var = m_defaultVal; }
 
@@ -373,10 +400,11 @@ public:
       \param description  Argument description.
       \param variable  Variable to which the value of the argument should
         be bound.
+      \param required  Is field required or not.
     */
     TArg(const std::string& longname, const std::string& shortname,
-        const std::string& description, T& variable) :
-        Arg(longname, shortname, description), m_var(variable),
+         const std::string& description, T& variable, const bool required) :
+        Arg(longname, shortname, description, required, TypeName<T>::get()), m_var(variable),
         m_defaultVal(T()), m_defaultProvided(false)
     { m_var = m_defaultVal; }
 
@@ -426,6 +454,8 @@ public:
     virtual void reset()
     {
         m_var = m_defaultVal;
+        m_valType = TypeName<T>::get();
+        m_required = false;
         m_set = false;
         m_hidden = false;
     }
@@ -499,11 +529,12 @@ public:
       \param variable  bool variable to which the value of the argument should
         be bound.
       \param def  Default value to be assigned to the bound variable.
+      \param required  Is field required or not.
     */
     TArg(const std::string& longname, const std::string& shortname,
-        const std::string& description, bool& variable, bool def) :
-        Arg(longname, shortname, description), m_val(variable),
-        m_defaultVal(def), m_defaultProvided(true)
+         const std::string& description, bool& variable, bool def, const bool required) :
+         Arg(longname, shortname, description, required, TypeName<bool>::get()), m_val(variable),
+         m_defaultVal(def), m_defaultProvided(true)
     { m_val = m_defaultVal; }
 
     /**
@@ -516,11 +547,12 @@ public:
       \param description  Argument description.
       \param variable  bool variable to which the value of the argument should
         be bound.
+      \param required  Is field required or not.
     */
     TArg(const std::string& longname, const std::string& shortname,
-        const std::string& description, bool& variable) :
-        Arg(longname, shortname, description), m_val(variable),
-        m_defaultVal(false), m_defaultProvided(false)
+         const std::string& description, bool& variable, const bool required) :
+         Arg(longname, shortname, description, required, TypeName<bool>::get()), m_val(variable),
+         m_defaultVal(false), m_defaultProvided(false)
     { m_val = m_defaultVal; }
 
     /**
@@ -568,6 +600,8 @@ public:
     virtual void reset()
     {
         m_val = m_defaultVal;
+        m_valType = TypeName<bool>::get();
+        m_required = false;
         m_set = false;
         m_hidden = false;
     }
@@ -637,7 +671,14 @@ public:
       \param description  Argument description.
     */
     BaseVArg(const std::string& longname, const std::string& shortname,
-        const std::string& description) : Arg(longname, shortname, description),
+        const std::string& description, const bool required) :
+        Arg(longname, shortname, description, required),
+        m_defaultProvided(false)
+    {}
+
+    BaseVArg(const std::string& longname, const std::string& shortname,
+        const std::string& description, const bool required, const std::string& valType) :
+        Arg(longname, shortname, description, required, valType),
         m_defaultProvided(false)
     {}
 
@@ -709,11 +750,12 @@ public:
       \param description  Argument description.
       \param variable  Variable to which the argument value(s) should be bound.
       \param def  Default value.
+      \param required  Is field required or not.
     */
     VArg(const std::string& longname, const std::string& shortname,
         const std::string& description, std::vector<T>& variable,
-        std::vector<T> def) :
-        BaseVArg(longname, shortname, description), m_var(variable),
+        std::vector<T> def, const bool required) :
+        BaseVArg(longname, shortname, description, required, TypeName<T>::get()), m_var(variable),
         m_defaultVal(def)
     {
         m_var = def;
@@ -729,10 +771,11 @@ public:
         line with "-" prefix.
       \param description  Argument description.
       \param variable  Variable to which the argument value(s) should be bound.
+      \param required  Is field required or not.
     */
     VArg(const std::string& longname, const std::string& shortname,
-        const std::string& description, std::vector<T>& variable) :
-        BaseVArg(longname, shortname, description), m_var(variable)
+        const std::string& description, std::vector<T>& variable, const bool required) :
+        BaseVArg(longname, shortname, description, required, TypeName<T>::get()), m_var(variable)
     {
         // Clearing the vector resets to "default" value.
         m_var.clear();
@@ -780,6 +823,8 @@ public:
     virtual void reset()
     {
         m_var = m_defaultVal;
+        m_valType = TypeName<T>::get();
+        m_required = false;
         m_set = false;
         m_hidden = false;
     }
@@ -825,11 +870,12 @@ public:
       \param description  Argument description.
       \param variable  Variable to which the argument value(s) should be bound.
       \param def  Default value.
+      \param required  Is field required or not.
     */
     VArg(const std::string& longname, const std::string& shortname,
         const std::string& description, std::vector<std::string>& variable,
-        std::vector<std::string> def) :
-        BaseVArg(longname, shortname, description), m_var(variable),
+        std::vector<std::string> def, const bool required) :
+        BaseVArg(longname, shortname, description, required, TypeName<std::string>::get()), m_var(variable),
         m_defaultVal(def)
     {
         m_var = def;
@@ -845,10 +891,11 @@ public:
         line with "-" prefix.
       \param description  Argument description.
       \param variable  Variable to which the argument value(s) should be bound.
+      \param required  Is field required or not.
     */
     VArg(const std::string& longname, const std::string& shortname,
-        const std::string& description, std::vector<std::string>& variable) :
-        BaseVArg(longname, shortname, description), m_var(variable)
+        const std::string& description, std::vector<std::string>& variable, const bool required) :
+        BaseVArg(longname, shortname, description, required, TypeName<std::string>::get()), m_var(variable)
     {}
 
     /**
@@ -889,6 +936,8 @@ public:
     virtual void reset()
     {
         m_var = m_defaultVal;
+        m_valType = TypeName<std::string>::get();
+        m_required = false;
         m_set = false;
         m_hidden = false;
     }
@@ -945,6 +994,24 @@ public:
     }
 
     /**
+      Add a string argument to the list of arguments.
+
+      \param name  Name of argument.  Argument names are specified as
+        "longname[,shortname]", where shortname is an optional one-character
+        abbreviation.
+      \param description  Description of the argument.
+      \param var  Reference to variable to bind to argument.
+      \param def  Default value of argument.
+      \return  Reference to the new argument.
+      \param required  Is field required or not.
+    */
+    Arg& addRequired(const std::string& name, const std::string description,
+        std::string& var, std::string def)
+    {
+        return addRequired<std::string>(name, description, var, def);
+    }
+
+    /**
       Add a list-based (vector) string argument
 
       \param name  Name of argument.  Argument names are specified as
@@ -958,6 +1025,23 @@ public:
         std::vector<std::string>& var)
     {
         return add<std::string>(name, description, var);
+    }
+
+    /**
+      Add a list-based (vector) string argument
+
+      \param name  Name of argument.  Argument names are specified as
+        "longname[,shortname]", where shortname is an optional one-character
+        abbreviation.
+      \param description  Description of the argument.
+      \param var  Reference to variable to bind to argument.
+      \return  Reference to the new argument.
+      \param required  Is field required or not.
+    */
+    Arg& addRequired(const std::string& name, const std::string& description,
+        std::vector<std::string>& var)
+    {
+        return addRequired<std::string>(name, description, var);
     }
 
     /**
@@ -989,7 +1073,32 @@ public:
         std::string longname, shortname;
         splitName(name, longname, shortname);
 
-        Arg *arg = new VArg<T>(longname, shortname, description, var);
+        Arg *arg = new VArg<T>(longname, shortname, description, var, false);
+        addLongArg(longname, arg);
+        addShortArg(shortname, arg);
+        m_args.push_back(std::unique_ptr<Arg>(arg));
+        return *arg;
+    }
+
+    /**
+      Add a list-based (vector) argument.
+
+      \param name  Name of argument.  Argument names are specified as
+        "longname[,shortname]", where shortname is an optional one-character
+        abbreviation.
+      \param description  Description of the argument.
+      \param var  Reference to variable to bind to argument.
+      \return  Reference to the new argument.
+      \param required  Is field required or not.
+    */
+    template<typename T>
+    Arg& addRequired(const std::string& name, const std::string& description,
+        std::vector<T>& var)
+    {
+        std::string longname, shortname;
+        splitName(name, longname, shortname);
+
+        Arg *arg = new VArg<T>(longname, shortname, description, var, true);
         addLongArg(longname, arg);
         addShortArg(shortname, arg);
         m_args.push_back(std::unique_ptr<Arg>(arg));
@@ -1013,7 +1122,32 @@ public:
         std::string longname, shortname;
         splitName(name, longname, shortname);
 
-        Arg *arg = new VArg<T>(longname, shortname, description, var, def);
+        Arg *arg = new VArg<T>(longname, shortname, description, var, def, false);
+        addLongArg(longname, arg);
+        addShortArg(shortname, arg);
+        m_args.push_back(std::unique_ptr<Arg>(arg));
+        return *arg;
+    }
+
+    /**
+      Add a list-based (vector) argument with a default.
+
+      \param name  Name of argument.  Argument names are specified as
+        "longname[,shortname]", where shortname is an optional one-character
+        abbreviation.
+      \param description  Description of the argument.
+      \param var  Reference to variable to bind to argument.
+      \return  Reference to the new argument.
+      \param required  Is field required or not.
+    */
+    template<typename T>
+    Arg& addRequired(const std::string& name, const std::string& description,
+        std::vector<T>& var, std::vector<T> def)
+    {
+        std::string longname, shortname;
+        splitName(name, longname, shortname);
+
+        Arg *arg = new VArg<T>(longname, shortname, description, var, def, true);
         addLongArg(longname, arg);
         addShortArg(shortname, arg);
         m_args.push_back(std::unique_ptr<Arg>(arg));
@@ -1038,7 +1172,33 @@ public:
         std::string longname, shortname;
         splitName(name, longname, shortname);
 
-        Arg *arg = new TArg<T>(longname, shortname, description, var, def);
+        Arg *arg = new TArg<T>(longname, shortname, description, var, def, false);
+        addLongArg(longname, arg);
+        addShortArg(shortname, arg);
+        m_args.push_back(std::unique_ptr<Arg>(arg));
+        return *arg;
+    }
+
+    /**
+      Add an argument to the list of arguments with a default.
+
+      \param name  Name of argument.  Argument names are specified as
+        "longname[,shortname]", where shortname is an optional one-character
+        abbreviation.
+      \param description  Description of the argument.
+      \param var  Reference to variable to bind to argument.
+      \param def  Default value of argument.
+      \return  Reference to the new argument.
+      \param required  Is field required or not.
+    */
+    template<typename T>
+    Arg& addRequired(const std::string& name, const std::string description, T& var,
+        T def)
+    {
+        std::string longname, shortname;
+        splitName(name, longname, shortname);
+
+        Arg *arg = new TArg<T>(longname, shortname, description, var, def, true);
         addLongArg(longname, arg);
         addShortArg(shortname, arg);
         m_args.push_back(std::unique_ptr<Arg>(arg));
@@ -1061,7 +1221,31 @@ public:
         std::string longname, shortname;
         splitName(name, longname, shortname);
 
-        Arg *arg = new TArg<T>(longname, shortname, description, var);
+        Arg *arg = new TArg<T>(longname, shortname, description, var, false);
+        addLongArg(longname, arg);
+        addShortArg(shortname, arg);
+        m_args.push_back(std::unique_ptr<Arg>(arg));
+        return *arg;
+    }
+
+    /**
+      Add an argument to the list of arguments.
+
+      \param name  Name of argument.  Argument names are specified as
+        "longname[,shortname]", where shortname is an optional one-character
+        abbreviation.
+      \param description  Description of the argument.
+      \param var  Reference to variable to bind to argument.
+      \return  Reference to the new argument.
+      \param required  Is field required or not.
+    */
+    template<typename T>
+    Arg& addRequired(const std::string& name, const std::string description, T& var)
+    {
+        std::string longname, shortname;
+        splitName(name, longname, shortname);
+
+        Arg *arg = new TArg<T>(longname, shortname, description, var, true);
         addLongArg(longname, arg);
         addShortArg(shortname, arg);
         m_args.push_back(std::unique_ptr<Arg>(arg));
@@ -1303,6 +1487,10 @@ public:
 
             if (a->defaultProvided())
                 out << ",\"default\":\"" << a->defaultVal() << "\"";
+
+            out << ",\"required\":\"" << std::boolalpha << a->isRequired() << std::noboolalpha << "\"";
+
+            out << ",\"type\":\"" << a->valType() << "\"";
 
             out << ",\"description\":\"" << a->description() << "\"}";
 

--- a/pdal/util/TypeName.hpp
+++ b/pdal/util/TypeName.hpp
@@ -1,0 +1,56 @@
+/******************************************************************************
+* Copyright (c) 2016, Hobu Inc., hobu@hobu.co
+*
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following
+* conditions are met:
+*
+*     * Redistributions of source code must retain the above copyright
+*       notice, this list of conditions and the following disclaimer.
+*     * Redistributions in binary form must reproduce the above copyright
+*       notice, this list of conditions and the following disclaimer in
+*       the documentation and/or other materials provided
+*       with the distribution.
+*     * Neither the name of Hobu, Inc. Consulting nor the
+*       names of its contributors may be used to endorse or promote
+*       products derived from this software without specific prior
+*       written permission.
+*
+****************************************************************************/
+
+#pragma once
+
+#include <typeinfo>
+
+#define TYPENAME_ADD(A) template<> struct TypeName<A> { static const char *get() { return #A; }};
+
+using std::string;
+
+namespace pdal
+{
+    template <typename T>
+    struct TypeName
+    {
+        static string get()
+        {
+            return string (typeid(T).name());
+        }
+    };
+
+    template <>
+    struct TypeName<char>
+    {
+        static string get()
+        {
+            return "string";
+        }
+    };
+
+    TYPENAME_ADD(int);
+    TYPENAME_ADD(long);
+    TYPENAME_ADD(float);
+    TYPENAME_ADD(double);
+    TYPENAME_ADD(bool);
+} // namespace pdal


### PR DESCRIPTION
For DSL generation (required here: https://github.com/PDAL/PDAL/pull/1492) it is required to have additional information about params: `type` and is field `required` or not.

The idea to make the following json document: 

```json
{
	"plugin" :
	[
		{
			"description" : "<description>",
			"name" : "<field name>",
			"default" : "<default value>",
			"required" : "{true | false}",
			"type" : "<string name of a type>"
		}
	]
}
```

_NOTE: There can be a small confusion about required field: the field can be required if another field is missing. In terms of DSL generation it means that such fields are _optional_. Probably it's enough to say some words about this dependency in docs or in a description field._

- [ ] Dirty version implementation
- [ ] Refactor according to reviews

So there we have a problem in identifying the type of argument: we can try it to convert basing on args type during compilation: https://github.com/pomadchin/PDAL/blob/feature/richer-showjson/pdal/util/TypeName.hpp or we can make additional functions overload with possibility to specify custom / hardcoded type which we want to be visible in the output json / strings.
Both variants are possible at the same time. 
Some questions:
+ can I find somewhere a list of required fields for all plugins?
+ what approach should be used to modify current code? as multiple overloads of all constructors of all types looks like not the best idea