### PR TITLE
Fix compilation with gcc > 7

### DIFF
--- a/cmake/unix_compiler_options.cmake
+++ b/cmake/unix_compiler_options.cmake
@@ -1,8 +1,15 @@
 if (${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
     if (${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS 4.7)
         set(PDAL_CXX_STANDARD "-std=c++0x")
-    else()
+    elseif(${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS 7.0)
         set(PDAL_CXX_STANDARD "-std=c++11")
+    else()
+        set(PDAL_CXX_STANDARD
+            -std=c++11
+            -Wno-implicit-fallthrough
+            -Wno-int-in-bool-context
+            -Wno-dangling-else
+            -Wno-noexcept-type)
     endif()
     set(PDAL_COMPILER_GCC 1)
 elseif (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
@@ -28,7 +35,6 @@ function(PDAL_TARGET_COMPILE_SETTINGS target)
         -Wno-long-long
         -Wno-unknown-pragmas
         -Wno-deprecated-declarations
-        -Werror
         )
     target_include_directories(${target} SYSTEM PUBLIC /usr/local/include)
 endfunction()

--- a/pdal/compression/Compression.hpp
+++ b/pdal/compression/Compression.hpp
@@ -34,6 +34,7 @@
 #pragma once
 
 #include <pdal/pdal_internal.hpp>
+#include <functional>
 
 namespace pdal
 {


### PR DESCRIPTION
Hi,

I had to add some gcc flags as well as adding a header to successfully compile with gcc 7.2.0. 

BTW, the `-Werror` flag is currently duplicated so I removed the second one.

Let me know if you're interested in this PR and if I have to modify something.

And thank you for your work!