### PR TITLE
Fix PgWriter DROP TABLE statement

### DIFF
--- a/plugins/pgpointcloud/io/PgWriter.cpp
+++ b/plugins/pgpointcloud/io/PgWriter.cpp
@@ -306,11 +306,10 @@ void PgWriter::DeleteTable(std::string const& schema_name,
 
     if (schema_name.size())
     {
-        name << schema_name << ".";
+        name << pg_quote_identifier(schema_name) << ".";
     }
-    name << table_name;
-    stmt << pg_quote_identifier(name.str());
-
+    name << pg_quote_identifier(table_name);
+    stmt << name.str();
 
     pg_execute(m_session, stmt.str());
 }


### PR DESCRIPTION
When a schema is specified the following statement is currently issued:

```sql
    DROP TABLE IF EXISTS "public.table_name"
```

which is not correct. With this patch the following statement is created:

```sql
    DROP TABLE IF EXISTS "public"."table_name"
```

I can add tests if people think it would be useful.