### PR TITLE
Protect GDALWriter from zero-point pipelines

### DIFF
--- a/io/GDALWriter.cpp
+++ b/io/GDALWriter.cpp
@@ -210,6 +210,10 @@ bool GDALWriter::processOne(PointRef& point)
 
 void GDALWriter::doneFile()
 {
+    if (!m_grid) {
+        throw pdal_error("Unable to write GDAL data, grid is uninitialized. You "
+                "might have provided the GDALWriter zero points.");
+    }
     std::array<double, 6> pixelToPos;
 
     pixelToPos[0] = m_curBounds.minx;


### PR DESCRIPTION
The GDALWriter throws a segfault due to an uninitialized `m_grid` member variable when trying to execute a pipeline that provides zero points to an upstream filter, e.g.:

```bash
pdal translate \
    -i test/data/las/no-points.las \
    -o /tmp/out.tif \
    -f range --filters.range.limits="Classification[2:2]" \
    --writers.gdal.resolution=1
```

I *think* this is due to `GDALWriter::writeView` never being called, so the grid is never initialized. My fix in this PR is to put a `if (!m_grid)` guard in `GDALWriter::doneFile()`.

Includes a test case.