### PR TITLE
Added PDAL_DLL to GreedyProjection

### DIFF
--- a/filters/GreedyProjection.hpp
+++ b/filters/GreedyProjection.hpp
@@ -131,7 +131,7 @@ namespace pdal
     * \author Zoltan Csaba Marton
     * \ingroup surface
     */
-  class GreedyProjection : public Filter
+  class PDAL_DLL GreedyProjection : public Filter
   {
     public:
 


### PR DESCRIPTION
Adding missing PDAL_DLL so GreedyProjection is exported on windows.