### PR TITLE
Fix laz-perf compression when the tmp buffer fills up

### DIFF
--- a/pdal/compression/LazPerfCompression.hpp
+++ b/pdal/compression/LazPerfCompression.hpp
@@ -306,6 +306,7 @@ public:
                 m_cb(reinterpret_cast<char *>(m_tmpbuf), CHUNKSIZE);
                 m_avail = CHUNKSIZE;
             }
+            buf += copyCnt;
             bufsize -= copyCnt;
         }
     }


### PR DESCRIPTION
`LazPerfCompressor::putBytes` did not advance the data buffer to be compressed when the tmp buffer was full - so the start of the buffer was re-written.