### PR TITLE
[doc] Mark readers and writers as built-in or plug-ins

### DIFF
--- a/doc/stages/readers.bpf.rst
+++ b/doc/stages/readers.bpf.rst
@@ -4,6 +4,8 @@
 readers.bpf
 ******************************************************************************
 
+.. admonition:: This is a built-in reader.
+
 BPF is an NGA specification for point cloud data. The specification can be
 found at https://nsgreg.nga.mil/doc/view?i=4220&month=8&day=30&year=2016 The **BPF Reader** supports
 reading from BPF files that are encoded as version 1, 2 or 3.

--- a/doc/stages/readers.buffer.rst
+++ b/doc/stages/readers.buffer.rst
@@ -3,6 +3,8 @@
 readers.buffer
 ==============
 
+.. admonition:: This is a built-in reader.
+
 The :ref:`readers.buffer` stage is a special stage that allows
 you to read data from your own PointView rather than
 fetching the data from a specific reader. In the :ref:`writing` example,

--- a/doc/stages/readers.faux.rst
+++ b/doc/stages/readers.faux.rst
@@ -3,6 +3,8 @@
 readers.faux
 ============
 
+.. admonition:: This is a built-in reader.
+
 The faux reader is used for testing pipelines. It does not read from a
 file or database, but generates synthetic data to feed into the pipeline.
 

--- a/doc/stages/readers.gdal.rst
+++ b/doc/stages/readers.gdal.rst
@@ -3,6 +3,8 @@
 readers.gdal
 ================================================================================
 
+.. admonition:: This is a built-in reader.
+
 The `GDAL`_ reader reads `GDAL readable raster`_ data sources as point clouds.
 
 .. _`GDAL`: http://gdal.org

--- a/doc/stages/readers.geowave.rst
+++ b/doc/stages/readers.geowave.rst
@@ -3,6 +3,8 @@
 readers.geowave
 ===============================================================================
 
+.. admonition:: This reader is built as an optional plug-in.
+
 .. index:: GeoWave
 
 The **GeoWave reader** uses `GeoWave`_ to read from Accumulo.  GeoWave entries

--- a/doc/stages/readers.greyhound.rst
+++ b/doc/stages/readers.greyhound.rst
@@ -3,6 +3,8 @@
 readers.greyhound
 =================
 
+.. admonition:: This reader is built as an optional plug-in.
+
 The **Greyhound Reader** allows you to query point data from a `Greyhound`_
 server.
 

--- a/doc/stages/readers.ilvis2.rst
+++ b/doc/stages/readers.ilvis2.rst
@@ -3,6 +3,8 @@
 readers.ilvis2
 ===============
 
+.. admonition:: This is a built-in reader.
+
 The **ILVIS2 reader** read from files in the ILVIS2 format. See http://nsidc.org/data/docs/daac/icebridge/ilvis2/index.html
 for more information
 

--- a/doc/stages/readers.las.rst
+++ b/doc/stages/readers.las.rst
@@ -3,6 +3,8 @@
 readers.las
 ===========
 
+.. admonition:: This is a built-in reader.
+
 The **LAS Reader** supports reading from `LAS format`_ files, the standard
 interchange format for LIDAR data.  The reader does NOT support point formats
 containing waveform data (4, 5, 9 and 10).

--- a/doc/stages/readers.mbio.rst
+++ b/doc/stages/readers.mbio.rst
@@ -3,6 +3,8 @@
 readers.mbio
 ============
 
+.. admonition:: This reader is built as an optional plug-in.
+
 The mbio reader allows sonar bathymetry data to be read into PDAL and
 treated as data collected using LIDAR sources.  PDAL uses the `MB-System`_
 library to read the data and therefore supports `all formats`_ supported by

--- a/doc/stages/readers.mrsid.rst
+++ b/doc/stages/readers.mrsid.rst
@@ -3,6 +3,8 @@
 readers.mrsid
 =============
 
+.. admonition:: This reader is built as an optional plug-in.
+
 Implements MrSID 4.0 LiDAR Compressor. It requires the `Lidar_DSDK`_ to be able to
 decompress and read data.
 

--- a/doc/stages/readers.nitf.rst
+++ b/doc/stages/readers.nitf.rst
@@ -3,6 +3,8 @@
 readers.nitf
 ============
 
+.. admonition:: This reader is built as an optional plug-in.
+
 The `NITF`_ format is used primarily by the US Department of Defense and
 supports many kinds of data inside a generic wrapper. The `NITF 2.1`_ version
 added support for LIDAR point cloud data, and the **NITF file reader** supports

--- a/doc/stages/readers.oci.rst
+++ b/doc/stages/readers.oci.rst
@@ -3,6 +3,8 @@
 readers.oci
 ===========
 
+.. admonition:: This reader is built as an optional plug-in.
+
 The OCI reader is used to read data from `Oracle point cloud`_ databases.
 
 

--- a/doc/stages/readers.optech.rst
+++ b/doc/stages/readers.optech.rst
@@ -3,6 +3,8 @@
 readers.optech
 ==============
 
+.. admonition:: This is a built-in reader.
+
 The **Optech reader** reads Corrected Sensor Data (.csd) files.
 These files contain scan angles, ranges, IMU and GNSS information, and boresight calibration values, all of which are combined in the reader into XYZ points using the WGS84 reference frame.
 

--- a/doc/stages/readers.pcd.rst
+++ b/doc/stages/readers.pcd.rst
@@ -4,6 +4,7 @@
 readers.pcd
 ******************************************************************************
 
+.. admonition:: This reader is built as an optional plug-in.
 
 The **PCD Reader** supports reading from `Point Cloud Data (PCD)`_ formatted
 files, which are used by the `Point Cloud Library (PCL)`_.

--- a/doc/stages/readers.pgpointcloud.rst
+++ b/doc/stages/readers.pgpointcloud.rst
@@ -3,6 +3,8 @@
 readers.pgpointcloud
 ====================
 
+.. admonition:: This reader is built as an optional plug-in.
+
 The **PostgreSQL Pointcloud Reader** allows you to read from a PostgreSQL database that the `PostgreSQL Pointcloud`_ extension enabled. The Pointcloud extension stores point cloud data in tables that contain rows of patches. Each patch in turn contains a large number of spatially nearby points.
 
 The reader pulls patches from a table, potentially sub-setting the query on the way with a "where" clause.

--- a/doc/stages/readers.ply.rst
+++ b/doc/stages/readers.ply.rst
@@ -3,6 +3,8 @@
 readers.ply
 ===========
 
+.. admonition:: This is a built-in reader.
+
 The **ply reader** reads points and vertices from the `polygon file format`_, a
 common file format for storing three dimensional models.  The `rply library`_
 is included with the PDAL source, so there are no external dependencies.

--- a/doc/stages/readers.pts.rst
+++ b/doc/stages/readers.pts.rst
@@ -3,6 +3,8 @@
 readers.pts
 ============
 
+.. admonition:: This is a built-in reader.
+
 The **PTS reader** reads data from Leica Cyclone PTS files. It is
 not very sophisticated.
 

--- a/doc/stages/readers.qfit.rst
+++ b/doc/stages/readers.qfit.rst
@@ -4,6 +4,8 @@
 readers.qfit
 ******************************************************************************
 
+.. admonition:: This is a built-in reader.
+
 The **QFIT reader** read from files in the `QFIT format`_ originated for the
 Airborne Topographic Mapper (ATM) project at NASA Goddard Space Flight Center.
 

--- a/doc/stages/readers.rxp.rst
+++ b/doc/stages/readers.rxp.rst
@@ -3,6 +3,8 @@
 readers.rxp
 ===========
 
+.. admonition:: This reader is built as an optional plug-in.
+
 The **RXP reader** read from files in the RXP format, the in-house streaming format used by `RIEGL Laser Measurement Systems`_.
 
 .. warning::

--- a/doc/stages/readers.sbet.rst
+++ b/doc/stages/readers.sbet.rst
@@ -3,6 +3,8 @@
 readers.sbet
 ============
 
+.. admonition:: This is a built-in reader.
+
 The **SBET reader** read from files in the SBET format, used for exchange data from interital measurement units (IMUs).
 
 

--- a/doc/stages/readers.sqlite.rst
+++ b/doc/stages/readers.sqlite.rst
@@ -3,6 +3,8 @@
 readers.sqlite
 ====================
 
+.. admonition:: This reader is built as an optional plug-in.
+
 The `SQLite`_ point cloud reader allows you to
 read data stored in a SQLite database using a scheme that
 PDAL wrote using the :ref:`writers.sqlite` writer. Much like

--- a/doc/stages/readers.text.rst
+++ b/doc/stages/readers.text.rst
@@ -3,6 +3,8 @@
 readers.text
 ============
 
+.. admonition:: This is a built-in reader.
+
 The **text reader** reads data from ASCII text files.  Each point is
 represented in the file as a single line.  Each line is expected to be divided
 into a number of fields by a separator.  Each field represents a value for

--- a/doc/stages/readers.tindex.rst
+++ b/doc/stages/readers.tindex.rst
@@ -3,6 +3,7 @@
 readers.tindex
 ================================================================================
 
+.. admonition:: This is a built-in reader.
 
 A `GDAL tile index`_ is an `OGR`_-readable data source of boundary information.
 PDAL provides a similar concept for PDAL-readable point cloud data. You can use


### PR DESCRIPTION
It is for users convenience to clearly distinguish built-in formats (everything in `/io` folder) and optional formats (everything in `/plugins`).

Closes #1612

------

I haven't found a better way to mark up and visualise some, sort of metadata about formats in PDAL docs, so I decided to use the generic [admonition](http://www.sphinx-doc.org/en/stable/rest.html) directive which should nicely render it in a tip/note-like way on HTML pages. Suggestions are welcome.