### PR TITLE
Supportobj

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,7 @@ endif()
 set(PDAL_UTIL_LIB_NAME pdal_util)
 set(PDAL_BOOST_LIB_NAME pdal_boost)
 set(PDAL_KAZHDAN_LIB_NAME pdal_kazhdan)
+set(PDAL_TEST_SUPPORT_OBJS pdal_test_support)
 
 set(CMAKE_INCLUDE_DIRECTORIES_PROJECT_BEFORE ON)
 

--- a/cmake/macros.cmake
+++ b/cmake/macros.cmake
@@ -162,14 +162,12 @@ macro(PDAL_ADD_TEST _name)
     set(oneValueArgs)
     set(multiValueArgs FILES LINK_WITH)
     cmake_parse_arguments(PDAL_ADD_TEST "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
-    set(common_srcs
-        ${PROJECT_SOURCE_DIR}/test/unit/Support.cpp
-    )
     if (WIN32)
         list(APPEND ${PDAL_ADD_TEST_FILES} ${PDAL_TARGET_OBJECTS})
         add_definitions("-DPDAL_DLL_EXPORT=1")
     endif()
-    add_executable(${_name} ${PDAL_ADD_TEST_FILES} ${common_srcs})
+    add_executable(${_name} ${PDAL_ADD_TEST_FILES}
+        $<TARGET_OBJECTS:${PDAL_TEST_SUPPORT_OBJS}>)
     target_include_directories(${_name} PRIVATE
         ${ROOT_DIR}
         ${PDAL_INCLUDE_DIR}

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -15,6 +15,16 @@ foreach(infileName ${inFiles})
         "${CMAKE_BINARY_DIR}/${outfileName}")
 endforeach()
 
+add_library(${PDAL_TEST_SUPPORT_OBJS} OBJECT Support.cpp)
+target_include_directories(${PDAL_TEST_SUPPORT_OBJS}
+    PRIVATE
+        ${ROOT_DIR}
+        ${PROJECT_BINARY_DIR}/include
+        ${PROJECT_BINARY_DIR}/test/unit
+        ${PDAL_INCLUDE_DIR}
+)
+PDAL_TARGET_COMPILE_SETTINGS(${PDAL_TEST_SUPPORT_OBJS})
+
 PDAL_ADD_TEST(pdal_bounds_test FILES BoundsTest.cpp)
 PDAL_ADD_TEST(pdal_config_test FILES ConfigTest.cpp)
 PDAL_ADD_TEST(pdal_eigen_test FILES EigenTest.cpp)

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -16,6 +16,7 @@ foreach(infileName ${inFiles})
 endforeach()
 
 add_library(${PDAL_TEST_SUPPORT_OBJS} OBJECT Support.cpp)
+add_dependencies(${PDAL_TEST_SUPPORT_OBJS} generate_dimension_hpp)
 target_include_directories(${PDAL_TEST_SUPPORT_OBJS}
     PRIVATE
         ${ROOT_DIR}


### PR DESCRIPTION
Treat Support.obj as a cmake "object" library.  This means that it's only compiled once, rather than once for each test.