### PR TITLE
Add Extended Local Maximum (ELM) filter

### DIFF
--- a/doc/references.rst
+++ b/doc/references.rst
@@ -7,6 +7,8 @@ References
 .. index:: References
 
 
+.. [Chen2012] Chen, Ziyue et al. “Upward-Fusion Urban DTM Generating Method Using Airborne Lidar Data.” ISPRS Journal of Photogrammetry and Remote Sensing 72 (2012): 121–130.
+
 .. [Cook1986] Cook, Robert L. "Stochastic sampling in computer graphics." *ACM Transactions on Graphics (TOG)* 5.1 (1986): 51-72.
 
 .. [Dippe1985] Dippé, Mark AZ, and Erling Henry Wold. "Antialiasing through stochastic sampling." *ACM Siggraph Computer Graphics* 19.3 (1985): 69-78.
@@ -16,5 +18,3 @@ References
 .. [Rusu2008] Rusu, Radu Bogdan, et al. "Towards 3D point cloud based object maps for household environments." Robotics and Autonomous Systems 56.11 (2008): 927-941.
 
 .. [Zhang2003] Zhang, Keqi, et al. "A progressive morphological filter for removing nonground measurements from airborne LIDAR data." Geoscience and Remote Sensing, IEEE Transactions on 41.4 (2003): 872-882.
-
-

--- a/doc/stages/filters.elm.rst
+++ b/doc/stages/filters.elm.rst
@@ -1,0 +1,76 @@
+.. _filters.elm:
+
+filters.elm
+===============================================================================
+
+The Extended Local Minimum (ELM) filter marks low points as noise. This filter
+is an implementation of the method described in [Chen2012]_.
+
+ELM begins by rasterizing the input point cloud data at the given ``cell`` size.
+Within each cell, the lowest point is considered noise if the next lowest point
+is a given threshold above the current point. If it is marked as noise, the
+difference between the next two points is also considered, marking points as
+noise if needed, and continuing until another neighbor is found to be within the
+threshold. At this point, iteration for the current cell stops, and the next
+cell is considered.
+
+Example #1
+----------
+
+The following PDAL pipeline applies the ELM filter, using a cell size of 20 and
+applying the classification code of 18 to those points determined to be noise.
+
+.. code-block:: json
+
+    {
+      "pipeline":[
+        "input.las",
+        {
+          "type":"filters.elm",
+          "cell":20.0,
+          "class":18
+        },
+        "output.las"
+      ]
+    }
+    
+Example #2
+----------
+
+This variation of the pipeline begins by assigning a value of 0 to all
+classifications, thus resetting any existing classifications. It then proceeds
+to compute ELM with a threshold value of 2.0, and finishes by extracting all
+returns that are not marked as noise.
+
+.. code-block:: json
+
+    {
+      "pipeline":[
+        "input.las",
+        {
+          "type":"filters.assign",
+          "assignment":"Classification[:]=0"
+        },
+        {
+          "type":"filters.elm",
+          "threshold":2.0
+        },
+        {
+          "type":"filters.range",
+          "limits":"Classification![7:7]"
+        },
+        "output.las"
+      ]
+    }
+
+Options
+-------------------------------------------------------------------------------
+
+cell
+  Cell size. [Default: **10.0**]
+
+class
+  Classification value to apply to noise points. [Default: **7**]
+
+threshold
+  Threshold value to identify low noise points. [Default: **1.0**]

--- a/filters/ELMFilter.cpp
+++ b/filters/ELMFilter.cpp
@@ -1,0 +1,132 @@
+/******************************************************************************
+ * Copyright (c) 2017, Bradley J Chambers (brad.chambers@gmail.com)
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of Hobu, Inc. or Flaxen Geo Consulting nor the
+ *       names of its contributors may be used to endorse or promote
+ *       products derived from this software without specific prior
+ *       written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ ****************************************************************************/
+
+// PDAL implementation of the Extended Local Minimum (ELM) method as published
+// in Z. Chen, B. Devereux, B. Gao, and G. Amable, “Upward-fusion urban DTM
+// generating method using airborne Lidar data,” ISPRS J. Photogramm. Remote
+// Sens., vol. 72, pp. 121–130, 2012.
+
+#include "ELMFilter.hpp"
+
+#include <pdal/pdal_macros.hpp>
+
+#include <map>
+#include <string>
+
+namespace pdal
+{
+
+static PluginInfo const s_info =
+    PluginInfo("filters.elm", "Extended Local Minimum Filter",
+               "http://pdal.io/stages/filters.elm.html");
+
+CREATE_STATIC_PLUGIN(1, 0, ELMFilter, Filter, s_info)
+
+std::string ELMFilter::getName() const
+{
+    return s_info.name;
+}
+
+void ELMFilter::addArgs(ProgramArgs& args)
+{
+    args.add("cell", "Cell size", m_cell, 10.0);
+    args.add("class", "Class to use for noise points", m_class, uint8_t(7));
+    args.add("threshold", "Threshold value", m_threshold, 1.0);
+}
+
+void ELMFilter::addDimensions(PointLayoutPtr layout)
+{
+    layout->registerDim(Dimension::Id::Classification);
+}
+
+void ELMFilter::filter(PointView& view)
+{
+    BOX2D bounds;
+    view.calculateBounds(bounds);
+
+    size_t cols = ((bounds.maxx - bounds.minx) / m_cell) + 1;
+    size_t rows = ((bounds.maxy - bounds.miny) / m_cell) + 1;
+
+    // Make an initial pass through the input PointView to index elevation
+    // values and PointIds by row and column.
+    std::map<uint32_t, std::multimap<double, PointId>> hash;
+    for (PointId id = 0; id < view.size(); ++id)
+    {
+        double x = view.getFieldAs<double>(Dimension::Id::X, id);
+        double y = view.getFieldAs<double>(Dimension::Id::Y, id);
+        double z = view.getFieldAs<double>(Dimension::Id::Z, id);
+
+        size_t c = static_cast<size_t>(floor(x - bounds.minx) / m_cell);
+        size_t r = static_cast<size_t>(floor(y - bounds.miny) / m_cell);
+
+        hash[c * rows + r].emplace(z, id);
+    }
+
+    // Count the number of points we classify as noise.
+    point_count_t num(0);
+
+    // Make a second pass through the now rasterized PointView to compute the
+    // extended local minimum.
+    for (size_t c = 0; c < cols; ++c)
+    {
+        for (size_t r = 0; r < rows; ++r)
+        {
+            std::multimap<double, PointId> ids(hash[c * rows + r]);
+
+            if (ids.size() <= 1)
+                continue;
+
+            for (auto it = ids.begin(); it != std::prev(ids.end()); ++it)
+            {
+                // Where the current value is sufficiently close to the next, we
+                // consider that this is not a low outlier and break the current
+                // loop.
+                if (std::fabs(it->first - std::next(it)->first) < m_threshold)
+                    break;
+
+                // Otherwise this point is classified as noise, and we proceed
+                // to the next lowest value.
+                view.setField(Dimension::Id::Classification, it->second,
+                              m_class);
+                ++num;
+            }
+        }
+    }
+
+    log()->get(LogLevel::Info)
+        << "Classified " << num
+        << " points as noise by Extended Local Minimum (ELM).\n";
+}
+
+} // namespace pdal

--- a/filters/ELMFilter.hpp
+++ b/filters/ELMFilter.hpp
@@ -1,0 +1,76 @@
+/******************************************************************************
+ * Copyright (c) 2017, Bradley J Chambers (brad.chambers@gmail.com)
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of Hobu, Inc. or Flaxen Geo Consulting nor the
+ *       names of its contributors may be used to endorse or promote
+ *       products derived from this software without specific prior
+ *       written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ ****************************************************************************/
+
+#pragma once
+
+#include <pdal/Filter.hpp>
+#include <pdal/plugin.hpp>
+
+#include <cstdint>
+#include <string>
+
+extern "C" int32_t ELMFilter_ExitFunc();
+extern "C" PF_ExitFunc ELMFilter_InitPlugin();
+
+namespace pdal
+{
+
+class PointLayout;
+class PointView;
+
+class PDAL_DLL ELMFilter : public Filter
+{
+public:
+    ELMFilter() : Filter()
+    {
+    }
+
+    static void* create();
+    static int32_t destroy(void*);
+    std::string getName() const;
+
+private:
+    double m_cell;
+    double m_threshold;
+    uint8_t m_class;
+
+    virtual void addArgs(ProgramArgs& args);
+    virtual void addDimensions(PointLayoutPtr layout);
+    virtual void filter(PointView& view);
+
+    ELMFilter& operator=(const ELMFilter&); // not implemented
+    ELMFilter(const ELMFilter&);            // not implemented
+};
+
+} // namespace pdal

--- a/pdal/StageFactory.cpp
+++ b/pdal/StageFactory.cpp
@@ -47,6 +47,7 @@
 #include <filters/DecimationFilter.hpp>
 #include <filters/DividerFilter.hpp>
 #include <filters/EigenvaluesFilter.hpp>
+#include <filters/ELMFilter.hpp>
 #include <filters/EstimateRankFilter.hpp>
 #include <filters/FerryFilter.hpp>
 #include <filters/GroupByFilter.hpp>
@@ -247,6 +248,7 @@ StageFactory::StageFactory(bool no_plugins)
     PluginManager::initializePlugin(DecimationFilter_InitPlugin);
     PluginManager::initializePlugin(DividerFilter_InitPlugin);
     PluginManager::initializePlugin(EigenvaluesFilter_InitPlugin);
+    PluginManager::initializePlugin(ELMFilter_InitPlugin);
     PluginManager::initializePlugin(EstimateRankFilter_InitPlugin);
     PluginManager::initializePlugin(FerryFilter_InitPlugin);
     PluginManager::initializePlugin(GroupByFilter_InitPlugin);


### PR DESCRIPTION
Based off the work of Chen, et al. In the original work, the authors used ELM
to generate grid minimums that were resistent to low outliers in ground
segmentation and DTM generation. We implement here as a standalone filter that
simply marks the low points as noise. Downstream filtering stages can ignore,
extract, or handle these noise points as they see fit.