### PR TITLE
Fix segfault by checking bounds when adding a point to a GDALGrid.

### DIFF
--- a/io/GDALGrid.cpp
+++ b/io/GDALGrid.cpp
@@ -281,9 +281,7 @@ void GDALGrid::addPoint(double x, double y, double z)
     // This is a questionable case.  If a point is in a cell, shouldn't
     // it just be counted?
     double d = distance(iOrigin, jOrigin, x, y);
-    if (d < m_radius &&
-        iOrigin >= 0 && jOrigin >= 0 &&
-        iOrigin < (int)m_width && jOrigin <= (int)m_height)
+    if (d < m_radius)
         update(iOrigin, jOrigin, z, d);
 }
 
@@ -298,6 +296,10 @@ void GDALGrid::update(int i, int j, double val, double dist)
     // See
     // https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance
     // https://en.wikipedia.org/wiki/Inverse_distance_weighting
+
+    // Perform a bounds check before indexing into the various data arrays.
+    if(!validIndex(i, j))
+        return;
 
     size_t offset = index(i, j);
 

--- a/io/GDALGrid.hpp
+++ b/io/GDALGrid.hpp
@@ -103,6 +103,10 @@ private:
     size_t index(size_t i, size_t j)
         { return (j * m_width) + i; }
 
+    // Determine if a cell i, j is within the bounds of the grid.
+    bool validIndex(int i, int j)
+        { return i >= 0 && j >= 0 && i < (int)width() && j < (int)height(); }
+
     // Determine if a cell i, j has no associated points.
     bool empty(size_t i, size_t j)
         { return empty(index(i, j)); }


### PR DESCRIPTION
This pull request fixes out-of-bounds reads and writes when adding a point to a `GDALGrid`. It's related to #1563, but it handles all of the remaining edge cases. Here's an example of how to duplicate one of those edge cases:

1. Construct a grid with `width = 10; height = 10; edgeLength = 1; radius = 5`.
2. Call `GDALGrid::addPoint(-1000, 1, 0)`.
3. The first iteration for the first quadrant calls `GDALGrid::update` with a grid index of `-999,1`.
4. Out of bounds memory access; `-999, 1` doesn't fall within the bounds of the grid.

In keeping with the perceived intent of #1563, points that fall outside of the grid are silently ignored.