### PR TITLE
Json

### DIFF
--- a/vendor/arbiter/CMakeLists.txt
+++ b/vendor/arbiter/CMakeLists.txt
@@ -13,7 +13,7 @@ endif()
 
 PDAL_ADD_FREE_LIBRARY(${PDAL_ARBITER_LIB_NAME} STATIC arbiter.cpp)
 target_include_directories(${PDAL_ARBITER_LIB_NAME} PRIVATE
-    ${PDAL_VENDOR_DIR}/jsoncpp/dist)
+    ${PDAL_JSONCPP_INCLUDE_DIR})
 target_link_libraries(${PDAL_ARBITER_LIB_NAME})
 #
 # Arbiter is built static but is included in a shared lib.

--- a/vendor/jsoncpp/dist/json/json.h
+++ b/vendor/jsoncpp/dist/json/json.h
@@ -209,8 +209,8 @@ typedef unsigned int LargestUInt;
 typedef __int64 Int64;
 typedef unsigned __int64 UInt64;
 #else                 // if defined(_MSC_VER) // Other platforms, use long long
-typedef long long int Int64;
-typedef unsigned long long int UInt64;
+typedef int64_t Int64;
+typedef uint64_t UInt64;
 #endif // if defined(_MSC_VER)
 typedef Int64 LargestInt;
 typedef UInt64 LargestUInt;


### PR DESCRIPTION
Fix arbiter's CMake to point to correct JSON header.
Fix JSON header to use standard native data types.