### PR TITLE
Add option to remove empty output files

### DIFF
--- a/kernels/PipelineKernel.cpp
+++ b/kernels/PipelineKernel.cpp
@@ -89,6 +89,7 @@ void PipelineKernel::addSwitches(ProgramArgs& args)
     args.add("stdin,s", "Read pipeline from standard input", m_usestdin);
     args.add("stream", "Attempt to run pipeline in streaming mode.", m_stream);
     args.add("metadata", "Metadata filename", m_metadataFile);
+    args.add("remove-empty", "Remove the output file if it is empty and the output writer supports removal.", m_removeEmpty);
 }
 
 
@@ -119,7 +120,10 @@ int PipelineKernel::execute()
         m_manager.executeStream(table);
     }
     else
+    {
+        m_manager.setRemoveEmpty(m_removeEmpty);
         m_manager.execute();
+    }
 
     if (m_metadataFile.size())
     {

--- a/kernels/PipelineKernel.hpp
+++ b/kernels/PipelineKernel.hpp
@@ -69,6 +69,7 @@ private:
     int m_progressFd;
     bool m_usestdin;
     bool m_stream;
+    bool m_removeEmpty;
 };
 
 } // pdal

--- a/kernels/TranslateKernel.cpp
+++ b/kernels/TranslateKernel.cpp
@@ -87,6 +87,7 @@ void TranslateKernel::addSwitches(ProgramArgs& args)
         m_metadataFile);
     args.add("reader,r", "Reader type", m_readerType);
     args.add("writer,w", "Writer type", m_writerType);
+    args.add("remove-empty", "Remove output file if empty", m_removeEmpty);
 }
 
 
@@ -206,6 +207,7 @@ int TranslateKernel::execute()
             m_pipelineOutputFile);
         return 0;
     }
+    m_manager.setRemoveEmpty(m_removeEmpty);
     m_manager.execute();
     if (metaOut)
     {

--- a/kernels/TranslateKernel.hpp
+++ b/kernels/TranslateKernel.hpp
@@ -72,6 +72,7 @@ private:
     std::string m_writerType;
     std::string m_filterJSON;
     std::string m_metadataFile;
+    bool m_removeEmpty;
 };
 
 } // namespace pdal

--- a/pdal/FlexWriter.hpp
+++ b/pdal/FlexWriter.hpp
@@ -36,12 +36,24 @@
 #include <pdal/PDALUtils.hpp>
 #include <pdal/Scaling.hpp>
 #include <pdal/Writer.hpp>
+#include <pdal/util/FileUtils.hpp>
 
 namespace pdal
 {
 
 class PDAL_DLL FlexWriter : public Writer
 {
+public:
+    virtual bool canRemove() const
+    {
+        return true;
+    }
+
+    virtual void remove()
+    {
+        FileUtils::deleteFile(m_filename);
+    }
+
 protected:
     FlexWriter() : m_filenum(1)
     {}

--- a/pdal/PipelineManager.cpp
+++ b/pdal/PipelineManager.cpp
@@ -195,6 +195,9 @@ point_count_t PipelineManager::execute()
         PointViewPtr view = *pi;
         cnt += view->size();
     }
+    if (cnt == 0 && m_removeEmpty && s->canRemove()) {
+        s->remove();
+    }
     return cnt;
 }
 

--- a/pdal/PipelineManager.hpp
+++ b/pdal/PipelineManager.hpp
@@ -132,6 +132,8 @@ public:
     std::vector<Stage *> roots() const;
     std::vector<Stage *> leaves() const;
     void replace(Stage *sOld, Stage *sNew);
+    void setRemoveEmpty(bool removeEmpty)
+        { m_removeEmpty = removeEmpty; }
 
 private:
     void setOptions(Stage& stage, const Options& addOps);
@@ -147,6 +149,7 @@ private:
     int m_progressFd;
     std::istream *m_input;
     LogPtr m_log;
+    bool m_removeEmpty;
 
     PipelineManager& operator=(const PipelineManager&); // not implemented
     PipelineManager(const PipelineManager&); // not implemented

--- a/pdal/Stage.hpp
+++ b/pdal/Stage.hpp
@@ -311,6 +311,31 @@ public:
     */
     static bool parseTagName(std::string o, std::string::size_type& pos);
 
+    /**
+      Can the output from this stage be "removed"?
+
+      "Removed" usually means deleting a file from the filesystem, but it
+      doesn't have to.
+
+      \return Whether this stage can be removed.
+    */
+    virtual bool canRemove() const
+    {
+        return false;
+    }
+
+    /**
+      Remove this stage. Throws an exception if removal fails or this stage
+      can't be removed.
+
+      "Remove" usually means deleting a file from the filesystem, but it
+      doesn't have to.
+    */
+    virtual void remove()
+    {
+        this->throwError("This stage is not removable");
+    }
+
 protected:
     Options m_options;          ///< Stage's options.
     MetadataNode m_metadata;    ///< Stage's metadata.

--- a/test/unit/PipelineManagerTest.cpp
+++ b/test/unit/PipelineManagerTest.cpp
@@ -155,3 +155,31 @@ TEST(PipelineManagerTest, InputGlobbing)
     FileUtils::deleteFile(Support::temppath("globbed.las"));
 }
 
+TEST(PipelineManagerTest, RemoveEmpty)
+{
+    const char * outfile = "temp.las";
+    FileUtils::deleteFile(outfile);
+
+    PipelineManager mgr;
+    mgr.setRemoveEmpty(true);
+
+    Options optsR;
+    optsR.add("filename", Support::datapath("las/no-points.las"));
+    Stage& reader = mgr.addReader("readers.las");
+    reader.setOptions(optsR);
+
+    Options optsW;
+    optsW.add("filename", outfile);
+    Stage& writer = mgr.addWriter("writers.las");
+    writer.setInput(reader);
+    writer.setOptions(optsW);
+
+    point_count_t np = mgr.execute();
+    EXPECT_EQ(np, 0u);
+
+    EXPECT_TRUE(std::ifstream(outfile).fail());
+    if (!std::ifstream(outfile).fail()) {
+        FileUtils::deleteFile(outfile);
+    }
+}
+

--- a/test/unit/apps/TranslateTest.cpp
+++ b/test/unit/apps/TranslateTest.cpp
@@ -205,3 +205,14 @@ TEST(translateTest, t3)
     EXPECT_EQ(std::stoi(output), 1);
 #endif
 }
+
+TEST(translateTest, RemoveEmpty)
+{
+    std::string output;
+
+    std::string in = Support::datapath("las/no-points.las");
+    std::string out = Support::temppath("out.las");
+
+    EXPECT_EQ(runTranslate(in + " " + out + " --remove-empty", output), 0);
+    EXPECT_TRUE(std::ifstream(out).fail());
+}


### PR DESCRIPTION
So I've been using PDAL for some batch processing, and I ran into a case where a certain range filter would produce zero-point output files, scattered among non-zero-point files. I thought it might be nice if PDAL could clean these up for me. This patch is a stab at the idea, but the mechanisms are totally up for debate. Here's how I did it for this pass:

- `Stage`s can advertise that they support "removal" via a `canRemove` method, i.e. they have an
output that can be removed. For now, `FlexWriter` supports removal,
since it has a filename. `Stage`s also get a `remove` method that throws an error by default, since by default stages aren't removable.
- `PipelineManager` has a `m_removeEmpty` option, that checks the total
point count and if (a) the point count is zero, (b)
`m_removeEmpty` is true, and (c) the last stage supports removal,
removes the output.
- Both the pipeline and translate kernels get a `--remove-empty` option.