### PR TITLE
Change fcntl.h include path

### DIFF
--- a/pdal/PDALUtils.hpp
+++ b/pdal/PDALUtils.hpp
@@ -42,7 +42,7 @@
 #include <pdal/util/Extractor.hpp>
 
 #ifndef WIN32
-#include <sys/fcntl.h>
+#include <fcntl.h>
 #include <unistd.h>
 #endif
 


### PR DESCRIPTION
Some operating systems (Alpine included) prefer fcntl.h over sys/fcntl.h. This
silences many warnings on such systems.