### PR TITLE
Add Alpine build scripts for Travis and Docker Hub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,19 @@
 # .travis.yml
 # Configure Travis CI service for http://github.com/PDAL
-language: cpp
 
+sudo: required
 
-sudo:
-    required
+services: docker
 
-services:
-    docker
-
-compiler:
-  - gcc
-
-env:
-  - PDAL_OPTIONAL_COMPONENTS=all
-  - PDAL_OPTIONAL_COMPONENTS=none
-
-
-before_install: ./scripts/ci/before_install.sh
+before_install:
+  - docker pull alpine:edge
 
 script:
-    docker run -v $TRAVIS_BUILD_DIR:/pdal -e CXX="$CXX" -e CC="$CC" -e PDAL_OPTIONAL_COMPONENTS="$PDAL_OPTIONAL_COMPONENTS" -t pdal/dependencies:latest /bin/sh -c "/pdal/scripts/ci/script.sh"
+  - docker run -v $TRAVIS_BUILD_DIR:/pdal -t alpine:edge /bin/sh -c "/pdal/scripts/ci/script.sh"
 
 after_success:
   - echo "secure travis:" "$TRAVIS_SECURE_ENV_VARS"
-  - sh -c 'if test "$TRAVIS_SECURE_ENV_VARS" = "true" -a "$TRAVIS_BRANCH" = "1.5-maintenance" -a "$PDAL_OPTIONAL_COMPONENTS" = "all"; then echo "publish website"; ./scripts/ci/build_docs.sh; ./scripts/ci/add_deploy_key.sh; ./scripts/ci/deploy_website.sh $TRAVIS_BUILD_DIR/doc/build /tmp; fi'
+  - sh -c 'if test "$TRAVIS_SECURE_ENV_VARS" = "true" -a "$TRAVIS_BRANCH" = "1.5-maintenance"; then echo "publish website"; ./scripts/ci/build_docs.sh; ./scripts/ci/add_deploy_key.sh; ./scripts/ci/deploy_website.sh $TRAVIS_BUILD_DIR/doc/build /tmp; fi'
 
 notifications:
   on_success: always

--- a/scripts/ci/script.sh
+++ b/scripts/ci/script.sh
@@ -1,86 +1,78 @@
-#!/bin/bash -e
+#!/bin/sh -e
 # Builds and tests PDAL
 
-clang --version
+echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
+apk update
+apk add \
+    cmake \
+    alpine-sdk \
+    eigen-dev \
+    hexer \
+    hexer-dev \
+    nitro \
+    nitro-dev \
+    gdal \
+    gdal-dev \
+    geos \
+    geos-dev \
+    laz-perf \
+    laz-perf-dev \
+    libgeotiff \
+    libgeotiff-dev \
+    libxml2 \
+    libxml2-dev \
+    python \
+    python-dev \
+    py-numpy \
+    py-numpy-dev \
+    jsoncpp \
+    jsoncpp-dev \
+    hdf5 \
+    hdf5-dev \
+    proj4 \
+    proj4-dev \
+    cpd \
+    cpd-dev \
+    fgt \
+    fgt-dev \
+    sqlite \
+    sqlite-dev \
+    postgresql-dev \
+    libcurl \
+    curl-dev \
+    linux-headers \
+    laszip \
+    laszip-dev \
+    libspatialite \
+    libspatialite-dev
+
 gcc --version
+g++ --version
 
 cd /pdal
-source ./scripts/ci/common.sh
 
 mkdir -p _build || exit 1
 cd _build || exit 1
 
-case "$PDAL_OPTIONAL_COMPONENTS" in
-    all)
-        OPTIONAL_COMPONENT_SWITCH=ON
-        ;;
-    none)
-        OPTIONAL_COMPONENT_SWITCH=OFF
-        ;;
-    *)
-        echo "Unrecognized value for PDAL_OPTIONAL_COMPONENTS=$PDAL_OPTIONAL_COMPONENTS"
-        exit 1
-esac
-
-
-cmake \
-    -DBUILD_PLUGIN_CPD=$OPTIONAL_COMPONENT_SWITCH \
-    -DBUILD_PLUGIN_GREYHOUND=OFF \
-    -DBUILD_PLUGIN_HEXBIN=$OPTIONAL_COMPONENT_SWITCH \
-    -DBUILD_PLUGIN_ICEBRIDGE=$OPTIONAL_COMPONENT_SWITCH \
-    -DBUILD_PLUGIN_MRSID=OFF \
-    -DBUILD_PLUGIN_NITF=OFF \
-    -DBUILD_PLUGIN_OCI=OFF \
-    -DBUILD_PLUGIN_OPENSCENEGRAPH=$OPTIONAL_COMPONENT_SWITCH \
-    -DBUILD_PLUGIN_PCL=$OPTIONAL_COMPONENT_SWITCH \
-    -DBUILD_PLUGIN_PGPOINTCLOUD=$OPTIONAL_COMPONENT_SWITCH \
+cmake .. \
+    -G "Unix Makefiles" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_C_COMPILER=gcc \
+    -DCMAKE_CXX_COMPILER=g++ \
+    -DCMAKE_MAKE_PROGRAM=make \
+    -DBUILD_PLUGIN_PYTHON=ON \
+    -DBUILD_PLUGIN_CPD=ON \
+    -DBUILD_PLUGIN_GREYHOUND=ON \
+    -DBUILD_PLUGIN_HEXBIN=ON \
+    -DBUILD_PLUGIN_NITF=ON \
+    -DBUILD_PLUGIN_ICEBRIDGE=ON \
+    -DBUILD_PLUGIN_PGPOINTCLOUD=ON \
     -DBUILD_PGPOINTCLOUD_TESTS=OFF \
-    -DBUILD_PLUGIN_SQLITE=$OPTIONAL_COMPONENT_SWITCH \
-    -DBUILD_PLUGIN_RIVLIB=OFF \
-    -DBUILD_PLUGIN_PYTHON=$OPTIONAL_COMPONENT_SWITCH \
-    -DENABLE_CTEST=OFF \
-    -DWITH_APPS=ON \
-    -DWITH_LAZPERF=$OPTIONAL_COMPONENT_SWITCH \
-    -DWITH_LASZIP=$OPTIONAL_COMPONENT_SWITCH \
-    -DWITH_PDAL_JNI=$OPTIONAL_COMPONENT_SWITCH \
-    -DWITH_TESTS=ON \
-    -G "$PDAL_CMAKE_GENERATOR" \
-    ..
+    -DBUILD_PLUGIN_SQLITE=ON \
+    -DWITH_LASZIP=ON \
+    -DWITH_LAZPERF=ON \
+    -DWITH_TESTS=ON
 
-cmake ..
-
-MAKECMD=make
-
-# Don't use ninja's default number of threads becuase it can
-# saturate Travis's available memory.
-NUMTHREADS=2
-${MAKECMD} -j ${NUMTHREADS} && \
-    LD_LIBRARY_PATH=./lib && \
-    PGUSER=postgres ctest -V && \
-    ${MAKECMD} install && \
-    /sbin/ldconfig
-
-if [ "${OPTIONAL_COMPONENT_SWITCH}" == "ON" ]; then
-    cd /pdal/python
-    pip install packaging
-    python setup.py build
-    echo "current path: " `pwd`
-    export PDAL_TEST_DIR=/pdal/_build/test
-    python setup.py test
-
-    # JNI tests
-    cd /pdal/java; PDAL_DEPEND_ON_NATIVE=false ./sbt -Djava.library.path=/pdal/_build/lib core/test
-    
-    # Scala tests
-    cd /pdal/java; PDAL_DEPEND_ON_NATIVE=false ./sbt -Djava.library.path=/pdal/_build/lib core-scala/test
-
-    # Build all examples
-    for EXAMPLE in writing writing-filter writing-kernel writing-reader writing-writer
-    do
-        cd /pdal/examples/$EXAMPLE
-        mkdir -p _build || exit 1
-        cd _build || exit 1
-        cmake -G "$PDAL_CMAKE_GENERATOR" .. && \
-        ${MAKECMD}
-    done
-fi
+make -j2
+LD_LIBRARY_PATH=./lib
+ctest -V

--- a/scripts/docker/1.4-maintenance/alpine/10-backtrace-guards.patch
+++ b/scripts/docker/1.4-maintenance/alpine/10-backtrace-guards.patch
@@ -1,0 +1,79 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index a91cee1..4e38769 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -146,6 +146,8 @@ endif()
+ 
+ set(pdal_defines_h_in "${CMAKE_CURRENT_SOURCE_DIR}/pdal_defines.h.in")
+ set(pdal_defines_h "${CMAKE_CURRENT_BINARY_DIR}/include/pdal/pdal_defines.h")
++include(CheckIncludeFiles)
++check_include_files(execinfo.h PDAL_HAVE_EXECINFO_H)
+ configure_file(${pdal_defines_h_in} ${pdal_defines_h})
+ 
+ #------------------------------------------------------------------------------
+diff --git a/apps/pdal.cpp b/apps/pdal.cpp
+index 3193196..548ea4f 100644
+--- a/apps/pdal.cpp
++++ b/apps/pdal.cpp
+@@ -355,6 +355,7 @@ int App::execute(StringList& cmdArgs, LogPtr& log)
+         log->setLevel(LogLevel::Debug);
+     PluginManager::setLog(log);
+ #ifndef _WIN32
++#ifdef PDAL_HAVE_EXECINFO_H
+     if (m_debug)
+     {
+         signal(SIGSEGV, [](int sig)
+@@ -368,6 +369,7 @@ int App::execute(StringList& cmdArgs, LogPtr& log)
+         });
+     }
+ #endif
++#endif
+ 
+     m_command = Utils::tolower(m_command);
+     if (!m_command.empty())
+diff --git a/pdal/util/Utils.cpp b/pdal/util/Utils.cpp
+index c2a9489..d0675c4 100644
+--- a/pdal/util/Utils.cpp
++++ b/pdal/util/Utils.cpp
+@@ -44,7 +44,9 @@
+ #include <cxxabi.h>
+ #include <sys/ioctl.h>
+ #include <sys/wait.h>  // WIFEXITED, WEXITSTATUS
++#ifdef PDAL_HAVE_EXECINFO_H
+ #include <execinfo.h> // backtrace
++#endif
+ #include <dlfcn.h> // dladdr
+ #endif
+ 
+@@ -605,6 +607,7 @@ std::vector<std::string> Utils::backtrace()
+ {
+     std::vector<std::string> lines;
+ #ifndef WIN32
++#ifdef PDAL_HAVE_EXECINFO_H
+     const int MAX_STACK_SIZE(100);
+     void* buffer[MAX_STACK_SIZE];
+     std::vector<std::string> prefixes;
+@@ -657,6 +660,7 @@ std::vector<std::string> Utils::backtrace()
+         }
+     }
+ #endif
++#endif
+     return lines;
+ }
+ 
+diff --git a/pdal_defines.h.in b/pdal_defines.h.in
+index 77dca12..15e3932 100644
+--- a/pdal_defines.h.in
++++ b/pdal_defines.h.in
+@@ -34,6 +34,11 @@
+ #cmakedefine PDAL_ARBITER_ENABLED
+ 
+ /*
++ * availability of execinfo.h
++ */
++#cmakedefine PDAL_HAVE_EXECINFO_H
++
++/*
+  * Debug or Release build?
+  */
+ #define PDAL_BUILD_TYPE "@PDAL_BUILD_TYPE@"

--- a/scripts/docker/1.4-maintenance/alpine/Dockerfile
+++ b/scripts/docker/1.4-maintenance/alpine/Dockerfile
@@ -1,0 +1,95 @@
+FROM alpine:edge
+
+ADD ./10-backtrace-guards.patch /10-backtrace-guards.patch
+
+RUN \
+    echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories; \
+    apk update; \
+    apk add --no-cache --virtual .build-deps \
+        alpine-sdk \
+        unzip \
+        cmake \
+        eigen-dev \
+        hexer-dev \
+        nitro-dev \
+        gdal-dev \
+        geos-dev \
+        laz-perf-dev \
+        libgeotiff-dev \
+        libxml2-dev \
+        python-dev \
+        py-numpy-dev \
+        jsoncpp-dev \
+        hdf5-dev \
+        proj4-dev \
+        sqlite-dev \
+        postgresql-dev \
+        curl-dev \
+        linux-headers \
+        laszip-dev \
+        libspatialite-dev \
+    ; \
+    apk add --no-cache \
+        hexer \
+        nitro \
+        gdal \
+        geos \
+        laz-perf \
+        libgeotiff \
+        libxml2 \
+        python \
+        py-numpy \
+        jsoncpp \
+        hdf5 \
+        proj4 \
+        sqlite \
+        postgresql \
+        libcurl \
+        laszip \
+        libspatialite \
+    ;\
+    mkdir /vdatum; \
+    cd /vdatum; \
+    wget http://download.osgeo.org/proj/vdatum/usa_geoid2012.zip && unzip -j -u usa_geoid2012.zip -d /usr/share/proj; \
+    wget http://download.osgeo.org/proj/vdatum/usa_geoid2009.zip && unzip -j -u usa_geoid2009.zip -d /usr/share/proj; \
+    wget http://download.osgeo.org/proj/vdatum/usa_geoid2003.zip && unzip -j -u usa_geoid2003.zip -d /usr/share/proj; \
+    wget http://download.osgeo.org/proj/vdatum/usa_geoid1999.zip && unzip -j -u usa_geoid1999.zip -d /usr/share/proj; \
+    wget http://download.osgeo.org/proj/vdatum/vertcon/vertconc.gtx && mv vertconc.gtx /usr/share/proj; \
+    wget http://download.osgeo.org/proj/vdatum/vertcon/vertcone.gtx && mv vertcone.gtx /usr/share/proj; \
+    wget http://download.osgeo.org/proj/vdatum/vertcon/vertconw.gtx && mv vertconw.gtx /usr/share/proj; \
+    wget http://download.osgeo.org/proj/vdatum/egm96_15/egm96_15.gtx && mv egm96_15.gtx /usr/share/proj; \
+    wget http://download.osgeo.org/proj/vdatum/egm08_25/egm08_25.gtx && mv egm08_25.gtx /usr/share/proj; \
+    cd /; \
+    rm -rf /vdatum; \
+    wget https://github.com/PDAL/PDAL/archive/1.4-maintenance.tar.gz; \
+    tar -xf 1.4-maintenance.tar.gz; \
+    rm 1.4-maintenance.tar.gz; \
+    cd /PDAL-1.4-maintenance; \
+    git apply /10-backtrace-guards.patch; \
+    rm /10-backtrace-guards.patch; \
+    mkdir -p _build; \
+    cd _build; \
+    cmake .. \
+        -G "Unix Makefiles" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_C_COMPILER=gcc \
+        -DCMAKE_CXX_COMPILER=g++ \
+        -DCMAKE_MAKE_PROGRAM=make \
+        -DBUILD_PLUGIN_PYTHON=ON \
+        -DBUILD_PLUGIN_CPD=OFF \
+        -DBUILD_PLUGIN_GREYHOUND=ON \
+        -DBUILD_PLUGIN_HEXBIN=ON \
+        -DBUILD_PLUGIN_NITF=ON \
+        -DBUILD_PLUGIN_ICEBRIDGE=ON \
+        -DBUILD_PLUGIN_PGPOINTCLOUD=ON \
+        -DBUILD_PLUGIN_SQLITE=ON \
+        -DWITH_LASZIP=ON \
+        -DWITH_LAZPERF=ON \
+    ; \
+    make -j2; \
+    make install; \
+    cd /; \
+    rm -rf /PDAL-1.4-maintenance; \
+    apk del .build-deps
+
+CMD ["pdal"]

--- a/scripts/docker/1.4-maintenance/ubuntu/Dockerfile
+++ b/scripts/docker/1.4-maintenance/ubuntu/Dockerfile
@@ -1,0 +1,357 @@
+FROM ubuntu:16.04
+MAINTAINER Howard Butler <howard@hobu.co>
+
+ENV CC gcc
+ENV CXX g++
+ENV JAVA_HOME /usr/lib/jvm/java-8-oracle
+
+RUN \
+    apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 16126D3A3E5C1192; \
+    apt-get update -qq; \
+    apt-get -qq remove postgis; \
+    echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | debconf-set-selections; \
+    apt-get install -y --fix-missing --no-install-recommends \
+        software-properties-common \
+    ; \
+    add-apt-repository -y ppa:webupd8team/java; \
+    add-apt-repository ppa:ubuntugis/ubuntugis-unstable -y; \
+    apt-get update; \
+    apt-get install -y --fix-missing --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        cmake \
+        curl \
+        gfortran \
+        git \
+        libarmadillo-dev \
+        libarpack2-dev \
+        libflann-dev \
+        libhdf5-serial-dev \
+        liblapack-dev \
+        libtiff5-dev \
+        openssh-client \
+        python-dev \
+        python-numpy \
+        python-software-properties \
+        wget \
+        automake \
+        libtool \
+        libspatialite-dev \
+        libsqlite3-mod-spatialite \
+        libhdf5-dev \
+        subversion \
+        libjsoncpp-dev \
+        libboost-filesystem1.58-dev \
+        libboost-iostreams1.58-dev \
+        libboost-program-options1.58-dev \
+        libboost-system1.58-dev \
+        libboost-thread1.58-dev \
+        subversion \
+        clang \
+        clang-3.6 \
+        libproj-dev \
+        libc6-dev \
+        libnetcdf-dev \
+        libjasper-dev \
+        libpng-dev \
+        libjpeg-dev \
+        libgif-dev \
+        libwebp-dev \
+        libhdf4-alt-dev \
+        libhdf5-dev \
+        libpq-dev \
+        libxerces-c-dev \
+        unixodbc-dev \
+        libsqlite3-dev \
+        libgeos-dev \
+        libmysqlclient-dev \
+        libltdl-dev \
+        libcurl4-openssl-dev \
+        libspatialite-dev \
+        libdap-dev\
+        cython \
+        python-pip \
+        libgdal1-dev \
+        gdal-bin \
+        libpcl-dev \
+        time \
+        libhpdf-dev \
+        python-setuptools \
+        libgeos++-dev \
+        libhpdf-dev \
+        unzip \
+        mbsystem \
+        mbsystem-dev \
+        oracle-java8-installer \
+    ; \
+    rm -rf /var/lib/apt/lists/*; \
+    rm -rf /var/cache/oracle-jdk8-installer; \
+    update-alternatives --install /usr/bin/clang clang /usr/bin/clang-3.6 20; \
+    update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-3.6 20; \
+    ln -s /usr/lib/x86_64-linux-gnu/libvtkCommonCore-6.2.so /usr/lib/libvtkproj4.so; \
+    git clone https://github.com/hobu/nitro; \
+    cd nitro; \
+    mkdir build; \
+    cd build; \
+    cmake ..\
+        -DCMAKE_INSTALL_PREFIX=/usr \
+    ; \
+    make; \
+    make install; \
+    cd /; \
+    rm -rf /nitro; \
+    git clone https://github.com/LASzip/LASzip.git laszip; \
+    cd laszip; \
+    git checkout e7065cbc5bdbbe0c6e50c9d93d1cd346e9be6778; \
+    mkdir build; \
+    cd build; \
+    cmake .. \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_BUILD_TYPE="Release" \
+    ; \
+    make; \
+    make install; \
+    cd /; \
+    rm -rf /laszip; \
+    git clone https://github.com/hobu/hexer.git; \
+    cd hexer; \
+    mkdir build; \
+    cd build; \
+    cmake .. \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_BUILD_TYPE="Release" \
+    ; \
+    make; \
+    make install; \
+    cd /; \
+    rm -rf /hexer; \
+    git clone  https://github.com/hobu/laz-perf.git; \
+    cd laz-perf; \
+    mkdir build; \
+    cd build; \
+    cmake .. \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_BUILD_TYPE="Release" \
+    ; \
+    make; \
+    make install; \
+    cd /; \
+    rm -rf /laz-perf; \
+    wget http://bitbucket.org/eigen/eigen/get/3.2.7.tar.gz; \
+    tar -xvf 3.2.7.tar.gz; \
+    cp -R eigen-eigen-b30b87236a1b/Eigen/ /usr/include/Eigen/; \
+    cp -R eigen-eigen-b30b87236a1b/unsupported/ /usr/include/unsupported/; \
+    rm -rf /3.2.7.tar.gz; \
+    rm -rf /eigen-eigen-b30b87236a1b; \
+    svn co -r 2691 https://svn.osgeo.org/metacrs/geotiff/trunk/libgeotiff/; \
+    cd libgeotiff; \
+    ./autogen.sh; \
+    ./configure --prefix=/usr; \
+    make; \
+    make install; \
+    cd /; \
+    rm -rf /libgeotiff; \
+    git clone --depth 1 --branch v0.4.6 https://github.com/gadomski/fgt.git; \
+    cd fgt; \
+    cmake . \
+        -DWITH_TESTS=OFF \
+        -DBUILD_SHARED_LIBS=ON \
+        -DEIGEN3_INCLUDE_DIR=/usr/include \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_BUILD_TYPE=Release \
+    ; \
+    make; \
+    make install; \
+    cd /; \
+    rm -rf /fgt; \
+    git clone --depth 1 --branch v0.5.0 https://github.com/gadomski/cpd.git; \
+    cd cpd; \
+    cmake . \
+        -DWITH_TESTS=OFF \
+        -DWITH_JSONCPP=OFF \
+        -DWITH_FGT=ON \
+        -DWITH_STRICT_WARNINGS=OFF \
+        -DWITH_DOCS=OFF \
+        -DEIGEN3_INCLUDE_DIR=/usr/include \
+        -DBUILD_SHARED_LIBS=ON \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_BUILD_TYPE=Release \
+    ; \
+    make; \
+    make install; \
+    cd /; \
+    rm -rf /cpd; \
+    mkdir /vdatum; \
+    cd /vdatum; \
+    wget http://download.osgeo.org/proj/vdatum/usa_geoid2012.zip && unzip -j -u usa_geoid2012.zip -d /usr/share/proj; \
+    wget http://download.osgeo.org/proj/vdatum/usa_geoid2009.zip && unzip -j -u usa_geoid2009.zip -d /usr/share/proj; \
+    wget http://download.osgeo.org/proj/vdatum/usa_geoid2003.zip && unzip -j -u usa_geoid2003.zip -d /usr/share/proj; \
+    wget http://download.osgeo.org/proj/vdatum/usa_geoid1999.zip && unzip -j -u usa_geoid1999.zip -d /usr/share/proj; \
+    wget http://download.osgeo.org/proj/vdatum/vertcon/vertconc.gtx && mv vertconc.gtx /usr/share/proj; \
+    wget http://download.osgeo.org/proj/vdatum/vertcon/vertcone.gtx && mv vertcone.gtx /usr/share/proj; \
+    wget http://download.osgeo.org/proj/vdatum/vertcon/vertconw.gtx && mv vertconw.gtx /usr/share/proj; \
+    wget http://download.osgeo.org/proj/vdatum/egm96_15/egm96_15.gtx && mv egm96_15.gtx /usr/share/proj; \
+    wget http://download.osgeo.org/proj/vdatum/egm08_25/egm08_25.gtx && mv egm08_25.gtx /usr/share/proj; \
+    cd /; \
+    rm -rf /vdatum; \
+    wget https://github.com/PDAL/PDAL/archive/1.4-maintenance.tar.gz; \
+    tar -xf 1.4-maintenance.tar.gz; \
+    rm 1.4-maintenance.tar.gz; \
+    cd /PDAL-1.4-maintenance; \
+    mkdir build; \
+    cd build; \
+    cmake .. \
+        -DBUILD_PLUGIN_CPD=OFF \
+        -DBUILD_PLUGIN_MBIO=ON \
+        -DBUILD_PLUGIN_GREYHOUND=ON \
+        -DBUILD_PLUGIN_HEXBIN=ON \
+        -DBUILD_PLUGIN_ICEBRIDGE=ON \
+        -DBUILD_PLUGIN_MRSID=ON \
+        -DBUILD_PLUGIN_NITF=ON \
+        -DBUILD_PLUGIN_OCI=OFF \
+        -DBUILD_PLUGIN_PCL=ON \
+        -DBUILD_PLUGIN_PGPOINTCLOUD=ON \
+        -DBUILD_PLUGIN_SQLITE=ON \
+        -DBUILD_PLUGIN_RIVLIB=OFF \
+        -DBUILD_PLUGIN_PYTHON=ON \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DENABLE_CTEST=OFF \
+        -DWITH_APPS=ON \
+        -DWITH_LAZPERF=ON \
+        -DWITH_LASZIP=ON \
+        -DWITH_TESTS=ON \
+        -DWITH_PDAL_JNI=ON \
+        -DCMAKE_BUILD_TYPE=Release \
+    ; \
+    make -j2; \
+    make install; \
+    cd /; \
+    rm -rf /PDAL; \
+    pip install packaging; \
+    pip install PDAL; \
+    git clone https://github.com/PDAL/PRC.git; \
+    cd PRC; \
+    git checkout master; \
+    mkdir build; \
+    cd build; \
+    cmake .. \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DPDAL_DIR=/usr/lib/pdal/cmake \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+    ; \
+    make; \
+    make install; \
+    cd /; \
+    rm -rf /PRC; \
+    apt-get purge -y \
+        build-essential \
+        ca-certificates \
+        cmake \
+        curl \
+        gfortran \
+        git \
+        libarmadillo-dev \
+        libarpack2-dev \
+        libflann-dev \
+        libhdf5-serial-dev \
+        liblapack-dev \
+        libtiff5-dev \
+        openssh-client \
+        python-dev \
+        python-numpy \
+        python-software-properties \
+        software-properties-common \
+        wget \
+        automake \
+        libtool \
+        libspatialite-dev \
+        libhdf5-dev \
+        subversion \
+        libjsoncpp-dev \
+        libboost-filesystem1.58-dev \
+        libboost-iostreams1.58-dev \
+        libboost-program-options1.58-dev \
+        libboost-system1.58-dev \
+        libboost-thread1.58-dev \
+        subversion \
+        clang \
+        libproj-dev \
+        libc6-dev \
+        libnetcdf-dev \
+        libjasper-dev \
+        libpng-dev \
+        libjpeg-dev \
+        libgif-dev \
+        libwebp-dev \
+        libhdf4-alt-dev \
+        libhdf5-dev \
+        libpq-dev \
+        libxerces-c-dev \
+        unixodbc-dev \
+        libsqlite3-dev \
+        libgeos-dev \
+        libmysqlclient-dev \
+        libltdl-dev \
+        libcurl4-openssl-dev \
+        libspatialite-dev \
+        libdap-dev\
+        cython \
+        python-pip \
+    ; \
+    apt-get autoremove -y; \
+    apt-get update; \
+    apt-get install -y \
+        libexpat1 \
+        libgomp1 \
+        libxml2 \
+        libgeos-c1v5 \
+        libjsoncpp1 \
+        libcurl3 \
+        libarmadillo6 \
+        libwebp5 \
+        libodbc1 \
+        odbcinst1debian2 \
+        libxerces-c3.1 \
+        libjasper1 \
+        netcdf-bin \
+        libhdf4-0-alt \
+        libgif7 \
+        libpq5 \
+        libdapclient6v5 \
+        libspatialite7 \
+        libsqlite3-mod-spatialite \
+        spatialite-bin \
+        libmysqlclient20 \
+        libtiff5 \
+        libboost-system1.58.0 \
+        libboost-filesystem1.58.0 \
+        libboost-thread1.58.0 \
+        libboost-program-options1.58.0 \
+        libboost-iostreams1.58.0 \
+        libboost-date-time1.58.0 \
+        libboost-serialization1.58.0 \
+        libboost-chrono1.58.0 \
+        libboost-atomic1.58.0 \
+        libboost-regex1.58.0 \
+        libgdal1i \
+        libflann1.8 \
+        libpython2.7 \
+        libhdf5-cpp-11 \
+        libpcl-common1.7 \
+        libpcl-features1.7 \
+        libpcl-filters1.7 \
+        libpcl-io1.7 \
+        libpcl-kdtree1.7 \
+        libpcl-keypoints1.7 \
+        libpcl-octree1.7 \
+        libpcl-outofcore1.7 \
+        libpcl-people1.7 \
+        libpcl-recognition1.7 \
+        libpcl-registration1.7 \
+        libpcl-sample-consensus1.7 \
+        libpcl-search1.7 \
+        libpcl-segmentation1.7 \
+        libpcl-surface1.7 \
+        libpcl-tracking1.7 \
+        libpcl-visualization1.7
+

--- a/scripts/docker/1.5-maintenance/alpine/10-backtrace-guards.patch
+++ b/scripts/docker/1.5-maintenance/alpine/10-backtrace-guards.patch
@@ -1,0 +1,79 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index a91cee1..4e38769 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -146,6 +146,8 @@ endif()
+ 
+ set(pdal_defines_h_in "${CMAKE_CURRENT_SOURCE_DIR}/pdal_defines.h.in")
+ set(pdal_defines_h "${CMAKE_CURRENT_BINARY_DIR}/include/pdal/pdal_defines.h")
++include(CheckIncludeFiles)
++check_include_files(execinfo.h PDAL_HAVE_EXECINFO_H)
+ configure_file(${pdal_defines_h_in} ${pdal_defines_h})
+ 
+ #------------------------------------------------------------------------------
+diff --git a/apps/pdal.cpp b/apps/pdal.cpp
+index 3193196..548ea4f 100644
+--- a/apps/pdal.cpp
++++ b/apps/pdal.cpp
+@@ -355,6 +355,7 @@ int App::execute(StringList& cmdArgs, LogPtr& log)
+         log->setLevel(LogLevel::Debug);
+     PluginManager::setLog(log);
+ #ifndef _WIN32
++#ifdef PDAL_HAVE_EXECINFO_H
+     if (m_debug)
+     {
+         signal(SIGSEGV, [](int sig)
+@@ -368,6 +369,7 @@ int App::execute(StringList& cmdArgs, LogPtr& log)
+         });
+     }
+ #endif
++#endif
+ 
+     m_command = Utils::tolower(m_command);
+     if (!m_command.empty())
+diff --git a/pdal/util/Utils.cpp b/pdal/util/Utils.cpp
+index c2a9489..d0675c4 100644
+--- a/pdal/util/Utils.cpp
++++ b/pdal/util/Utils.cpp
+@@ -44,7 +44,9 @@
+ #include <cxxabi.h>
+ #include <sys/ioctl.h>
+ #include <sys/wait.h>  // WIFEXITED, WEXITSTATUS
++#ifdef PDAL_HAVE_EXECINFO_H
+ #include <execinfo.h> // backtrace
++#endif
+ #include <dlfcn.h> // dladdr
+ #endif
+ 
+@@ -605,6 +607,7 @@ std::vector<std::string> Utils::backtrace()
+ {
+     std::vector<std::string> lines;
+ #ifndef WIN32
++#ifdef PDAL_HAVE_EXECINFO_H
+     const int MAX_STACK_SIZE(100);
+     void* buffer[MAX_STACK_SIZE];
+     std::vector<std::string> prefixes;
+@@ -657,6 +660,7 @@ std::vector<std::string> Utils::backtrace()
+         }
+     }
+ #endif
++#endif
+     return lines;
+ }
+ 
+diff --git a/pdal_defines.h.in b/pdal_defines.h.in
+index 77dca12..15e3932 100644
+--- a/pdal_defines.h.in
++++ b/pdal_defines.h.in
+@@ -34,6 +34,11 @@
+ #cmakedefine PDAL_ARBITER_ENABLED
+ 
+ /*
++ * availability of execinfo.h
++ */
++#cmakedefine PDAL_HAVE_EXECINFO_H
++
++/*
+  * Debug or Release build?
+  */
+ #define PDAL_BUILD_TYPE "@PDAL_BUILD_TYPE@"

--- a/scripts/docker/1.5-maintenance/alpine/Dockerfile
+++ b/scripts/docker/1.5-maintenance/alpine/Dockerfile
@@ -1,0 +1,99 @@
+FROM alpine:edge
+
+ADD ./10-backtrace-guards.patch /10-backtrace-guards.patch
+
+RUN \
+    echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories; \
+    apk update; \
+    apk add --no-cache --virtual .build-deps \
+        alpine-sdk \
+        unzip \
+        cmake \
+        eigen-dev \
+        hexer-dev \
+        nitro-dev \
+        gdal-dev \
+        geos-dev \
+        laz-perf-dev \
+        libgeotiff-dev \
+        libxml2-dev \
+        python-dev \
+        py-numpy-dev \
+        jsoncpp-dev \
+        hdf5-dev \
+        proj4-dev \
+        cpd-dev \
+        fgt-dev \
+        sqlite-dev \
+        postgresql-dev \
+        curl-dev \
+        linux-headers \
+        laszip-dev \
+        libspatialite-dev \
+    ; \
+    apk add --no-cache \
+        hexer \
+        nitro \
+        gdal \
+        geos \
+        laz-perf \
+        libgeotiff \
+        libxml2 \
+        python \
+        py-numpy \
+        jsoncpp \
+        hdf5 \
+        proj4 \
+        cpd \
+        fgt \
+        sqlite \
+        postgresql \
+        libcurl \
+        laszip \
+        libspatialite \
+    ;\
+    mkdir /vdatum; \
+    cd /vdatum; \
+    wget http://download.osgeo.org/proj/vdatum/usa_geoid2012.zip && unzip -j -u usa_geoid2012.zip -d /usr/share/proj; \
+    wget http://download.osgeo.org/proj/vdatum/usa_geoid2009.zip && unzip -j -u usa_geoid2009.zip -d /usr/share/proj; \
+    wget http://download.osgeo.org/proj/vdatum/usa_geoid2003.zip && unzip -j -u usa_geoid2003.zip -d /usr/share/proj; \
+    wget http://download.osgeo.org/proj/vdatum/usa_geoid1999.zip && unzip -j -u usa_geoid1999.zip -d /usr/share/proj; \
+    wget http://download.osgeo.org/proj/vdatum/vertcon/vertconc.gtx && mv vertconc.gtx /usr/share/proj; \
+    wget http://download.osgeo.org/proj/vdatum/vertcon/vertcone.gtx && mv vertcone.gtx /usr/share/proj; \
+    wget http://download.osgeo.org/proj/vdatum/vertcon/vertconw.gtx && mv vertconw.gtx /usr/share/proj; \
+    wget http://download.osgeo.org/proj/vdatum/egm96_15/egm96_15.gtx && mv egm96_15.gtx /usr/share/proj; \
+    wget http://download.osgeo.org/proj/vdatum/egm08_25/egm08_25.gtx && mv egm08_25.gtx /usr/share/proj; \
+    cd /; \
+    rm -rf /vdatum; \
+    wget https://github.com/PDAL/PDAL/archive/1.5-maintenance.tar.gz; \
+    tar -xf 1.5-maintenance.tar.gz; \
+    rm 1.5-maintenance.tar.gz; \
+    cd /PDAL-1.5-maintenance; \
+    git apply /10-backtrace-guards.patch; \
+    rm /10-backtrace-guards.patch; \
+    mkdir -p _build; \
+    cd _build; \
+    cmake .. \
+        -G "Unix Makefiles" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_C_COMPILER=gcc \
+        -DCMAKE_CXX_COMPILER=g++ \
+        -DCMAKE_MAKE_PROGRAM=make \
+        -DBUILD_PLUGIN_PYTHON=ON \
+        -DBUILD_PLUGIN_CPD=ON \
+        -DBUILD_PLUGIN_GREYHOUND=ON \
+        -DBUILD_PLUGIN_HEXBIN=ON \
+        -DBUILD_PLUGIN_NITF=ON \
+        -DBUILD_PLUGIN_ICEBRIDGE=ON \
+        -DBUILD_PLUGIN_PGPOINTCLOUD=ON \
+        -DBUILD_PLUGIN_SQLITE=ON \
+        -DWITH_LASZIP=ON \
+        -DWITH_LAZPERF=ON \
+    ; \
+    make -j2; \
+    make install; \
+    cd /; \
+    rm -rf /PDAL-1.5-maintenance; \
+    apk del .build-deps
+
+CMD ["pdal"]

--- a/scripts/docker/1.5-maintenance/ubuntu/Dockerfile
+++ b/scripts/docker/1.5-maintenance/ubuntu/Dockerfile
@@ -1,0 +1,357 @@
+FROM ubuntu:16.04
+MAINTAINER Howard Butler <howard@hobu.co>
+
+ENV CC gcc
+ENV CXX g++
+ENV JAVA_HOME /usr/lib/jvm/java-8-oracle
+
+RUN \
+    apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 16126D3A3E5C1192; \
+    apt-get update -qq; \
+    apt-get -qq remove postgis; \
+    echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | debconf-set-selections; \
+    apt-get install -y --fix-missing --no-install-recommends \
+        software-properties-common \
+    ; \
+    add-apt-repository -y ppa:webupd8team/java; \
+    add-apt-repository ppa:ubuntugis/ubuntugis-unstable -y; \
+    apt-get update; \
+    apt-get install -y --fix-missing --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        cmake \
+        curl \
+        gfortran \
+        git \
+        libarmadillo-dev \
+        libarpack2-dev \
+        libflann-dev \
+        libhdf5-serial-dev \
+        liblapack-dev \
+        libtiff5-dev \
+        openssh-client \
+        python-dev \
+        python-numpy \
+        python-software-properties \
+        wget \
+        automake \
+        libtool \
+        libspatialite-dev \
+        libsqlite3-mod-spatialite \
+        libhdf5-dev \
+        subversion \
+        libjsoncpp-dev \
+        libboost-filesystem1.58-dev \
+        libboost-iostreams1.58-dev \
+        libboost-program-options1.58-dev \
+        libboost-system1.58-dev \
+        libboost-thread1.58-dev \
+        subversion \
+        clang \
+        clang-3.6 \
+        libproj-dev \
+        libc6-dev \
+        libnetcdf-dev \
+        libjasper-dev \
+        libpng-dev \
+        libjpeg-dev \
+        libgif-dev \
+        libwebp-dev \
+        libhdf4-alt-dev \
+        libhdf5-dev \
+        libpq-dev \
+        libxerces-c-dev \
+        unixodbc-dev \
+        libsqlite3-dev \
+        libgeos-dev \
+        libmysqlclient-dev \
+        libltdl-dev \
+        libcurl4-openssl-dev \
+        libspatialite-dev \
+        libdap-dev\
+        cython \
+        python-pip \
+        libgdal1-dev \
+        gdal-bin \
+        libpcl-dev \
+        time \
+        libhpdf-dev \
+        python-setuptools \
+        libgeos++-dev \
+        libhpdf-dev \
+        unzip \
+        mbsystem \
+        mbsystem-dev \
+        oracle-java8-installer \
+    ; \
+    rm -rf /var/lib/apt/lists/*; \
+    rm -rf /var/cache/oracle-jdk8-installer; \
+    update-alternatives --install /usr/bin/clang clang /usr/bin/clang-3.6 20; \
+    update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-3.6 20; \
+    ln -s /usr/lib/x86_64-linux-gnu/libvtkCommonCore-6.2.so /usr/lib/libvtkproj4.so; \
+    git clone https://github.com/hobu/nitro; \
+    cd nitro; \
+    mkdir build; \
+    cd build; \
+    cmake ..\
+        -DCMAKE_INSTALL_PREFIX=/usr \
+    ; \
+    make; \
+    make install; \
+    cd /; \
+    rm -rf /nitro; \
+    git clone https://github.com/LASzip/LASzip.git laszip; \
+    cd laszip; \
+    git checkout e7065cbc5bdbbe0c6e50c9d93d1cd346e9be6778; \
+    mkdir build; \
+    cd build; \
+    cmake .. \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_BUILD_TYPE="Release" \
+    ; \
+    make; \
+    make install; \
+    cd /; \
+    rm -rf /laszip; \
+    git clone https://github.com/hobu/hexer.git; \
+    cd hexer; \
+    mkdir build; \
+    cd build; \
+    cmake .. \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_BUILD_TYPE="Release" \
+    ; \
+    make; \
+    make install; \
+    cd /; \
+    rm -rf /hexer; \
+    git clone  https://github.com/hobu/laz-perf.git; \
+    cd laz-perf; \
+    mkdir build; \
+    cd build; \
+    cmake .. \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_BUILD_TYPE="Release" \
+    ; \
+    make; \
+    make install; \
+    cd /; \
+    rm -rf /laz-perf; \
+    wget http://bitbucket.org/eigen/eigen/get/3.2.7.tar.gz; \
+    tar -xvf 3.2.7.tar.gz; \
+    cp -R eigen-eigen-b30b87236a1b/Eigen/ /usr/include/Eigen/; \
+    cp -R eigen-eigen-b30b87236a1b/unsupported/ /usr/include/unsupported/; \
+    rm -rf /3.2.7.tar.gz; \
+    rm -rf /eigen-eigen-b30b87236a1b; \
+    svn co -r 2691 https://svn.osgeo.org/metacrs/geotiff/trunk/libgeotiff/; \
+    cd libgeotiff; \
+    ./autogen.sh; \
+    ./configure --prefix=/usr; \
+    make; \
+    make install; \
+    cd /; \
+    rm -rf /libgeotiff; \
+    git clone --depth 1 --branch v0.4.6 https://github.com/gadomski/fgt.git; \
+    cd fgt; \
+    cmake . \
+        -DWITH_TESTS=OFF \
+        -DBUILD_SHARED_LIBS=ON \
+        -DEIGEN3_INCLUDE_DIR=/usr/include \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_BUILD_TYPE=Release \
+    ; \
+    make; \
+    make install; \
+    cd /; \
+    rm -rf /fgt; \
+    git clone --depth 1 --branch v0.5.0 https://github.com/gadomski/cpd.git; \
+    cd cpd; \
+    cmake . \
+        -DWITH_TESTS=OFF \
+        -DWITH_JSONCPP=OFF \
+        -DWITH_FGT=ON \
+        -DWITH_STRICT_WARNINGS=OFF \
+        -DWITH_DOCS=OFF \
+        -DEIGEN3_INCLUDE_DIR=/usr/include \
+        -DBUILD_SHARED_LIBS=ON \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_BUILD_TYPE=Release \
+    ; \
+    make; \
+    make install; \
+    cd /; \
+    rm -rf /cpd; \
+    mkdir /vdatum; \
+    cd /vdatum; \
+    wget http://download.osgeo.org/proj/vdatum/usa_geoid2012.zip && unzip -j -u usa_geoid2012.zip -d /usr/share/proj; \
+    wget http://download.osgeo.org/proj/vdatum/usa_geoid2009.zip && unzip -j -u usa_geoid2009.zip -d /usr/share/proj; \
+    wget http://download.osgeo.org/proj/vdatum/usa_geoid2003.zip && unzip -j -u usa_geoid2003.zip -d /usr/share/proj; \
+    wget http://download.osgeo.org/proj/vdatum/usa_geoid1999.zip && unzip -j -u usa_geoid1999.zip -d /usr/share/proj; \
+    wget http://download.osgeo.org/proj/vdatum/vertcon/vertconc.gtx && mv vertconc.gtx /usr/share/proj; \
+    wget http://download.osgeo.org/proj/vdatum/vertcon/vertcone.gtx && mv vertcone.gtx /usr/share/proj; \
+    wget http://download.osgeo.org/proj/vdatum/vertcon/vertconw.gtx && mv vertconw.gtx /usr/share/proj; \
+    wget http://download.osgeo.org/proj/vdatum/egm96_15/egm96_15.gtx && mv egm96_15.gtx /usr/share/proj; \
+    wget http://download.osgeo.org/proj/vdatum/egm08_25/egm08_25.gtx && mv egm08_25.gtx /usr/share/proj; \
+    cd /; \
+    rm -rf /vdatum; \
+    wget https://github.com/PDAL/PDAL/archive/1.5-maintenance.tar.gz; \
+    tar -xf 1.5-maintenance.tar.gz; \
+    rm 1.5-maintenance.tar.gz; \
+    cd /PDAL-1.5-maintenance; \
+    mkdir build; \
+    cd build; \
+    cmake .. \
+        -DBUILD_PLUGIN_CPD=ON \
+        -DBUILD_PLUGIN_MBIO=ON \
+        -DBUILD_PLUGIN_GREYHOUND=ON \
+        -DBUILD_PLUGIN_HEXBIN=ON \
+        -DBUILD_PLUGIN_ICEBRIDGE=ON \
+        -DBUILD_PLUGIN_MRSID=ON \
+        -DBUILD_PLUGIN_NITF=ON \
+        -DBUILD_PLUGIN_OCI=OFF \
+        -DBUILD_PLUGIN_PCL=ON \
+        -DBUILD_PLUGIN_PGPOINTCLOUD=ON \
+        -DBUILD_PLUGIN_SQLITE=ON \
+        -DBUILD_PLUGIN_RIVLIB=OFF \
+        -DBUILD_PLUGIN_PYTHON=ON \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DENABLE_CTEST=OFF \
+        -DWITH_APPS=ON \
+        -DWITH_LAZPERF=ON \
+        -DWITH_LASZIP=ON \
+        -DWITH_TESTS=ON \
+        -DWITH_PDAL_JNI=ON \
+        -DCMAKE_BUILD_TYPE=Release \
+    ; \
+    make -j2; \
+    make install; \
+    cd /; \
+    rm -rf /PDAL; \
+    pip install packaging; \
+    pip install PDAL; \
+    git clone https://github.com/PDAL/PRC.git; \
+    cd PRC; \
+    git checkout master; \
+    mkdir build; \
+    cd build; \
+    cmake .. \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DPDAL_DIR=/usr/lib/pdal/cmake \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+    ; \
+    make; \
+    make install; \
+    cd /; \
+    rm -rf /PRC; \
+    apt-get purge -y \
+        build-essential \
+        ca-certificates \
+        cmake \
+        curl \
+        gfortran \
+        git \
+        libarmadillo-dev \
+        libarpack2-dev \
+        libflann-dev \
+        libhdf5-serial-dev \
+        liblapack-dev \
+        libtiff5-dev \
+        openssh-client \
+        python-dev \
+        python-numpy \
+        python-software-properties \
+        software-properties-common \
+        wget \
+        automake \
+        libtool \
+        libspatialite-dev \
+        libhdf5-dev \
+        subversion \
+        libjsoncpp-dev \
+        libboost-filesystem1.58-dev \
+        libboost-iostreams1.58-dev \
+        libboost-program-options1.58-dev \
+        libboost-system1.58-dev \
+        libboost-thread1.58-dev \
+        subversion \
+        clang \
+        libproj-dev \
+        libc6-dev \
+        libnetcdf-dev \
+        libjasper-dev \
+        libpng-dev \
+        libjpeg-dev \
+        libgif-dev \
+        libwebp-dev \
+        libhdf4-alt-dev \
+        libhdf5-dev \
+        libpq-dev \
+        libxerces-c-dev \
+        unixodbc-dev \
+        libsqlite3-dev \
+        libgeos-dev \
+        libmysqlclient-dev \
+        libltdl-dev \
+        libcurl4-openssl-dev \
+        libspatialite-dev \
+        libdap-dev\
+        cython \
+        python-pip \
+    ; \
+    apt-get autoremove -y; \
+    apt-get update; \
+    apt-get install -y \
+        libexpat1 \
+        libgomp1 \
+        libxml2 \
+        libgeos-c1v5 \
+        libjsoncpp1 \
+        libcurl3 \
+        libarmadillo6 \
+        libwebp5 \
+        libodbc1 \
+        odbcinst1debian2 \
+        libxerces-c3.1 \
+        libjasper1 \
+        netcdf-bin \
+        libhdf4-0-alt \
+        libgif7 \
+        libpq5 \
+        libdapclient6v5 \
+        libspatialite7 \
+        libsqlite3-mod-spatialite \
+        spatialite-bin \
+        libmysqlclient20 \
+        libtiff5 \
+        libboost-system1.58.0 \
+        libboost-filesystem1.58.0 \
+        libboost-thread1.58.0 \
+        libboost-program-options1.58.0 \
+        libboost-iostreams1.58.0 \
+        libboost-date-time1.58.0 \
+        libboost-serialization1.58.0 \
+        libboost-chrono1.58.0 \
+        libboost-atomic1.58.0 \
+        libboost-regex1.58.0 \
+        libgdal1i \
+        libflann1.8 \
+        libpython2.7 \
+        libhdf5-cpp-11 \
+        libpcl-common1.7 \
+        libpcl-features1.7 \
+        libpcl-filters1.7 \
+        libpcl-io1.7 \
+        libpcl-kdtree1.7 \
+        libpcl-keypoints1.7 \
+        libpcl-octree1.7 \
+        libpcl-outofcore1.7 \
+        libpcl-people1.7 \
+        libpcl-recognition1.7 \
+        libpcl-registration1.7 \
+        libpcl-sample-consensus1.7 \
+        libpcl-search1.7 \
+        libpcl-segmentation1.7 \
+        libpcl-surface1.7 \
+        libpcl-tracking1.7 \
+        libpcl-visualization1.7
+

--- a/scripts/docker/master/alpine/Dockerfile
+++ b/scripts/docker/master/alpine/Dockerfile
@@ -1,0 +1,95 @@
+FROM alpine:edge
+
+RUN \
+    echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories; \
+    apk update; \
+    apk add --no-cache --virtual .build-deps \
+        alpine-sdk \
+        unzip \
+        cmake \
+        eigen-dev \
+        hexer-dev \
+        nitro-dev \
+        gdal-dev \
+        geos-dev \
+        laz-perf-dev \
+        libgeotiff-dev \
+        libxml2-dev \
+        python-dev \
+        py-numpy-dev \
+        jsoncpp-dev \
+        hdf5-dev \
+        proj4-dev \
+        cpd-dev \
+        fgt-dev \
+        sqlite-dev \
+        postgresql-dev \
+        curl-dev \
+        linux-headers \
+        laszip-dev \
+        libspatialite-dev \
+    ; \
+    apk add --no-cache \
+        hexer \
+        nitro \
+        gdal \
+        geos \
+        laz-perf \
+        libgeotiff \
+        libxml2 \
+        python \
+        py-numpy \
+        jsoncpp \
+        hdf5 \
+        proj4 \
+        cpd \
+        fgt \
+        sqlite \
+        postgresql \
+        libcurl \
+        laszip \
+        libspatialite \
+    ;\
+    mkdir /vdatum; \
+    cd /vdatum; \
+    wget http://download.osgeo.org/proj/vdatum/usa_geoid2012.zip && unzip -j -u usa_geoid2012.zip -d /usr/share/proj; \
+    wget http://download.osgeo.org/proj/vdatum/usa_geoid2009.zip && unzip -j -u usa_geoid2009.zip -d /usr/share/proj; \
+    wget http://download.osgeo.org/proj/vdatum/usa_geoid2003.zip && unzip -j -u usa_geoid2003.zip -d /usr/share/proj; \
+    wget http://download.osgeo.org/proj/vdatum/usa_geoid1999.zip && unzip -j -u usa_geoid1999.zip -d /usr/share/proj; \
+    wget http://download.osgeo.org/proj/vdatum/vertcon/vertconc.gtx && mv vertconc.gtx /usr/share/proj; \
+    wget http://download.osgeo.org/proj/vdatum/vertcon/vertcone.gtx && mv vertcone.gtx /usr/share/proj; \
+    wget http://download.osgeo.org/proj/vdatum/vertcon/vertconw.gtx && mv vertconw.gtx /usr/share/proj; \
+    wget http://download.osgeo.org/proj/vdatum/egm96_15/egm96_15.gtx && mv egm96_15.gtx /usr/share/proj; \
+    wget http://download.osgeo.org/proj/vdatum/egm08_25/egm08_25.gtx && mv egm08_25.gtx /usr/share/proj; \
+    cd /; \
+    rm -rf /vdatum; \
+    wget https://github.com/PDAL/PDAL/archive/master.tar.gz; \
+    tar -xf master.tar.gz; \
+    rm master.tar.gz; \
+    cd /PDAL-master; \
+    mkdir -p _build; \
+    cd _build; \
+    cmake .. \
+        -G "Unix Makefiles" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_C_COMPILER=gcc \
+        -DCMAKE_CXX_COMPILER=g++ \
+        -DCMAKE_MAKE_PROGRAM=make \
+        -DBUILD_PLUGIN_PYTHON=ON \
+        -DBUILD_PLUGIN_CPD=ON \
+        -DBUILD_PLUGIN_GREYHOUND=ON \
+        -DBUILD_PLUGIN_HEXBIN=ON \
+        -DBUILD_PLUGIN_NITF=ON \
+        -DBUILD_PLUGIN_ICEBRIDGE=ON \
+        -DBUILD_PLUGIN_PGPOINTCLOUD=ON \
+        -DBUILD_PLUGIN_SQLITE=ON \
+        -DWITH_LASZIP=ON \
+        -DWITH_LAZPERF=ON \
+    ; \
+    make -j2; \
+    make install; \
+    cd /; \
+    rm -rf /PDAL-master; \
+    apk del .build-deps
+
+CMD ["pdal"]

--- a/scripts/docker/master/ubuntu/Dockerfile
+++ b/scripts/docker/master/ubuntu/Dockerfile
@@ -1,0 +1,357 @@
+FROM ubuntu:16.04
+MAINTAINER Howard Butler <howard@hobu.co>
+
+ENV CC gcc
+ENV CXX g++
+ENV JAVA_HOME /usr/lib/jvm/java-8-oracle
+
+RUN \
+    apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 16126D3A3E5C1192; \
+    apt-get update -qq; \
+    apt-get -qq remove postgis; \
+    echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | debconf-set-selections; \
+    apt-get install -y --fix-missing --no-install-recommends \
+        software-properties-common \
+    ; \
+    add-apt-repository -y ppa:webupd8team/java; \
+    add-apt-repository ppa:ubuntugis/ubuntugis-unstable -y; \
+    apt-get update; \
+    apt-get install -y --fix-missing --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        cmake \
+        curl \
+        gfortran \
+        git \
+        libarmadillo-dev \
+        libarpack2-dev \
+        libflann-dev \
+        libhdf5-serial-dev \
+        liblapack-dev \
+        libtiff5-dev \
+        openssh-client \
+        python-dev \
+        python-numpy \
+        python-software-properties \
+        wget \
+        automake \
+        libtool \
+        libspatialite-dev \
+        libsqlite3-mod-spatialite \
+        libhdf5-dev \
+        subversion \
+        libjsoncpp-dev \
+        libboost-filesystem1.58-dev \
+        libboost-iostreams1.58-dev \
+        libboost-program-options1.58-dev \
+        libboost-system1.58-dev \
+        libboost-thread1.58-dev \
+        subversion \
+        clang \
+        clang-3.6 \
+        libproj-dev \
+        libc6-dev \
+        libnetcdf-dev \
+        libjasper-dev \
+        libpng-dev \
+        libjpeg-dev \
+        libgif-dev \
+        libwebp-dev \
+        libhdf4-alt-dev \
+        libhdf5-dev \
+        libpq-dev \
+        libxerces-c-dev \
+        unixodbc-dev \
+        libsqlite3-dev \
+        libgeos-dev \
+        libmysqlclient-dev \
+        libltdl-dev \
+        libcurl4-openssl-dev \
+        libspatialite-dev \
+        libdap-dev\
+        cython \
+        python-pip \
+        libgdal1-dev \
+        gdal-bin \
+        libpcl-dev \
+        time \
+        libhpdf-dev \
+        python-setuptools \
+        libgeos++-dev \
+        libhpdf-dev \
+        unzip \
+        mbsystem \
+        mbsystem-dev \
+        oracle-java8-installer \
+    ; \
+    rm -rf /var/lib/apt/lists/*; \
+    rm -rf /var/cache/oracle-jdk8-installer; \
+    update-alternatives --install /usr/bin/clang clang /usr/bin/clang-3.6 20; \
+    update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-3.6 20; \
+    ln -s /usr/lib/x86_64-linux-gnu/libvtkCommonCore-6.2.so /usr/lib/libvtkproj4.so; \
+    git clone https://github.com/hobu/nitro; \
+    cd nitro; \
+    mkdir build; \
+    cd build; \
+    cmake ..\
+        -DCMAKE_INSTALL_PREFIX=/usr \
+    ; \
+    make; \
+    make install; \
+    cd /; \
+    rm -rf /nitro; \
+    git clone https://github.com/LASzip/LASzip.git laszip; \
+    cd laszip; \
+    git checkout e7065cbc5bdbbe0c6e50c9d93d1cd346e9be6778; \
+    mkdir build; \
+    cd build; \
+    cmake .. \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_BUILD_TYPE="Release" \
+    ; \
+    make; \
+    make install; \
+    cd /; \
+    rm -rf /laszip; \
+    git clone https://github.com/hobu/hexer.git; \
+    cd hexer; \
+    mkdir build; \
+    cd build; \
+    cmake .. \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_BUILD_TYPE="Release" \
+    ; \
+    make; \
+    make install; \
+    cd /; \
+    rm -rf /hexer; \
+    git clone  https://github.com/hobu/laz-perf.git; \
+    cd laz-perf; \
+    mkdir build; \
+    cd build; \
+    cmake .. \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_BUILD_TYPE="Release" \
+    ; \
+    make; \
+    make install; \
+    cd /; \
+    rm -rf /laz-perf; \
+    wget http://bitbucket.org/eigen/eigen/get/3.2.7.tar.gz; \
+    tar -xvf 3.2.7.tar.gz; \
+    cp -R eigen-eigen-b30b87236a1b/Eigen/ /usr/include/Eigen/; \
+    cp -R eigen-eigen-b30b87236a1b/unsupported/ /usr/include/unsupported/; \
+    rm -rf /3.2.7.tar.gz; \
+    rm -rf /eigen-eigen-b30b87236a1b; \
+    svn co -r 2691 https://svn.osgeo.org/metacrs/geotiff/trunk/libgeotiff/; \
+    cd libgeotiff; \
+    ./autogen.sh; \
+    ./configure --prefix=/usr; \
+    make; \
+    make install; \
+    cd /; \
+    rm -rf /libgeotiff; \
+    git clone --depth 1 --branch v0.4.6 https://github.com/gadomski/fgt.git; \
+    cd fgt; \
+    cmake . \
+        -DWITH_TESTS=OFF \
+        -DBUILD_SHARED_LIBS=ON \
+        -DEIGEN3_INCLUDE_DIR=/usr/include \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_BUILD_TYPE=Release \
+    ; \
+    make; \
+    make install; \
+    cd /; \
+    rm -rf /fgt; \
+    git clone --depth 1 --branch v0.5.0 https://github.com/gadomski/cpd.git; \
+    cd cpd; \
+    cmake . \
+        -DWITH_TESTS=OFF \
+        -DWITH_JSONCPP=OFF \
+        -DWITH_FGT=ON \
+        -DWITH_STRICT_WARNINGS=OFF \
+        -DWITH_DOCS=OFF \
+        -DEIGEN3_INCLUDE_DIR=/usr/include \
+        -DBUILD_SHARED_LIBS=ON \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_BUILD_TYPE=Release \
+    ; \
+    make; \
+    make install; \
+    cd /; \
+    rm -rf /cpd; \
+    mkdir /vdatum; \
+    cd /vdatum; \
+    wget http://download.osgeo.org/proj/vdatum/usa_geoid2012.zip && unzip -j -u usa_geoid2012.zip -d /usr/share/proj; \
+    wget http://download.osgeo.org/proj/vdatum/usa_geoid2009.zip && unzip -j -u usa_geoid2009.zip -d /usr/share/proj; \
+    wget http://download.osgeo.org/proj/vdatum/usa_geoid2003.zip && unzip -j -u usa_geoid2003.zip -d /usr/share/proj; \
+    wget http://download.osgeo.org/proj/vdatum/usa_geoid1999.zip && unzip -j -u usa_geoid1999.zip -d /usr/share/proj; \
+    wget http://download.osgeo.org/proj/vdatum/vertcon/vertconc.gtx && mv vertconc.gtx /usr/share/proj; \
+    wget http://download.osgeo.org/proj/vdatum/vertcon/vertcone.gtx && mv vertcone.gtx /usr/share/proj; \
+    wget http://download.osgeo.org/proj/vdatum/vertcon/vertconw.gtx && mv vertconw.gtx /usr/share/proj; \
+    wget http://download.osgeo.org/proj/vdatum/egm96_15/egm96_15.gtx && mv egm96_15.gtx /usr/share/proj; \
+    wget http://download.osgeo.org/proj/vdatum/egm08_25/egm08_25.gtx && mv egm08_25.gtx /usr/share/proj; \
+    cd /; \
+    rm -rf /vdatum; \
+    wget https://github.com/PDAL/PDAL/archive/master.tar.gz; \
+    tar -xf master.tar.gz; \
+    rm master.tar.gz; \
+    cd /PDAL-master; \
+    mkdir build; \
+    cd build; \
+    cmake .. \
+        -DBUILD_PLUGIN_CPD=OFF \
+        -DBUILD_PLUGIN_MBIO=ON \
+        -DBUILD_PLUGIN_GREYHOUND=ON \
+        -DBUILD_PLUGIN_HEXBIN=ON \
+        -DBUILD_PLUGIN_ICEBRIDGE=ON \
+        -DBUILD_PLUGIN_MRSID=ON \
+        -DBUILD_PLUGIN_NITF=ON \
+        -DBUILD_PLUGIN_OCI=OFF \
+        -DBUILD_PLUGIN_PCL=ON \
+        -DBUILD_PLUGIN_PGPOINTCLOUD=ON \
+        -DBUILD_PLUGIN_SQLITE=ON \
+        -DBUILD_PLUGIN_RIVLIB=OFF \
+        -DBUILD_PLUGIN_PYTHON=ON \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DENABLE_CTEST=OFF \
+        -DWITH_APPS=ON \
+        -DWITH_LAZPERF=ON \
+        -DWITH_LASZIP=ON \
+        -DWITH_TESTS=ON \
+        -DWITH_PDAL_JNI=ON \
+        -DCMAKE_BUILD_TYPE=Release \
+    ; \
+    make -j2; \
+    make install; \
+    cd /; \
+    rm -rf /PDAL; \
+    pip install packaging; \
+    pip install PDAL; \
+    git clone https://github.com/PDAL/PRC.git; \
+    cd PRC; \
+    git checkout master; \
+    mkdir build; \
+    cd build; \
+    cmake .. \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DPDAL_DIR=/usr/lib/pdal/cmake \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+    ; \
+    make; \
+    make install; \
+    cd /; \
+    rm -rf /PRC; \
+    apt-get purge -y \
+        build-essential \
+        ca-certificates \
+        cmake \
+        curl \
+        gfortran \
+        git \
+        libarmadillo-dev \
+        libarpack2-dev \
+        libflann-dev \
+        libhdf5-serial-dev \
+        liblapack-dev \
+        libtiff5-dev \
+        openssh-client \
+        python-dev \
+        python-numpy \
+        python-software-properties \
+        software-properties-common \
+        wget \
+        automake \
+        libtool \
+        libspatialite-dev \
+        libhdf5-dev \
+        subversion \
+        libjsoncpp-dev \
+        libboost-filesystem1.58-dev \
+        libboost-iostreams1.58-dev \
+        libboost-program-options1.58-dev \
+        libboost-system1.58-dev \
+        libboost-thread1.58-dev \
+        subversion \
+        clang \
+        libproj-dev \
+        libc6-dev \
+        libnetcdf-dev \
+        libjasper-dev \
+        libpng-dev \
+        libjpeg-dev \
+        libgif-dev \
+        libwebp-dev \
+        libhdf4-alt-dev \
+        libhdf5-dev \
+        libpq-dev \
+        libxerces-c-dev \
+        unixodbc-dev \
+        libsqlite3-dev \
+        libgeos-dev \
+        libmysqlclient-dev \
+        libltdl-dev \
+        libcurl4-openssl-dev \
+        libspatialite-dev \
+        libdap-dev\
+        cython \
+        python-pip \
+    ; \
+    apt-get autoremove -y; \
+    apt-get update; \
+    apt-get install -y \
+        libexpat1 \
+        libgomp1 \
+        libxml2 \
+        libgeos-c1v5 \
+        libjsoncpp1 \
+        libcurl3 \
+        libarmadillo6 \
+        libwebp5 \
+        libodbc1 \
+        odbcinst1debian2 \
+        libxerces-c3.1 \
+        libjasper1 \
+        netcdf-bin \
+        libhdf4-0-alt \
+        libgif7 \
+        libpq5 \
+        libdapclient6v5 \
+        libspatialite7 \
+        libsqlite3-mod-spatialite \
+        spatialite-bin \
+        libmysqlclient20 \
+        libtiff5 \
+        libboost-system1.58.0 \
+        libboost-filesystem1.58.0 \
+        libboost-thread1.58.0 \
+        libboost-program-options1.58.0 \
+        libboost-iostreams1.58.0 \
+        libboost-date-time1.58.0 \
+        libboost-serialization1.58.0 \
+        libboost-chrono1.58.0 \
+        libboost-atomic1.58.0 \
+        libboost-regex1.58.0 \
+        libgdal1i \
+        libflann1.8 \
+        libpython2.7 \
+        libhdf5-cpp-11 \
+        libpcl-common1.7 \
+        libpcl-features1.7 \
+        libpcl-filters1.7 \
+        libpcl-io1.7 \
+        libpcl-kdtree1.7 \
+        libpcl-keypoints1.7 \
+        libpcl-octree1.7 \
+        libpcl-outofcore1.7 \
+        libpcl-people1.7 \
+        libpcl-recognition1.7 \
+        libpcl-registration1.7 \
+        libpcl-sample-consensus1.7 \
+        libpcl-search1.7 \
+        libpcl-segmentation1.7 \
+        libpcl-surface1.7 \
+        libpcl-tracking1.7 \
+        libpcl-visualization1.7
+


### PR DESCRIPTION
This PR converts the Travis build scripts to use Alpine. It is not a 100% match to the plugins that are built and tested in the current Ubuntu system, but it should be very close.

The PR also adds Dockerfiles to build images for both Ubuntu and Alpine on the master, 1.4-maintenance, and 1.5-maintenance branches. Automated builds can, if desired, be setup to point directly to these Dockerfile variants.