### PR TITLE
Refactor SMRF code

### DIFF
--- a/doc/stages/filters.smrf.rst
+++ b/doc/stages/filters.smrf.rst
@@ -6,20 +6,6 @@ filters.smrf
 Filter ground returns using the Simple Morphological Filter (SMRF) approach
 outlined in [Pingel2013]_.
 
-.. note::
-  
-  Our implmentation of SMRF is in an alpha state. We'd love to have you kick
-  the tires and provide feedback, but do not plan on using this in production.
-  
-The current implementation of ``filters.smrf`` differs slightly from the
-original paper. We weren't too happy with the performance of (our implementation
-of) the inpainting routine, so we started exploring some other methods.
-
-Some warts about the current implementation:
-
-* It writes a bunch of intermediate/debugging outputs to the current directory
-  while processing. This should be made optional and then eventually go away.
-  
 .. [Pingel2013] Pingel, T.J., Clarke, K.C., McBride, W.A., 2013. An improved simple morphological filter for the terrain classification of airborne LIDAR data. ISPRS J. Photogramm. Remote Sens. 77, 21–30.
 
 Example
@@ -34,9 +20,12 @@ returns, writing only the ground returns to the output file.
       "pipeline":[
         "input.las",
         {
-          "type":"filters.smrf",
-          "extract":true
+          "type":"filters.smrf"
         },
+        {
+          "type":"filters.range",
+          "limits":"Classification[2:2]"
+        }
         "output.laz"
       ]
     }
@@ -47,20 +36,20 @@ Options
 cell
   Cell size. [Default: **1.0**]
 
-classify
-  Apply classification labels (i.e., ground = 2)? [Default: **true**]
-
 cut
   Cut net size (``cut=0`` skips the net cutting step). [Default: **0.0**]
   
-extract
-  Extract ground returns (non-ground returns are cropped)? [Default: **false**]
+outdir
+  Optional output directory for debugging intermediate rasters.
+  
+scalar
+  Elevation scalar. [Default: **1.25**]
   
 slope
   Slope (rise over run). [Default: **0.15**]
   
 threshold
-  Elevation threshold. [Default: **0.15**]
+  Elevation threshold. [Default: **0.5**]
   
 window
-  Max window size. [Default: **21.0**]
+  Max window size. [Default: **18.0**]

--- a/filters/SMRFilter.cpp
+++ b/filters/SMRFilter.cpp
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (c) 2016, Bradley J Chambers (brad.chambers@gmail.com)
+* Copyright (c) 2016-2017, Bradley J Chambers (brad.chambers@gmail.com)
 *
 * All rights reserved.
 *
@@ -32,43 +32,39 @@
 * OF SUCH DAMAGE.
 ****************************************************************************/
 
+// PDAL implementation of T. J. Pingel, K. C. Clarke, and W. A. McBride, “An
+// improved simple morphological filter for the terrain classification of
+// airborne LIDAR data,” ISPRS J. Photogramm. Remote Sens., vol. 77, pp. 21–30,
+// 2013.
+
 #include "SMRFilter.hpp"
 
 #include <pdal/EigenUtils.hpp>
+#include <pdal/KDIndex.hpp>
 #include <pdal/pdal_macros.hpp>
-#include <pdal/PipelineManager.hpp>
-#include <pdal/SpatialReference.hpp>
 #include <pdal/util/FileUtils.hpp>
 #include <pdal/util/ProgramArgs.hpp>
-#include <pdal/util/Utils.hpp>
-#include <io/BufferReader.hpp>
 
 #include <Eigen/Dense>
-#include <Eigen/Sparse>
+
+#include <cmath>
+#include <limits>
+#include <string>
+#include <vector>
 
 namespace pdal
 {
+
+using namespace Dimension;
 using namespace Eigen;
+using namespace eigen;
 
 static PluginInfo const s_info =
-    PluginInfo("filters.smrf", "Pingel et al. (2013)",
+    PluginInfo("filters.smrf",
+               "Simple Morphological Filter (Pingel et al., 2013)",
                "http://pdal.io/stages/filters.smrf.html");
 
 CREATE_STATIC_PLUGIN(1, 0, SMRFilter, Filter, s_info)
-
-struct distElev
-{
-    double dist;
-    double elev;
-};
-
-struct by_dist
-{
-    bool operator()(distElev const& a, distElev const& b)
-    {
-        return a.dist < b.dist;
-    }
-};
 
 std::string SMRFilter::getName() const
 {
@@ -77,275 +73,289 @@ std::string SMRFilter::getName() const
 
 void SMRFilter::addArgs(ProgramArgs& args)
 {
-    args.add("classify", "Apply classification labels?", m_classify, true);
-    args.add("extract", "Extract ground returns?", m_extract);
-    args.add("cell", "Cell size?", m_cellSize, 1.0);
-    args.add("slope", "Slope?", m_percentSlope, 0.15);
-    args.add("window", "Max window size?", m_maxWindow, 18.0);
+    args.add("cell", "Cell size?", m_cell, 1.0);
+    args.add("slope", "Percent slope?", m_slope, 0.15);
+    args.add("window", "Max window size?", m_window, 18.0);
     args.add("scalar", "Elevation scalar?", m_scalar, 1.25);
     args.add("threshold", "Elevation threshold?", m_threshold, 0.5);
-    args.add("cut", "Cut net size?", m_cutNet, 0.0);
-    args.add("outdir", "Optional output directory for debugging", m_outDir);
+    args.add("cut", "Cut net size?", m_cut, 0.0);
+    args.add("dir", "Optional output directory for debugging", m_dir);
 }
 
 void SMRFilter::addDimensions(PointLayoutPtr layout)
 {
-    layout->registerDim(Dimension::Id::Classification);
+    layout->registerDim(Id::Classification);
 }
 
 void SMRFilter::ready(PointTableRef table)
 {
-    if (m_outDir.empty())
+    if (m_dir.empty())
         return;
 
-    if (!FileUtils::directoryExists(m_outDir))
-        throwError("Output directory '" + m_outDir + "' does not exist");
+    if (!FileUtils::directoryExists(m_dir))
+        throwError("Output directory '" + m_dir + "' does not exist");
 }
 
-MatrixXd SMRFilter::inpaintKnn(MatrixXd cx, MatrixXd cy, MatrixXd cz)
+PointViewSet SMRFilter::run(PointViewPtr view)
 {
-    MatrixXd out = cz;
+    PointViewSet viewSet;
+    if (!view->size())
+        return viewSet;
 
-    for (auto c = 0; c < m_numCols; ++c)
+    m_srs = view->spatialReference();
+
+    view->calculateBounds(m_bounds);
+    m_cols = ((m_bounds.maxx - m_bounds.minx) / m_cell) + 1;
+    m_rows = ((m_bounds.maxy - m_bounds.miny) / m_cell) + 1;
+
+    // Create raster of minimum Z values per element.
+    MatrixXd ZImin = createZImin(view);
+
+    // Create raster mask of pixels containing low outlier points.
+    MatrixXi Low = createLowMask(ZImin);
+
+    // Create raster mask of net cuts. Net cutting is used to when a scene
+    // contains large buildings in highly differentiated terrain.
+    MatrixXi isNetCell = createNetMask();
+
+    // Apply net cutting to minimum Z raster.
+    MatrixXd ZInet = createZInet(ZImin, isNetCell);
+
+    // Create raster mask of pixels containing object points. Note that we use
+    // ZInet, the result of net cutting, to identify object pixels.
+    MatrixXi Obj = createObjMask(ZInet);
+
+    // Create raster representing the provisional DEM. Note that we use the
+    // original ZImin (not ZInet), however the net cut mask will still force
+    // interpolation at these pixels.
+    MatrixXd ZIpro = createZIpro(view, ZImin, Low, isNetCell, Obj);
+
+    // Classify ground returns by comparing elevation values to the provisional
+    // DEM.
+    classifyGround(view, ZIpro);
+
+    viewSet.insert(view);
+
+    return viewSet;
+}
+
+void SMRFilter::classifyGround(PointViewPtr view, Eigen::MatrixXd const& ZIpro)
+{
+    // "While many authors use a single value for the elevation threshold, we
+    // suggest that a second parameter be used to increase the threshold on
+    // steep slopes, transforming the threshold to a slope-dependent value. The
+    // total permissible distance is then equal to a fixed elevation threshold
+    // plus the scaling value multiplied by the slope of the DEM at each LIDAR
+    // point. The rationale behind this approach is that small horizontal and
+    // vertical displacements yield larger errors on steep slopes, and as a
+    // result the BE/OBJ threshold distance should be more permissive at these
+    // points."
+    MatrixXd gsurfs(m_rows, m_cols);
+    MatrixXd thresh(m_rows, m_cols);
     {
-        for (auto r = 0; r < m_numRows; ++r)
+        MatrixXd scaled = ZIpro / m_cell;
+
+        MatrixXd gx = gradX(scaled);
+        MatrixXd gy = gradY(scaled);
+        gsurfs = (gx.cwiseProduct(gx) + gy.cwiseProduct(gy)).cwiseSqrt();
+        MatrixXd gsurfs_fill = knnfill(view, gsurfs);
+        gsurfs = gsurfs_fill;
+        thresh = (m_threshold + m_scalar * gsurfs.array()).matrix();
+
+        if (!m_dir.empty())
         {
-            if (!std::isnan(cz(r, c)))
-                continue;
+            std::string fname = FileUtils::toAbsolutePath("gx.tif", m_dir);
+            writeMatrix(gx, fname, "GTiff", m_cell, m_bounds, m_srs);
 
-            int radius = 1;
-            bool enough = false;
+            fname = FileUtils::toAbsolutePath("gy.tif", m_dir);
+            writeMatrix(gy, fname, "GTiff", m_cell, m_bounds, m_srs);
 
-            while (!enough)
+            fname = FileUtils::toAbsolutePath("gsurfs.tif", m_dir);
+            writeMatrix(gsurfs, fname, "GTiff", m_cell, m_bounds, m_srs);
+
+            fname = FileUtils::toAbsolutePath("gsurfs_fill.tif", m_dir);
+            writeMatrix(gsurfs_fill, fname, "GTiff", m_cell, m_bounds, m_srs);
+
+            fname = FileUtils::toAbsolutePath("thresh.tif", m_dir);
+            writeMatrix(thresh, fname, "GTiff", m_cell, m_bounds, m_srs);
+        }
+    }
+
+    for (PointId i = 0; i < view->size(); ++i)
+    {
+        double x = view->getFieldAs<double>(Id::X, i);
+        double y = view->getFieldAs<double>(Id::Y, i);
+        double z = view->getFieldAs<double>(Id::Z, i);
+
+        size_t c = static_cast<size_t>(std::floor(x - m_bounds.minx) / m_cell);
+        size_t r = static_cast<size_t>(std::floor(y - m_bounds.miny) / m_cell);
+
+        // TODO(chambbj): We don't quite do this by the book and yet it seems to
+        // work reasonably well:
+        // "The calculation requires that both elevation and slope are
+        // interpolated from the provisional DEM. There are any number of
+        // interpolation techniques that might be used, and even nearest
+        // neighbor approaches work quite well, so long as the cell size of the
+        // DEM nearly corresponds to the resolution of the LIDAR data. Based on
+        // these results, we find that a splined cubic interpolation provides
+        // the best results."
+        if (std::isnan(ZIpro(r, c)))
+            continue;
+
+        if (std::isnan(gsurfs(r, c)))
+            continue;
+
+        // "The final step of the algorithm is the identification of
+        // ground/object // LIDAR points. This is accomplished by measuring the
+        // vertical distance // between each LIDAR point and the provisional
+        // DEM, and applying a // threshold calculation."
+        if (std::fabs(ZIpro(r, c) - z) > thresh(r, c))
+            continue;
+
+        view->setField(Id::Classification, i, 2);
+    }
+}
+
+Eigen::MatrixXi SMRFilter::createLowMask(Eigen::MatrixXd const& ZImin)
+{
+    // "[The] minimum surface is checked for low outliers by inverting the point
+    // cloud in the z-axis and applying the filter with parameters (slope =
+    // 500%, maxWindowSize = 1). The resulting mask is used to flag low outlier
+    // cells as OBJ before the inpainting of the provisional DEM."
+    MatrixXi Low = progressiveFilter(-ZImin, 5.0, 1.0);
+
+    if (!m_dir.empty())
+    {
+        std::string fname = FileUtils::toAbsolutePath("zilow.tif", m_dir);
+        writeMatrix(Low.cast<double>(), fname, "GTiff", m_cell, m_bounds,
+                    m_srs);
+    }
+
+    return Low;
+}
+
+Eigen::MatrixXi SMRFilter::createNetMask()
+{
+    // "To accommodate the removal of [very large buildings on highly
+    // differentiated terrain], we implemented a feature in the published SMRF
+    // algorithm which is helpful in removing such features. We accomplish this
+    // by introducing into the initial minimum surface a "net" of minimum values
+    // at a spacing equal to the maximum window diameter, where these minimum
+    // values are found by applying a morphological open operation with a disk
+    // shaped structuring element of radius (2*wkmax)."
+    MatrixXi isNetCell = MatrixXi::Zero(m_rows, m_cols);
+    if (m_cut > 0.0)
+    {
+        int v = std::ceil(m_cut / m_cell);
+
+        for (auto c = 0; c < m_cols; c += v)
+        {
+            for (auto r = 0; r < m_rows; ++r)
             {
-                // log()->get(LogLevel::Debug) << r << "\t" << c << "\t" << radius << std::endl;
-                int cs = Utils::clamp(c-radius, 0, m_numCols-1);
-                int ce = Utils::clamp(c+radius, 0, m_numCols-1);
-                int col_size = ce - cs + 1;
-                int rs = Utils::clamp(r-radius, 0, m_numRows-1);
-                int re = Utils::clamp(r+radius, 0, m_numRows-1);
-                int row_size = re - rs + 1;
-
-                // MatrixXd Xn = cx.block(rs, cs, row_size, col_size);
-                // MatrixXd Yn = cy.block(rs, cs, row_size, col_size);
-                MatrixXd Zn = cz.block(rs, cs, row_size, col_size);
-
-                auto notNaN = [](double x)
-                {
-                    return !std::isnan(x);
-                };
-
-                enough = Zn.unaryExpr(notNaN).count() >= 8;
-                if (!enough)
-                {
-                    ++radius;
-                    continue;
-                }
-
-                // auto zNotNaN = [](double x)
-                // {
-                //     if (!std::isnan(x))
-                //         return x;
-                //     else
-                //         return 0.0;
-                // };
-                //
-                // // proceed to find 8 nearest neighbors and average the z values
-                // // std::cerr << Zn.unaryExpr(zNotNaN).sum() << "\t" << Zn.size() << "\t" << Zn.unaryExpr(zNotNaN).sum() / Zn.size() << std::endl;
-                // out(r, c) = Zn.unaryExpr(zNotNaN).sum() / Zn.size();
-
-                std::vector<distElev> de;
-
-                for (auto cc = cs; cc <= ce; ++cc)
-                {
-                    for (auto rr = rs; rr <= re; ++rr)
-                    {
-                        if (std::isnan(cz(rr, cc)))
-                            continue;
-
-                        // compute distance to !isnan neighbor
-                        double dx = cx(rr, cc) - cx(r, c);
-                        double dy = cy(rr, cc) - cy(r, c);
-                        double sqrdist = dx * dx + dy * dy;
-                        de.push_back(distElev{sqrdist, cz(rr, cc)});
-                    }
-                }
-                // sort dists
-                std::sort(de.begin(), de.end(), by_dist());
-
-                // average elevatio of lowest eight dists
-                double sum = 0.0;
-                for (auto i = 0; i < 8; ++i)
-                {
-                    sum += de[i].elev;
-                }
-                sum /= 8.0;
-
-                out(r, c) = sum;
+                isNetCell(r, c) = 1;
+            }
+        }
+        for (auto c = 0; c < m_cols; ++c)
+        {
+            for (auto r = 0; r < m_rows; r += v)
+            {
+                isNetCell(r, c) = 1;
             }
         }
     }
 
-    return out;
+    return isNetCell;
 }
 
-std::vector<PointId> SMRFilter::processGround(PointViewPtr view)
+Eigen::MatrixXi SMRFilter::createObjMask(Eigen::MatrixXd const& ZImin)
 {
-    log()->get(LogLevel::Info) << "processGround: Running SMRF...\n";
-
-    // The algorithm consists of four conceptually distinct stages. The first is
-    // the creation of the minimum surface (ZImin). The second is the processing
-    // of the minimum surface, in which grid cells from the raster are
-    // identified as either containing bare earth (BE) or objects (OBJ). This
-    // second stage represents the heart of the algorithm. The third step is the
-    // creation of a DEM from these gridded points. The fourth step is the
-    // identification of the original LIDAR points as either BE or OBJ based on
-    // their relationship to the interpolated
-
-    std::vector<PointId> groundIdx;
-
-    BOX2D bounds;
-    view->calculateBounds(bounds);
-    SpatialReference srs(view->spatialReference());
-
-    // Determine the number of rows and columns at the given cell size.
-    m_numCols = ((bounds.maxx - bounds.minx) / m_cellSize) + 1;
-    m_numRows = ((bounds.maxy - bounds.miny) / m_cellSize) + 1;
-
-    MatrixXd cx(m_numRows, m_numCols);
-    MatrixXd cy(m_numRows, m_numCols);
-    for (auto c = 0; c < m_numCols; ++c)
-    {
-        for (auto r = 0; r < m_numRows; ++r)
-        {
-            cx(r, c) = bounds.minx + (c + 0.5) * m_cellSize;
-            cy(r, c) = bounds.miny + (r + 0.5) * m_cellSize;
-        }
-    }
-
-    // STEP 1:
-
-    // As with many other ground filtering algorithms, the first step is
-    // generation of ZImin from the cell size parameter and the extent of the
-    // data. The two vectors corresponding to [min:cellSize:max] for each
-    // coordinate – xi and yi – may be supplied by the user or may be easily and
-    // automatically calculated from the data. Without supplied ranges, the SMRF
-    // algorithm creates a raster from the ceiling of the minimum to the floor
-    // of the maximum values for each of the (x,y) dimensions. If the supplied
-    // cell size parameter is not an integer, the same general rule applies to
-    // values evenly divisible by the cell size. For example, if cell size is
-    // equal to 0.5 m, and the x values range from 52345.6 to 52545.4, the range
-    // would be [52346 52545].
-
-    // The minimum surface grid ZImin defined by vectors (xi,yi) is filled with
-    // the nearest, lowest elevation from the original point cloud (x,y,z)
-    // values, provided that the distance to the nearest point does not exceed
-    // the supplied cell size parameter. This provision means that some grid
-    // points of ZImin will go unfilled. To fill these values, we rely on
-    // computationally inexpensive image inpainting techniques. Image inpainting
-    // involves the replacement of the empty cells in an image (or matrix) with
-    // values calculated from other nearby values. It is a type of interpolation
-    // technique derived from artistic replacement of damaged portions of
-    // photographs and paintings, where preservation of texture is an important
-    // concern (Bertalmio et al., 2000). When empty values are spread through
-    // the image, and the ratio of filled to empty pixels is quite high, most
-    // methods of inpainting will produce satisfactory results. In an evaluation
-    // of inpainting methods on ground identification from the final terrain
-    // model, we found that Laplacian techniques produced error rates nearly
-    // three times higher than either an average of the eight nearest neighbors
-    // or D’Errico’s spring-metaphor inpainting technique (D’Errico, 2004). The
-    // spring-metaphor technique imagines springs connecting each cell with its
-    // eight adjacent neighbors, where the inpainted value corresponds to the
-    // lowest energy state of the set, and where the entire (sparse) set of
-    // linear equations is solved using partial differential equations. Both of
-    // these latter techniques were nearly the same with regards to total error,
-    // with the spring technique performing slightly better than the k-nearest
-    // neighbor (KNN) approach.
-
-    MatrixXd ZImin = eigen::createMinMatrix(*view.get(), m_numRows, m_numCols,
-                                            m_cellSize, bounds);
-
-    // MatrixXd ZImin_painted = inpaintKnn(cx, cy, ZImin);
-    // MatrixXd ZImin_painted = TPS(cx, cy, ZImin);
-    MatrixXd ZImin_painted = expandingTPS(cx, cy, ZImin);
-
-    if (!m_outDir.empty())
-    {
-        std::string filename = FileUtils::toAbsolutePath("zimin.tif", m_outDir);
-        eigen::writeMatrix(ZImin, filename, "GTiff", m_cellSize, bounds, srs);
-
-        filename = FileUtils::toAbsolutePath("zimin_painted.tif", m_outDir);
-        eigen::writeMatrix(ZImin_painted, filename, "GTiff", m_cellSize,
-            bounds, srs);
-    }
-
-    ZImin = ZImin_painted;
-
-    // STEP 2:
-
-    // The second stage of the ground identification algorithm involves the
+    // "The second stage of the ground identification algorithm involves the
     // application of a progressive morphological filter to the minimum surface
-    // grid (ZImin). At the first iteration, the filter applies an image opening
-    // operation to the minimum surface. An opening operation consists of an
-    // application of an erosion filter followed by a dilation filter. The
-    // erosion acts to snap relative high values to relative lows, where a
-    // supplied window radius and shape (or structuring element) defines the
-    // search neighborhood. The dilation uses the same window radius and
-    // structuring element, acting to outwardly expand relative highs. Fig. 2
-    // illustrates an opening operation on a cross section of a transect from
-    // Sample 1–1 in the ISPRS LIDAR reference dataset (Sithole and Vosselman,
-    // 2003), following Zhang et al. (2003).
+    // grid (ZImin)."
+    MatrixXi Obj = progressiveFilter(ZImin, m_slope, m_window);
 
-    // paper has low point happening later, i guess it doesn't matter
-    // too much, this is where he does it in matlab code
-    MatrixXi Low = progressiveFilter(-ZImin, m_cellSize, 5.0, 1.0);
-
-    // matlab code has net cutting occurring here
-    MatrixXd ZInet = ZImin;
-    MatrixXi isNetCell = MatrixXi::Zero(m_numRows, m_numCols);
-    if (m_cutNet > 0.0)
+    if (!m_dir.empty())
     {
-        MatrixXd bigOpen = eigen::matrixOpen(ZImin,
-            2*std::ceil(m_cutNet / m_cellSize));
-        for (auto c = 0; c < m_numCols; c += std::ceil(m_cutNet/m_cellSize))
+        std::string fname = FileUtils::toAbsolutePath("ziobj.tif", m_dir);
+        writeMatrix(Obj.cast<double>(), fname, "GTiff", m_cell, m_bounds,
+                    m_srs);
+    }
+
+    return Obj;
+}
+
+Eigen::MatrixXd SMRFilter::createZImin(PointViewPtr view)
+{
+    // "As with many other ground filtering algorithms, the first step is
+    // generation of ZImin from the cell size parameter and the extent of the
+    // data."
+    MatrixXd ZImin = createMinMatrix(*view.get(), m_rows, m_cols, m_cell,
+                                     m_bounds);
+
+    // "...some grid points of ZImin will go unfilled. To fill these values, we
+    // rely on computationally inexpensive image inpainting techniques. Image
+    // inpainting involves the replacement of the empty cells in an image (or
+    // matrix) with values calculated from other nearby values."
+    MatrixXd ZImin_fill = knnfill(view, ZImin);
+
+    if (!m_dir.empty())
+    {
+        std::string fname = FileUtils::toAbsolutePath("zimin.tif", m_dir);
+        writeMatrix(ZImin, fname, "GTiff", m_cell, m_bounds, m_srs);
+
+        fname = FileUtils::toAbsolutePath("zimin_fill.tif", m_dir);
+        writeMatrix(ZImin_fill, fname, "GTiff", m_cell, m_bounds, m_srs);
+    }
+
+    return ZImin_fill;
+}
+
+Eigen::MatrixXd SMRFilter::createZInet(Eigen::MatrixXd const& ZImin,
+                                       Eigen::MatrixXi const& isNetCell)
+{
+    // "To accommodate the removal of [very large buildings on highly
+    // differentiated terrain], we implemented a feature in the published SMRF
+    // algorithm which is helpful in removing such features. We accomplish this
+    // by introducing into the initial minimum surface a "net" of minimum values
+    // at a spacing equal to the maximum window diameter, where these minimum
+    // values are found by applying a morphological open operation with a disk
+    // shaped structuring element of radius (2*wkmax)."
+    MatrixXd ZInet = ZImin;
+    if (m_cut > 0.0)
+    {
+        int v = std::ceil(m_cut / m_cell);
+        MatrixXd bigOpen = openDiamond(ZImin, 2 * v);
+        for (auto c = 0; c < m_cols; ++c)
         {
-            for (auto r = 0; r < m_numRows; ++r)
-            {
-                isNetCell(r, c) = 1;
-            }
-        }
-        for (auto c = 0; c < m_numCols; ++c)
-        {
-            for (auto r = 0; r < m_numRows; r += std::ceil(m_cutNet/m_cellSize))
-            {
-                isNetCell(r, c) = 1;
-            }
-        }
-        for (auto c = 0; c < m_numCols; ++c)
-        {
-            for (auto r = 0; r < m_numRows; ++r)
+            for (auto r = 0; r < m_rows; ++r)
             {
                 if (isNetCell(r, c)==1)
+                {
                     ZInet(r, c) = bigOpen(r, c);
+                }
             }
         }
     }
 
-    // and finally object detection
-    MatrixXi Obj = progressiveFilter(ZInet, m_cellSize, m_percentSlope,
-        m_maxWindow);
+    if (!m_dir.empty())
+    {
+        std::string fname = FileUtils::toAbsolutePath("zinet.tif", m_dir);
+        writeMatrix(ZInet, fname, "GTiff", m_cell, m_bounds, m_srs);
+    }
 
-    // STEP 3:
+    return ZInet;
+}
 
-    // The end result of the iteration process described above is a binary grid
+Eigen::MatrixXd SMRFilter::createZIpro(PointViewPtr view,
+                                       Eigen::MatrixXd const& ZImin,
+                                       Eigen::MatrixXi const& Low,
+                                       Eigen::MatrixXi const& isNetCell,
+                                       Eigen::MatrixXi const& Obj)
+{
+    // "The end result of the iteration process described above is a binary grid
     // where each cell is classified as being either bare earth (BE) or object
     // (OBJ). The algorithm then applies this mask to the starting minimum
-    // surface to eliminate nonground cells. These cells are then inpainted
-    // according to the same process described previously, producing a
-    // provisional DEM (ZIpro).
-
-    // we currently aren't checking for net cells or empty cells
-    // (haven't I already marked empty cells as NaNs?)
+    // surface to eliminate nonground cells."
     MatrixXd ZIpro = ZImin;
     for (int i = 0; i < Obj.size(); ++i)
     {
@@ -353,620 +363,140 @@ std::vector<PointId> SMRFilter::processGround(PointViewPtr view)
             ZIpro(i) = std::numeric_limits<double>::quiet_NaN();
     }
 
-    // MatrixXd ZIpro_painted = inpaintKnn(cx, cy, ZIpro);
-    // MatrixXd ZIpro_painted = TPS(cx, cy, ZIpro);
-    MatrixXd ZIpro_painted = expandingTPS(cx, cy, ZIpro);
+    // "These cells are then inpainted according to the same process described
+    // previously, producing a provisional DEM (ZIpro)."
+    MatrixXd ZIpro_fill = knnfill(view, ZIpro);
 
-    if (!m_outDir.empty())
+    if (!m_dir.empty())
     {
-        std::string filename = FileUtils::toAbsolutePath("zilow.tif", m_outDir);
-        eigen::writeMatrix(Low.cast<double>(), filename, "GTiff",
-            m_cellSize, bounds, srs);
+        std::string fname = FileUtils::toAbsolutePath("zipro.tif", m_dir);
+        writeMatrix(ZIpro, fname, "GTiff", m_cell, m_bounds, m_srs);
 
-        filename = FileUtils::toAbsolutePath("zinet.tif", m_outDir);
-        eigen::writeMatrix(ZInet, filename, "GTiff", m_cellSize, bounds, srs);
-
-        filename = FileUtils::toAbsolutePath("ziobj.tif", m_outDir);
-        eigen::writeMatrix(Obj.cast<double>(), filename, "GTiff",
-            m_cellSize, bounds, srs);
-
-        filename = FileUtils::toAbsolutePath("zipro.tif", m_outDir);
-        eigen::writeMatrix(ZIpro, filename, "GTiff", m_cellSize, bounds, srs);
-
-        filename = FileUtils::toAbsolutePath("zipro_painted.tif", m_outDir);
-        eigen::writeMatrix(ZIpro_painted, filename, "GTiff",
-            m_cellSize, bounds, srs);
+        fname = FileUtils::toAbsolutePath("zipro_fill.tif", m_dir);
+        writeMatrix(ZIpro_fill, fname, "GTiff", m_cell, m_bounds, m_srs);
     }
 
-    ZIpro = ZIpro_painted;
-
-    // STEP 4:
-
-    // The final step of the algorithm is the identification of ground/object
-    // LIDAR points. This is accomplished by measuring the vertical distance
-    // between each LIDAR point and the provisional DEM, and applying a
-    // threshold calculation. While many authors use a single value for the
-    // elevation threshold, we suggest that a second parameter be used to
-    // increase the threshold on steep slopes, transforming the threshold to a
-    // slope-dependent value. The total permissible distance is then equal to a
-    // fixed elevation threshold plus the scaling value multiplied by the slope
-    // of the DEM at each LIDAR point. The rationale behind this approach is
-    // that small horizontal and vertical displacements yield larger errors on
-    // steep slopes, and as a result the BE/OBJ threshold distance should be
-    // more per- missive at these points.
-
-    // The calculation requires that both elevation and slope are interpolated
-    // from the provisional DEM. There are any number of interpolation
-    // techniques that might be used, and even nearest neighbor approaches work
-    // quite well, so long as the cell size of the DEM nearly corresponds to the
-    // resolution of the LIDAR data. A comparison of how well these different
-    // methods of interpolation perform is given in the next section. Based on
-    // these results, we find that a splined cubic interpolation provides the
-    // best results.
-
-    // It is common in LIDAR point clouds to have a small number of outliers
-    // which may be either above or below the terrain surface. While
-    // above-ground outliers (e.g., a random return from a bird in flight) are
-    // filtered during the normal algorithm routine, the below-ground outliers
-    // (e.g., those caused by a reflection) require a separate approach. Early
-    // in the routine and along a separate processing fork, the minimum surface
-    // is checked for low outliers by inverting the point cloud in the z-axis
-    // and applying the filter with parameters (slope = 500%, maxWindowSize =
-    // 1). The resulting mask is used to flag low outlier cells as OBJ before
-    // the inpainting of the provisional DEM. This outlier identification
-    // methodology is functionally the same as that of Zhang et al. (2003).
-
-    // The provisional DEM (ZIpro), created by removing OBJ cells from the
-    // original minimum surface (ZImin) and then inpainting, tends to be less
-    // smooth than one might wish, especially when the surfaces are to be used
-    // to create visual products like immersive geographic virtual environments.
-    // As a result, it is often worthwhile to reinter- polate a final DEM from
-    // the identified ground points of the original LIDAR data (ZIfin). Surfaces
-    // created from these data tend to be smoother and more visually satisfying
-    // than those derived from the provisional DEM.
-
-    // Very large (>40m in length) buildings can sometimes prove troublesome to
-    // remove on highly differentiated terrain. To accommodate the removal of
-    // such objects, we implemented a feature in the published SMRF algorithm
-    // which is helpful in removing such features. We accomplish this by
-    // introducing into the initial minimum surface a ‘‘net’’ of minimum values
-    // at a spacing equal to the maximum window diameter, where these minimum
-    // values are found by applying a morphological open operation with a disk
-    // shaped structuring element of radius (2?wkmax). Since only one example in
-    // this dataset had features this large (Sample 4–2, a trainyard) we did not
-    // include this portion of the algorithm in the formal testing procedure,
-    // though we provide a brief analysis of the effect of using this net filter
-    // in the next section.
-
-    MatrixXd scaled = ZIpro / m_cellSize;
-
-    MatrixXd gx = eigen::gradX(scaled);
-    MatrixXd gy = eigen::gradY(scaled);
-    MatrixXd gsurfs = (gx.cwiseProduct(gx) + gy.cwiseProduct(gy)).cwiseSqrt();
-
-    // MatrixXd gsurfs_painted = inpaintKnn(cx, cy, gsurfs);
-    // MatrixXd gsurfs_painted = TPS(cx, cy, gsurfs);
-    MatrixXd gsurfs_painted = expandingTPS(cx, cy, gsurfs);
-
-    if (!m_outDir.empty())
-    {
-        std::string filename = FileUtils::toAbsolutePath("gx.tif", m_outDir);
-        eigen::writeMatrix(gx, filename, "GTiff", m_cellSize, bounds, srs);
-
-        filename = FileUtils::toAbsolutePath("gy.tif", m_outDir);
-        eigen::writeMatrix(gy, filename, "GTiff", m_cellSize, bounds, srs);
-
-        filename = FileUtils::toAbsolutePath("gsurfs.tif", m_outDir);
-        eigen::writeMatrix(gsurfs, filename, "GTiff", m_cellSize, bounds, srs);
-
-        filename = FileUtils::toAbsolutePath("gsurfs_painted.tif", m_outDir);
-        eigen::writeMatrix(gsurfs_painted, filename, "GTiff",
-            m_cellSize, bounds, srs);
-    }
-
-    gsurfs = gsurfs_painted;
-
-    MatrixXd thresh = (m_threshold + m_scalar * gsurfs.array()).matrix();
-
-    if (!m_outDir.empty())
-    {
-        std::string filename = FileUtils::toAbsolutePath("thresh.tif",
-            m_outDir);
-        eigen::writeMatrix(thresh, filename, "GTiff", m_cellSize, bounds, srs);
-    }
-
-    for (PointId i = 0; i < view->size(); ++i)
-    {
-        using namespace Dimension;
-        double x = view->getFieldAs<double>(Id::X, i);
-        double y = view->getFieldAs<double>(Id::Y, i);
-        double z = view->getFieldAs<double>(Id::Z, i);
-
-        int c = Utils::clamp(
-            static_cast<int>(floor(x - bounds.minx) / m_cellSize), 0,
-            m_numCols-1);
-        int r = Utils::clamp(
-            static_cast<int>(floor(y - bounds.miny) / m_cellSize), 0,
-            m_numRows-1);
-
-        // author uses spline interpolation to get value from ZIpro and gsurfs
-
-        if (std::isnan(ZIpro(r, c)))
-            continue;
-
-        // not sure i should just brush this under the rug...
-        if (std::isnan(gsurfs(r, c)))
-            continue;
-
-        double ez = ZIpro(r, c);
-        // double ez = interp2(r, c, cx, cy, ZIpro);
-        // double si = gsurfs(r, c);
-        // double si = interp2(r, c, cx, cy, gsurfs);
-        // double reqVal = m_threshold + 1.2 * si;
-
-        if (std::abs(ez - z) > thresh(r, c))
-            continue;
-
-        // if (std::abs(ZIpro(r, c) - z) > m_threshold)
-        //     continue;
-
-        groundIdx.push_back(i);
-    }
-
-    return groundIdx;
+    return ZIpro_fill;
 }
 
-MatrixXi SMRFilter::progressiveFilter(MatrixXd const& ZImin, double cell_size,
-                                      double slope, double max_window)
+// Fill voids with the average of eight nearest neighbors.
+Eigen::MatrixXd SMRFilter::knnfill(PointViewPtr view, Eigen::MatrixXd const& cz)
 {
-    log()->get(LogLevel::Info) <<
-        "progressiveFilter: Progressive filtering...\n";
+    // Create a temporary PointView that encodes our raster values so that we
+    // can construct a 2D KDIndex and perform nearest neighbor searches.
+    PointViewPtr temp = view->makeNew();
+    PointId i(0);
+    for (int c = 0; c < cz.cols(); ++c)
+    {
+        for (int r = 0; r < cz.rows(); ++r)
+        {
+            if (std::isnan(cz(r, c)))
+                continue;
 
-    MatrixXi Obj(m_numRows, m_numCols);
-    Obj.setZero();
+            temp->setField(Id::X, i, m_bounds.minx + (c + 0.5) * m_cell);
+            temp->setField(Id::Y, i, m_bounds.miny + (r + 0.5) * m_cell);
+            temp->setField(Id::Z, i, cz(r, c));
+            i++;
+        }
+    }
 
-    // In this case, we selected a disk-shaped structuring element, and the
-    // radius of the element at each step was increased by one pixel from a
-    // starting value of one pixel to the pixel equivalent of the maximum value
-    // (wkmax). The maximum window radius is supplied as a distance metric
-    // (e.g., 21 m), but is internally converted to a pixel equivalent by
-    // dividing it by the cell size and rounding the result toward positive
-    // infinity (i.e., taking the ceiling value). For example, for a supplied
-    // maximum window radius of 21 m, and a cell size of 2m per pixel, the
-    // result would be a maximum window radius of 11 pixels. While this
-    // represents a relatively slow progression in the expansion of the window
-    // radius, we believe that the high efficiency associated with the opening
-    // operation mitigates the potential for computational waste. The
-    // improvements in classification accuracy using slow, linear progressions
-    // are documented in the next section.
-    int max_radius = ceil(max_window/cell_size);
-    MatrixXd ZIlocal = ZImin;
+    KD2Index kdi(*temp);
+    kdi.build();
+
+    // Where the raster has voids (i.e., NaN), we search for that cell's eight
+    // nearest neighbors, and fill the void with the average value of the
+    // neighbors.
+    MatrixXd out = cz;
+    for (int c = 0; c < cz.cols(); ++c)
+    {
+        for (int r = 0; r < cz.rows(); ++r)
+        {
+            if (!std::isnan(out(r, c)))
+                continue;
+
+            double x = m_bounds.minx + (c + 0.5) * m_cell;
+            double y = m_bounds.miny + (r + 0.5) * m_cell;
+            int k = 8;
+            std::vector<PointId> neighbors(k);
+            std::vector<double> sqr_dists(k);
+            kdi.knnSearch(x, y, k, &neighbors, &sqr_dists);
+
+            double M1(0.0);
+            size_t j(0);
+            for (auto const& n : neighbors)
+            {
+                j++;
+                double delta = temp->getFieldAs<double>(Id::Z, n) - M1;
+                M1 += (delta / j);
+            }
+
+            out(r, c) = M1;
+        }
+    }
+
+    return out;
+};
+
+// Iteratively open the estimated surface. progressiveFilter can be used to
+// identify both low points and object (i.e., non-ground) points, depending on
+// the inputs.
+MatrixXi SMRFilter::progressiveFilter(MatrixXd const& ZImin, double slope,
+                                      double max_window)
+{
+    // "The maximum window radius is supplied as a distance metric (e.g., 21 m),
+    // but is internally converted to a pixel equivalent by dividing it by the
+    // cell size and rounding the result toward positive infinity (i.e., taking
+    // the ceiling value)."
+    int max_radius = std::ceil(max_window / m_cell);
+    MatrixXd prevSurface = ZImin;
+    MatrixXd prevErosion = ZImin;
+
+    // "...the radius of the element at each step [is] increased by one pixel
+    // from a starting value of one pixel to the pixel equivalent of the maximum
+    // value."
+    MatrixXi Obj = MatrixXi::Zero(m_rows, m_cols);
     for (int radius = 1; radius <= max_radius; ++radius)
     {
-        // On the first iteration, the minimum surface (ZImin) is opened using a
-        // disk-shaped structuring element with a radius of one pixel.
-        MatrixXd mo = eigen::matrixOpen(ZIlocal, radius);
+        // "On the first iteration, the minimum surface (ZImin) is opened using
+        // a disk-shaped structuring element with a radius of one pixel."
+        MatrixXd curErosion = erodeDiamond(prevErosion, 1);
+        MatrixXd curOpening = dilateDiamond(curErosion, radius);
+        prevErosion = curErosion;
 
-        // An elevation threshold is then calculated, where the value is equal
+        // "An elevation threshold is then calculated, where the value is equal
         // to the supplied slope tolerance parameter multiplied by the product
-        // of the window radius and the cell size. For example, if the user
-        // supplied a slope tolerance parameter of 15%, a cell size of 2m per
-        // pixel, the elevation threshold would be 0.3m at a window of one pixel
-        // (0.15 ? 1 ? 2).
-        double threshold = slope * cell_size * radius;
+        // of the window radius and the cell size."
+        double threshold = slope * m_cell * radius;
 
-        // This elevation threshold is applied to the difference of the minimum
-        // and the opened surfaces.
-        MatrixXd diff = ZIlocal - mo;
+        // "This elevation threshold is applied to the difference of the minimum
+        // and the opened surfaces."
+        MatrixXd diff = prevSurface - curOpening;
 
-        // Any grid cell with a difference value exceeding the calculated
-        // elevation threshold for the iteration is then flagged as an OBJ cell.
-        for (int i = 0; i < diff.size(); ++i)
+        // "Any grid cell with a difference value exceeding the calculated
+        // elevation threshold for the iteration is then flagged as an OBJ
+        // cell."
+        diff = diff.unaryExpr([threshold](double x)
         {
-            if (diff(i) > threshold)
-                Obj(i) = 1;
-        }
-        // eigen::writeMatrix(Obj, "obj.tif", "GTiff", m_cellSize, bounds, srs);
+            return (x > threshold) ? 1 : 0;
+        });
+        Obj = Obj.cwiseMax(diff.cast<int>());
 
-        // The algorithm then proceeds to the next window radius (up to the
+        // "The algorithm then proceeds to the next window radius (up to the
         // maximum), and proceeds as above with the last opened surface acting
-        // as the ‘‘minimum surface’’ for the next difference calculation.
-        ZIlocal = mo;
+        // as the minimum surface for the next difference calculation."
+        prevSurface = curOpening;
 
-        log()->get(LogLevel::Info) << "progressiveFilter: Radius = " << radius
-                                   << ", " << Obj.sum() << " object pixels\n";
+        size_t ng(Obj.sum());
+        size_t g(Obj.size() - ng);
+        double p(100.0 * double(ng) / double(Obj.size()));
+        log()->floatPrecision(2);
+        log()->get(LogLevel::Debug) << "progressiveFilter: radius = " << radius
+                                    << "\t" << g << " ground"
+                                    << "\t" << ng << " non-ground"
+                                    << "\t(" << p << "%)\n";
     }
 
     return Obj;
-}
-
-PointViewSet SMRFilter::run(PointViewPtr view)
-{
-    log()->get(LogLevel::Info) << "run: Process SMRFilter...\n";
-
-    std::vector<PointId> idx = processGround(view);
-
-    PointViewSet viewSet;
-
-    if (!idx.empty() && (m_classify || m_extract))
-    {
-
-        if (m_classify)
-        {
-            log()->get(LogLevel::Info) << "run: Labeled " << idx.size() <<
-                " ground returns!\n";
-
-            // set the classification label of ground returns as 2
-            // (corresponding to ASPRS LAS specification)
-            for (const auto& i : idx)
-            {
-                view->setField(Dimension::Id::Classification, i, 2);
-            }
-
-            viewSet.insert(view);
-        }
-
-        if (m_extract)
-        {
-            log()->get(LogLevel::Info) << "run: Extracted " << idx.size() <<
-                " ground returns!\n";
-
-            // create new PointView containing only ground returns
-            PointViewPtr output = view->makeNew();
-            for (const auto& i : idx)
-            {
-                output->appendPoint(*view, i);
-            }
-
-            viewSet.erase(view);
-            viewSet.insert(output);
-        }
-    }
-    else
-    {
-        if (idx.empty())
-            log()->get(LogLevel::Info) << "run: Filtered cloud has no "
-                "ground returns!\n";
-
-        if (!(m_classify || m_extract))
-            log()->get(LogLevel::Info) << "run: Must choose --classify or "
-                "--extract\n";
-
-        // return the view buffer unchanged
-        viewSet.insert(view);
-    }
-
-    return viewSet;
-}
-
-
-MatrixXd SMRFilter::TPS(MatrixXd cx, MatrixXd cy, MatrixXd cz)
-{
-    log()->get(LogLevel::Info) << "TPS: Reticulating splines...\n";
-
-    MatrixXd S = cz;
-
-    int num_nan_detect(0);
-    int num_nan_replace(0);
-
-    for (auto outer_col = 0; outer_col < m_numCols; ++outer_col)
-    {
-        for (auto outer_row = 0; outer_row < m_numRows; ++outer_row)
-        {
-            if (!std::isnan(S(outer_row, outer_col)))
-                continue;
-
-            num_nan_detect++;
-
-            // Further optimizations are achieved by estimating only the
-            // interpolated surface within a local neighbourhood (e.g. a 7 x 7
-            // neighbourhood is used in our case) of the cell being filtered.
-            int radius = 3;
-
-            int cs = Utils::clamp(outer_col-radius, 0, m_numCols-1);
-            int ce = Utils::clamp(outer_col+radius, 0, m_numCols-1);
-            int col_size = ce - cs + 1;
-            int rs = Utils::clamp(outer_row-radius, 0, m_numRows-1);
-            int re = Utils::clamp(outer_row+radius, 0, m_numRows-1);
-            int row_size = re - rs + 1;
-
-            MatrixXd Xn = cx.block(rs, cs, row_size, col_size);
-            MatrixXd Yn = cy.block(rs, cs, row_size, col_size);
-            MatrixXd Hn = cz.block(rs, cs, row_size, col_size);
-
-            int nsize = Hn.size();
-            VectorXd T = VectorXd::Zero(nsize);
-            MatrixXd P = MatrixXd::Zero(nsize, 3);
-            MatrixXd K = MatrixXd::Zero(nsize, nsize);
-
-            int numK(0);
-            for (auto id = 0; id < Hn.size(); ++id)
-            {
-                double xj = Xn(id);
-                double yj = Yn(id);
-                double zj = Hn(id);
-                if (std::isnan(zj))
-                    continue;
-                numK++;
-                T(id) = zj;
-                P.row(id) << 1, xj, yj;
-                for (auto id2 = 0; id2 < Hn.size(); ++id2)
-                {
-                    if (id == id2)
-                        continue;
-                    double xk = Xn(id2);
-                    double yk = Yn(id2);
-                    double rsqr = (xj - xk) * (xj - xk) + (yj - yk) * (yj - yk);
-                    if (rsqr == 0.0)
-                        continue;
-                    K(id, id2) = rsqr * std::log10(std::sqrt(rsqr));
-                }
-            }
-
-            if (numK < 20)
-                continue;
-
-            MatrixXd A = MatrixXd::Zero(nsize+3, nsize+3);
-            A.block(0,0,nsize,nsize) = K;
-            A.block(0,nsize,nsize,3) = P;
-            A.block(nsize,0,3,nsize) = P.transpose();
-
-            VectorXd b = VectorXd::Zero(nsize+3);
-            b.head(nsize) = T;
-
-            VectorXd x = A.fullPivHouseholderQr().solve(b);
-
-            Vector3d a = x.tail(3);
-            VectorXd w = x.head(nsize);
-
-            double sum = 0.0;
-            double xi2 = cx(outer_row, outer_col);
-            double yi2 = cy(outer_row, outer_col);
-            for (auto j = 0; j < nsize; ++j)
-            {
-                double xj = Xn(j);
-                double yj = Yn(j);
-                double rsqr = (xj - xi2) * (xj - xi2) + (yj - yi2) * (yj - yi2);
-                if (rsqr == 0.0)
-                    continue;
-                sum += w(j) * rsqr * std::log10(std::sqrt(rsqr));
-            }
-
-            S(outer_row, outer_col) = a(0) + a(1)*xi2 + a(2)*yi2 + sum;
-
-            if (!std::isnan(S(outer_row, outer_col)))
-                num_nan_replace++;
-
-            // std::cerr << std::fixed;
-            // std::cerr << std::setprecision(3)
-            //           << std::left
-            //           << "S(" << outer_row << "," << outer_col << "): "
-            //           << std::setw(10)
-            //           << S(outer_row, outer_col)
-            //           // << std::setw(3)
-            //           // << "\tz: "
-            //           // << std::setw(10)
-            //           // << zi
-            //           // << std::setw(7)
-            //           // << "\tzdiff: "
-            //           // << std::setw(5)
-            //           // << zi - S(outer_row, outer_col)
-            //           // << std::setw(7)
-            //           // << "\txdiff: "
-            //           // << std::setw(5)
-            //           // << xi2 - xi
-            //           // << std::setw(7)
-            //           // << "\tydiff: "
-            //           // << std::setw(5)
-            //           // << yi2 - yi
-            //           << std::setw(7)
-            //           << "\t# pts: "
-            //           << std::setw(3)
-            //           << nsize
-            //           << std::setw(5)
-            //           << "\tsum: "
-            //           << std::setw(10)
-            //           << sum
-            //           << std::setw(9)
-            //           << "\tw.sum(): "
-            //           << std::setw(5)
-            //           << w.sum()
-            //           << std::setw(6)
-            //           << "\txsum: "
-            //           << std::setw(5)
-            //           << w.dot(P.col(1))
-            //           << std::setw(6)
-            //           << "\tysum: "
-            //           << std::setw(5)
-            //           << w.dot(P.col(2))
-            //           << std::setw(3)
-            //           << "\ta: "
-            //           << std::setw(8)
-            //           << a.transpose()
-            //           << std::endl;
-        }
-    }
-
-    double frac = static_cast<double>(num_nan_replace);
-    frac /= static_cast<double>(num_nan_detect);
-    log()->get(LogLevel::Info) << "TPS: Filled " << num_nan_replace << " of "
-                               << num_nan_detect << " holes ("
-                               << frac * 100.0 << "%)\n";
-
-    return S;
-}
-
-MatrixXd SMRFilter::expandingTPS(MatrixXd cx, MatrixXd cy, MatrixXd cz)
-{
-    log()->get(LogLevel::Info) << "TPS: Reticulating splines...\n";
-
-    MatrixXd S = cz;
-
-    int num_nan_detect(0);
-    int num_nan_replace(0);
-
-    for (auto outer_col = 0; outer_col < m_numCols; ++outer_col)
-    {
-        for (auto outer_row = 0; outer_row < m_numRows; ++outer_row)
-        {
-            if (!std::isnan(S(outer_row, outer_col)))
-                continue;
-
-            num_nan_detect++;
-
-            // Further optimizations are achieved by estimating only the
-            // interpolated surface within a local neighbourhood (e.g. a 7 x 7
-            // neighbourhood is used in our case) of the cell being filtered.
-            int radius = 3;
-            bool solution = false;
-
-            while (!solution)
-            {
-                // std::cerr << radius;
-                int cs = Utils::clamp(outer_col-radius, 0, m_numCols-1);
-                int ce = Utils::clamp(outer_col+radius, 0, m_numCols-1);
-                int col_size = ce - cs + 1;
-                int rs = Utils::clamp(outer_row-radius, 0, m_numRows-1);
-                int re = Utils::clamp(outer_row+radius, 0, m_numRows-1);
-                int row_size = re - rs + 1;
-
-                MatrixXd Xn = cx.block(rs, cs, row_size, col_size);
-                MatrixXd Yn = cy.block(rs, cs, row_size, col_size);
-                MatrixXd Hn = cz.block(rs, cs, row_size, col_size);
-
-                int nsize = Hn.size();
-                VectorXd T = VectorXd::Zero(nsize);
-                MatrixXd P = MatrixXd::Zero(nsize, 3);
-                MatrixXd K = MatrixXd::Zero(nsize, nsize);
-
-                int numK(0);
-                for (auto id = 0; id < Hn.size(); ++id)
-                {
-                    double xj = Xn(id);
-                    double yj = Yn(id);
-                    double zj = Hn(id);
-                    if (std::isnan(zj))
-                        continue;
-                    numK++;
-                    T(id) = zj;
-                    P.row(id) << 1, xj, yj;
-                    for (auto id2 = 0; id2 < Hn.size(); ++id2)
-                    {
-                        if (id == id2)
-                            continue;
-                        double xk = Xn(id2);
-                        double yk = Yn(id2);
-                        double rsqr = (xj - xk) * (xj - xk) +
-                            (yj - yk) * (yj - yk);
-                        if (rsqr == 0.0)
-                            continue;
-                        K(id, id2) = rsqr * std::log10(std::sqrt(rsqr));
-                    }
-                }
-
-                // if (numK < 20)
-                //     continue;
-
-                MatrixXd A = MatrixXd::Zero(nsize+3, nsize+3);
-                A.block(0,0,nsize,nsize) = K;
-                A.block(0,nsize,nsize,3) = P;
-                A.block(nsize,0,3,nsize) = P.transpose();
-
-                VectorXd b = VectorXd::Zero(nsize+3);
-                b.head(nsize) = T;
-
-                VectorXd x = A.fullPivHouseholderQr().solve(b);
-
-                Vector3d a = x.tail(3);
-                VectorXd w = x.head(nsize);
-
-                double sum = 0.0;
-                double xi2 = cx(outer_row, outer_col);
-                double yi2 = cy(outer_row, outer_col);
-                for (auto j = 0; j < nsize; ++j)
-                {
-                    double xj = Xn(j);
-                    double yj = Yn(j);
-                    double rsqr = (xj - xi2) * (xj - xi2) +
-                        (yj - yi2) * (yj - yi2);
-                    if (rsqr == 0.0)
-                        continue;
-                    sum += w(j) * rsqr * std::log10(std::sqrt(rsqr));
-                }
-
-                double val = a(0) + a(1)*xi2 + a(2)*yi2 + sum;
-                solution = !std::isnan(val);
-
-                if (!solution)
-                {
-                    std::cerr << "..." << radius << std::endl;;
-                    ++radius;
-                    continue;
-                }
-
-                S(outer_row, outer_col) = val;
-                num_nan_replace++;
-
-                // std::cerr << std::endl;
-
-                // std::cerr << std::fixed;
-                // std::cerr << std::setprecision(3)
-                //           << std::left
-                //           << "S(" << outer_row << "," << outer_col << "): "
-                //           << std::setw(10)
-                //           << S(outer_row, outer_col)
-                //           // << std::setw(3)
-                //           // << "\tz: "
-                //           // << std::setw(10)
-                //           // << zi
-                //           // << std::setw(7)
-                //           // << "\tzdiff: "
-                //           // << std::setw(5)
-                //           // << zi - S(outer_row, outer_col)
-                //           // << std::setw(7)
-                //           // << "\txdiff: "
-                //           // << std::setw(5)
-                //           // << xi2 - xi
-                //           // << std::setw(7)
-                //           // << "\tydiff: "
-                //           // << std::setw(5)
-                //           // << yi2 - yi
-                //           << std::setw(7)
-                //           << "\t# pts: "
-                //           << std::setw(3)
-                //           << nsize
-                //           << std::setw(5)
-                //           << "\tsum: "
-                //           << std::setw(10)
-                //           << sum
-                //           << std::setw(9)
-                //           << "\tw.sum(): "
-                //           << std::setw(5)
-                //           << w.sum()
-                //           << std::setw(6)
-                //           << "\txsum: "
-                //           << std::setw(5)
-                //           << w.dot(P.col(1))
-                //           << std::setw(6)
-                //           << "\tysum: "
-                //           << std::setw(5)
-                //           << w.dot(P.col(2))
-                //           << std::setw(3)
-                //           << "\ta: "
-                //           << std::setw(8)
-                //           << a.transpose()
-                //           << std::endl;
-            }
-        }
-    }
-
-    double frac = static_cast<double>(num_nan_replace);
-    frac /= static_cast<double>(num_nan_detect);
-    log()->get(LogLevel::Info) << "TPS: Filled " << num_nan_replace << " of "
-                               << num_nan_detect << " holes ("
-                               << frac * 100.0 << "%)\n";
-
-    return S;
 }
 
 } // namespace pdal

--- a/pdal/EigenUtils.cpp
+++ b/pdal/EigenUtils.cpp
@@ -468,6 +468,133 @@ Eigen::MatrixXd matrixOpen(Eigen::MatrixXd data, int radius)
     return maxZ.block(radius, radius, data.rows(), data.cols());
 }
 
+Eigen::MatrixXd erodeDiamond(Eigen::MatrixXd data, int iterations)
+{
+    using namespace Eigen;
+
+    MatrixXd prev(data.rows()+2, data.cols()+2);
+    prev.setConstant(std::numeric_limits<double>::max());
+    prev.block(1, 1, data.rows(), data.cols()) = data;
+
+    // Construct a list of indices relative to the current pixel to be used in
+    // the diamond kernel.
+    std::list<int> idx {
+      static_cast<int>(-prev.rows()),
+      -1,
+      0,
+      1,
+      static_cast<int>(prev.rows())
+    };
+    
+    // Generate lists of rows, cols, and iterations to be used in subsequent for
+    // loops.
+    std::list<int> rows(data.rows());
+    std::iota(rows.begin(), rows.end(), 1);
+    
+    std::list<int> cols(data.cols());
+    std::iota(cols.begin(), cols.end(), 1);
+    
+    std::list<int> iters(iterations);
+    std::iota(iters.begin(), iters.end(), 0);
+ 
+    // Implementation note. We tried a number of different approaches here,
+    // including using Eigen block extraction and min/maxCoeff, but those always
+    // resulted in a ~2x increase in runtime.
+ 
+    // Begin by initializing the min Z matrix to max double, so that we always
+    // find a value smaller than the initial value.
+    MatrixXd minZ(prev.rows(), prev.cols());
+    minZ.setConstant(std::numeric_limits<double>::max());
+    
+    // To repeat a morphological opening, we actually repeat the erosion step
+    // first, followed by the repeated dilation step.
+    for (auto const& i : iters)
+    {
+        for (auto const& c : cols)
+        {
+            int index_base = c*prev.rows();
+            for (auto const& r : rows)
+            {              
+                int index = index_base + r;
+                for (auto const& j : idx)
+                {
+                    double v = prev(index+j);
+                    if (v < minZ(r, c))
+                        minZ(r, c) = v;
+                }
+            }
+        }
+        
+        prev = minZ;
+    }
+
+    // Do not return the padded borders.
+    return prev.block(1, 1, data.rows(), data.cols());
+}
+
+Eigen::MatrixXd dilateDiamond(Eigen::MatrixXd data, int iterations)
+{
+    using namespace Eigen;
+
+    MatrixXd prev(data.rows()+2, data.cols()+2);
+    prev.setConstant(std::numeric_limits<double>::lowest());
+    prev.block(1, 1, data.rows(), data.cols()) = data;
+
+    // Construct a list of indices relative to the current pixel to be used in
+    // the diamond kernel.
+    std::list<int> idx {
+      static_cast<int>(-prev.rows()),
+      -1,
+      0,
+      1,
+      static_cast<int>(prev.rows())
+    };
+    
+    // Generate lists of rows, cols, and iterations to be used in subsequent for
+    // loops.
+    std::list<int> rows(data.rows());
+    std::iota(rows.begin(), rows.end(), 1);
+    
+    std::list<int> cols(data.cols());
+    std::iota(cols.begin(), cols.end(), 1);
+    
+    std::list<int> iters(iterations);
+    std::iota(iters.begin(), iters.end(), 0);
+ 
+    // Implementation note. We tried a number of different approaches here,
+    // including using Eigen block extraction and min/maxCoeff, but those always
+    // resulted in a ~2x increase in runtime.
+    
+    // Begin by initializing max Z matrix to lowest double, so that we always
+    // find a value larger than the initial value.
+    MatrixXd maxZ(prev.rows(), prev.cols());
+    maxZ.setConstant(std::numeric_limits<double>::lowest());
+    
+    // Complete the repeated opening by repeating the dilation step.
+    for (auto const& i : iters)
+    {
+        for (auto const& c : cols)
+        {
+            int index_base = c*prev.rows();
+            for (auto const& r : rows)
+            {                
+                int index = index_base + r;
+                for (auto const& j : idx)
+                {
+                    double v = prev(index+j);
+                    if (v > maxZ(r, c))
+                        maxZ(r, c) = v;
+                }
+            }
+        }
+        
+        prev = maxZ;
+    }
+
+    // Do not return the padded borders.
+    return prev.block(1, 1, data.rows(), data.cols());
+}
+
 Eigen::MatrixXd openDiamond(Eigen::MatrixXd data, int iterations)
 {
     using namespace Eigen;

--- a/pdal/EigenUtils.hpp
+++ b/pdal/EigenUtils.hpp
@@ -316,6 +316,9 @@ PDAL_DLL Eigen::MatrixXd matrixClose(Eigen::MatrixXd data, int radius);
 */
 PDAL_DLL Eigen::MatrixXd matrixOpen(Eigen::MatrixXd data, int radius);
 
+Eigen::MatrixXd erodeDiamond(Eigen::MatrixXd data, int iterations);
+Eigen::MatrixXd dilateDiamond(Eigen::MatrixXd data, int iterations);
+
 /**
   Perform a morphological opening of the input matrix.
 


### PR DESCRIPTION
* only write intermediate rasters for debugging when optional output directory is provided

* make program args more consistent with the paper

* revert from TPS interpolation back to average of 8 nearest neighbors

* use iterative morphological operations and diamond structuring element for speedup

* remove the classify/extract args, always classify, and extract with range filter if desired