### PR TITLE
Accelerate morphological operations

### DIFF
--- a/filters/PMFFilter.cpp
+++ b/filters/PMFFilter.cpp
@@ -1,47 +1,45 @@
 /******************************************************************************
-* Copyright (c) 2015-2017, Bradley J Chambers (brad.chambers@gmail.com)
-*
-* All rights reserved.
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following
-* conditions are met:
-*
-*     * Redistributions of source code must retain the above copyright
-*       notice, this list of conditions and the following disclaimer.
-*     * Redistributions in binary form must reproduce the above copyright
-*       notice, this list of conditions and the following disclaimer in
-*       the documentation and/or other materials provided
-*       with the distribution.
-*     * Neither the name of Hobu, Inc. or Flaxen Geo Consulting nor the
-*       names of its contributors may be used to endorse or promote
-*       products derived from this software without specific prior
-*       written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-* FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-* COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-* BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
-* OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
-* AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
-* OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
-* OF SUCH DAMAGE.
-****************************************************************************/
+ * Copyright (c) 2015-2017, Bradley J Chambers (brad.chambers@gmail.com)
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of Hobu, Inc. or Flaxen Geo Consulting nor the
+ *       names of its contributors may be used to endorse or promote
+ *       products derived from this software without specific prior
+ *       written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ ****************************************************************************/
 
 #include "PMFFilter.hpp"
 
 #include <pdal/EigenUtils.hpp>
 #include <pdal/KDIndex.hpp>
-#include <pdal/pdal_macros.hpp>
 #include <pdal/QuadIndex.hpp>
+#include <pdal/pdal_macros.hpp>
 #include <pdal/util/ProgramArgs.hpp>
 #include <pdal/util/Utils.hpp>
-
-#include <Eigen/Dense>
 
 namespace pdal
 {
@@ -57,7 +55,6 @@ std::string PMFFilter::getName() const
     return s_info.name;
 }
 
-
 void PMFFilter::addArgs(ProgramArgs& args)
 {
     args.add("max_window_size", "Maximum window size", m_maxWindowSize, 33.0);
@@ -70,12 +67,10 @@ void PMFFilter::addArgs(ProgramArgs& args)
     args.add("approximate", "Use approximate algorithm?", m_approximate);
 }
 
-
 void PMFFilter::addDimensions(PointLayoutPtr layout)
 {
     layout->registerDim(Dimension::Id::Classification);
 }
-
 
 std::vector<double> PMFFilter::morphOpen(PointViewPtr view, float radius)
 {
@@ -91,8 +86,8 @@ std::vector<double> PMFFilter::morphOpen(PointViewPtr view, float radius)
         double x = view->getFieldAs<double>(Dimension::Id::X, i);
         double y = view->getFieldAs<double>(Dimension::Id::Y, i);
 
-        std::vector<PointId> ids = idx.getPoints(x - radius, y - radius,
-                                   x + radius, y + radius);
+        std::vector<PointId> ids =
+            idx.getPoints(x - radius, y - radius, x + radius, y + radius);
 
         double localMin(std::numeric_limits<double>::max());
         for (auto const& j : ids)
@@ -110,8 +105,8 @@ std::vector<double> PMFFilter::morphOpen(PointViewPtr view, float radius)
         double x = view->getFieldAs<double>(Dimension::Id::X, i);
         double y = view->getFieldAs<double>(Dimension::Id::Y, i);
 
-        std::vector<PointId> ids = idx.getPoints(x - radius, y - radius,
-                                   x + radius, y + radius);
+        std::vector<PointId> ids =
+            idx.getPoints(x - radius, y - radius, x + radius, y + radius);
 
         double localMax(std::numeric_limits<double>::lowest());
         for (auto const& j : ids)
@@ -125,7 +120,6 @@ std::vector<double> PMFFilter::morphOpen(PointViewPtr view, float radius)
 
     return maxZ;
 }
-
 
 std::vector<PointId> PMFFilter::processGround(PointViewPtr view)
 {
@@ -142,13 +136,13 @@ std::vector<PointId> PMFFilter::processGround(PointViewPtr view)
         if (1) // exponential
             ws = m_cellSize * (2.0f * std::pow(2, iter) + 1.0f);
         else
-            ws = m_cellSize * (2.0f * (iter+1) * 2 + 1.0f);
+            ws = m_cellSize * (2.0f * (iter + 1) * 2 + 1.0f);
 
         // Calculate the height threshold to be used in the next iteration.
         if (iter == 0)
             ht = m_initialDistance;
         else
-            ht = m_slope * (ws - wsvec[iter-1]) * m_cellSize +
+            ht = m_slope * (ws - wsvec[iter - 1]) * m_cellSize +
                  m_initialDistance;
 
         // Enforce max distance on height threshold
@@ -173,14 +167,13 @@ std::vector<PointId> PMFFilter::processGround(PointViewPtr view)
         for (auto const& i : groundIdx)
             ground->appendPoint(*view, i);
 
-        log()->get(LogLevel::Debug) <<  "Iteration " << j
-                                    << " (height threshold = " << htvec[j]
-                                    << ", window size = " << wsvec[j]
-                                    << ")...\n";
+        log()->get(LogLevel::Debug)
+            << "Iteration " << j << " (height threshold = " << htvec[j]
+            << ", window size = " << wsvec[j] << ")...\n";
 
         // Create new cloud to hold the filtered results. Apply the
         // morphological opening operation at the current window size.
-        auto maxZ = morphOpen(ground, wsvec[j]*0.5);
+        auto maxZ = morphOpen(ground, wsvec[j] * 0.5);
 
         // Find indices of the points whose difference between the source and
         // filtered point clouds is less than the current height threshold.
@@ -195,33 +188,48 @@ std::vector<PointId> PMFFilter::processGround(PointViewPtr view)
 
         groundIdx.swap(groundNewIdx);
 
-        log()->get(LogLevel::Debug) << "Ground now has " << groundIdx.size()
-                                    << " points.\n";
+        log()->get(LogLevel::Debug)
+            << "Ground now has " << groundIdx.size() << " points.\n";
     }
 
     return groundIdx;
 }
 
-
-Eigen::MatrixXd PMFFilter::fillNearest(PointViewPtr view, Eigen::MatrixXd cz,
-                                       double cell_size, BOX2D bounds)
+std::vector<double> PMFFilter::fillNearest(PointViewPtr view, size_t rows,
+                                           size_t cols, double cell_size,
+                                           BOX2D bounds)
 {
     using namespace Dimension;
-    using namespace Eigen;
+
+    std::vector<double> ZImin(rows * cols,
+                              std::numeric_limits<double>::quiet_NaN());
+
+    for (PointId i = 0; i < view->size(); ++i)
+    {
+        double x = view->getFieldAs<double>(Id::X, i);
+        double y = view->getFieldAs<double>(Id::Y, i);
+        double z = view->getFieldAs<double>(Id::Z, i);
+
+        int c = static_cast<int>(floor(x - bounds.minx) / cell_size);
+        int r = static_cast<int>(floor(y - bounds.miny) / cell_size);
+
+        if (z < ZImin[c * rows + r] || std::isnan(ZImin[c * rows + r]))
+            ZImin[c * rows + r] = z;
+    }
 
     // convert cz into PointView
     PointViewPtr temp = view->makeNew();
     PointId i(0);
-    for (int c = 0; c < cz.cols(); ++c)
+    for (size_t c = 0; c < cols; ++c)
     {
-        for (int r = 0; r < cz.rows(); ++r)
+        for (size_t r = 0; r < rows; ++r)
         {
-            if (std::isnan(cz(r, c)))
+            if (std::isnan(ZImin[c * rows + r]))
                 continue;
 
-            temp->setField(Id::X, i, bounds.minx + (c+0.5) * cell_size);
-            temp->setField(Id::Y, i, bounds.miny + (r+0.5) * cell_size);
-            temp->setField(Id::Z, i, cz(r, c));
+            temp->setField(Id::X, i, bounds.minx + (c + 0.5) * cell_size);
+            temp->setField(Id::Y, i, bounds.miny + (r + 0.5) * cell_size);
+            temp->setField(Id::Z, i, ZImin[c * rows + r]);
             i++;
         }
     }
@@ -230,40 +238,37 @@ Eigen::MatrixXd PMFFilter::fillNearest(PointViewPtr view, Eigen::MatrixXd cz,
     KD2Index kdi(*temp);
     kdi.build();
 
-    MatrixXd out = cz;
-    for (int c = 0; c < cz.cols(); ++c)
+    std::vector<double> out = ZImin;
+    for (size_t c = 0; c < cols; ++c)
     {
-        for (int r = 0; r < cz.rows(); ++r)
+        for (size_t r = 0; r < rows; ++r)
         {
-            if (!std::isnan(out(r, c)))
+            if (!std::isnan(out[c * rows + r]))
                 continue;
 
             // find k nearest points
-            double x = bounds.minx + (c+0.5) * cell_size;
-            double y = bounds.miny + (r+0.5) * cell_size;
+            double x = bounds.minx + (c + 0.5) * cell_size;
+            double y = bounds.miny + (r + 0.5) * cell_size;
             int k = 1;
             std::vector<PointId> neighbors(k);
             std::vector<double> sqr_dists(k);
             kdi.knnSearch(x, y, k, &neighbors, &sqr_dists);
 
-            out(r, c) = temp->getFieldAs<double>(Dimension::Id::Z,
-                                                 neighbors[0]);
+            out[c * rows + r] =
+                temp->getFieldAs<double>(Dimension::Id::Z, neighbors[0]);
         }
     }
 
     return out;
 };
 
-
 std::vector<PointId> PMFFilter::processGroundApprox(PointViewPtr view)
 {
-    using namespace Eigen;
-
     BOX2D bounds;
     view->calculateBounds(bounds);
 
-    size_t cols = ((bounds.maxx - bounds.minx)/m_cellSize) + 1;
-    size_t rows = ((bounds.maxy - bounds.miny)/m_cellSize) + 1;
+    size_t cols = ((bounds.maxx - bounds.minx) / m_cellSize) + 1;
+    size_t rows = ((bounds.maxy - bounds.miny) / m_cellSize) + 1;
 
     // Compute the series of window sizes and height thresholds
     std::vector<float> htvec;
@@ -278,13 +283,13 @@ std::vector<PointId> PMFFilter::processGroundApprox(PointViewPtr view)
         if (1) // exponential
             ws = m_cellSize * (2.0f * std::pow(2, iter) + 1.0f);
         else
-            ws = m_cellSize * (2.0f * (iter+1) * 2 + 1.0f);
+            ws = m_cellSize * (2.0f * (iter + 1) * 2 + 1.0f);
 
         // Calculate the height threshold to be used in the next iteration.
         if (iter == 0)
             ht = m_initialDistance;
         else
-            ht = m_slope * (ws - wsvec[iter-1]) * m_cellSize +
+            ht = m_slope * (ws - wsvec[iter - 1]) * m_cellSize +
                  m_initialDistance;
 
         // Enforce max distance on height threshold
@@ -301,20 +306,20 @@ std::vector<PointId> PMFFilter::processGroundApprox(PointViewPtr view)
     for (PointId i = 0; i < view->size(); ++i)
         groundIdx.push_back(i);
 
-    MatrixXd ZImin = eigen::createMinMatrix(*view.get(), rows, cols, m_cellSize,
-                                            bounds);
-
-    ZImin = fillNearest(view, ZImin, m_cellSize, bounds);
+    std::vector<double> ZImin =
+        fillNearest(view, rows, cols, m_cellSize, bounds);
 
     // Progressively filter ground returns using morphological open
     for (size_t j = 0; j < wsvec.size(); ++j)
     {
-        log()->get(LogLevel::Debug) <<  "Iteration " << j
-                                    << " (height threshold = " << htvec[j]
-                                    << ", window size = " << wsvec[j]
-                                    << ")...\n";
+        log()->get(LogLevel::Debug)
+            << "Iteration " << j << " (height threshold = " << htvec[j]
+            << ", window size = " << wsvec[j] << ")...\n";
 
-        MatrixXd mo = eigen::openDiamond(ZImin, 0.5*(wsvec[j]-1));
+        std::vector<double> me =
+            eigen::erodeDiamond(ZImin, rows, cols, 0.5 * (wsvec[j] - 1));
+        std::vector<double> mo =
+            eigen::dilateDiamond(me, rows, cols, 0.5 * (wsvec[j] - 1));
 
         std::vector<PointId> groundNewIdx;
         for (auto p_idx : groundIdx)
@@ -326,20 +331,19 @@ std::vector<PointId> PMFFilter::processGroundApprox(PointViewPtr view)
             int c = static_cast<int>(floor((x - bounds.minx) / m_cellSize));
             int r = static_cast<int>(floor((y - bounds.miny) / m_cellSize));
 
-            if ((z - mo(r, c)) < htvec[j])
+            if ((z - mo[c * rows + r]) < htvec[j])
                 groundNewIdx.push_back(p_idx);
         }
 
         ZImin.swap(mo);
         groundIdx.swap(groundNewIdx);
 
-        log()->get(LogLevel::Debug) << "Ground now has " << groundIdx.size()
-                                    << " points.\n";
+        log()->get(LogLevel::Debug)
+            << "Ground now has " << groundIdx.size() << " points.\n";
     }
 
     return groundIdx;
 }
-
 
 PointViewSet PMFFilter::run(PointViewPtr input)
 {
@@ -360,8 +364,8 @@ PointViewSet PMFFilter::run(PointViewPtr input)
 
         if (m_classify)
         {
-            log()->get(LogLevel::Debug2) << "Labeled " << idx.size()
-                                         << " ground returns!\n";
+            log()->get(LogLevel::Debug2)
+                << "Labeled " << idx.size() << " ground returns!\n";
 
             // set the classification label of ground returns as 2
             // (corresponding to ASPRS LAS specification)
@@ -375,8 +379,8 @@ PointViewSet PMFFilter::run(PointViewPtr input)
 
         if (m_extract)
         {
-            log()->get(LogLevel::Debug2) << "Extracted " << idx.size()
-                                         << " ground returns!\n";
+            log()->get(LogLevel::Debug2)
+                << "Extracted " << idx.size() << " ground returns!\n";
 
             // create new PointView containing only ground returns
             PointViewPtr output = input->makeNew();
@@ -393,11 +397,11 @@ PointViewSet PMFFilter::run(PointViewPtr input)
     {
         if (idx.empty())
             log()->get(LogLevel::Debug2) << "Filtered cloud has no "
-                                         "ground returns!\n";
+                                            "ground returns!\n";
 
         if (!(m_classify || m_extract))
             log()->get(LogLevel::Debug2) << "Must choose --classify "
-                                         "or --extract\n";
+                                            "or --extract\n";
 
         // return the input buffer unchanged
         viewSet.insert(input);

--- a/filters/PMFFilter.hpp
+++ b/filters/PMFFilter.hpp
@@ -1,43 +1,41 @@
 /******************************************************************************
-* Copyright (c) 2016-2017, Bradley J Chambers (brad.chambers@gmail.com)
-*
-* All rights reserved.
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following
-* conditions are met:
-*
-*     * Redistributions of source code must retain the above copyright
-*       notice, this list of conditions and the following disclaimer.
-*     * Redistributions in binary form must reproduce the above copyright
-*       notice, this list of conditions and the following disclaimer in
-*       the documentation and/or other materials provided
-*       with the distribution.
-*     * Neither the name of Hobu, Inc. or Flaxen Geo Consulting nor the
-*       names of its contributors may be used to endorse or promote
-*       products derived from this software without specific prior
-*       written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-* FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-* COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-* BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
-* OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
-* AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
-* OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
-* OF SUCH DAMAGE.
-****************************************************************************/
+ * Copyright (c) 2016-2017, Bradley J Chambers (brad.chambers@gmail.com)
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of Hobu, Inc. or Flaxen Geo Consulting nor the
+ *       names of its contributors may be used to endorse or promote
+ *       products derived from this software without specific prior
+ *       written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ ****************************************************************************/
 
 #pragma once
 
 #include <pdal/Filter.hpp>
 #include <pdal/plugin.hpp>
-
-#include <Eigen/Dense>
 
 #include <memory>
 
@@ -56,10 +54,11 @@ class PDAL_DLL PMFFilter : public Filter
 {
 public:
     PMFFilter() : Filter()
-    {}
+    {
+    }
 
-    static void * create();
-    static int32_t destroy(void *);
+    static void* create();
+    static int32_t destroy(void*);
     std::string getName() const;
 
 private:
@@ -74,15 +73,15 @@ private:
 
     virtual void addDimensions(PointLayoutPtr layout);
     virtual void addArgs(ProgramArgs& args);
-    Eigen::MatrixXd fillNearest(PointViewPtr view, Eigen::MatrixXd cz,
-                                double cell_size, BOX2D bounds);
+    std::vector<double> fillNearest(PointViewPtr view, size_t rows, size_t cols,
+                                    double cell_size, BOX2D bounds);
     std::vector<double> morphOpen(PointViewPtr view, float radius);
     std::vector<PointId> processGround(PointViewPtr view);
     std::vector<PointId> processGroundApprox(PointViewPtr view);
     virtual PointViewSet run(PointViewPtr view);
 
     PMFFilter& operator=(const PMFFilter&); // not implemented
-    PMFFilter(const PMFFilter&); // not implemented
+    PMFFilter(const PMFFilter&);            // not implemented
 };
 
 } // namespace pdal

--- a/filters/SMRFilter.cpp
+++ b/filters/SMRFilter.cpp
@@ -49,6 +49,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <iterator>
 #include <limits>
 #include <numeric>
 #include <string>

--- a/filters/SMRFilter.hpp
+++ b/filters/SMRFilter.hpp
@@ -1,43 +1,41 @@
 /******************************************************************************
-* Copyright (c) 2016-2017, Bradley J Chambers (brad.chambers@gmail.com)
-*
-* All rights reserved.
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following
-* conditions are met:
-*
-*     * Redistributions of source code must retain the above copyright
-*       notice, this list of conditions and the following disclaimer.
-*     * Redistributions in binary form must reproduce the above copyright
-*       notice, this list of conditions and the following disclaimer in
-*       the documentation and/or other materials provided
-*       with the distribution.
-*     * Neither the name of Hobu, Inc. or Flaxen Geo Consulting nor the
-*       names of its contributors may be used to endorse or promote
-*       products derived from this software without specific prior
-*       written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-* FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-* COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-* BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
-* OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
-* AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
-* OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
-* OF SUCH DAMAGE.
-****************************************************************************/
+ * Copyright (c) 2016-2017, Bradley J Chambers (brad.chambers@gmail.com)
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of Hobu, Inc. or Flaxen Geo Consulting nor the
+ *       names of its contributors may be used to endorse or promote
+ *       products derived from this software without specific prior
+ *       written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ ****************************************************************************/
 
 #pragma once
 
 #include <pdal/Filter.hpp>
 #include <pdal/plugin.hpp>
-
-#include <Eigen/Dense>
 
 #include <string>
 
@@ -51,10 +49,11 @@ class PDAL_DLL SMRFilter : public Filter
 {
 public:
     SMRFilter() : Filter()
-    {}
+    {
+    }
 
-    static void * create();
-    static int32_t destroy(void *);
+    static void* create();
+    static int32_t destroy(void*);
     std::string getName() const;
 
 private:
@@ -75,20 +74,23 @@ private:
     virtual void ready(PointTableRef table);
     virtual PointViewSet run(PointViewPtr view);
 
-    void classifyGround(PointViewPtr, Eigen::MatrixXd const&);
-    Eigen::MatrixXi createLowMask(Eigen::MatrixXd const&);
-    Eigen::MatrixXi createNetMask();
-    Eigen::MatrixXi createObjMask(Eigen::MatrixXd const&);
-    Eigen::MatrixXd createZImin(PointViewPtr);
-    Eigen::MatrixXd createZInet(Eigen::MatrixXd const&, Eigen::MatrixXi const&);
-    Eigen::MatrixXd createZIpro(PointViewPtr, Eigen::MatrixXd const&,
-                                Eigen::MatrixXi const&, Eigen::MatrixXi const&,
-                                Eigen::MatrixXi const&);
-    Eigen::MatrixXd knnfill(PointViewPtr, Eigen::MatrixXd const&);
-    Eigen::MatrixXi progressiveFilter(Eigen::MatrixXd const&, double, double);
+    void classifyGround(PointViewPtr, std::vector<double>&);
+    std::vector<int> createLowMask(std::vector<double> const&);
+    std::vector<int> createNetMask();
+    std::vector<int> createObjMask(std::vector<double> const&);
+    std::vector<double> createZImin(PointViewPtr view);
+    std::vector<double> createZInet(std::vector<double> const&,
+                                    std::vector<int> const&);
+    std::vector<double> createZIpro(PointViewPtr, std::vector<double> const&,
+                                    std::vector<int> const&,
+                                    std::vector<int> const&,
+                                    std::vector<int> const&);
+    std::vector<double> knnfill(PointViewPtr, std::vector<double> const&);
+    std::vector<int> progressiveFilter(std::vector<double> const&, double,
+                                       double);
 
     SMRFilter& operator=(const SMRFilter&); // not implemented
-    SMRFilter(const SMRFilter&); // not implemented
+    SMRFilter(const SMRFilter&);            // not implemented
 };
 
 } // namespace pdal

--- a/pdal/EigenUtils.cpp
+++ b/pdal/EigenUtils.cpp
@@ -468,221 +468,72 @@ Eigen::MatrixXd matrixOpen(Eigen::MatrixXd data, int radius)
     return maxZ.block(radius, radius, data.rows(), data.cols());
 }
 
-Eigen::MatrixXd erodeDiamond(Eigen::MatrixXd data, int iterations)
+std::vector<double> dilateDiamond(std::vector<double> data, size_t rows, size_t cols, int iterations)
 {
-    using namespace Eigen;
-
-    MatrixXd prev(data.rows()+2, data.cols()+2);
-    prev.setConstant(std::numeric_limits<double>::max());
-    prev.block(1, 1, data.rows(), data.cols()) = data;
-
-    // Construct a list of indices relative to the current pixel to be used in
-    // the diamond kernel.
-    std::list<int> idx {
-      static_cast<int>(-prev.rows()),
-      -1,
-      0,
-      1,
-      static_cast<int>(prev.rows())
-    };
+    std::vector<double> out(data.size(), std::numeric_limits<double>::lowest());
+    std::vector<size_t> idx(5);
     
-    // Generate lists of rows, cols, and iterations to be used in subsequent for
-    // loops.
-    std::list<int> rows(data.rows());
-    std::iota(rows.begin(), rows.end(), 1);
-    
-    std::list<int> cols(data.cols());
-    std::iota(cols.begin(), cols.end(), 1);
-    
-    std::list<int> iters(iterations);
-    std::iota(iters.begin(), iters.end(), 0);
- 
-    // Implementation note. We tried a number of different approaches here,
-    // including using Eigen block extraction and min/maxCoeff, but those always
-    // resulted in a ~2x increase in runtime.
- 
-    // Begin by initializing the min Z matrix to max double, so that we always
-    // find a value smaller than the initial value.
-    MatrixXd minZ(prev.rows(), prev.cols());
-    minZ.setConstant(std::numeric_limits<double>::max());
-    
-    // To repeat a morphological opening, we actually repeat the erosion step
-    // first, followed by the repeated dilation step.
-    for (auto const& i : iters)
+    for (int iter = 0; iter < iterations; ++iter)
     {
-        for (auto const& c : cols)
+        for (size_t col = 0; col < cols; ++col)
         {
-            int index_base = c*prev.rows();
-            for (auto const& r : rows)
-            {              
-                int index = index_base + r;
-                for (auto const& j : idx)
+            size_t index = col*rows;
+            for (size_t row = 0; row < rows; ++row)
+            {
+                size_t j = 0;
+                idx[j++] = index+row;
+                if (row > 0)
+                    idx[j++] = idx[0]-1;
+                if (row < rows-1)
+                    idx[j++] = idx[0]+1;
+                if (col > 0)
+                    idx[j++] = idx[0]-rows;
+                if (col < cols-1)
+                    idx[j++] = idx[0]+rows;
+                for (size_t i = 0; i < j; ++i)
                 {
-                    double v = prev(index+j);
-                    if (v < minZ(r, c))
-                        minZ(r, c) = v;
+                    if (data[idx[i]] > out[index+row])
+                        out[index+row] = data[idx[i]];
                 }
             }
         }
-        
-        prev = minZ;
+        data.swap(out);
     }
-
-    // Do not return the padded borders.
-    return prev.block(1, 1, data.rows(), data.cols());
+    return data;
 }
 
-Eigen::MatrixXd dilateDiamond(Eigen::MatrixXd data, int iterations)
+std::vector<double> erodeDiamond(std::vector<double> data, size_t rows, size_t cols, int iterations)
 {
-    using namespace Eigen;
-
-    MatrixXd prev(data.rows()+2, data.cols()+2);
-    prev.setConstant(std::numeric_limits<double>::lowest());
-    prev.block(1, 1, data.rows(), data.cols()) = data;
-
-    // Construct a list of indices relative to the current pixel to be used in
-    // the diamond kernel.
-    std::list<int> idx {
-      static_cast<int>(-prev.rows()),
-      -1,
-      0,
-      1,
-      static_cast<int>(prev.rows())
-    };
+    std::vector<double> out(data.size(), std::numeric_limits<double>::max());
+    std::vector<size_t> idx(5);
     
-    // Generate lists of rows, cols, and iterations to be used in subsequent for
-    // loops.
-    std::list<int> rows(data.rows());
-    std::iota(rows.begin(), rows.end(), 1);
-    
-    std::list<int> cols(data.cols());
-    std::iota(cols.begin(), cols.end(), 1);
-    
-    std::list<int> iters(iterations);
-    std::iota(iters.begin(), iters.end(), 0);
- 
-    // Implementation note. We tried a number of different approaches here,
-    // including using Eigen block extraction and min/maxCoeff, but those always
-    // resulted in a ~2x increase in runtime.
-    
-    // Begin by initializing max Z matrix to lowest double, so that we always
-    // find a value larger than the initial value.
-    MatrixXd maxZ(prev.rows(), prev.cols());
-    maxZ.setConstant(std::numeric_limits<double>::lowest());
-    
-    // Complete the repeated opening by repeating the dilation step.
-    for (auto const& i : iters)
+    for (int iter = 0; iter < iterations; ++iter)
     {
-        for (auto const& c : cols)
+        for (size_t col = 0; col < cols; ++col)
         {
-            int index_base = c*prev.rows();
-            for (auto const& r : rows)
-            {                
-                int index = index_base + r;
-                for (auto const& j : idx)
+            size_t index = col*rows;
+            for (size_t row = 0; row < rows; ++row)
+            {
+                size_t j = 0;
+                idx[j++] = index+row;
+                if (row > 0)
+                    idx[j++] = idx[0]-1;
+                if (row < rows-1)
+                    idx[j++] = idx[0]+1;
+                if (col > 0)
+                    idx[j++] = idx[0]-rows;
+                if (col < cols-1)
+                    idx[j++] = idx[0]+rows;
+                for (size_t i = 0; i < j; ++i)
                 {
-                    double v = prev(index+j);
-                    if (v > maxZ(r, c))
-                        maxZ(r, c) = v;
+                    if (data[idx[i]] < out[index+row])
+                        out[index+row] = data[idx[i]];
                 }
             }
         }
-        
-        prev = maxZ;
+        data.swap(out);
     }
-
-    // Do not return the padded borders.
-    return prev.block(1, 1, data.rows(), data.cols());
-}
-
-Eigen::MatrixXd openDiamond(Eigen::MatrixXd data, int iterations)
-{
-    using namespace Eigen;
-
-    MatrixXd prev(data.rows()+2, data.cols()+2);
-    prev.setConstant(std::numeric_limits<double>::max());
-    prev.block(1, 1, data.rows(), data.cols()) = data;
-    
-    // Construct a list of indices relative to the current pixel to be used in
-    // the diamond kernel.
-    std::list<int> idx {
-      static_cast<int>(-prev.rows()),
-      -1,
-      0,
-      1,
-      static_cast<int>(prev.rows())
-    };
-    
-    // Generate lists of rows, cols, and iterations to be used in subsequent for
-    // loops.
-    std::list<int> rows(data.rows());
-    std::iota(rows.begin(), rows.end(), 1);
-    
-    std::list<int> cols(data.cols());
-    std::iota(cols.begin(), cols.end(), 1);
-    
-    std::list<int> iters(iterations);
-    std::iota(iters.begin(), iters.end(), 0);
- 
-    // Implementation note. We tried a number of different approaches here,
-    // including using Eigen block extraction and min/maxCoeff, but those always
-    // resulted in a ~2x increase in runtime.
- 
-    // Begin by initializing the min Z matrix to max double, so that we always
-    // find a value smaller than the initial value.
-    MatrixXd minZ(prev.rows(), prev.cols());
-    minZ.setConstant(std::numeric_limits<double>::max());
-    
-    // To repeat a morphological opening, we actually repeat the erosion step
-    // first, followed by the repeated dilation step.
-    for (auto const& i : iters)
-    {
-        for (auto const& c : cols)
-        {
-            int index_base = c*prev.rows();
-            for (auto const& r : rows)
-            {              
-                int index = index_base + r;
-                for (auto const& j : idx)
-                {
-                    double v = prev(index+j);
-                    if (v < minZ(r, c))
-                        minZ(r, c) = v;
-                }
-            }
-        }
-        
-        prev = minZ;
-    }
-    
-    // Begin by initializing max Z matrix to lowest double, so that we always
-    // find a value larger than the initial value.
-    MatrixXd maxZ(prev.rows(), prev.cols());
-    maxZ.setConstant(std::numeric_limits<double>::lowest());
-    
-    // Complete the repeated opening by repeating the dilation step.
-    for (auto const& i : iters)
-    {
-        for (auto const& c : cols)
-        {
-            int index_base = c*prev.rows();
-            for (auto const& r : rows)
-            {                
-                int index = index_base + r;
-                for (auto const& j : idx)
-                {
-                    double v = prev(index+j);
-                    if (v > maxZ(r, c))
-                        maxZ(r, c) = v;
-                }
-            }
-        }
-        
-        prev = maxZ;
-    }
-
-    // Do not return the padded borders.
-    return prev.block(1, 1, data.rows(), data.cols());
+    return data;
 }
 
 Eigen::MatrixXd pointViewToEigen(const PointView& view)

--- a/pdal/EigenUtils.hpp
+++ b/pdal/EigenUtils.hpp
@@ -331,7 +331,9 @@ PDAL_DLL Eigen::MatrixXd matrixOpen(Eigen::MatrixXd data, int radius);
          structuring element.
   \return the morphological dilation of the input raster.
 */
-std::vector<double> dilateDiamond(std::vector<double> data, size_t rows, size_t cols, int iterations);
+PDAL_DLL std::vector<double> dilateDiamond(std::vector<double> data,
+                                           size_t rows, size_t cols,
+                                           int iterations);
 
 /**
   Perform a morphological erosion of the input raster.
@@ -348,7 +350,9 @@ std::vector<double> dilateDiamond(std::vector<double> data, size_t rows, size_t 
          structuring element.
   \return the morphological erosion of the input raster.
 */
-std::vector<double> erodeDiamond(std::vector<double> data, size_t rows, size_t cols, int iterations);
+PDAL_DLL std::vector<double> erodeDiamond(std::vector<double> data,
+                                          size_t rows, size_t cols,
+                                          int iterations);
 
 /**
   Pad input matrix symmetrically.

--- a/pdal/EigenUtils.hpp
+++ b/pdal/EigenUtils.hpp
@@ -316,23 +316,39 @@ PDAL_DLL Eigen::MatrixXd matrixClose(Eigen::MatrixXd data, int radius);
 */
 PDAL_DLL Eigen::MatrixXd matrixOpen(Eigen::MatrixXd data, int radius);
 
-Eigen::MatrixXd erodeDiamond(Eigen::MatrixXd data, int iterations);
-Eigen::MatrixXd dilateDiamond(Eigen::MatrixXd data, int iterations);
-
 /**
-  Perform a morphological opening of the input matrix.
+  Perform a morphological dilation of the input raster.
 
-  Performs a morphological opening of the input matrix using a diamond
+  Performs a morphological dilation of the input raster using a diamond
   structuring element. Larger structuring elements are approximated by applying
-  multiple iterations of the opening operation. Data will be symmetrically
-  padded at its edges.
+  multiple iterations of the opening operation. The input and output rasters are
+  stored in column major order.
 
-  \param data the input matrix.
+  \param data the input raster.
+  \param rows the number of rows.
+  \param cols the number of cols.
   \param iterations the number of iterations used to approximate a larger 
          structuring element.
-  \return the morphological opening of the input radius.
+  \return the morphological dilation of the input raster.
 */
-PDAL_DLL Eigen::MatrixXd openDiamond(Eigen::MatrixXd data, int iterations);
+std::vector<double> dilateDiamond(std::vector<double> data, size_t rows, size_t cols, int iterations);
+
+/**
+  Perform a morphological erosion of the input raster.
+
+  Performs a morphological erosion of the input raster using a diamond
+  structuring element. Larger structuring elements are approximated by applying
+  multiple iterations of the opening operation. The input and output rasters are
+  stored in column major order.
+
+  \param data the input raster.
+  \param rows the number of rows.
+  \param cols the number of cols.
+  \param iterations the number of iterations used to approximate a larger 
+         structuring element.
+  \return the morphological erosion of the input raster.
+*/
+std::vector<double> erodeDiamond(std::vector<double> data, size_t rows, size_t cols, int iterations);
 
 /**
   Pad input matrix symmetrically.

--- a/test/unit/EigenTest.cpp
+++ b/test/unit/EigenTest.cpp
@@ -1,36 +1,36 @@
 /******************************************************************************
-* Copyright (c) 2016, Peter J. Gadomski <pete.gadomski@gmail.com>
-*
-* All rights reserved.
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following
-* conditions are met:
-*
-*     * Redistributions of source code must retain the above copyright
-*       notice, this list of conditions and the following disclaimer.
-*     * Redistributions in binary form must reproduce the above copyright
-*       notice, this list of conditions and the following disclaimer in
-*       the documentation and/or other materials provided
-*       with the distribution.
-*     * Neither the name of Hobu, Inc. or Flaxen Geo Consulting nor the
-*       names of its contributors may be used to endorse or promote
-*       products derived from this software without specific prior
-*       written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-* FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-* COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-* BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
-* OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
-* AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
-* OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
-* OF SUCH DAMAGE.
-****************************************************************************/
+ * Copyright (c) 2016, Peter J. Gadomski <pete.gadomski@gmail.com>
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of Hobu, Inc. or Flaxen Geo Consulting nor the
+ *       names of its contributors may be used to endorse or promote
+ *       products derived from this software without specific prior
+ *       written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ ****************************************************************************/
 
 #include <pdal/pdal_test_main.hpp>
 
@@ -66,9 +66,8 @@ TEST(EigenTest, ComputeValues)
     using namespace Eigen;
 
     Matrix3d A;
-    A << 1.8339,  0.3188, 0.3426,
-        -2.2588, -1.3077, 3.5784,
-         0.8622, -0.4336, 2.7694;
+    A << 1.8339, 0.3188, 0.3426, -2.2588, -1.3077, 3.5784, 0.8622, -0.4336,
+        2.7694;
 
     double spacing(1.4);
 
@@ -127,24 +126,22 @@ TEST(EigenTest, ComputeValues)
     EXPECT_NEAR(269.8718, afd, 0.0001);
 
     double hs = eigen::computeHillshade(A, spacing, 45.0, 315.0);
-    
+
     MatrixXd out = eigen::gradX(A);
-    
+
     Matrix3d gx;
-    gx << -1.5151, -0.7457, 0.0238,
-           0.9511,  2.9186, 4.8861,
-          -1.2958,  0.9536, 3.2030;
-    
+    gx << -1.5151, -0.7457, 0.0238, 0.9511, 2.9186, 4.8861, -1.2958, 0.9536,
+        3.2030;
+
     for (size_t i = 0; i < 9; ++i)
         EXPECT_NEAR(gx(i), out(i), 0.0001);
-    
+
     MatrixXd out2 = eigen::gradY(A);
-    
+
     Matrix3d gy;
-    gy << -4.0927, -1.6265,  3.2358,
-          -0.4859, -0.3762,  1.2134,
-           3.1210,  0.8741, -0.8090;
-    
+    gy << -4.0927, -1.6265, 3.2358, -0.4859, -0.3762, 1.2134, 3.1210, 0.8741,
+        -0.8090;
+
     for (size_t i = 0; i < 9; ++i)
         EXPECT_NEAR(gy(i), out2(i), 0.0001);
 
@@ -201,9 +198,8 @@ TEST(EigenTest, Padding)
     using namespace Eigen;
 
     MatrixXd A(3, 3);
-    A << 1.8339,  0.3188, 0.3426,
-        -2.2588, -1.3077, 3.5784,
-         0.8622, -0.4336, 2.7694;
+    A << 1.8339, 0.3188, 0.3426, -2.2588, -1.3077, 3.5784, 0.8622, -0.4336,
+        2.7694;
 
     MatrixXd B = eigen::padMatrix(A, 1);
 
@@ -216,32 +212,41 @@ TEST(EigenTest, Padding)
     EXPECT_EQ(-0.4336, B(4, 2));
 }
 
-TEST(EigenTest, Dilate)
+TEST(EigenTest, Morphological)
 {
     using namespace Eigen;
-    
+
     MatrixXd C(5, 5);
-    C << 0, 0, 0, 0, 0,
-         0, 1, 0, 0, 0,
-         0, 1, 1, 0, 0,
-         0, 0, 1, 1, 0,
-         0, 0, 0, 0, 0;
-    
+    C << 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0,
+        0;
+    std::vector<double> Cv(C.data(), C.data() + C.size());
+
     MatrixXd D = eigen::dilate(C, 1);
-    
+    std::vector<double> Dv = eigen::dilateDiamond(Cv, 5, 5, 1);
+    std::vector<double> Dv2 = eigen::dilateDiamond(Cv, 5, 5, 2);
+
     EXPECT_EQ(0, D(0, 0));
     EXPECT_EQ(1, D(1, 0));
     EXPECT_EQ(1, D(0, 1));
-    
+    EXPECT_EQ(0, Dv[0]);
+    EXPECT_EQ(1, Dv[1]);
+    EXPECT_EQ(1, Dv[5]);
+    EXPECT_EQ(1, Dv2[0]);
+    EXPECT_EQ(1, Dv2[10]);
+    EXPECT_EQ(0, Dv2[15]);
+
     MatrixXd E(5, 5);
-    E << 0, 0, 0, 0, 0,
-         0, 1, 1, 1, 0,
-         0, 1, 1, 1, 0,
-         0, 1, 1, 1, 0,
-         0, 0, 0, 0, 0;
-    
+    E << 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 1, 1, 1, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0,
+        0;
+    std::vector<double> Ev(E.data(), E.data() + E.size());
+
     MatrixXd F = eigen::erode(E, 1);
-    
+    std::vector<double> Fv = eigen::erodeDiamond(Ev, 5, 5, 1);
+    std::vector<double> Fv2 = eigen::erodeDiamond(Ev, 5, 5, 2);
+
     EXPECT_EQ(0, F(1, 3));
     EXPECT_EQ(1, F(2, 2));
+    EXPECT_EQ(0, Fv[16]);
+    EXPECT_EQ(1, Fv[12]);
+    EXPECT_EQ(0, Fv2[12]);
 }


### PR DESCRIPTION
`filters.pmf` and `filters.smrf` both spend a majority of their time in the
morphological operations (erosion and dilation). As it turns out, we don't gain
much by using Eigen to implement these either. By storing our matrices as
vectors in column-major order, and refactoring the erosion and dilation
functions slightly, we have achieved speedups of greater than 2x for both
filters.

We also had a bug in SMRF, as the erosion and dilation steps were reversed in
the net cutting procedure.

Finally, we have added some additional tests for both erosion and dilation.