### PR TITLE
Changes the expectations slightly for this sparse dataset

### DIFF
--- a/test/unit/OldPCLBlockTest.cpp
+++ b/test/unit/OldPCLBlockTest.cpp
@@ -213,8 +213,8 @@ TEST(OldPCLBlockTests, PMF)
     assign->setInput(*r);
 
     Options fo;
-    fo.add("max_window_size", 33);
-    fo.add("cell_size", 1.0);
+    fo.add("max_window_size", 33.0);
+    fo.add("cell_size", 10.0);
     fo.add("slope", 1.0);
     fo.add("initial_distance", 0.15);
     fo.add("max_distance", 2.5);
@@ -239,5 +239,5 @@ TEST(OldPCLBlockTests, PMF)
 
     EXPECT_EQ(1u, viewSet.size());
     PointViewPtr view = *viewSet.begin();
-    EXPECT_EQ(106u, view->size());
+    EXPECT_EQ(79u, view->size());
 }


### PR DESCRIPTION
The dataset for this test is sparse. For PMF, this means many empty cells with the original (default) cell size of 1.0. Bump the cell size up to 10.0 and update the expected number of filtered points.