### PR TITLE
Fix python install

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -189,6 +189,7 @@ setup_args = dict(
         'Topic :: Scientific/Engineering :: GIS',
     ],
     cmdclass           = {},
+    install_requires   = ['numpy', 'packaging'],
 )
 setup(ext_modules=extensions, **setup_args)
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -16,7 +16,6 @@ import os
 import platform
 import sys
 import numpy
-from Cython.Build import cythonize
 
 USE_CYTHON = True
 try:


### PR DESCRIPTION
`pip install pdal` on a fairly clean system results in a few errors. If Cython is not installed the setup script raises an exception. The same happens when numpy and packaging are not installed.

This PR should fix that. The first problems is fixed by removing the initial import of Cython and relying on the import guarded by `try` just below. The second by adding installation requirements. 