### PR TITLE
Change 'filters.change' to 'filters.{cpd|icp}'

### DIFF
--- a/doc/stages/filters.cpd.rst
+++ b/doc/stages/filters.cpd.rst
@@ -33,7 +33,7 @@ Examples
             "fixed.las",
             "moving.las",
             {
-                "type": "filters.rigid",
+                "type": "filters.cpd",
                 "method": "rigid"
             },
             "output.las"

--- a/plugins/cpd/filters/CpdFilter.cpp
+++ b/plugins/cpd/filters/CpdFilter.cpp
@@ -64,7 +64,7 @@ void addMetadata(CpdFilter* filter, const cpd::Result& result)
 }
 
 static PluginInfo const s_info = PluginInfo(
-    "filters.change", "CPD filter", "http://pdal.io/stages/filters.cpd.html");
+    "filters.cpd", "CPD filter", "http://pdal.io/stages/filters.cpd.html");
 
 CREATE_SHARED_PLUGIN(1, 0, CpdFilter, Filter, s_info);
 
@@ -90,7 +90,7 @@ PointViewSet CpdFilter::run(PointViewPtr view)
     if (this->m_complete)
     {
         throw pdal_error(
-            "filters.change must have two point view inputs, no more, no less");
+            "filters.cpd must have two point view inputs, no more, no less");
     }
     else if (this->m_fixed)
     {
@@ -98,7 +98,7 @@ PointViewSet CpdFilter::run(PointViewPtr view)
         PointViewPtr result = this->change(this->m_fixed, view);
         viewSet.insert(result);
         this->m_complete = true;
-        log()->get(LogLevel::Debug2) << "filters.change complete\n";
+        log()->get(LogLevel::Debug2) << "filters.cpd complete\n";
     }
     else
     {
@@ -113,7 +113,7 @@ void CpdFilter::done(PointTableRef _)
     if (!this->m_complete)
     {
         throw pdal_error(
-            "filters.change must have two point view inputs, no more, no less");
+            "filters.cpd must have two point view inputs, no more, no less");
     }
 }
 
@@ -122,7 +122,7 @@ PointViewPtr CpdFilter::change(PointViewPtr fixed, PointViewPtr moving)
     MetadataNode root = this->getMetadata();
     root.add("method", this->m_method);
     log()->get(LogLevel::Debug2)
-        << "filters.change running method:" << this->m_method << "\n";
+        << "filters.cpd running method:" << this->m_method << "\n";
     if (this->m_method == "rigid")
     {
         this->cpd_rigid(fixed, moving);
@@ -138,7 +138,7 @@ PointViewPtr CpdFilter::change(PointViewPtr fixed, PointViewPtr moving)
     else
     {
         std::stringstream ss;
-        ss << "Invalid change detection method: " << this->m_method;
+        ss << "Invalid cpd detection method: " << this->m_method;
         throw pdal_error(ss.str());
     }
     return moving;

--- a/plugins/pcl/filters/IcpFilter.cpp
+++ b/plugins/pcl/filters/IcpFilter.cpp
@@ -77,7 +77,7 @@ void IcpFilter::done(PointTableRef _)
     if (!this->m_complete)
     {
         throw pdal_error(
-            "filters.change must have two point view inputs, no more, no less");
+            "filters.icp must have two point view inputs, no more, no less");
     }
 }
 


### PR DESCRIPTION
Per #1577 we ended up splitting the change filter into "cpd" and "icp",
but the plugin naming wasn't done correctly. This patch removes
lingering "filters.change" references.

Fixes #1670.