### PR TITLE
Remove warning: ignoring return value of VSILFILE* VSIFileFromMemBuff…

### DIFF
--- a/filters/ColorinterpFilter.cpp
+++ b/filters/ColorinterpFilter.cpp
@@ -67,6 +67,12 @@ std::string ColorinterpFilter::getName() const { return s_info.name; }
 // The VSIFILE* that VSIFileFromMemBuffer creates in this
 // macro is never cleaned up. We're opening seven PNGs in the
 // ColorInterpRamps-ramps.hpp header. We always open them so they're available.
+//
+// GDAL forces to keep track of the return value, and its being ignored here,
+// To avoid the warning message:
+// warning: ignoring return value of 'VSILFILE* VSIFileFromMemBuffer(....)'
+//          declared with attribute warn_unused_result [-Wunused-result]
+// Using a tmp variable
 #define GETRAMP(name) \
     if (pdal::Utils::iequals(#name, rampFilename)) \
     { \
@@ -75,7 +81,7 @@ std::string ColorinterpFilter::getName() const { return s_info.name; }
         location = name; \
         size = sizeof(name); \
         rampFilename = "/vsimem/" + std::string(#name) + ".png"; \
-        (void)VSIFileFromMemBuffer(rampFilename.c_str(), location, size, FALSE); \
+        auto tmp(VSIFileFromMemBuffer(rampFilename.c_str(), location, size, FALSE)); \
     }
 //
 std::shared_ptr<gdal::Raster> openRamp(std::string& rampFilename)


### PR DESCRIPTION
## Remove warning: ignoring return value of VSILFILE* VSIFileFromMemBuffer(....)

From:
https://travis-ci.org/PDAL/PDAL/builds/319810009#L795
```
Building CXX object CMakeFiles/pdal_base.dir/filters/ColorizationFilter.cpp.o
/pdal/filters/ColorinterpFilter.cpp: In function 'std::shared_ptr<pdal::gdal::Raster> pdal::openRamp(std::__cxx11::string&)':
/pdal/filters/ColorinterpFilter.cpp:78:80: warning: ignoring return value of 'VSILFILE* VSIFileFromMemBuffer(const char*, GByte*, vsi_l_offset, int)', declared with attribute warn_unused_result [-Wunused-result]
         (void)VSIFileFromMemBuffer(rampFilename.c_str(), location, size, FALSE); \
                                                                                ^
/pdal/filters/ColorinterpFilter.cpp:91:5: note: in expansion of macro 'GETRAMP'
     GETRAMP(awesome_green);
     ^~~~~~~
```

