### PR TITLE
Remove '..' in configured temp path for unit tests

### DIFF
--- a/test/unit/Support.cpp
+++ b/test/unit/Support.cpp
@@ -72,7 +72,7 @@ std::string Support::configuredpath(const std::string& file)
 
 std::string Support::temppath()
 {
-    return TestConfig::dataPath() + "../temp/";
+    return TestConfig::tempPath();
 }
 
 std::string Support::temppath(const std::string& file)

--- a/test/unit/TestConfig.hpp.in
+++ b/test/unit/TestConfig.hpp.in
@@ -36,6 +36,7 @@
 #define UNITTEST_TESTCONFIG_INCLUDED
 
 #define UNITTEST_TESTCONFIG_DATA_PATH "@CMAKE_SOURCE_DIR@/test/data/"
+#define UNITTEST_TESTCONFIG_TEMP_PATH "@CMAKE_SOURCE_DIR@/test/temp/"
 #define UNITTEST_TESTCONFIG_CONFIGURED_PATH "@CMAKE_BINARY_DIR@/test/data/"
 #define UNITTEST_TESTCONFIG_BINARY_PATH "@CMAKE_BINARY_DIR@/bin/"
 #define UNITTEST_TESTCONFIG_OCI_CONNECTION "@OCI_CONNECTION@"
@@ -47,6 +48,9 @@ namespace TestConfig
 
 inline std::string dataPath()
     { return UNITTEST_TESTCONFIG_DATA_PATH; }
+
+inline std::string tempPath()
+    { return UNITTEST_TESTCONFIG_TEMP_PATH; }
 
 inline std::string configuredPath()
     { return UNITTEST_TESTCONFIG_CONFIGURED_PATH; }


### PR DESCRIPTION
musl has changed it's handling of '.' and '..' when globbing [1]. These only
recently made their way into the alpine:edge image that we use in Travis and
for Docker automated builds [2]. For now, we simply configure the temp path
directly, rather than relying on '..'.

[1] https://github.com/alpinelinux/aports/blob/afdba0ba0b8c0e92c376e7f1bfb151c07bf654b6/main/musl/0068-fix-glob-descent-into-.-and-.-with-GLOB_PERIOD.patch
[2] http://www.openwall.com/lists/musl/2017/01/12/5