### PR TITLE
LAS extra_dims handling for standard PDAL dimensions

### DIFF
--- a/io/LasReader.cpp
+++ b/io/LasReader.cpp
@@ -506,7 +506,7 @@ void LasReader::addDimensions(PointLayoutPtr layout)
             continue;
         if (dim.m_dimType.m_xform.nonstandard())
             type = Dimension::Type::Double;
-        dim.m_dimType.m_id = layout->assignDim(dim.m_name, type);
+        dim.m_dimType.m_id = layout->registerOrAssignDim(dim.m_name, type);
     }
 }
 

--- a/test/unit/io/LasReaderTest.cpp
+++ b/test/unit/io/LasReaderTest.cpp
@@ -273,7 +273,7 @@ TEST(LasReaderTest, extraBytes)
     reader.prepare(table);
 
     DimTypeList dimTypes = layout->dimTypes();
-    EXPECT_EQ(dimTypes.size(), (size_t)25);
+    EXPECT_EQ(dimTypes.size(), (size_t)24);
 
     Dimension::Id color0 = layout->findProprietaryDim("Colors0");
     EXPECT_EQ(layout->dimType(color0), Dimension::Type::Unsigned16);
@@ -287,10 +287,7 @@ TEST(LasReaderTest, extraBytes)
     Dimension::Id flag1 = layout->findProprietaryDim("Flags1");
     EXPECT_EQ(layout->dimType(flag1), Dimension::Type::Signed8);
 
-    Dimension::Id intense2 = layout->findProprietaryDim("Intensity");
-    EXPECT_EQ(layout->dimType(intense2), Dimension::Type::Unsigned32);
-
-    Dimension::Id time2 = layout->findProprietaryDim("Time");
+    Dimension::Id time2 = layout->findDim("Time");
     EXPECT_EQ(layout->dimType(time2), Dimension::Type::Unsigned64);
 
     PointViewSet viewSet = reader.execute(table);
@@ -309,23 +306,20 @@ TEST(LasReaderTest, extraBytes)
 
     for (PointId idx = 0; idx < view->size(); ++idx)
     {
-        EXPECT_EQ(view->getFieldAs<uint16_t>(red, idx),
+        ASSERT_EQ(view->getFieldAs<uint16_t>(red, idx),
             view->getFieldAs<uint16_t>(color0, idx));
-        EXPECT_EQ(view->getFieldAs<uint16_t>(green, idx),
+        ASSERT_EQ(view->getFieldAs<uint16_t>(green, idx),
             view->getFieldAs<uint16_t>(color1, idx));
-        EXPECT_EQ(view->getFieldAs<uint16_t>(blue, idx),
+        ASSERT_EQ(view->getFieldAs<uint16_t>(blue, idx),
             view->getFieldAs<uint16_t>(color2, idx));
 
-        EXPECT_EQ(view->getFieldAs<uint16_t>(flag0, idx),
+        ASSERT_EQ(view->getFieldAs<uint16_t>(flag0, idx),
             view->getFieldAs<uint16_t>(returnNum, idx));
-        EXPECT_EQ(view->getFieldAs<uint16_t>(flag1, idx),
+        ASSERT_EQ(view->getFieldAs<uint16_t>(flag1, idx),
             view->getFieldAs<uint16_t>(numReturns, idx));
 
-        EXPECT_EQ(view->getFieldAs<uint16_t>(intensity, idx),
-            view->getFieldAs<uint16_t>(intense2, idx));
-
         // Time was written truncated rather than rounded.
-        EXPECT_NEAR(view->getFieldAs<double>(time, idx),
+        ASSERT_NEAR(view->getFieldAs<double>(time, idx),
             view->getFieldAs<double>(time2, idx), 1.0);
     }
 }


### PR DESCRIPTION
Previously, if a standard PDAL dimension (but which was not a standard LAS dimension) was written to a LAS file with the `extra_dims` option, it would appear as a proprietary dimension when reading the file.  This PR allows the registered value to be used.

This breaks a previously allowed behavior - where you could have an unrelated proprietary dimension with the same name as a standard dimension in the same file.  Was anyone relying on this behavior?  Tests have been updated accordingly.