### PR TITLE
Update Alpine version to 3.7 for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,10 @@ sudo: required
 services: docker
 
 before_install:
-  - docker pull alpine:3.6
+  - docker pull alpine:3.7
 
 script:
-  - docker run -v $TRAVIS_BUILD_DIR:/pdal -t alpine:3.6 /bin/sh -c "/pdal/scripts/ci/script.sh"
+  - docker run -v $TRAVIS_BUILD_DIR:/pdal -t alpine:3.7 /bin/sh -c "/pdal/scripts/ci/script.sh"
 
 after_success:
   - echo "secure travis:" "$TRAVIS_SECURE_ENV_VARS"


### PR DESCRIPTION
We have been pushing Docker images built on Alpine v3.7, but our Travis config
has been stuck back on v3.6. These should match.