### PR TITLE
Refine ignore patterns for build directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,8 +76,10 @@ test/data/local
 #
 .DS_Store
 
-_build
-build
+/_build*
+/build*
+/*local*.bat
+/*local*.sh
 Makefile
 doc/build
 bin/


### PR DESCRIPTION
Add build.local.sh and build.local.bat to ignored patterns.
For example, ignore variety `_build.{platform}` or `_build.{compiler}`

---

A tiny life hack ;-)