### PR TITLE
Updated smrf's out directory parameter reference

### DIFF
--- a/doc/stages/filters.smrf.rst
+++ b/doc/stages/filters.smrf.rst
@@ -42,7 +42,7 @@ cell
 cut
   Cut net size (``cut=0`` skips the net cutting step). [Default: **0.0**]
 
-outdir
+dir
   Optional output directory for debugging intermediate rasters.
 
 scalar


### PR DESCRIPTION
Per https://github.com/PDAL/PDAL/blob/master/filters/SMRFilter.cpp#L87 this should be `dir`, not `outdir`.