### PR TITLE
Add int to char cast of toupper result

### DIFF
--- a/pdal/pdal_types.hpp
+++ b/pdal/pdal_types.hpp
@@ -201,7 +201,7 @@ inline std::ostream& operator<<(std::ostream& out, const LogLevel& level)
     if ((size_t)level < logNames.size())
     {
         sval = logNames[(size_t)level];
-        sval[0] = toupper(sval[0]);   // Make "Debug", "Error", etc.
+        sval[0] = (char)toupper(sval[0]);   // Make "Debug", "Error", etc.
     }
     out << sval;
     return out;


### PR DESCRIPTION
Tiny fix for compilation warnings.