### PR TITLE
Add ability to groupby list of DimRanges

### DIFF
--- a/doc/stages/filters.groupby.rst
+++ b/doc/stages/filters.groupby.rst
@@ -3,13 +3,17 @@
 filters.groupby
 ===============================================================================
 
-The groupby filter takes a single PointView as its input and creates a PointView
-for each category in the named ``dimension`` as its output.
+The groupby filter takes a single PointView as its input and creates an output
+PointView for each category in the named ``dimension`` or each range in
+``ranges``.
 
 .. embed::
 
-Example
--------
+Example #1
+----------
+
+The first example pipeline will create a new output PointView for each unique
+classification value.
 
 .. code-block:: json
 
@@ -24,8 +28,35 @@ Example
       ]
     }
 
+Example #2
+----------
+
+The second example pipeline will create a new output PointView for each
+specified range, in this case a ``ReturnNumber`` of 1, or a ``ReturnNumber`` of
+anything but 1.
+
+.. code-block:: json
+
+    {
+      "pipeline":[
+        "input.las",
+        {
+          "type":"filters.groupby",
+          "ranges":"ReturnNumber[1:1],ReturnNumber![1:1]"
+        },
+        "output_#.las"
+      ]
+    }
+
 Options
 -------
 
 dimension
   The dimension containing data to be grouped.
+
+ranges
+  A comma-separated list of :ref:`ranges` to be grouped.
+
+.. warning::
+
+    You must specify exactly one of either ``dimension`` or ``ranges``.

--- a/filters/GroupByFilter.cpp
+++ b/filters/GroupByFilter.cpp
@@ -42,9 +42,9 @@
 namespace pdal
 {
 
-static PluginInfo const s_info =
-    PluginInfo("filters.groupby", "Split data categorically by dimension.",
-               "http://pdal.io/stages/filters.groupby.html");
+static PluginInfo const s_info = PluginInfo(
+    "filters.groupby", "Group data categorically by dimension or range.",
+    "http://pdal.io/stages/filters.groupby.html");
 
 CREATE_STATIC_PLUGIN(1, 0, GroupByFilter, Filter, s_info)
 

--- a/filters/GroupByFilter.cpp
+++ b/filters/GroupByFilter.cpp
@@ -1,5 +1,5 @@
 /******************************************************************************
- * Copyright (c) 2016, Bradley J Chambers (brad.chambers@gmail.com)
+ * Copyright (c) 2016-2017, Bradley J Chambers (brad.chambers@gmail.com)
  *
  * All rights reserved.
  *
@@ -37,6 +37,8 @@
 #include <pdal/pdal_macros.hpp>
 #include <pdal/util/ProgramArgs.hpp>
 
+#include "private/DimRange.hpp"
+
 namespace pdal
 {
 
@@ -47,7 +49,8 @@ static PluginInfo const s_info =
 CREATE_STATIC_PLUGIN(1, 0, GroupByFilter, Filter, s_info)
 
 GroupByFilter::GroupByFilter() : m_viewMap()
-{}
+{
+}
 
 std::string GroupByFilter::getName() const
 {
@@ -56,16 +59,64 @@ std::string GroupByFilter::getName() const
 
 void GroupByFilter::addArgs(ProgramArgs& args)
 {
-    args.add("dimension", "Dimension containing data to be grouped", m_dimName);
+    m_dimArg = &args.add("dimension", "Dimension containing data to be grouped",
+                         m_dimName);
+    m_rngArg = &args.add("ranges", "Ranges to be grouped", m_rangeSpec);
+}
+
+void GroupByFilter::initialize()
+{
+    if (m_dimArg->set() && m_rngArg->set())
+        throwError(
+            "Can't specify both option 'dimension' and option 'ranges'.");
+    if (!m_dimArg->set() && !m_rngArg->set())
+        throwError(
+            "Must specify either option 'dimension' or option 'ranges'.");
+
+    if (m_rngArg->set())
+    {
+        // Would be better to have the range know how to read from an input
+        // stream.
+        for (auto const& r : m_rangeSpec)
+        {
+            try
+            {
+                DimRange range;
+                range.parse(r);
+                m_range_list.push_back(range);
+            }
+            catch (const DimRange::error& err)
+            {
+                throwError("Invalid 'ranges' option: '" + r +
+                           "': " + err.what());
+            }
+        }
+    }
 }
 
 void GroupByFilter::prepared(PointTableRef table)
 {
-    PointLayoutPtr layout(table.layout());
-    m_dimId = layout->findDim(m_dimName);
-    if (m_dimId == Dimension::Id::Unknown)
-        throwError("Invalid dimension name '" + m_dimName + "'.");
-    // also need to check that we have a dimension with discrete values
+    const PointLayoutPtr layout(table.layout());
+
+    if (m_dimArg->set())
+    {
+        m_dimId = layout->findDim(m_dimName);
+        if (m_dimId == Dimension::Id::Unknown)
+            throwError("Invalid dimension name '" + m_dimName + "'.");
+        // also need to check that we have a dimension with discrete values
+    }
+
+    if (m_rngArg->set())
+    {
+        for (auto& r : m_range_list)
+        {
+            r.m_id = layout->findDim(r.m_name);
+            if (r.m_id == Dimension::Id::Unknown)
+                throwError("Invalid dimension name in 'ranges' option: '" +
+                           r.m_name + "'.");
+        }
+        std::sort(m_range_list.begin(), m_range_list.end());
+    }
 }
 
 PointViewSet GroupByFilter::run(PointViewPtr inView)
@@ -74,19 +125,37 @@ PointViewSet GroupByFilter::run(PointViewPtr inView)
     if (!inView->size())
         return viewSet;
 
-    for (PointId idx = 0; idx < inView->size(); idx++)
+    if (m_dimArg->set())
     {
-        uint64_t val = inView->getFieldAs<uint64_t>(m_dimId, idx);
-        PointViewPtr& outView = m_viewMap[val];
-        if (!outView)
-            outView = inView->makeNew();
-        outView->appendPoint(*inView.get(), idx);
+        for (PointId idx = 0; idx < inView->size(); idx++)
+        {
+            uint64_t val = inView->getFieldAs<uint64_t>(m_dimId, idx);
+            PointViewPtr& outView = m_viewMap[val];
+            if (!outView)
+                outView = inView->makeNew();
+            outView->appendPoint(*inView.get(), idx);
+        }
+
+        // Pull the buffers out of the map and stick them in the standard
+        // output set.
+        for (auto bi = m_viewMap.begin(); bi != m_viewMap.end(); ++bi)
+            viewSet.insert(bi->second);
+    }
+    else if (m_rngArg->set())
+    {
+        for (auto const& r : m_range_list)
+        {
+            PointViewPtr outView = inView->makeNew();
+            for (PointId idx = 0; idx < inView->size(); idx++)
+            {
+                PointRef point = inView->point(idx);
+                if (r.valuePasses(point.getFieldAs<double>(r.m_id)))
+                    outView->appendPoint(*inView, idx);
+            }
+            viewSet.insert(outView);
+        }
     }
 
-    // Pull the buffers out of the map and stick them in the standard
-    // output set.
-    for (auto bi = m_viewMap.begin(); bi != m_viewMap.end(); ++bi)
-        viewSet.insert(bi->second);
     return viewSet;
 }
 

--- a/filters/GroupByFilter.hpp
+++ b/filters/GroupByFilter.hpp
@@ -1,5 +1,5 @@
 /******************************************************************************
- * Copyright (c) 2016, Bradley J Chambers (brad.chambers@gmail.com)
+ * Copyright (c) 2016-2017, Bradley J Chambers (brad.chambers@gmail.com)
  *
  * All rights reserved.
  *
@@ -37,6 +37,8 @@
 #include <pdal/Filter.hpp>
 #include <pdal/plugin.hpp>
 
+#include "private/DimRange.hpp"
+
 #include <map>
 #include <string>
 
@@ -54,21 +56,26 @@ class PDAL_DLL GroupByFilter : public Filter
 public:
     GroupByFilter();
 
-    static void * create();
-    static int32_t destroy(void *);
+    static void* create();
+    static int32_t destroy(void*);
     std::string getName() const;
 
 private:
     std::map<uint64_t, PointViewPtr> m_viewMap;
     std::string m_dimName;
     Dimension::Id m_dimId;
+    StringList m_rangeSpec;
+    std::vector<DimRange> m_range_list;
+    Arg* m_dimArg;
+    Arg* m_rngArg;
 
     virtual void addArgs(ProgramArgs& args);
+    virtual void initialize();
     virtual void prepared(PointTableRef table);
     virtual PointViewSet run(PointViewPtr view);
 
     GroupByFilter& operator=(const GroupByFilter&); // not implemented
-    GroupByFilter(const GroupByFilter&); // not implemented
+    GroupByFilter(const GroupByFilter&);            // not implemented
 };
 
 } // namespace pdal


### PR DESCRIPTION
Inspired by recent mailing list question, this is at least one possible solution to being able to split into multiple PointViews such as `ReturnNumber == 1` and `ReturnNumber != 1` natively within PDAL versus subsetting in Python.