### PR TITLE
Updating outlier, PMF, and SMRF filters

### DIFF
--- a/filters/OutlierFilter.hpp
+++ b/filters/OutlierFilter.hpp
@@ -1,5 +1,5 @@
 /******************************************************************************
- * Copyright (c) 2016, Bradley J Chambers (brad.chambers@gmail.com)
+ * Copyright (c) 2016-2017, Bradley J Chambers (brad.chambers@gmail.com)
  *
  * All rights reserved.
  *
@@ -37,8 +37,8 @@
 #include <pdal/Filter.hpp>
 #include <pdal/plugin.hpp>
 
-#include <memory>
 #include <map>
+#include <memory>
 #include <string>
 
 extern "C" int32_t OutlierFilter_ExitFunc();
@@ -59,10 +59,11 @@ class PDAL_DLL OutlierFilter : public pdal::Filter
 {
 public:
     OutlierFilter() : Filter()
-    {}
+    {
+    }
 
-    static void * create();
-    static int32_t destroy(void *);
+    static void* create();
+    static int32_t destroy(void*);
     std::string getName() const;
 
 private:
@@ -71,8 +72,7 @@ private:
     double m_radius;
     int m_meanK;
     double m_multiplier;
-    bool m_classify;
-    bool m_extract;
+    uint8_t m_class;
 
     virtual void addDimensions(PointLayoutPtr layout);
     virtual void addArgs(ProgramArgs& args);
@@ -81,7 +81,7 @@ private:
     virtual PointViewSet run(PointViewPtr view);
 
     OutlierFilter& operator=(const OutlierFilter&); // not implemented
-    OutlierFilter(const OutlierFilter&); // not implemented
+    OutlierFilter(const OutlierFilter&);            // not implemented
 };
 
 } // namespace pdal

--- a/filters/PMFFilter.cpp
+++ b/filters/PMFFilter.cpp
@@ -397,6 +397,7 @@ PointViewSet PMFFilter::run(PointViewPtr input)
     else
         idx = processGround(lastView);
 
+    PointViewPtr outView = input->makeNew();
     if (!idx.empty())
     {
 
@@ -410,9 +411,9 @@ PointViewSet PMFFilter::run(PointViewPtr input)
             lastView->setField(Dimension::Id::Classification, i, 2);
         }
 
-        viewSet.insert(ignoredView);
-        viewSet.insert(nonlastView);
-        viewSet.insert(lastView);
+        outView->append(*ignoredView);
+        outView->append(*nonlastView);
+        outView->append(*lastView);
     }
     else
     {
@@ -421,8 +422,9 @@ PointViewSet PMFFilter::run(PointViewPtr input)
                                             "ground returns!\n";
 
         // return the input buffer unchanged
-        viewSet.insert(input);
+        outView->append(*input);
     }
+    viewSet.insert(outView);
 
     return viewSet;
 }

--- a/filters/PMFFilter.cpp
+++ b/filters/PMFFilter.cpp
@@ -37,9 +37,12 @@
 #include <pdal/EigenUtils.hpp>
 #include <pdal/KDIndex.hpp>
 #include <pdal/QuadIndex.hpp>
+#include <pdal/Segmentation.hpp>
 #include <pdal/pdal_macros.hpp>
 #include <pdal/util/ProgramArgs.hpp>
 #include <pdal/util/Utils.hpp>
+
+#include "private/DimRange.hpp"
 
 namespace pdal
 {
@@ -62,14 +65,34 @@ void PMFFilter::addArgs(ProgramArgs& args)
     args.add("max_distance", "Maximum distance", m_maxDistance, 2.5);
     args.add("initial_distance", "Initial distance", m_initialDistance, 0.15);
     args.add("cell_size", "Cell size", m_cellSize, 1.0);
-    args.add("classify", "Apply classification labels?", m_classify, true);
-    args.add("extract", "Extract ground returns?", m_extract);
     args.add("approximate", "Use approximate algorithm?", m_approximate);
+    args.add("ignore", "Ignore values", m_ignored);
+    args.add("last", "Consider last returns only?", m_lastOnly, true);
 }
 
 void PMFFilter::addDimensions(PointLayoutPtr layout)
 {
     layout->registerDim(Dimension::Id::Classification);
+}
+
+void PMFFilter::prepared(PointTableRef table)
+{
+    const PointLayoutPtr layout(table.layout());
+
+    m_ignored.m_id = layout->findDim(m_ignored.m_name);
+    if (m_ignored.m_id == Dimension::Id::Unknown)
+    {
+        throwError("Invalid dimension name in 'ignore' option: '" +
+                   m_ignored.m_name + "'.");
+    }
+
+    if (m_lastOnly)
+    {
+        if (!layout->hasDim(Dimension::Id::ReturnNumber) ||
+            !layout->hasDim(Dimension::Id::NumberOfReturns))
+            throwError("Cannot filter using last returns only without "
+                       "ReturnNumber and NumberOfReturns.");
+    }
 }
 
 std::vector<double> PMFFilter::morphOpen(PointViewPtr view, float radius)
@@ -347,61 +370,57 @@ std::vector<PointId> PMFFilter::processGroundApprox(PointViewPtr view)
 
 PointViewSet PMFFilter::run(PointViewPtr input)
 {
-    bool logOutput = log()->getLevel() > LogLevel::Debug1;
-    if (logOutput)
-        log()->floatPrecision(8);
-    log()->get(LogLevel::Debug2) << "Process PMFFilter...\n";
+    PointViewSet viewSet;
+    if (!input->size())
+        return viewSet;
+
+    // Segment input view into ignored/kept views.
+    PointViewPtr ignoredView = input->makeNew();
+    PointViewPtr keptView = input->makeNew();
+    Segmentation::ignoreDimRange(m_ignored, input, keptView, ignoredView);
+
+    // Segment kept view into last/other-than-last return views.
+    PointViewPtr lastView = keptView->makeNew();
+    PointViewPtr nonlastView = keptView->makeNew();
+    if (m_lastOnly)
+        Segmentation::segmentLastReturns(keptView, lastView, nonlastView);
+    else
+        lastView->append(*keptView);
+
+    for (PointId i = 0; i < nonlastView->size(); ++i)
+        nonlastView->setField(Dimension::Id::Classification, i, 1);
+
+    for (PointId i = 0; i < lastView->size(); ++i)
+        lastView->setField(Dimension::Id::Classification, i, 1);
 
     std::vector<PointId> idx;
     if (m_approximate)
-        idx = processGroundApprox(input);
+        idx = processGroundApprox(lastView);
     else
-        idx = processGround(input);
+        idx = processGround(lastView);
 
-    PointViewSet viewSet;
-    if (!idx.empty() && (m_classify || m_extract))
+    if (!idx.empty())
     {
 
-        if (m_classify)
+        log()->get(LogLevel::Debug2)
+            << "Labeled " << idx.size() << " ground returns!\n";
+
+        // set the classification label of ground returns as 2
+        // (corresponding to ASPRS LAS specification)
+        for (const auto& i : idx)
         {
-            log()->get(LogLevel::Debug2)
-                << "Labeled " << idx.size() << " ground returns!\n";
-
-            // set the classification label of ground returns as 2
-            // (corresponding to ASPRS LAS specification)
-            for (const auto& i : idx)
-            {
-                input->setField(Dimension::Id::Classification, i, 2);
-            }
-
-            viewSet.insert(input);
+            lastView->setField(Dimension::Id::Classification, i, 2);
         }
 
-        if (m_extract)
-        {
-            log()->get(LogLevel::Debug2)
-                << "Extracted " << idx.size() << " ground returns!\n";
-
-            // create new PointView containing only ground returns
-            PointViewPtr output = input->makeNew();
-            for (const auto& i : idx)
-            {
-                output->appendPoint(*input, i);
-            }
-
-            viewSet.erase(input);
-            viewSet.insert(output);
-        }
+        viewSet.insert(ignoredView);
+        viewSet.insert(nonlastView);
+        viewSet.insert(lastView);
     }
     else
     {
         if (idx.empty())
             log()->get(LogLevel::Debug2) << "Filtered cloud has no "
                                             "ground returns!\n";
-
-        if (!(m_classify || m_extract))
-            log()->get(LogLevel::Debug2) << "Must choose --classify "
-                                            "or --extract\n";
 
         // return the input buffer unchanged
         viewSet.insert(input);

--- a/filters/PMFFilter.cpp
+++ b/filters/PMFFilter.cpp
@@ -80,11 +80,6 @@ void PMFFilter::prepared(PointTableRef table)
     const PointLayoutPtr layout(table.layout());
 
     m_ignored.m_id = layout->findDim(m_ignored.m_name);
-    if (m_ignored.m_id == Dimension::Id::Unknown)
-    {
-        throwError("Invalid dimension name in 'ignore' option: '" +
-                   m_ignored.m_name + "'.");
-    }
 
     if (m_lastOnly)
     {
@@ -377,7 +372,10 @@ PointViewSet PMFFilter::run(PointViewPtr input)
     // Segment input view into ignored/kept views.
     PointViewPtr ignoredView = input->makeNew();
     PointViewPtr keptView = input->makeNew();
-    Segmentation::ignoreDimRange(m_ignored, input, keptView, ignoredView);
+    if (m_ignored.m_id == Dimension::Id::Unknown)
+        keptView->append(*input);
+    else
+        Segmentation::ignoreDimRange(m_ignored, input, keptView, ignoredView);
 
     // Segment kept view into last/other-than-last return views.
     PointViewPtr lastView = keptView->makeNew();

--- a/filters/PMFFilter.cpp
+++ b/filters/PMFFilter.cpp
@@ -85,8 +85,13 @@ void PMFFilter::prepared(PointTableRef table)
     {
         if (!layout->hasDim(Dimension::Id::ReturnNumber) ||
             !layout->hasDim(Dimension::Id::NumberOfReturns))
-            throwError("Cannot filter using last returns only without "
-                       "ReturnNumber and NumberOfReturns.");
+        {
+            log()->get(LogLevel::Warning) << "Could not find ReturnNumber and "
+                                             "NumberOfReturns. Skipping "
+                                             "segmentation of last returns and "
+                                             "proceeding with all returns.\n";
+            m_lastOnly = false;
+        }
     }
 }
 

--- a/filters/PMFFilter.hpp
+++ b/filters/PMFFilter.hpp
@@ -37,6 +37,8 @@
 #include <pdal/Filter.hpp>
 #include <pdal/plugin.hpp>
 
+#include "private/DimRange.hpp"
+
 #include <memory>
 
 extern "C" int32_t PMFFilter_ExitFunc();
@@ -67,15 +69,16 @@ private:
     double m_maxDistance;
     double m_initialDistance;
     double m_cellSize;
-    bool m_classify;
-    bool m_extract;
     bool m_approximate;
+    DimRange m_ignored;
+    bool m_lastOnly;
 
     virtual void addDimensions(PointLayoutPtr layout);
     virtual void addArgs(ProgramArgs& args);
     std::vector<double> fillNearest(PointViewPtr view, size_t rows, size_t cols,
                                     double cell_size, BOX2D bounds);
     std::vector<double> morphOpen(PointViewPtr view, float radius);
+    virtual void prepared(PointTableRef table);
     std::vector<PointId> processGround(PointViewPtr view);
     std::vector<PointId> processGroundApprox(PointViewPtr view);
     virtual PointViewSet run(PointViewPtr view);

--- a/filters/SMRFilter.cpp
+++ b/filters/SMRFilter.cpp
@@ -104,8 +104,13 @@ void SMRFilter::prepared(PointTableRef table)
     {
         if (!layout->hasDim(Dimension::Id::ReturnNumber) ||
             !layout->hasDim(Dimension::Id::NumberOfReturns))
-            throwError("Cannot filter using last returns only without "
-                       "ReturnNumber and NumberOfReturns.");
+        {
+            log()->get(LogLevel::Warning) << "Could not find ReturnNumber and "
+                                             "NumberOfReturns. Skipping "
+                                             "segmentation of last returns and "
+                                             "proceeding with all returns.\n";
+            m_lastOnly = false;
+        }
     }
 }
 

--- a/filters/SMRFilter.cpp
+++ b/filters/SMRFilter.cpp
@@ -99,11 +99,6 @@ void SMRFilter::prepared(PointTableRef table)
     const PointLayoutPtr layout(table.layout());
 
     m_ignored.m_id = layout->findDim(m_ignored.m_name);
-    if (m_ignored.m_id == Dimension::Id::Unknown)
-    {
-        throwError("Invalid dimension name in 'ignore' option: '" +
-                   m_ignored.m_name + "'.");
-    }
 
     if (m_lastOnly)
     {
@@ -132,7 +127,10 @@ PointViewSet SMRFilter::run(PointViewPtr view)
     // Segment input view into ignored/kept views.
     PointViewPtr ignoredView = view->makeNew();
     PointViewPtr keptView = view->makeNew();
-    Segmentation::ignoreDimRange(m_ignored, view, keptView, ignoredView);
+    if (m_ignored.m_id == Dimension::Id::Unknown)
+        keptView->append(*view);
+    else
+        Segmentation::ignoreDimRange(m_ignored, view, keptView, ignoredView);
 
     // Segment kept view into last/other-than-last return views.
     PointViewPtr lastView = keptView->makeNew();

--- a/filters/SMRFilter.cpp
+++ b/filters/SMRFilter.cpp
@@ -41,9 +41,12 @@
 
 #include <pdal/EigenUtils.hpp>
 #include <pdal/KDIndex.hpp>
+#include <pdal/Segmentation.hpp>
 #include <pdal/pdal_macros.hpp>
 #include <pdal/util/FileUtils.hpp>
 #include <pdal/util/ProgramArgs.hpp>
+
+#include "private/DimRange.hpp"
 
 #include <Eigen/Dense>
 
@@ -82,11 +85,33 @@ void SMRFilter::addArgs(ProgramArgs& args)
     args.add("threshold", "Elevation threshold?", m_threshold, 0.5);
     args.add("cut", "Cut net size?", m_cut, 0.0);
     args.add("dir", "Optional output directory for debugging", m_dir);
+    args.add("ignore", "Ignore values", m_ignored);
+    args.add("last", "Consider last returns only?", m_lastOnly, true);
 }
 
 void SMRFilter::addDimensions(PointLayoutPtr layout)
 {
     layout->registerDim(Id::Classification);
+}
+
+void SMRFilter::prepared(PointTableRef table)
+{
+    const PointLayoutPtr layout(table.layout());
+
+    m_ignored.m_id = layout->findDim(m_ignored.m_name);
+    if (m_ignored.m_id == Dimension::Id::Unknown)
+    {
+        throwError("Invalid dimension name in 'ignore' option: '" +
+                   m_ignored.m_name + "'.");
+    }
+
+    if (m_lastOnly)
+    {
+        if (!layout->hasDim(Dimension::Id::ReturnNumber) ||
+            !layout->hasDim(Dimension::Id::NumberOfReturns))
+            throwError("Cannot filter using last returns only without "
+                       "ReturnNumber and NumberOfReturns.");
+    }
 }
 
 void SMRFilter::ready(PointTableRef table)
@@ -104,14 +129,30 @@ PointViewSet SMRFilter::run(PointViewPtr view)
     if (!view->size())
         return viewSet;
 
-    m_srs = view->spatialReference();
+    // Segment input view into ignored/kept views.
+    PointViewPtr ignoredView = view->makeNew();
+    PointViewPtr keptView = view->makeNew();
+    Segmentation::ignoreDimRange(m_ignored, view, keptView, ignoredView);
 
-    view->calculateBounds(m_bounds);
+    // Segment kept view into last/other-than-last return views.
+    PointViewPtr lastView = keptView->makeNew();
+    PointViewPtr nonlastView = keptView->makeNew();
+    if (m_lastOnly)
+        Segmentation::segmentLastReturns(keptView, lastView, nonlastView);
+    else
+        lastView->append(*keptView);
+
+    for (PointId i = 0; i < nonlastView->size(); ++i)
+        nonlastView->setField(Dimension::Id::Classification, i, 1);
+
+    m_srs = lastView->spatialReference();
+
+    lastView->calculateBounds(m_bounds);
     m_cols = ((m_bounds.maxx - m_bounds.minx) / m_cell) + 1;
     m_rows = ((m_bounds.maxy - m_bounds.miny) / m_cell) + 1;
 
     // Create raster of minimum Z values per element.
-    std::vector<double> ZImin = createZImin(view);
+    std::vector<double> ZImin = createZImin(lastView);
 
     // Create raster mask of pixels containing low outlier points.
     std::vector<int> Low = createLowMask(ZImin);
@@ -130,13 +171,16 @@ PointViewSet SMRFilter::run(PointViewPtr view)
     // Create raster representing the provisional DEM. Note that we use the
     // original ZImin (not ZInet), however the net cut mask will still force
     // interpolation at these pixels.
-    std::vector<double> ZIpro = createZIpro(view, ZImin, Low, isNetCell, Obj);
+    std::vector<double> ZIpro =
+        createZIpro(lastView, ZImin, Low, isNetCell, Obj);
 
     // Classify ground returns by comparing elevation values to the provisional
     // DEM.
-    classifyGround(view, ZIpro);
+    classifyGround(lastView, ZIpro);
 
-    viewSet.insert(view);
+    viewSet.insert(ignoredView);
+    viewSet.insert(nonlastView);
+    viewSet.insert(lastView);
 
     return viewSet;
 }
@@ -217,9 +261,9 @@ void SMRFilter::classifyGround(PointViewPtr view, std::vector<double>& ZIpro)
         // vertical distance between each LIDAR point and the provisional
         // DEM, and applying a threshold calculation."
         if (std::fabs(ZIpro[c * m_rows + r] - z) > thresh(r, c))
-            continue;
-
-        view->setField(Id::Classification, i, 2);
+            view->setField(Id::Classification, i, 1);
+        else
+            view->setField(Id::Classification, i, 2);
     }
 }
 

--- a/filters/SMRFilter.cpp
+++ b/filters/SMRFilter.cpp
@@ -176,9 +176,11 @@ PointViewSet SMRFilter::run(PointViewPtr view)
     // DEM.
     classifyGround(lastView, ZIpro);
 
-    viewSet.insert(ignoredView);
-    viewSet.insert(nonlastView);
-    viewSet.insert(lastView);
+    PointViewPtr outView = view->makeNew();
+    outView->append(*ignoredView);
+    outView->append(*nonlastView);
+    outView->append(*lastView);
+    viewSet.insert(outView);
 
     return viewSet;
 }

--- a/filters/SMRFilter.hpp
+++ b/filters/SMRFilter.hpp
@@ -37,6 +37,8 @@
 #include <pdal/Filter.hpp>
 #include <pdal/plugin.hpp>
 
+#include "private/DimRange.hpp"
+
 #include <string>
 
 extern "C" int32_t SMRFilter_ExitFunc();
@@ -66,11 +68,14 @@ private:
     double m_scalar;
     double m_threshold;
     std::string m_dir;
+    DimRange m_ignored;
+    bool m_lastOnly;
     BOX2D m_bounds;
     SpatialReference m_srs;
 
     virtual void addArgs(ProgramArgs& args);
     virtual void addDimensions(PointLayoutPtr layout);
+    virtual void prepared(PointTableRef table);
     virtual void ready(PointTableRef table);
     virtual PointViewSet run(PointViewPtr view);
 

--- a/pdal/Segmentation.cpp
+++ b/pdal/Segmentation.cpp
@@ -1,36 +1,36 @@
 /******************************************************************************
-* Copyright (c) 2016, Bradley J. Chambers (brad.chambers@gmail.com)
-*
-* All rights reserved.
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following
-* conditions are met:
-*
-*     * Redistributions of source code must retain the above copyright
-*       notice, this list of conditions and the following disclaimer.
-*     * Redistributions in binary form must reproduce the above copyright
-*       notice, this list of conditions and the following disclaimer in
-*       the documentation and/or other materials provided
-*       with the distribution.
-*     * Neither the name of Hobu, Inc. or Flaxen Geo Consulting nor the
-*       names of its contributors may be used to endorse or promote
-*       products derived from this software without specific prior
-*       written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-* FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-* COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-* BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
-* OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
-* AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
-* OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
-* OF SUCH DAMAGE.
-****************************************************************************/
+ * Copyright (c) 2016-2017, Bradley J. Chambers (brad.chambers@gmail.com)
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of Hobu, Inc. or Flaxen Geo Consulting nor the
+ *       names of its contributors may be used to endorse or promote
+ *       products derived from this software without specific prior
+ *       written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ ****************************************************************************/
 
 #include <pdal/PDALUtils.hpp>
 
@@ -38,6 +38,8 @@
 #include <pdal/PointView.hpp>
 #include <pdal/Segmentation.hpp>
 #include <pdal/pdal_types.hpp>
+
+#include "../filters/private/DimRange.hpp"
 
 #include <vector>
 
@@ -48,8 +50,9 @@ namespace Segmentation
 {
 
 std::vector<std::vector<PointId>> extractClusters(PointView& view,
-                               uint64_t min_points, uint64_t max_points,
-                               double tolerance)
+                                                  uint64_t min_points,
+                                                  uint64_t max_points,
+                                                  double tolerance)
 {
     // Index the incoming PointView for subsequent radius searches.
     KD3Index kdi(view);
@@ -108,6 +111,35 @@ std::vector<std::vector<PointId>> extractClusters(PointView& view,
     }
 
     return clusters;
+}
+
+void ignoreDimRange(DimRange dr, PointViewPtr input, PointViewPtr keep,
+                    PointViewPtr ignore)
+{
+    PointRef point(*input, 0);
+    for (PointId i = 0; i < input->size(); ++i)
+    {
+        point.setPointId(i);
+        if (dr.valuePasses(point.getFieldAs<double>(dr.m_id)))
+            ignore->appendPoint(*input, i);
+        else
+            keep->appendPoint(*input, i);
+    }
+}
+
+void segmentLastReturns(PointViewPtr input, PointViewPtr last,
+                        PointViewPtr other)
+{
+    PointRef point(*input, 0);
+    for (PointId i = 0; i < input->size(); ++i)
+    {
+        point.setPointId(i);
+        if (point.getFieldAs<uint8_t>(Dimension::Id::ReturnNumber) ==
+            point.getFieldAs<uint8_t>(Dimension::Id::NumberOfReturns))
+            last->appendPoint(*input, i);
+        else
+            other->appendPoint(*input, i);
+    }
 }
 
 } // namespace Segmentation

--- a/pdal/Segmentation.hpp
+++ b/pdal/Segmentation.hpp
@@ -1,5 +1,5 @@
 /******************************************************************************
- * Copyright (c) 2016, Bradley J. Chambers (brad.chambers@gmail.com)
+ * Copyright (c) 2016-2017, Bradley J. Chambers (brad.chambers@gmail.com)
  *
  * All rights reserved.
  *
@@ -37,6 +37,8 @@
 #include <pdal/pdal_export.hpp>
 #include <pdal/pdal_types.hpp>
 
+#include "../filters/private/DimRange.hpp"
+
 #include <vector>
 
 namespace pdal
@@ -62,8 +64,15 @@ namespace Segmentation
   \returns a vector of clusters (themselves vectors of PointIds).
 */
 PDAL_DLL std::vector<std::vector<PointId>> extractClusters(PointView& view,
-                                        uint64_t min_points,
-                                        uint64_t max_points, double tolerance);
+                                                           uint64_t min_points,
+                                                           uint64_t max_points,
+                                                           double tolerance);
+
+PDAL_DLL void ignoreDimRange(DimRange dr, PointViewPtr input, PointViewPtr keep,
+                             PointViewPtr ignore);
+
+PDAL_DLL void segmentLastReturns(PointViewPtr input, PointViewPtr last,
+                                 PointViewPtr other);
 
 } // namespace Segmentation
 } // namespace pdal

--- a/test/unit/OldPCLBlockTest.cpp
+++ b/test/unit/OldPCLBlockTest.cpp
@@ -1,41 +1,41 @@
 /******************************************************************************
-* Copyright (c) 2016, Bradley J Chambers (brad.chambers@gmail.com)
-*
-* All rights reserved.
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following
-* conditions are met:
-*
-*     * Redistributions of source code must retain the above copyright
-*       notice, this list of conditions and the following disclaimer.
-*     * Redistributions in binary form must reproduce the above copyright
-*       notice, this list of conditions and the following disclaimer in
-*       the documentation and/or other materials provided
-*       with the distribution.
-*     * Neither the name of Hobu, Inc. or Flaxen Geo Consulting nor the
-*       names of its contributors may be used to endorse or promote
-*       products derived from this software without specific prior
-*       written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-* FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-* COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-* BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
-* OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
-* AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
-* OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
-* OF SUCH DAMAGE.
-****************************************************************************/
+ * Copyright (c) 2016-2017, Bradley J Chambers (brad.chambers@gmail.com)
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of Hobu, Inc. or Flaxen Geo Consulting nor the
+ *       names of its contributors may be used to endorse or promote
+ *       products derived from this software without specific prior
+ *       written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ ****************************************************************************/
 
 #include <string>
 
-#include <pdal/pdal_test_main.hpp>
 #include <pdal/StageFactory.hpp>
+#include <pdal/pdal_test_main.hpp>
 
 #include "Support.hpp"
 
@@ -44,29 +44,36 @@ using namespace pdal;
 TEST(OldPCLBlockTests, StatisticalOutliers1)
 {
     StageFactory f;
-    
+
     Options ro;
     ro.add("filename", Support::datapath("autzen/autzen-point-format-3.las"));
-    
+
     Stage* r(f.createStage("readers.las"));
     EXPECT_TRUE(r);
     r->setOptions(ro);
-    
+
     Options fo;
     fo.add("method", "statistical");
     fo.add("multiplier", 1.5);
     fo.add("mean_k", 2);
-    fo.add("extract", true);
-    
+
     Stage* outlier(f.createStage("filters.outlier"));
     EXPECT_TRUE(outlier);
     outlier->setOptions(fo);
     outlier->setInput(*r);
-    
+
+    Options rangeOpts;
+    rangeOpts.add("limits", "Classification![7:7]");
+
+    Stage* range(f.createStage("filters.range"));
+    EXPECT_TRUE(range);
+    range->setOptions(rangeOpts);
+    range->setInput(*outlier);
+
     PointTable table;
-    outlier->prepare(table);
-    PointViewSet viewSet = outlier->execute(table);
-    
+    range->prepare(table);
+    PointViewSet viewSet = range->execute(table);
+
     EXPECT_EQ(1u, viewSet.size());
     PointViewPtr view = *viewSet.begin();
     EXPECT_EQ(96u, view->size());
@@ -75,29 +82,36 @@ TEST(OldPCLBlockTests, StatisticalOutliers1)
 TEST(OldPCLBlockTests, StatisticalOutliers2)
 {
     StageFactory f;
-    
+
     Options ro;
     ro.add("filename", Support::datapath("autzen/autzen-point-format-3.las"));
-    
+
     Stage* r(f.createStage("readers.las"));
     EXPECT_TRUE(r);
     r->setOptions(ro);
-    
+
     Options fo;
     fo.add("method", "statistical");
     fo.add("multiplier", 0.0);
     fo.add("mean_k", 5);
-    fo.add("extract", true);
-    
+
     Stage* outlier(f.createStage("filters.outlier"));
     EXPECT_TRUE(outlier);
     outlier->setOptions(fo);
     outlier->setInput(*r);
-    
+
+    Options rangeOpts;
+    rangeOpts.add("limits", "Classification![7:7]");
+
+    Stage* range(f.createStage("filters.range"));
+    EXPECT_TRUE(range);
+    range->setOptions(rangeOpts);
+    range->setInput(*outlier);
+
     PointTable table;
-    outlier->prepare(table);
-    PointViewSet viewSet = outlier->execute(table);
-    
+    range->prepare(table);
+    PointViewSet viewSet = range->execute(table);
+
     EXPECT_EQ(1u, viewSet.size());
     PointViewPtr view = *viewSet.begin();
     EXPECT_EQ(63u, view->size());
@@ -106,29 +120,36 @@ TEST(OldPCLBlockTests, StatisticalOutliers2)
 TEST(OldPCLBlockTests, RadiusOutliers1)
 {
     StageFactory f;
-    
+
     Options ro;
     ro.add("filename", Support::datapath("autzen/autzen-point-format-3.las"));
-    
+
     Stage* r(f.createStage("readers.las"));
     EXPECT_TRUE(r);
     r->setOptions(ro);
-    
+
     Options fo;
     fo.add("method", "radius");
     fo.add("radius", 200.0);
     fo.add("min_k", 1);
-    fo.add("extract", true);
-    
+
     Stage* outlier(f.createStage("filters.outlier"));
     EXPECT_TRUE(outlier);
     outlier->setOptions(fo);
     outlier->setInput(*r);
-    
+
+    Options rangeOpts;
+    rangeOpts.add("limits", "Classification![7:7]");
+
+    Stage* range(f.createStage("filters.range"));
+    EXPECT_TRUE(range);
+    range->setOptions(rangeOpts);
+    range->setInput(*outlier);
+
     PointTable table;
-    outlier->prepare(table);
-    PointViewSet viewSet = outlier->execute(table);
-    
+    range->prepare(table);
+    PointViewSet viewSet = range->execute(table);
+
     EXPECT_EQ(1u, viewSet.size());
     PointViewPtr view = *viewSet.begin();
     EXPECT_EQ(60u, view->size());
@@ -137,29 +158,36 @@ TEST(OldPCLBlockTests, RadiusOutliers1)
 TEST(OldPCLBlockTests, RadiusOutliers2)
 {
     StageFactory f;
-    
+
     Options ro;
     ro.add("filename", Support::datapath("autzen/autzen-point-format-3.las"));
-    
+
     Stage* r(f.createStage("readers.las"));
     EXPECT_TRUE(r);
     r->setOptions(ro);
-    
+
     Options fo;
     fo.add("method", "radius");
     fo.add("radius", 100.0);
     fo.add("min_k", 2);
-    fo.add("extract", true);
-    
+
     Stage* outlier(f.createStage("filters.outlier"));
     EXPECT_TRUE(outlier);
     outlier->setOptions(fo);
     outlier->setInput(*r);
-    
+
+    Options rangeOpts;
+    rangeOpts.add("limits", "Classification![7:7]");
+
+    Stage* range(f.createStage("filters.range"));
+    EXPECT_TRUE(range);
+    range->setOptions(rangeOpts);
+    range->setInput(*outlier);
+
     PointTable table;
-    outlier->prepare(table);
-    PointViewSet viewSet = outlier->execute(table);
-    
+    range->prepare(table);
+    PointViewSet viewSet = range->execute(table);
+
     EXPECT_EQ(1u, viewSet.size());
     PointViewPtr view = *viewSet.begin();
     EXPECT_EQ(3u, view->size());
@@ -168,27 +196,43 @@ TEST(OldPCLBlockTests, RadiusOutliers2)
 TEST(OldPCLBlockTests, PMF1)
 {
     StageFactory f;
-    
+
     Options ro;
     ro.add("filename", Support::datapath("autzen/autzen-point-format-3.las"));
-    
+
     Stage* r(f.createStage("readers.las"));
     EXPECT_TRUE(r);
     r->setOptions(ro);
-    
+
+    Options ao;
+    ao.add("assignment", "Classification[:]=0");
+
+    Stage* assign(f.createStage("filters.assign"));
+    EXPECT_TRUE(assign);
+    assign->setOptions(ao);
+    assign->setInput(*r);
+
     Options fo;
     fo.add("max_window_size", 200);
-    fo.add("extract", true);
-    
+    fo.add("last", false);
+
     Stage* outlier(f.createStage("filters.pmf"));
     EXPECT_TRUE(outlier);
     outlier->setOptions(fo);
-    outlier->setInput(*r);
-    
+    outlier->setInput(*assign);
+
+    Options rangeOpts;
+    rangeOpts.add("limits", "Classification[2:2]");
+
+    Stage* range(f.createStage("filters.range"));
+    EXPECT_TRUE(range);
+    range->setOptions(rangeOpts);
+    range->setInput(*outlier);
+
     PointTable table;
-    outlier->prepare(table);
-    PointViewSet viewSet = outlier->execute(table);
-    
+    range->prepare(table);
+    PointViewSet viewSet = range->execute(table);
+
     EXPECT_EQ(1u, viewSet.size());
     PointViewPtr view = *viewSet.begin();
     EXPECT_EQ(93u, view->size());
@@ -197,31 +241,47 @@ TEST(OldPCLBlockTests, PMF1)
 TEST(OldPCLBlockTests, PMF2)
 {
     StageFactory f;
-    
+
     Options ro;
     ro.add("filename", Support::datapath("autzen/autzen-point-format-3.las"));
-    
+
     Stage* r(f.createStage("readers.las"));
     EXPECT_TRUE(r);
     r->setOptions(ro);
-    
+
+    Options ao;
+    ao.add("assignment", "Classification[:]=0");
+
+    Stage* assign(f.createStage("filters.assign"));
+    EXPECT_TRUE(assign);
+    assign->setOptions(ao);
+    assign->setInput(*r);
+
     Options fo;
     fo.add("max_window_size", 200);
     fo.add("cell_size", 1.0);
     fo.add("slope", 1.0);
     fo.add("initial_distance", 0.05);
     fo.add("max_distance", 3.0);
-    fo.add("extract", true);
-    
+    fo.add("last", false);
+
     Stage* outlier(f.createStage("filters.pmf"));
     EXPECT_TRUE(outlier);
     outlier->setOptions(fo);
-    outlier->setInput(*r);
-    
+    outlier->setInput(*assign);
+
+    Options rangeOpts;
+    rangeOpts.add("limits", "Classification[2:2]");
+
+    Stage* range(f.createStage("filters.range"));
+    EXPECT_TRUE(range);
+    range->setOptions(rangeOpts);
+    range->setInput(*outlier);
+
     PointTable table;
-    outlier->prepare(table);
-    PointViewSet viewSet = outlier->execute(table);
-    
+    range->prepare(table);
+    PointViewSet viewSet = range->execute(table);
+
     EXPECT_EQ(1u, viewSet.size());
     PointViewPtr view = *viewSet.begin();
     EXPECT_EQ(94u, view->size());
@@ -230,31 +290,47 @@ TEST(OldPCLBlockTests, PMF2)
 TEST(OldPCLBlockTests, PMF3)
 {
     StageFactory f;
-    
+
     Options ro;
     ro.add("filename", Support::datapath("autzen/autzen-point-format-3.las"));
-    
+
     Stage* r(f.createStage("readers.las"));
     EXPECT_TRUE(r);
     r->setOptions(ro);
-    
+
+    Options ao;
+    ao.add("assignment", "Classification[:]=0");
+
+    Stage* assign(f.createStage("filters.assign"));
+    EXPECT_TRUE(assign);
+    assign->setOptions(ao);
+    assign->setInput(*r);
+
     Options fo;
     fo.add("max_window_size", 33);
     fo.add("cell_size", 1.0);
     fo.add("slope", 1.0);
     fo.add("initial_distance", 0.15);
     fo.add("max_distance", 2.5);
-    fo.add("extract", true);
-    
+    fo.add("last", false);
+
     Stage* outlier(f.createStage("filters.pmf"));
     EXPECT_TRUE(outlier);
     outlier->setOptions(fo);
-    outlier->setInput(*r);
-    
+    outlier->setInput(*assign);
+
+    Options rangeOpts;
+    rangeOpts.add("limits", "Classification[2:2]");
+
+    Stage* range(f.createStage("filters.range"));
+    EXPECT_TRUE(range);
+    range->setOptions(rangeOpts);
+    range->setInput(*outlier);
+
     PointTable table;
-    outlier->prepare(table);
-    PointViewSet viewSet = outlier->execute(table);
-    
+    range->prepare(table);
+    PointViewSet viewSet = range->execute(table);
+
     EXPECT_EQ(1u, viewSet.size());
     PointViewPtr view = *viewSet.begin();
     EXPECT_EQ(106u, view->size());


### PR DESCRIPTION
It is desirable to exclude noise points from further processing, as well as
anything but last returns (i.e., return number equals number of returns).
Although this can be accomplished with various other filters, we currently
require that those points be dropped from the PointView if we wanted to exclude
them from the bare earth filters. Provide a mechanism for segmenting last
returns and ignoring an optional, user-defined DimRange. Apply this to both
SMRF and PMF. This allows us to set them aside for the filtering step, without
losing them altogether.

This also marks the first point at which we remove the "extract" and "classify"
options from the PMF and outlier filters. Ground/noise points will always be
classified, but not extracted. Users wishing to extract ground or noise returns
should use the range filter as a downstream processing step.

The outlier filter now allows the user to specify the class they would like to
use for noise points. The default value for noise points has been changed from
18 to 7.

Finally, the outlier filter now uses online updates when computing mean,
variance, and standard deviation.