### PR TITLE
SortFilter::getName is an override

### DIFF
--- a/filters/SortFilter.hpp
+++ b/filters/SortFilter.hpp
@@ -63,7 +63,7 @@ public:
 
     static void * create();
     static int32_t destroy(void *);
-    std::string getName() const;
+    std::string getName() const override;
 
 private:
     // Dimension on which to sort.


### PR DESCRIPTION
Triggered by -Winconsistent-missing-override from clang-800.0.42.1:

```
[65/374] Building CXX object CMakeFiles/pdalcpp.dir/filters/SortFilter.cpp.o
In file included from /Users/rdcrlpjg/Repos/PDAL/filters/SortFilter.cpp:35:
/Users/rdcrlpjg/Repos/PDAL/filters/SortFilter.hpp:66:17: warning: 'getName' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
    std::string getName() const;
                ^
../pdal/Stage.hpp:253:25: note: overridden virtual function is here
    virtual std::string getName() const = 0;
                        ^
1 warning generated.
```