### PR TITLE
Allow dimension names to contain slashes for the assign/range filters.

### DIFF
--- a/pdal/DimUtil.hpp
+++ b/pdal/DimUtil.hpp
@@ -181,7 +181,7 @@ inline std::size_t extractName(const std::string& s, std::string::size_type p)
         return 0;
     auto isvalid = [](int c)
     {
-        return std::isalpha(c) || std::isdigit(c) || c == '_';
+        return std::isalpha(c) || std::isdigit(c) || c == '_' || c == '/';
     };
     return Utils::extract(s, p, isvalid) + 1;
 }


### PR DESCRIPTION
Dimension names with the `/` character mostly work within PDAL except for when they are parsed with `extractName`, used by the range and the assign filters.  This PR allows `/` characters in dimension names, which would allow an application to apply meaning to this if desired without it being disallowed by PDAL.

An example might be an application-level collaborative effort via Greyhound with different users  applying dimensions `connor/Ground` and `andrew/Ground` to the same resource.