### PR TITLE
Remove 2D and output filename options from delta kernel

### DIFF
--- a/doc/apps/delta.rst
+++ b/doc/apps/delta.rst
@@ -5,21 +5,16 @@ delta
 ******************************************************************************
 
 The ``delta`` command is used to select a nearest point from a candidate file
-for each point in the source file. If the ``--2d`` option is used, the
-query only happens in XY coordinate space.
+for each point in the source file.
 
 ::
 
-    $ pdal delta <source> <candidate> [output]
-
-Standard out is used if no output file is specified.
+    $ pdal delta <source> <candidate>
 
 ::
 
     --source           source file name
     --candidate        candidate file name
-    --output           output file name
-    --2d               only 2D comparisons/indexing
     --detail           Output deltas per-point
     --alldims          Compute diffs for all dimensions (not just X,Y,Z)
 

--- a/kernels/DeltaKernel.cpp
+++ b/kernels/DeltaKernel.cpp
@@ -47,7 +47,7 @@ CREATE_STATIC_PLUGIN(1, 0, DeltaKernel, Kernel, s_info)
 
 std::string DeltaKernel::getName() const { return s_info.name; }
 
-DeltaKernel::DeltaKernel() : m_3d(true), m_detail(false), m_allDims(false)
+DeltaKernel::DeltaKernel() : m_detail(false), m_allDims(false)
 {}
 
 
@@ -58,9 +58,6 @@ void DeltaKernel::addSwitches(ProgramArgs& args)
     Arg& candidate = args.add("candidate", "candidate file name",
         m_candidateFile);
     candidate.setPositional();
-    Arg& output = args.add("output", "output file name", m_outputFile);
-    output.setPositional();
-    args.add("2d", "only 2D comparisons/indexing", m_3d, true);
     args.add("detail", "Output deltas per-point", m_detail);
     args.add("alldims", "Compute diffs for all dimensions (not just X,Y,Z)",
         m_allDims);

--- a/kernels/DeltaKernel.hpp
+++ b/kernels/DeltaKernel.hpp
@@ -86,13 +86,11 @@ private:
 
     std::string m_sourceFile;
     std::string m_candidateFile;
-    std::string m_outputFile;
 
     /**
     std::ostream* m_outputStream;
     **/
 
-    bool m_3d;
     bool m_detail;
     bool m_allDims;
 };


### PR DESCRIPTION
While parsed (and even required in the case of output filename), neither of
these have any impact on the code as written.