### PR TITLE
WIP Issue1749

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,25 +12,9 @@ plugins/pgpointcloud/Pgtest-Support.hpp
 #
 # cmake stuff
 #
-PDALConfig.cmake
-PDALConfigVersion.cmake
-PDALTargets.cmake
-CMakeCache.txt
-CMakeFiles/
-CPackConfig.cmake
-CPackSourceConfig.cmake
-cmake_install.cmake
-CTestTestfile.cmake
-Testing/
-test/temp/
 apps/pdal-config
-apps/pdal-config.bat
-apps/pdal.pc
-src/CMakeScripts/
-apps/CMakeScripts/
-CMakeScripts/
-_CPack_Packages/
-install_manifest.txt
+apps/Makefile
+
 
 #
 # visual studio cruft
@@ -90,6 +74,8 @@ pdal/gitsha.cpp
 test/unit/TestConfig.hpp
 *.pyc
 
+test/data/autzen/autzen-interpolate.json
+test/data/autzen/hag.py
 test/data/bpf/bpf.xml
 test/data/bpf/bpf2nitf.xml
 test/data/filters/attribute.xml
@@ -113,8 +99,10 @@ test/data/filters/reproject.xml
 test/data/filters/sort.xml
 test/data/filters/splitter.xml
 test/data/filters/stats.xml
+test/data/filters/pcl/passthrough.json
 test/data/hole/crop.xml
 test/data/icebridge/pipeline.xml
+test/data/icebridge/pipeline.json
 test/data/io/p2g-writer.xml
 test/data/io/sqlite-reader.xml
 test/data/io/sqlite-writer.xml
@@ -150,6 +138,8 @@ test/data/qfit/little-endian-conversion.xml
 test/data/qfit/pipeline.xml
 test/data/qfit/reader.xml
 test/data/sbet/pipeline.xml
+test/data/sbet/pipeline.json
+
 
 python/*.egg*
 python/build/*

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ plugins/pgpointcloud/Pgtest-Support.hpp
 #
 # cmake stuff
 #
+build
 apps/pdal-config
 apps/Makefile
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,15 @@ set(ROOT_DIR "${PROJECT_SOURCE_DIR}")
 include(${ROOT_DIR}/cmake/common.cmake NO_POLICY_SCOPE)
 
 #------------------------------------------------------------------------------
+# This prevents cmake to be executed in the source directory
+#------------------------------------------------------------------------------
+if ( ${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR} )
+    message(FATAL_ERROR "In-source builds not allowed.
+    Please make a new directory (called a build directory) and run CMake from there.
+    You may need to remove CMakeCache.txt." )
+endif()
+
+#------------------------------------------------------------------------------
 # internal cmake settings
 #------------------------------------------------------------------------------
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -80,6 +80,8 @@ deploy:
       secure: 6DDLMtbxyT6amL3m5gmMObyL0ucWzIGxylinnYuMJPM=
     secret_access_key:
       secure: cSqZlsaCxFwXgxJw0BLd7npMFvQk3Vbr74ZPLaBQWLKnOz1cKss9qab1SzSygwkh
+    on:
+      branch: 1.6-maintenance
     bucket: "pdal"
     folder: "osgeo4w/"
     artifact: pdalosgeo4w

--- a/scripts/appveyor/build.cmd
+++ b/scripts/appveyor/build.cmd
@@ -1,1 +1,3 @@
+cd build
 nmake /f Makefile
+cd ..

--- a/scripts/appveyor/config.cmd
+++ b/scripts/appveyor/config.cmd
@@ -24,7 +24,7 @@ REM needed or else CMake won't find the Oracle library that OSGeo4W installs
 SET ORACLE_HOME="C:/OSGEO4W64/"
 
 mkdir build
-pushd build
+cd build
 cmake -G "NMake Makefiles" ^
     -DBUILD_PLUGIN_CPD=OFF ^
     -DBUILD_PLUGIN_GREYHOUND=%PDAL_OPTIONAL_COMPONENTS% ^
@@ -64,4 +64,4 @@ cmake -G "NMake Makefiles" ^
     -DBUILD_OCI_TESTS=OFF ^
     .
 
-popd
+cd ..

--- a/scripts/appveyor/config.cmd
+++ b/scripts/appveyor/config.cmd
@@ -23,6 +23,8 @@ REM needed or else CMake won't find the Oracle library that OSGeo4W installs
 
 SET ORACLE_HOME="C:/OSGEO4W64/"
 
+mkdir build
+pushd build
 cmake -G "NMake Makefiles" ^
     -DBUILD_PLUGIN_CPD=OFF ^
     -DBUILD_PLUGIN_GREYHOUND=%PDAL_OPTIONAL_COMPONENTS% ^
@@ -62,4 +64,4 @@ cmake -G "NMake Makefiles" ^
     -DBUILD_OCI_TESTS=OFF ^
     .
 
-
+popd


### PR DESCRIPTION
#1749 

## Tasks

- [x]  add the snipet
- [x]  make sure travis & appveyor tests pass
   - [x]  make changes if needed
- [x]   modify .gitignore to ignore build directory instead of all the "in source" stuff

## Additional task
- [x] appveyor: building the artifacts (similar to travis) only on  `1.6-maintenance` branch

## Links
- https://travis-ci.org/Georepublic/PDAL/builds/319797466
 https://ci.appveyor.com/project/Georepublic/pdal

## TODO
- appveyor send a message to Slack and I get:
  - "Error sending Slack notification: Value cannot be null. Parameter name: Either incoming webhook URL or Slack authentication token is required."
- Developers to try it out
  - use the `Step 1` of the `command line instructions` of the `Merge button`
  - keeps the source directory cleaner
  - You will need to remove the "in source" files
- Some tests I made locally fail , maybe because I did not compile with everything ON, or because of those JSON files that appeared on the source directory:
```
test/data/autzen/autzen-interpolate.json
test/data/autzen/hag.py
test/data/filters/pcl/passthrough.json
test/data/icebridge/pipeline.json
test/data/sbet/pipeline.json
```
These are the failing tests that I have:
```
The following tests FAILED:
          3 - pdal_filters_python_test (Failed)
          4 - sqlitetest (Failed)
         12 - pdal_log_test (Failed)
         16 - pdal_pipeline_manager_test (Failed)
         26 - pdal_support_test (Failed)
         35 - pdal_io_las_writer_test (Failed)
         67 - pdal_app_test (Failed)
         68 - pc2pc_test (Failed)
         69 - hausdorff_test (Failed)
         70 - random_test (Failed)
         71 - translate_test (Failed)
```
  But travis works, and its not an "in source" build, it makes the build in `_build` directory

