### PR TITLE
#1591: add --count to html docs

### DIFF
--- a/doc/stages/readers.bpf.rst
+++ b/doc/stages/readers.bpf.rst
@@ -42,3 +42,5 @@ Options
 filename
     BPF file to read [Required]
 
+count
+    Maximum number of points to read [Optional]

--- a/doc/stages/readers.buffer.rst
+++ b/doc/stages/readers.buffer.rst
@@ -19,3 +19,5 @@ See :ref:`writing` for an example usage scenario for :ref:`readers.buffer`.
 Options
 -------
 
+count
+    Maximum number of points to read [Optional]

--- a/doc/stages/readers.buffer.rst
+++ b/doc/stages/readers.buffer.rst
@@ -19,5 +19,3 @@ See :ref:`writing` for an example usage scenario for :ref:`readers.buffer`.
 Options
 -------
 
-count
-    Maximum number of points to read [Optional]

--- a/doc/stages/readers.gdal.rst
+++ b/doc/stages/readers.gdal.rst
@@ -63,7 +63,7 @@ RGB values of an `ASPRS LAS`_ file using :ref:`writers.las`.
           "filename":"./pdal/test/data/autzen/autzen.jpg"
         },
         {
-          "type":"filters.ferry"
+          "type":"filters.ferry",
           "dimensions":"band-1=Red, band-2=Green, band-3=Blue",
         },
         {

--- a/doc/stages/readers.gdal.rst
+++ b/doc/stages/readers.gdal.rst
@@ -83,4 +83,5 @@ filename
 
 .. _`GDALOpen`: http://www.gdal.org/gdal_8h.html#a6836f0f810396c5e45622c8ef94624d4
 
-
+count
+    Maximum number of points to read [Optional]

--- a/doc/stages/readers.greyhound.rst
+++ b/doc/stages/readers.greyhound.rst
@@ -94,3 +94,5 @@ _`threads`
 .. _comparison: https://docs.mongodb.com/manual/reference/operator/query-comparison/
 .. _logical: https://docs.mongodb.com/manual/reference/operator/query-logical/
 
+- `count`
+    Maximum number of points to read [Optional]

--- a/doc/stages/readers.greyhound.rst
+++ b/doc/stages/readers.greyhound.rst
@@ -94,5 +94,5 @@ _`threads`
 .. _comparison: https://docs.mongodb.com/manual/reference/operator/query-comparison/
 .. _logical: https://docs.mongodb.com/manual/reference/operator/query-logical/
 
--`count`
+_`count`
     Maximum number of points to read [Optional]

--- a/doc/stages/readers.greyhound.rst
+++ b/doc/stages/readers.greyhound.rst
@@ -94,5 +94,5 @@ _`threads`
 .. _comparison: https://docs.mongodb.com/manual/reference/operator/query-comparison/
 .. _logical: https://docs.mongodb.com/manual/reference/operator/query-logical/
 
-- `count`
+-`count`
     Maximum number of points to read [Optional]

--- a/doc/stages/readers.ilvis2.rst
+++ b/doc/stages/readers.ilvis2.rst
@@ -46,3 +46,6 @@ mapping
 
 metadata
   XML metadata file to coincidentally read [Optional]
+
+count
+  Maximum number of points to read [Optional]

--- a/doc/stages/readers.las.rst
+++ b/doc/stages/readers.las.rst
@@ -103,5 +103,5 @@ _`spatialreference`
   reference information in the file itself.  Most text-based formats of
   SRS information are accepted, including WKT and proj.4.
 
-- `count`
+_`count`
     Maximum number of points read [Optional]

--- a/doc/stages/readers.las.rst
+++ b/doc/stages/readers.las.rst
@@ -93,7 +93,7 @@ _`extra_dims`
 
 _`compression`
   May be set to "lazperf" or "laszip" to choose either the LazPerf decompressor
-  or the LasZip decompressor for LAZ files.  PDAL must have been build with
+  or the LASzip decompressor for LAZ files.  PDAL must have been built with
   support for the decompressor being requested.  The LazPerf decompressor
   doesn't support version 1 LAZ files or version 1.4 of LAS.
   [Default: "laszip"]
@@ -102,3 +102,6 @@ _`spatialreference`
   Sets the spatial reference for the file data.  Overrides any spatial
   reference information in the file itself.  Most text-based formats of
   SRS information are accepted, including WKT and proj.4.
+
+- `count`
+    Maximum number of points read [Optional]

--- a/doc/stages/readers.mbio.rst
+++ b/doc/stages/readers.mbio.rst
@@ -55,3 +55,6 @@ format
 .. _MB-System: http://www.ldeo.columbia.edu/res/pi/MB-System/
 
 .. _all formats: https://www.ldeo.columbia.edu/res/pi/MB-System/html/mbio.html#lbAI
+
+count
+  Maximum number of points to read [Optional]

--- a/doc/stages/readers.mrsid.rst
+++ b/doc/stages/readers.mrsid.rst
@@ -1,4 +1,4 @@
-.. _readers.mrsid:
+  .. _readers.mrsid:
 
 readers.mrsid
 =============
@@ -41,3 +41,6 @@ filename
 .. _NITF 2.1: http://www.gwg.nga.mil/ntb/baseline/docs/2500c/index.html
 
 .. _DES segment: http://jitc.fhu.disa.mil/cgi/nitf/registers/desreg.aspx
+
+count
+  Maximum number of points to read [Optional]

--- a/doc/stages/readers.mrsid.rst
+++ b/doc/stages/readers.mrsid.rst
@@ -41,6 +41,3 @@ filename
 .. _NITF 2.1: http://www.gwg.nga.mil/ntb/baseline/docs/2500c/index.html
 
 .. _DES segment: http://jitc.fhu.disa.mil/cgi/nitf/registers/desreg.aspx
-
-count
-  Maximum number of points to read [Optional]

--- a/doc/stages/readers.nitf.rst
+++ b/doc/stages/readers.nitf.rst
@@ -60,7 +60,21 @@ Options
 filename
   Filename to read from [Required]
 
+count
+  Maximum number of points to read [Optional]
 
+spatialreference
+  Spatial reference to apply to data
+
+extra_dims
+  Dimensions to assign to extra byte data
+
+compression
+  May be set to "lazperf" or "laszip" to choose either the LazPerf decompressor
+  or the LASzip decompressor for LAZ files.  PDAL must have been built with
+  support for the decompressor being requested.  The LazPerf decompressor
+  doesn't support version 1 LAZ files or version 1.4 of LAS.
+  [Default: "laszip"]
 
 .. _NITF: http://en.wikipedia.org/wiki/National_Imagery_Transmission_Format
 

--- a/doc/stages/readers.optech.rst
+++ b/doc/stages/readers.optech.rst
@@ -35,3 +35,6 @@ Options
 
 filename
   csd file to read [Required]
+
+count
+  Maximum number of points read [Optional]

--- a/doc/stages/readers.pcd.rst
+++ b/doc/stages/readers.pcd.rst
@@ -39,7 +39,8 @@ Options
 filename
   PCD file to read [Required]
 
-
+count
+  Maximum number of points to read [Optional]
 
 .. _Point Cloud Data (PCD): http://pointclouds.org/documentation/tutorials/pcd_file_format.php
 .. _Point Cloud Library (PCL): http://pointclouds.org

--- a/doc/stages/readers.pgpointcloud.rst
+++ b/doc/stages/readers.pgpointcloud.rst
@@ -52,10 +52,9 @@ column
   Table column to read patches from. [Default: **pa**]
 
 spatialreference
-  _`spatialreference`
-    Sets the spatial reference for the point data.  Overrides any spatial
-    reference information read from the database.  Most text-based formats of
-    SRS information are accepted, including WKT and proj.4.
+  Sets the spatial reference for the point data.  Overrides any spatial
+  reference information read from the database.  Most text-based formats of
+  SRS information are accepted, including WKT and proj.4.
 
 count
   Maximum number of points to read [Optional]

--- a/doc/stages/readers.pgpointcloud.rst
+++ b/doc/stages/readers.pgpointcloud.rst
@@ -57,4 +57,7 @@ spatialreference
     reference information read from the database.  Most text-based formats of
     SRS information are accepted, including WKT and proj.4.
 
+count
+  Maximum number of points to read [Optional]
+
 .. _PostgreSQL Pointcloud: https://github.com/pramsey/pointcloud

--- a/doc/stages/readers.ply.rst
+++ b/doc/stages/readers.ply.rst
@@ -41,7 +41,8 @@ Options
 filename
   ply file to read [Required]
 
-
+count 
+  Maximum number of points to read [Optional]
 
 .. _polygon file format: http://paulbourke.net/dataformats/ply/
 .. _rply library: http://w3.impa.br/~diego/software/rply/

--- a/doc/stages/readers.pts.rst
+++ b/doc/stages/readers.pts.rst
@@ -35,3 +35,5 @@ Options
 filename
   text file to read [Required]
 
+count 
+  Maximum number of points to read [Optional]

--- a/doc/stages/readers.qfit.rst
+++ b/doc/stages/readers.qfit.rst
@@ -45,6 +45,8 @@ scale_z
 little_endian
   Are data in little endian format? This should be automatically detected by the driver.
 
+count 
+  Maximum number of points to read [Optional]
 
 .. _QFIT format: http://nsidc.org/data/docs/daac/icebridge/ilatm1b/docs/ReadMe.qfit.txt
 

--- a/doc/stages/readers.sbet.rst
+++ b/doc/stages/readers.sbet.rst
@@ -28,3 +28,6 @@ Options
 
 filename
   File to read from [Required]
+
+count
+  Maximum number of points to read [Optional]

--- a/doc/stages/readers.sqlite.rst
+++ b/doc/stages/readers.sqlite.rst
@@ -42,5 +42,7 @@ query
 spatialreference
   The spatial reference to use for the points. Over-rides the value read from the database.
 
+count
+  Maximum number of points to read [Optional]
 
 .. _SQLite: https://sqlite.org/

--- a/doc/stages/readers.text.rst
+++ b/doc/stages/readers.text.rst
@@ -70,4 +70,7 @@ filename
 separator
   Separator character to override that found in header line.
 
+count
+  Maximum number of points to read [Optional]
+
 .. _formatted: http://en.cppreference.com/w/cpp/string/basic_string/stof

--- a/doc/stages/readers.tindex.rst
+++ b/doc/stages/readers.tindex.rst
@@ -105,6 +105,9 @@ dialect
   `OGR SQL`_ dialect to use when querying tile index layer
   [Default: OGRSQL]
 
+count
+  Maximum number of points to read [Optional]
+
 .. _`OGR SQL`: http://www.gdal.org/ogr_sql.html
 
 


### PR DESCRIPTION
Added `--count` to html docs for most readers. Where `--count` is not present, it is either not listed in the output of `pdal --options all --showjson` for the specific reader; OR, the reader is not present in the PDAL docker build (latest or 1.5).

A couple of different syntaxes are used to list options (see readers.las.rst vs readers.ilvis.rst). Happy to standardise, would appreciate any available guidance on a preferred syntax.