### PR TITLE
Use Alpine v3.6 for main and community, edge for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,10 @@ sudo: required
 services: docker
 
 before_install:
-  - docker pull alpine:edge
+  - docker pull alpine:3.6
 
 script:
-  - docker run -v $TRAVIS_BUILD_DIR:/pdal -t alpine:edge /bin/sh -c "/pdal/scripts/ci/script.sh"
+  - docker run -v $TRAVIS_BUILD_DIR:/pdal -t alpine:3.6 /bin/sh -c "/pdal/scripts/ci/script.sh"
 
 after_success:
   - echo "secure travis:" "$TRAVIS_SECURE_ENV_VARS"


### PR DESCRIPTION
Regardless of how we want to handle the issues outlined in #1703, this PR pins the Alpine base image at a more stable v3.6. Any dependencies in the `main` or `community` repositories will be installed from v3.6. We will still install dependencies in the `testing` repository from `edge`.

For more on the repositories, see [this](https://wiki.alpinelinux.org/wiki/Aports_what_is_edge).

Alpine releases are outlined [here](https://wiki.alpinelinux.org/wiki/Alpine_Linux:Releases).