### PR TITLE
Persist the proj4-dev package

### DIFF
--- a/scripts/docker/1.4-maintenance/alpine/Dockerfile
+++ b/scripts/docker/1.4-maintenance/alpine/Dockerfile
@@ -21,7 +21,6 @@ RUN \
         py-numpy-dev \
         jsoncpp-dev \
         hdf5-dev \
-        proj4-dev \
         sqlite-dev \
         postgresql-dev \
         curl-dev \
@@ -42,6 +41,7 @@ RUN \
         jsoncpp \
         hdf5 \
         proj4 \
+        proj4-dev \
         sqlite \
         postgresql \
         libcurl \

--- a/scripts/docker/1.5-maintenance/alpine/Dockerfile
+++ b/scripts/docker/1.5-maintenance/alpine/Dockerfile
@@ -21,7 +21,6 @@ RUN \
         py-numpy-dev \
         jsoncpp-dev \
         hdf5-dev \
-        proj4-dev \
         cpd-dev \
         fgt-dev \
         sqlite-dev \
@@ -44,6 +43,7 @@ RUN \
         jsoncpp \
         hdf5 \
         proj4 \
+        proj4-dev \
         cpd \
         fgt \
         sqlite \

--- a/scripts/docker/1.6-maintenance/alpine/Dockerfile
+++ b/scripts/docker/1.6-maintenance/alpine/Dockerfile
@@ -19,7 +19,6 @@ RUN \
         py-numpy-dev \
         jsoncpp-dev \
         hdf5-dev \
-        proj4-dev \
         cpd-dev \
         fgt-dev \
         sqlite-dev \
@@ -45,6 +44,7 @@ RUN \
         jsoncpp \
         hdf5 \
         proj4 \
+        proj4-dev \
         cpd \
         fgt \
         sqlite \

--- a/scripts/docker/master/alpine/Dockerfile
+++ b/scripts/docker/master/alpine/Dockerfile
@@ -19,7 +19,6 @@ RUN \
         py-numpy-dev \
         jsoncpp-dev \
         hdf5-dev \
-        proj4-dev \
         cpd-dev \
         fgt-dev \
         sqlite-dev \
@@ -48,6 +47,7 @@ RUN \
         jsoncpp \
         hdf5 \
         proj4 \
+        proj4-dev \
         cpd \
         zstd \
         xz \


### PR DESCRIPTION
proj4-dev contains the libproj.so symbolic link that GDAL expects. We need it
at runtime and cannot delete it as build-only dependency.