### PR TITLE
appveyor: creating artifacts only on branch: 1.6-maintenance

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -80,6 +80,8 @@ deploy:
       secure: 6DDLMtbxyT6amL3m5gmMObyL0ucWzIGxylinnYuMJPM=
     secret_access_key:
       secure: cSqZlsaCxFwXgxJw0BLd7npMFvQk3Vbr74ZPLaBQWLKnOz1cKss9qab1SzSygwkh
+    on:
+      branch: 1.6-maintenance
     bucket: "pdal"
     folder: "osgeo4w/"
     artifact: pdalosgeo4w


### PR DESCRIPTION
Currently builds on all branches
Travis has a guard that only deploys if it is `1.6-maintenance` branch:
```
sh -c 'if test "$TRAVIS_SECURE_ENV_VARS" = "true" -a "$TRAVIS_BRANCH" = "1.6-maintenance";
```