### PR TITLE
Provide for normal flipping

### DIFF
--- a/doc/stages/filters.normal.rst
+++ b/doc/stages/filters.normal.rst
@@ -28,6 +28,14 @@ default the viewpoint is located at the midpoint of the X and Y extents, and
 1000 units above the max Z value. Users can override any of the XYZ coordinates,
 or set them all to zero to effectively disable the normal flipping.
 
+.. note::
+
+  By default, the Normal filter will invert normals such that they are always
+  pointed "up" (positive Z). If the user provides a ``viewpoint``, normals will
+  instead be inverted such that they are oriented towards the viewpoint,
+  regardless of the ``always_up`` flag. To disable all normal flipping, do not
+  provide a ``viewpoint`` and set ``always_up=false``.
+
 .. embed::
 
 Example
@@ -60,11 +68,10 @@ Options
 knn
   The number of k-nearest neighbors. [Default: **8**]
 
-vx
-  The X coordinate of the viewpoint. Defaults to midpoint of the X extents.
+viewpoint
+  A single WKT or GeoJSON 3D point. Normals will be inverted such that they are
+  all oriented towards the viewpoint.
 
-vy
-  The Y coordinate of the viewpoint. Defaults to the midpoint of the Y extents.
-
-vz
-  The Z coordinate of the viewpoint. Defaults to the max value of Z plus 1000.
+always_up
+  A flag indicating whether or not normals should be inverted only when the Z
+  component is negative. [Default: **true**]

--- a/doc/stages/filters.normal.rst
+++ b/doc/stages/filters.normal.rst
@@ -23,6 +23,11 @@ The eigenvalue decomposition is performed using Eigen's
 ``SelfAdjointEigenSolver``. For more information see
 https://eigen.tuxfamily.org/dox/classEigen_1_1SelfAdjointEigenSolver.html.
 
+Normals will be automatically flipped towards the viewpoint to be consistent. By
+default the viewpoint is located at the midpoint of the X and Y extents, and
+1000 units above the max Z value. Users can override any of the XYZ coordinates,
+or set them all to zero to effectively disable the normal flipping.
+
 .. embed::
 
 Example
@@ -54,3 +59,12 @@ Options
 
 knn
   The number of k-nearest neighbors. [Default: **8**]
+
+vx
+  The X coordinate of the viewpoint. Defaults to midpoint of the X extents.
+
+vy
+  The Y coordinate of the viewpoint. Defaults to the midpoint of the Y extents.
+
+vz
+  The Z coordinate of the viewpoint. Defaults to the max value of Z plus 1000.

--- a/filters/CropFilter.cpp
+++ b/filters/CropFilter.cpp
@@ -40,7 +40,8 @@
 #include <pdal/Polygon.hpp>
 #include <pdal/pdal_macros.hpp>
 #include <pdal/util/ProgramArgs.hpp>
-#include <filters/private/Point.hpp>
+
+#include "private/Point.hpp"
 
 #include <sstream>
 #include <cstdarg>
@@ -251,7 +252,7 @@ void CropFilter::crop(const Polygon& g, PointView& input, PointView& output)
 }
 
 
-bool CropFilter::crop(const PointRef& point, const Point& center)
+bool CropFilter::crop(const PointRef& point, const filter::Point& center)
 {
     double x = point.getFieldAs<double>(Dimension::Id::X);
     double y = point.getFieldAs<double>(Dimension::Id::Y);
@@ -275,7 +276,7 @@ bool CropFilter::crop(const PointRef& point, const Point& center)
 }
 
 
-void CropFilter::crop(const Point& center, PointView& input,
+void CropFilter::crop(const filter::Point& center, PointView& input,
     PointView& output)
 {
     PointRef point = input.point(0);

--- a/filters/CropFilter.cpp
+++ b/filters/CropFilter.cpp
@@ -40,7 +40,7 @@
 #include <pdal/Polygon.hpp>
 #include <pdal/pdal_macros.hpp>
 #include <pdal/util/ProgramArgs.hpp>
-#include <filters/private/crop/Point.hpp>
+#include <filters/private/Point.hpp>
 
 #include <sstream>
 #include <cstdarg>
@@ -251,7 +251,7 @@ void CropFilter::crop(const Polygon& g, PointView& input, PointView& output)
 }
 
 
-bool CropFilter::crop(const PointRef& point, const cropfilter::Point& center)
+bool CropFilter::crop(const PointRef& point, const Point& center)
 {
     double x = point.getFieldAs<double>(Dimension::Id::X);
     double y = point.getFieldAs<double>(Dimension::Id::Y);
@@ -275,7 +275,7 @@ bool CropFilter::crop(const PointRef& point, const cropfilter::Point& center)
 }
 
 
-void CropFilter::crop(const cropfilter::Point& center, PointView& input,
+void CropFilter::crop(const Point& center, PointView& input,
     PointView& output)
 {
     PointRef point = input.point(0);

--- a/filters/CropFilter.hpp
+++ b/filters/CropFilter.hpp
@@ -43,12 +43,8 @@ extern "C" PF_ExitFunc CropFilter_InitPlugin();
 
 namespace pdal
 {
-namespace cropfilter
-{
-    class Point;
-};
 
-
+class Point;
 class ProgramArgs;
 
 // removes any points outside of the given range
@@ -69,7 +65,7 @@ private:
     SpatialReference m_assignedSrs;
     double m_distance;
     double m_distance2;
-    std::vector<cropfilter::Point> m_centers;
+    std::vector<Point> m_centers;
     std::vector<Polygon> m_geoms;
     std::vector<BOX2D> m_boxes;
 
@@ -83,8 +79,8 @@ private:
     void crop(const BOX2D& box, PointView& input, PointView& output);
     bool crop(const PointRef& point, const Polygon& g);
     void crop(const Polygon& g, PointView& input, PointView& output);
-    bool crop(const PointRef& point, const cropfilter::Point& center);
-    void crop(const cropfilter::Point& center, PointView& input,
+    bool crop(const PointRef& point, const Point& center);
+    void crop(const Point& center, PointView& input,
         PointView& output);
     void transform(const SpatialReference& srs);
 
@@ -93,4 +89,3 @@ private:
 };
 
 } // namespace pdal
-

--- a/filters/CropFilter.hpp
+++ b/filters/CropFilter.hpp
@@ -38,13 +38,14 @@
 #include <pdal/Polygon.hpp>
 #include <pdal/plugin.hpp>
 
+#include "private/Point.hpp"
+
 extern "C" int32_t CropFilter_ExitFunc();
 extern "C" PF_ExitFunc CropFilter_InitPlugin();
 
 namespace pdal
 {
 
-class Point;
 class ProgramArgs;
 
 // removes any points outside of the given range
@@ -65,7 +66,7 @@ private:
     SpatialReference m_assignedSrs;
     double m_distance;
     double m_distance2;
-    std::vector<Point> m_centers;
+    std::vector<filter::Point> m_centers;
     std::vector<Polygon> m_geoms;
     std::vector<BOX2D> m_boxes;
 
@@ -79,8 +80,8 @@ private:
     void crop(const BOX2D& box, PointView& input, PointView& output);
     bool crop(const PointRef& point, const Polygon& g);
     void crop(const Polygon& g, PointView& input, PointView& output);
-    bool crop(const PointRef& point, const Point& center);
-    void crop(const Point& center, PointView& input,
+    bool crop(const PointRef& point, const filter::Point& center);
+    void crop(const filter::Point& center, PointView& input,
         PointView& output);
     void transform(const SpatialReference& srs);
 

--- a/filters/NormalFilter.cpp
+++ b/filters/NormalFilter.cpp
@@ -39,8 +39,6 @@
 #include <pdal/pdal_macros.hpp>
 #include <pdal/util/ProgramArgs.hpp>
 
-#include "private/Point.hpp"
-
 #include <Eigen/Dense>
 
 #include <string>

--- a/filters/NormalFilter.cpp
+++ b/filters/NormalFilter.cpp
@@ -1,36 +1,36 @@
 /******************************************************************************
-* Copyright (c) 2016, Bradley J Chambers (brad.chambers@gmail.com)
-*
-* All rights reserved.
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following
-* conditions are met:
-*
-*     * Redistributions of source code must retain the above copyright
-*       notice, this list of conditions and the following disclaimer.
-*     * Redistributions in binary form must reproduce the above copyright
-*       notice, this list of conditions and the following disclaimer in
-*       the documentation and/or other materials provided
-*       with the distribution.
-*     * Neither the name of Hobu, Inc. or Flaxen Geo Consulting nor the
-*       names of its contributors may be used to endorse or promote
-*       products derived from this software without specific prior
-*       written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-* FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-* COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-* BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
-* OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
-* AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
-* OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
-* OF SUCH DAMAGE.
-****************************************************************************/
+ * Copyright (c) 2016-2017, Bradley J Chambers (brad.chambers@gmail.com)
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of Hobu, Inc. or Flaxen Geo Consulting nor the
+ *       names of its contributors may be used to endorse or promote
+ *       products derived from this software without specific prior
+ *       written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ ****************************************************************************/
 
 #include "NormalFilter.hpp"
 
@@ -58,21 +58,21 @@ std::string NormalFilter::getName() const
     return s_info.name;
 }
 
-
 void NormalFilter::addArgs(ProgramArgs& args)
 {
     args.add("knn", "k-Nearest Neighbors", m_knn, 8);
+    m_vxArg = &args.add("vx", "Viewpoint X coordinate", m_vx);
+    m_vyArg = &args.add("vy", "Viewpoint Y coordinate", m_vy);
+    m_vzArg = &args.add("vz", "Viewpoint Z coordinate", m_vz);
 }
-
 
 void NormalFilter::addDimensions(PointLayoutPtr layout)
 {
     using namespace Dimension;
 
-    layout->registerDims({Id::NormalX, Id::NormalY, Id::NormalZ,
-        Id::Curvature});
+    layout->registerDims(
+        {Id::NormalX, Id::NormalY, Id::NormalZ, Id::Curvature});
 }
-
 
 void NormalFilter::doFilter(PointView& view)
 {
@@ -80,10 +80,18 @@ void NormalFilter::doFilter(PointView& view)
     filter(view);
 }
 
-
 void NormalFilter::filter(PointView& view)
 {
     KD3Index& kdi = view.build3dIndex();
+
+    BOX3D bounds;
+    view.calculateBounds(bounds);
+
+    double vx =
+        m_vxArg->set() ? m_vx : bounds.minx + (bounds.maxx - bounds.minx) * 0.5;
+    double vy =
+        m_vyArg->set() ? m_vy : bounds.miny + (bounds.maxy - bounds.miny) * 0.5;
+    double vz = m_vzArg->set() ? m_vz : bounds.maxz + 1000;
 
     for (PointId i = 0; i < view.size(); ++i)
     {
@@ -98,15 +106,23 @@ void NormalFilter::filter(PointView& view)
         if (solver.info() != Eigen::Success)
             throwError("Cannot perform eigen decomposition.");
         auto eval = solver.eigenvalues();
-        auto evec = solver.eigenvectors().col(0);
+        Eigen::Vector3f normal = solver.eigenvectors().col(0);
 
-        view.setField(Dimension::Id::NormalX, i, evec[0]);
-        view.setField(Dimension::Id::NormalY, i, evec[1]);
-        view.setField(Dimension::Id::NormalZ, i, evec[2]);
+        // flip normal towards viewpoint
+        PointRef p = view.point(i);
+        Eigen::Vector3f vp(vx - p.getFieldAs<double>(Dimension::Id::X),
+                           vy - p.getFieldAs<double>(Dimension::Id::Y),
+                           vz - p.getFieldAs<double>(Dimension::Id::Z));
+        if (vp.dot(normal) < 0)
+            normal *= -1.0;
+
+        view.setField(Dimension::Id::NormalX, i, normal[0]);
+        view.setField(Dimension::Id::NormalY, i, normal[1]);
+        view.setField(Dimension::Id::NormalZ, i, normal[2]);
 
         double sum = eval[0] + eval[1] + eval[2];
         view.setField(Dimension::Id::Curvature, i,
-            sum ? std::fabs(eval[0] / sum) : 0);
+                      sum ? std::fabs(eval[0] / sum) : 0);
     }
 }
 

--- a/filters/NormalFilter.hpp
+++ b/filters/NormalFilter.hpp
@@ -1,41 +1,42 @@
 /******************************************************************************
-* Copyright (c) 2016, Bradley J Chambers (brad.chambers@gmail.com)
-*
-* All rights reserved.
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following
-* conditions are met:
-*
-*     * Redistributions of source code must retain the above copyright
-*       notice, this list of conditions and the following disclaimer.
-*     * Redistributions in binary form must reproduce the above copyright
-*       notice, this list of conditions and the following disclaimer in
-*       the documentation and/or other materials provided
-*       with the distribution.
-*     * Neither the name of Hobu, Inc. or Flaxen Geo Consulting nor the
-*       names of its contributors may be used to endorse or promote
-*       products derived from this software without specific prior
-*       written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-* FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-* COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-* BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
-* OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
-* AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
-* OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
-* OF SUCH DAMAGE.
-****************************************************************************/
+ * Copyright (c) 2016-2017, Bradley J Chambers (brad.chambers@gmail.com)
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of Hobu, Inc. or Flaxen Geo Consulting nor the
+ *       names of its contributors may be used to endorse or promote
+ *       products derived from this software without specific prior
+ *       written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ ****************************************************************************/
 
 #pragma once
 
 #include <pdal/Filter.hpp>
 #include <pdal/plugin.hpp>
+#include <pdal/util/ProgramArgs.hpp>
 
 #include <cstdint>
 #include <memory>
@@ -55,23 +56,25 @@ class PDAL_DLL NormalFilter : public Filter
 {
 public:
     NormalFilter() : Filter()
-    {}
+    {
+    }
     NormalFilter& operator=(const NormalFilter&) = delete;
     NormalFilter(const NormalFilter&) = delete;
 
     void doFilter(PointView& view);
 
-    static void * create();
-    static int32_t destroy(void *);
+    static void* create();
+    static int32_t destroy(void*);
     std::string getName() const;
 
 private:
     int m_knn;
+    double m_vx, m_vy, m_vz;
+    Arg *m_vxArg, *m_vyArg, *m_vzArg;
 
     virtual void addArgs(ProgramArgs& args);
     virtual void addDimensions(PointLayoutPtr layout);
     virtual void filter(PointView& view);
-
 };
 
 } // namespace pdal

--- a/filters/NormalFilter.hpp
+++ b/filters/NormalFilter.hpp
@@ -71,9 +71,11 @@ private:
     int m_knn;
     double m_vx, m_vy, m_vz;
     Arg *m_vxArg, *m_vyArg, *m_vzArg;
+    bool m_up;
 
     virtual void addArgs(ProgramArgs& args);
     virtual void addDimensions(PointLayoutPtr layout);
+    virtual void prepared(PointTableRef table);
     virtual void filter(PointView& view);
 };
 

--- a/filters/NormalFilter.hpp
+++ b/filters/NormalFilter.hpp
@@ -38,6 +38,8 @@
 #include <pdal/plugin.hpp>
 #include <pdal/util/ProgramArgs.hpp>
 
+#include "private/Point.hpp"
+
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -69,8 +71,8 @@ public:
 
 private:
     int m_knn;
-    double m_vx, m_vy, m_vz;
-    Arg *m_vxArg, *m_vyArg, *m_vzArg;
+    Point m_viewpoint;
+    Arg* m_viewpointArg;
     bool m_up;
 
     virtual void addArgs(ProgramArgs& args);

--- a/filters/NormalFilter.hpp
+++ b/filters/NormalFilter.hpp
@@ -71,7 +71,7 @@ public:
 
 private:
     int m_knn;
-    Point m_viewpoint;
+    filter::Point m_viewpoint;
     Arg* m_viewpointArg;
     bool m_up;
 

--- a/filters/private/Point.cpp
+++ b/filters/private/Point.cpp
@@ -37,6 +37,9 @@
 namespace pdal
 {
 
+namespace filter
+{
+
 namespace
 {
 
@@ -111,4 +114,6 @@ bool Point::is3d() const
     return (z != LOWEST);
 }
 
-} //namespace pdal
+} // namespace filter
+
+} // namespace pdal

--- a/filters/private/Point.cpp
+++ b/filters/private/Point.cpp
@@ -45,9 +45,6 @@ const double HIGHEST = (std::numeric_limits<double>::max)();
 
 }
 
-namespace cropfilter
-{
-
 Point::Point()
     : Geometry()
     , x(LOWEST)
@@ -114,7 +111,4 @@ bool Point::is3d() const
     return (z != LOWEST);
 }
 
-} //namespace cropfilter
-
 } //namespace pdal
-

--- a/filters/private/Point.hpp
+++ b/filters/private/Point.hpp
@@ -39,9 +39,6 @@
 namespace pdal
 {
 
-namespace cropfilter
-{
-
 class PDAL_DLL Point : public Geometry
 {
 public:
@@ -58,5 +55,5 @@ public:
     double y;
     double z;
 };
-} // namespace cropfilter
+
 } // namespace pdal

--- a/filters/private/Point.hpp
+++ b/filters/private/Point.hpp
@@ -39,6 +39,9 @@
 namespace pdal
 {
 
+namespace filter
+{
+
 class PDAL_DLL Point : public Geometry
 {
 public:
@@ -55,5 +58,7 @@ public:
     double y;
     double z;
 };
+
+} // namespace filter
 
 } // namespace pdal


### PR DESCRIPTION
User can always set a preferred viewpoint by providing X, Y, and Z coordinates.
If a viewpoint coordinate is not provided, it will be replaced as follows.

* X and Y will default to the midpoint of the X/Y extents
* Z will default to the maximum Z plus 1000

Normals are flipped when the dot product of the normal and the vector between
the current point and the viewpoint is less than zero.