### PR TITLE
More clean-up in the Chipper filter

### DIFF
--- a/filters/ChipperFilter.cpp
+++ b/filters/ChipperFilter.cpp
@@ -251,13 +251,8 @@ void ChipperFilter::split(ChipRefList& wide, ChipRefList& narrow, ChipRefList& s
             }
         }
 
-        // Save away the direction so we know which array is X and which is Y
-        // so that when we emit, we can properly label the max/min points.
-        Direction dir = narrow.m_dir;
-        spare.m_dir = dir;
         decideSplit(wide, spare, narrow, pleft, pcenter);
         decideSplit(wide, spare, narrow, pcenter, pright);
-        narrow.m_dir = dir;
     }
 }
 

--- a/filters/ChipperFilter.hpp
+++ b/filters/ChipperFilter.hpp
@@ -57,14 +57,6 @@ class Stage;
 
 class PDAL_DLL ChipperFilter;
 
-enum Direction
-{
-    DIR_X,
-    DIR_Y,
-    DIR_NONE
-};
-
-
 class PDAL_DLL ChipPtRef
 {
     friend class ChipRefList;
@@ -89,10 +81,7 @@ class PDAL_DLL ChipRefList
 
 private:
     std::vector<ChipPtRef> m_vec;
-    Direction m_dir;
 
-    ChipRefList(Direction dir = DIR_NONE) : m_dir(dir)
-    {}
     std::vector<ChipPtRef>::size_type size() const
     {
         return m_vec.size();
@@ -121,25 +110,13 @@ private:
     {
         return m_vec[pos];
     }
-    std::string Dir()
-    {
-        if (m_dir == DIR_X)
-            return "X";
-        else if (m_dir == DIR_Y)
-            return "Y";
-        else
-            return "NONE";
-    }
 };
 
 
 class PDAL_DLL ChipperFilter : public pdal::Filter
 {
 public:
-    ChipperFilter() : Filter(),
-        m_xvec(DIR_X), m_yvec(DIR_Y), m_spare(DIR_NONE)
-    {}
-
+    ChipperFilter() {}
     static void * create();
     static int32_t destroy(void *);
     std::string getName() const;


### PR DESCRIPTION
ChipRefList objects include a direction (m_dir) that was necessary when bounds were provided for each cell. Now that no bounds are provided having this direction property is no more necessary.

This follows up on https://github.com/PDAL/PDAL/pull/1617.