### PR TITLE
Fix warn misleading indentation when compiling PoissonFilter.cpp

### DIFF
--- a/vendor/kazhdan/MultiGridOctreeData.Evaluation.inl
+++ b/vendor/kazhdan/MultiGridOctreeData.Evaluation.inl
@@ -306,7 +306,7 @@ V Octree< Real >::_getValue( const ConstPointSupportKey< FEMDegree >& neighborKe
 	LocalDepth d = _localDepth( node );
 
 	for( int dd=0 ; dd<3 ; dd++ )
-    {
+	{
 		if     ( p[dd]==0 ) p[dd] = (Real)(0.+1e-6);
 		else if( p[dd]==1 ) p[dd] = (Real)(1.-1e-6);
 
@@ -360,7 +360,7 @@ V Octree< Real >::_getValue( const ConstPointSupportKey< FEMDegree >& neighborKe
 				}
 			}
 		}
-    }
+	}
 	return value;
 }
 template< class Real >
@@ -415,7 +415,7 @@ std::pair< Real , Point3D< Real > > Octree< Real >::_getValueAndGradient( const 
 	LocalDepth d = _localDepth( node );
 
 	for( int dd=0 ; dd<3 ; dd++ )
-    {
+	{
 		if     ( p[dd]==0 ) p[dd] = (Real)(0.+1e-6);
 		else if( p[dd]==1 ) p[dd] = (Real)(1.-1e-6);
 
@@ -481,7 +481,7 @@ std::pair< Real , Point3D< Real > > Octree< Real >::_getValueAndGradient( const 
 				}
 			}
 		}
-    }
+	}
 	return std::pair< Real , Point3D< Real > >( value , gradient );
 }
 template< class Real >

--- a/vendor/kazhdan/MultiGridOctreeData.Evaluation.inl
+++ b/vendor/kazhdan/MultiGridOctreeData.Evaluation.inl
@@ -306,6 +306,7 @@ V Octree< Real >::_getValue( const ConstPointSupportKey< FEMDegree >& neighborKe
 	LocalDepth d = _localDepth( node );
 
 	for( int dd=0 ; dd<3 ; dd++ )
+    {
 		if     ( p[dd]==0 ) p[dd] = (Real)(0.+1e-6);
 		else if( p[dd]==1 ) p[dd] = (Real)(1.-1e-6);
 
@@ -359,7 +360,8 @@ V Octree< Real >::_getValue( const ConstPointSupportKey< FEMDegree >& neighborKe
 				}
 			}
 		}
-		return value;
+    }
+	return value;
 }
 template< class Real >
 template< int FEMDegree , BoundaryType BType >

--- a/vendor/kazhdan/MultiGridOctreeData.Evaluation.inl
+++ b/vendor/kazhdan/MultiGridOctreeData.Evaluation.inl
@@ -415,6 +415,7 @@ std::pair< Real , Point3D< Real > > Octree< Real >::_getValueAndGradient( const 
 	LocalDepth d = _localDepth( node );
 
 	for( int dd=0 ; dd<3 ; dd++ )
+    {
 		if     ( p[dd]==0 ) p[dd] = (Real)(0.+1e-6);
 		else if( p[dd]==1 ) p[dd] = (Real)(1.-1e-6);
 
@@ -480,7 +481,8 @@ std::pair< Real , Point3D< Real > > Octree< Real >::_getValueAndGradient( const 
 				}
 			}
 		}
-		return std::pair< Real , Point3D< Real > >( value , gradient );
+    }
+	return std::pair< Real , Point3D< Real > >( value , gradient );
 }
 template< class Real >
 template< class V , int FEMDegree , BoundaryType BType >

--- a/vendor/kazhdan/MultiGridOctreeData.h
+++ b/vendor/kazhdan/MultiGridOctreeData.h
@@ -694,11 +694,11 @@ public:
 				if( normal[0]!=0 || normal[1]!=0 || normal[2]!=0 ) return true;
 			}
 			if( node->children )
-            {
+			{
                 for( int c=0 ; c<(int)Cube::CORNERS ; c++ )
                     if( (*this)( node->children + c ) )
                         return true;
-            }
+			}
 			return false;
 		}
 	};

--- a/vendor/kazhdan/MultiGridOctreeData.h
+++ b/vendor/kazhdan/MultiGridOctreeData.h
@@ -693,10 +693,12 @@ public:
 				const Point3D< Real >& normal = *n;
 				if( normal[0]!=0 || normal[1]!=0 || normal[2]!=0 ) return true;
 			}
-			if( node->children ) {
+			if( node->children )
+            {
                 for( int c=0 ; c<(int)Cube::CORNERS ; c++ )
                     if( (*this)( node->children + c ) )
-                        return true; }
+                        return true;
+            }
 			return false;
 		}
 	};

--- a/vendor/kazhdan/MultiGridOctreeData.h
+++ b/vendor/kazhdan/MultiGridOctreeData.h
@@ -695,9 +695,9 @@ public:
 			}
 			if( node->children )
 			{
-                for( int c=0 ; c<(int)Cube::CORNERS ; c++ )
-                    if( (*this)( node->children + c ) )
-                        return true;
+				for( int c=0 ; c<(int)Cube::CORNERS ; c++ )
+					if( (*this)( node->children + c ) )
+					return true;
 			}
 			return false;
 		}

--- a/vendor/kazhdan/MultiGridOctreeData.h
+++ b/vendor/kazhdan/MultiGridOctreeData.h
@@ -693,10 +693,10 @@ public:
 				const Point3D< Real >& normal = *n;
 				if( normal[0]!=0 || normal[1]!=0 || normal[2]!=0 ) return true;
 			}
-			if( node->children )
+			if( node->children ) {
                 for( int c=0 ; c<(int)Cube::CORNERS ; c++ )
                     if( (*this)( node->children + c ) )
-                        return true;
+                        return true; }
 			return false;
 		}
 	};


### PR DESCRIPTION
From:
https://travis-ci.org/PDAL/PDAL/builds/320286569#L824
Several warnings of this kind show when compiling PoissonFilter.cpp
```
[ 16%] Building CXX object CMakeFiles/pdal_base.dir/filters/PoissonFilter.cpp.o
In file included from /pdal/vendor/kazhdan/PoissonRecon.h:49:0,
                 from /pdal/filters/PoissonFilter.cpp:40:
/pdal/vendor/kazhdan/MultiGridOctreeData.h: In member function 'bool Octree<Real>::HasNormalDataFunctor<NormalDegree>::operator()(const TreeOctNode*) const':
/pdal/vendor/kazhdan/MultiGridOctreeData.h:698:21: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
                     if( (*this)( node->children + c ) )
                     ^~
/pdal/vendor/kazhdan/MultiGridOctreeData.h:700:4: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
    return false;
```

Wrapping with `{` and `}`