### PR TITLE
Add a buffer option to the splitter

### DIFF
--- a/doc/stages/filters.splitter.rst
+++ b/doc/stages/filters.splitter.rst
@@ -48,3 +48,6 @@ origin_x
 origin_y
   Y Origin of the tiles.  [Default: none (chosen arbitarily)]
 
+buffer
+  Amount of overlap to include in each tile. This buffer is added onto length in both the x and the y direction.
+  [Default: 0.0]

--- a/filters/SplitterFilter.hpp
+++ b/filters/SplitterFilter.hpp
@@ -71,10 +71,13 @@ private:
     double m_length;
     double m_xOrigin;
     double m_yOrigin;
+    double m_buffer;
     std::map<Coord, PointViewPtr, CoordCompare> m_viewMap;
 
     virtual void addArgs(ProgramArgs& args);
+    virtual void initialize();
     virtual PointViewSet run(PointViewPtr view);
+    bool squareContains(int xpos, int ypos, double x, double y) const;
 
     SplitterFilter& operator=(const SplitterFilter&); // not implemented
     SplitterFilter(const SplitterFilter&); // not implemented


### PR DESCRIPTION
This buffer grows each square by the specified amount, allowing for an
overlap between tiles. This is particularily useful for tiled change
detection and other such algorithms.