### PR TITLE
Removed extra ";"

### DIFF
--- a/filters/MortonOrderFilter.cpp
+++ b/filters/MortonOrderFilter.cpp
@@ -60,7 +60,7 @@ namespace
 bool less_msb(const int& x, const int& y)
 {
     return x < y && x < (x ^ y);
-};
+}
 
 class CmpZOrder
 {

--- a/filters/SMRFilter.cpp
+++ b/filters/SMRFilter.cpp
@@ -522,7 +522,7 @@ std::vector<double> SMRFilter::knnfill(PointViewPtr view,
     }
 
     return out;
-};
+}
 
 // Iteratively open the estimated surface. progressiveFilter can be used to
 // identify both low points and object (i.e., non-ground) points, depending on

--- a/io/GDALReader.cpp
+++ b/io/GDALReader.cpp
@@ -49,7 +49,7 @@ static PluginInfo const s_info = PluginInfo(
         "http://pdal.io/stages/reader.gdal.html");
 
 
-CREATE_STATIC_PLUGIN(1, 0, GDALReader, Reader, s_info);
+CREATE_STATIC_PLUGIN(1, 0, GDALReader, Reader, s_info)
 
 
 std::string GDALReader::getName() const

--- a/io/GDALWriter.cpp
+++ b/io/GDALWriter.cpp
@@ -48,7 +48,7 @@ static PluginInfo const s_info = PluginInfo(
         "http://pdal.io/stages/writers.gdal.html");
 
 
-CREATE_STATIC_PLUGIN(1, 0, GDALWriter, Writer, s_info);
+CREATE_STATIC_PLUGIN(1, 0, GDALWriter, Writer, s_info)
 
 std::string GDALWriter::getName() const
 {

--- a/io/OGRWriter.cpp
+++ b/io/OGRWriter.cpp
@@ -58,7 +58,7 @@ static PluginInfo const s_info = PluginInfo(
         "http://pdal.io/stages/writers.ogr.html");
 
 
-CREATE_STATIC_PLUGIN(1, 0, OGRWriter, Writer, s_info);
+CREATE_STATIC_PLUGIN(1, 0, OGRWriter, Writer, s_info)
 
 OGRWriter::OGRWriter() : m_driver(nullptr), m_ds(nullptr), m_layer(nullptr),
     m_feature(nullptr)

--- a/io/OptechReader.cpp
+++ b/io/OptechReader.cpp
@@ -52,7 +52,7 @@ static PluginInfo const s_info = PluginInfo(
     "Optech reader support.",
     "http://pdal.io/stages/readers.optech.html" );
 
-CREATE_STATIC_PLUGIN(1, 0, OptechReader, Reader, s_info);
+CREATE_STATIC_PLUGIN(1, 0, OptechReader, Reader, s_info)
 
 std::string OptechReader::getName() const
 {

--- a/io/PlyReader.cpp
+++ b/io/PlyReader.cpp
@@ -49,7 +49,7 @@ static PluginInfo const s_info = PluginInfo(
         "Read ply files.",
         "http://pdal.io/stages/reader.ply.html");
 
-CREATE_STATIC_PLUGIN(1, 0, PlyReader, Reader, s_info);
+CREATE_STATIC_PLUGIN(1, 0, PlyReader, Reader, s_info)
 
 
 PlyReader::PlyReader() : m_vertexElt(nullptr)

--- a/pdal/EigenUtils.hpp
+++ b/pdal/EigenUtils.hpp
@@ -459,7 +459,7 @@ PDAL_DLL Derived gradX(const Eigen::MatrixBase<Derived>& A)
     out.col(out.cols()-1) = A.col(A.cols()-1) - A.col(A.cols()-2);
 
     return out;
-};
+}
 
 /**
   Compute the numerical gradient in the Y direction.
@@ -484,7 +484,7 @@ PDAL_DLL Derived gradY(const Eigen::MatrixBase<Derived>& A)
     out.row(out.rows()-1) = A.row(A.rows()-1) - A.row(A.rows()-2);
 
     return out;
-};
+}
 
 /**
   Compute contour curvature for a single 3x3 matrix.

--- a/pdal/PDALUtils.cpp
+++ b/pdal/PDALUtils.cpp
@@ -184,7 +184,7 @@ std::string tempFilename(const std::string& path)
     const std::string basename(arbiter::util::getBasename(path));
 
     return arbiter::util::join(tempdir, basename);
-};
+}
 #endif
 
 // RAII handling of a temp file to make sure file gets deleted.

--- a/plugins/sqlite/io/SQLiteWriter.hpp
+++ b/plugins/sqlite/io/SQLiteWriter.hpp
@@ -95,7 +95,7 @@ private:
     std::string m_cloudBoundary;
     long m_pcId;
     bool m_is3d;
-    bool m_doCompression;;
+    bool m_doCompression;
     bool m_overwrite;
     PatchPtr m_patch;
 };


### PR DESCRIPTION
I temporarily added the `-pedantic flag` and removed almost all the warnings of extra `;` it showed, and removed the flag.
I didn't fix the ones here:
https://travis-ci.org/Georepublic/PDAL/builds/322294088#L1076
because is almost modifying the whole file. When the real issue is on the way the macro is defined with a semicolon at the end.
