### PR TITLE
Remove superfluous semi-colon following CREATE_STATIC_PLUGIN

### DIFF
--- a/io/OGRWriterV1.cpp
+++ b/io/OGRWriterV1.cpp
@@ -58,7 +58,7 @@ static PluginInfo const s_info = PluginInfo(
         "http://pdal.io/stages/writers.ogr.html");
 
 
-CREATE_STATIC_PLUGIN(1, 0, OGRWriter, Writer, s_info);
+CREATE_STATIC_PLUGIN(1, 0, OGRWriter, Writer, s_info)
 
 OGRWriter::OGRWriter() : m_driver(nullptr), m_ds(nullptr), m_layer(nullptr),
     m_feature(nullptr)


### PR DESCRIPTION
Fixes GCC 5.6.0 error: `extra ‘;’ [-Werror=pedantic]`