### PR TITLE
Get stage debug information from log level

### DIFF
--- a/pdal/Stage.cpp
+++ b/pdal/Stage.cpp
@@ -115,9 +115,9 @@ QuickInfo Stage::preview()
 {
     m_args.reset(new ProgramArgs);
     handleOptions();
-    pushLogLeader();
+    startLogging();
     QuickInfo qi = inspect();
-    popLogLeader();
+    stopLogging();
     return qi;
 }
 
@@ -131,18 +131,18 @@ void Stage::prepare(PointTableRef table)
         prev->prepare(table);
     }
     handleOptions();
-    pushLogLeader();
+    startLogging();
     l_initialize(table);
     initialize(table);
     addDimensions(table.layout());
     prepared(table);
-    popLogLeader();
+    stopLogging();
 }
 
 
 PointViewSet Stage::execute(PointTableRef table)
 {
-    pushLogLeader();
+    startLogging();
     table.finalize();
 
     PointViewSet views;
@@ -177,7 +177,6 @@ PointViewSet Stage::execute(PointTableRef table)
     // first on the list for table.
     for (auto it = views.rbegin(); it != views.rend(); it++)
         table.addSpatialReference((*it)->spatialReference());
-    gdal::ErrorHandler::getGlobalErrorHandler().set(m_log, isDebug());
 
     // Count the number of views and the number of points and faces so they're
     // available to stages.
@@ -216,7 +215,7 @@ PointViewSet Stage::execute(PointTableRef table)
         outViews.insert(temp.begin(), temp.end());
     }
     l_done(table);
-    popLogLeader();
+    stopLogging();
     m_pointCount = 0;
     m_faceCount = 0;
     return outViews;
@@ -248,9 +247,9 @@ void Stage::execute(StreamPointTable& table)
         {
             for (auto s : *this)
             {
-                s->pushLogLeader();
+                s->startLogging();
                 s->ready(table);
-                s->pushLogLeader();
+                s->stopLogging();
                 SpatialReference srs = s->getSpatialReference();
                 if (!srs.empty())
                     table.setSpatialReference(srs);
@@ -261,9 +260,9 @@ void Stage::execute(StreamPointTable& table)
         {
             for (auto s : *this)
             {
-                s->pushLogLeader();
+                s->startLogging();
                 s->l_done(table);
-                s->popLogLeader();
+                s->stopLogging();
             }
         }
     };
@@ -351,7 +350,7 @@ void Stage::execute(StreamPointTable& table, std::list<Stage *>& stages)
         PointRef point(table, idx);
         point_count_t pointLimit = table.capacity();
 
-        reader->pushLogLeader();
+        reader->startLogging();
         // When we get false back from a reader, we're done, so set
         // the point limit to the number of points processed in this loop
         // of the table.
@@ -365,7 +364,7 @@ void Stage::execute(StreamPointTable& table, std::list<Stage *>& stages)
             if (finished)
                 pointLimit = idx;
         }
-        reader->popLogLeader();
+        reader->stopLogging();
         srs = reader->getSpatialReference();
         if (!srs.empty())
             table.setSpatialReference(srs);
@@ -380,7 +379,7 @@ void Stage::execute(StreamPointTable& table, std::list<Stage *>& stages)
                 s->spatialReferenceChanged(srs);
                 srsMap[s] = srs;
             }
-            s->pushLogLeader();
+            s->startLogging();
             for (PointId idx = 0; idx < pointLimit; idx++)
             {
                 if (skips[idx])
@@ -392,7 +391,7 @@ void Stage::execute(StreamPointTable& table, std::list<Stage *>& stages)
             srs = s->getSpatialReference();
             if (!srs.empty())
                 table.setSpatialReference(srs);
-            s->popLogLeader();
+            s->stopLogging();
         }
 
         // Yes, vector<bool> is terrible.  Can do something better later.
@@ -436,8 +435,7 @@ void Stage::setupLog()
         m_logLeader += " ";
     m_logLeader += getName();
 
-    bool debug(l > LogLevel::Debug);
-    gdal::ErrorHandler::getGlobalErrorHandler().set(m_log, debug);
+    gdal::ErrorHandler::getGlobalErrorHandler().set(m_log, isDebug());
 }
 
 
@@ -516,6 +514,19 @@ bool Stage::parseTagName(std::string o, std::string::size_type& pos)
 void Stage::throwError(const std::string& s) const
 {
     throw pdal_error(getName() + ": " + s);
+}
+
+
+void Stage::startLogging() const
+{
+    m_log->pushLeader(m_logLeader);
+    gdal::ErrorHandler::getGlobalErrorHandler().set(m_log, isDebug());
+}
+
+
+void Stage::stopLogging() const
+{
+    m_log->popLeader();
 }
 
 } // namespace pdal

--- a/pdal/Stage.cpp
+++ b/pdal/Stage.cpp
@@ -49,8 +49,8 @@
 namespace pdal
 {
 
-Stage::Stage() : m_progressFd(-1), m_debug(false), m_verbose(0),
-    m_pointCount(0), m_faceCount(0)
+Stage::Stage() : m_progressFd(-1), m_verbose(0), m_pointCount(0),
+    m_faceCount(0)
 {}
 
 
@@ -177,7 +177,7 @@ PointViewSet Stage::execute(PointTableRef table)
     // first on the list for table.
     for (auto it = views.rbegin(); it != views.rend(); it++)
         table.addSpatialReference((*it)->spatialReference());
-    gdal::ErrorHandler::getGlobalErrorHandler().set(m_log, m_debug);
+    gdal::ErrorHandler::getGlobalErrorHandler().set(m_log, isDebug());
 
     // Count the number of views and the number of points and faces so they're
     // available to stages.

--- a/pdal/Stage.hpp
+++ b/pdal/Stage.hpp
@@ -228,14 +228,12 @@ public:
     /**
       Push the stage's leader into the log.
     */
-    void pushLogLeader() const
-        { m_log->pushLeader(m_logLeader); }
+    void startLogging() const;
 
     /**
         Pop the stage's leader from the log.
     */
-    void popLogLeader() const
-        { m_log->popLeader(); }
+    void stopLogging() const;
 
     /**
       Determine whether the stage is in debug mode or not.

--- a/pdal/Stage.hpp
+++ b/pdal/Stage.hpp
@@ -243,7 +243,7 @@ public:
       \return  The stage's debug state.
     */
     bool isDebug() const
-        { return m_debug; }
+        { return m_log && m_log->getLevel() > LogLevel::Debug; }
 
     /**
       Return the name of a stage.
@@ -346,7 +346,6 @@ protected:
     }
 
 private:
-    bool m_debug;
     uint32_t m_verbose;
     std::string m_logname;
     std::vector<Stage *> m_inputs;


### PR DESCRIPTION
Stage was using a dead variable, m_debug.  This PR bases the state of debugging on the log level.  It also consolidates the log changes so that the GDAL logging goes along with the PDAL logging.