### PR TITLE
Add note to docs about pgpointcloud tests

### DIFF
--- a/doc/development/testing.rst
+++ b/doc/development/testing.rst
@@ -312,6 +312,18 @@ the available flags type::
 Key among these flags are the ability to list tests (``--gtest_list_tests``)
 and to run only select tests (``--gtest_filter``).
 
+.. note::
+
+    If the PostgreSQL PointCloud plugin was enabled on the CMake command line
+    (with ``-DBUILD_PLUGIN_PGPOINTCLOUD=ON``) then `ctest` will attempt to run
+    the ``pgpointcloud`` tests. And you will get PostgreSQL connection errors
+    if the `libpq environment variables`_ are not correctly set in your shell.
+    This is for example how you can run the ``pgpointcloud`` tests::
+
+        $ PGUSER=pdal PGPASSWORD=pdal PGHOST=localhost ctest -R pgpointcloudtest
+
+.. _`libpg environment variables`: https://www.postgresql.org/docs/current/static/libpq-envars.html
+
 Test Data
 =========
 


### PR DESCRIPTION
This adds a note to the testing doc page on how to run the pgpointcloud tests.