### PR TITLE
Build PDAL Python package for Docker images on master branch

### DIFF
--- a/scripts/docker/master/alpine/Dockerfile
+++ b/scripts/docker/master/alpine/Dockerfile
@@ -28,6 +28,8 @@ RUN \
         linux-headers \
         laszip-dev \
         libspatialite-dev \
+        cython-dev \
+        py-packaging \
     ; \
     apk add --no-cache \
         hexer \
@@ -49,6 +51,7 @@ RUN \
         libcurl \
         laszip \
         libspatialite \
+        py-setuptools \
     ;\
     mkdir /vdatum; \
     cd /vdatum; \
@@ -88,6 +91,8 @@ RUN \
     ; \
     make -j2; \
     make install; \
+    cd ../python; \
+    python setup.py install; \
     cd /; \
     rm -rf /PDAL-master; \
     apk del .build-deps

--- a/scripts/docker/master/ubuntu/Dockerfile
+++ b/scripts/docker/master/ubuntu/Dockerfile
@@ -225,10 +225,11 @@ RUN \
     ; \
     make -j2; \
     make install; \
+    pip install packaging; \
+    cd ../python; \
+    python setup.py install; \
     cd /; \
     rm -rf /PDAL; \
-    pip install packaging; \
-    pip install PDAL; \
     git clone https://github.com/PDAL/PRC.git; \
     cd PRC; \
     git checkout master; \


### PR DESCRIPTION
The PDAL Python package available via PyPI may not be guaranteed to work with
the master branch. Rather than installing via pip, just build it during image
creation.