### PR TITLE
Add edge/community package repository

### DIFF
--- a/scripts/ci/script.sh
+++ b/scripts/ci/script.sh
@@ -2,11 +2,12 @@
 # Builds and tests PDAL
 
 echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
+echo "@edgecommunity http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories; \
 apk update
 apk add \
     cmake \
     alpine-sdk \
-    eigen-dev \
+    eigen-dev@edgecommunity \
     hexer \
     hexer-dev \
     nitro \

--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -2,6 +2,7 @@ FROM alpine:3.7
 
 RUN \
     echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories; \
+    echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories; \
     apk update; \
     apk add --no-cache --virtual .build-deps \
         alpine-sdk \

--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -2,13 +2,13 @@ FROM alpine:3.7
 
 RUN \
     echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories; \
-    echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories; \
+    echo "@edgecommunity http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories; \
     apk update; \
     apk add --no-cache --virtual .build-deps \
         alpine-sdk \
         unzip \
         cmake \
-        eigen-dev \
+        eigen-dev@edgecommunity \
         hexer-dev \
         nitro-dev \
         gdal-dev \


### PR DESCRIPTION
eigen-dev has been moved from edge/testing to edge/community

Will need to backport this to maintenance branches as well, should their Docker images need to be rebuilt.