### PR TITLE
Fix for windows linking in PDALTargets.cmake.in

### DIFF
--- a/PDALConfig.cmake.in
+++ b/PDALConfig.cmake.in
@@ -17,6 +17,11 @@ endforeach(_dir)
 
 include("${CMAKE_CURRENT_LIST_DIR}/PDALTargets.cmake")
 
-set(PDAL_LIBRARIES "@PDAL_LIB_NAME@" "pdal_util" "pdal_jsoncpp" "pdal_arbiter" "pdal_boost")
+if (WIN32)
+# On windows link in pdal_util as well
+  set(PDAL_LIBRARIES "@PDAL_LIB_NAME@" "pdal_util")
+else (WIN32)
+  set(PDAL_LIBRARIES "@PDAL_LIB_NAME@")
+endif(WIN32)
 
 check_required_components(PDAL)

--- a/PDALConfig.cmake.in
+++ b/PDALConfig.cmake.in
@@ -19,7 +19,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/PDALTargets.cmake")
 
 if (WIN32)
 # On windows link in pdal_util as well
-  set(PDAL_LIBRARIES "@PDAL_LIB_NAME@" "pdal_util")
+  set(PDAL_LIBRARIES "@PDAL_LIB_NAME@" "@PDAL_UTIL_LIB_NAME@")
 else (WIN32)
   set(PDAL_LIBRARIES "@PDAL_LIB_NAME@")
 endif(WIN32)

--- a/PDALConfig.cmake.in
+++ b/PDALConfig.cmake.in
@@ -17,6 +17,6 @@ endforeach(_dir)
 
 include("${CMAKE_CURRENT_LIST_DIR}/PDALTargets.cmake")
 
-set(PDAL_LIBRARIES "@PDAL_LIB_NAME@")
+set(PDAL_LIBRARIES "@PDAL_LIB_NAME@" "pdal_util" "pdal_jsoncpp" "pdal_arbiter" "pdal_boost")
 
 check_required_components(PDAL)


### PR DESCRIPTION
This may not be the correct way to fix this, but I had issues linking applications against PDAL (at least on Windows) using the PDAL CMake scripts because not all the pdal libraries are actually included in the PDAL_LIBRARIES list.  It's only including pdalcpp.

This patch adds all of the pdal libraries that might need to be linked to.

If there is a better way to get around this I'd be interested in that as well.

Thanks!

Jason