### PR TITLE
Use raster types as PDAL types when creating dimensions.

### DIFF
--- a/doc/stages/filters.colorization.rst
+++ b/doc/stages/filters.colorization.rst
@@ -110,7 +110,8 @@ raster
 
 dimensions
   A comma separated list of dimensions to populate with values from the raster
-  file. The format of each dimension is <name>:<band_number>:<scale_factor>.
+  file. Dimensions will be created if they don't already exist.  The format
+  of each dimension is <name>:<band_number>:<scale_factor>.
   Either or both of band number and scale factor may be omitted as may ':'
   separators if the data is not ambiguous.  If not supplied, band numbers
   begin at 1 and increment from the band number of the previous dimension.

--- a/filters/ColorizationFilter.cpp
+++ b/filters/ColorizationFilter.cpp
@@ -91,6 +91,8 @@ ColorizationFilter::BandInfo parseDim(const std::string& dim,
         band = std::strtoul(start, &end, 10);
         if (start == end)
             band = defaultBand;
+        if (band == 0)
+            throw std::string("Invalid band number 0. Bands start at 1.");
         pos += (end - start);
 
         count = Utils::extractSpaces(dim, pos);
@@ -147,8 +149,9 @@ void ColorizationFilter::initialize()
         {
             BandInfo bi = parseDim(dim, defaultBand);
             defaultBand = bi.m_band + 1;
-            if (bi.m_band < bandTypes.size())
-                bi.m_type = bandTypes[bi.m_band];
+            // Band types are 0 offset but band numbers are 1 offset.
+            if (bi.m_band <= bandTypes.size())
+                bi.m_type = bandTypes[bi.m_band - 1];
             m_bands.push_back(bi);
         }
         catch(const std::string& what)

--- a/filters/ColorizationFilter.hpp
+++ b/filters/ColorizationFilter.hpp
@@ -59,7 +59,7 @@ public:
     {
         BandInfo(const std::string& name, uint32_t band, double scale) :
             m_name(name), m_band(band), m_scale(scale),
-            m_dim(Dimension::Id::Unknown)
+            m_dim(Dimension::Id::Unknown), m_type(Dimension::Type::Double)
         {}
 
         BandInfo() : m_band(0), m_scale(1.0), m_dim(Dimension::Id::Unknown)
@@ -69,6 +69,7 @@ public:
         uint32_t m_band;
         double m_scale;
         Dimension::Id m_dim;
+        Dimension::Type m_type;
     };
 
 

--- a/io/GDALReader.cpp
+++ b/io/GDALReader.cpp
@@ -78,6 +78,7 @@ void GDALReader::initialize()
     }
 
     m_count = m_raster->width() * m_raster->height();
+    m_bandTypes = m_raster->getPDALDimensionTypes();
     m_raster->close();
 }
 
@@ -111,7 +112,7 @@ void GDALReader::addDimensions(PointLayoutPtr layout)
     {
         std::ostringstream oss;
         oss << "band-" << (i + 1);
-        layout->registerOrAssignDim(oss.str(), Dimension::Type::Double);
+        layout->registerOrAssignDim(oss.str(), m_bandTypes[i]);
     }
 }
 
@@ -142,13 +143,11 @@ point_count_t GDALReader::read(PointViewPtr view, point_count_t num)
     }
 
     std::vector<uint8_t> band;
-    std::vector<Dimension::Type> band_types =
-        m_raster->getPDALDimensionTypes();
 
     for (int b = 0; b < m_raster->bandCount(); ++b)
     {
         // Bands count from 1
-        switch (band_types[b])
+        switch (m_bandTypes[b])
         {
         case Dimension::Type::Signed8:
             readBandData<int8_t>(b + 1, view, count);

--- a/io/GDALReader.hpp
+++ b/io/GDALReader.hpp
@@ -72,6 +72,7 @@ private:
     void readBandData(int band, PointViewPtr view, point_count_t count);
 
     std::unique_ptr<gdal::Raster> m_raster;
+    std::vector<Dimension::Type> m_bandTypes;
     point_count_t m_index;
 
 };


### PR DESCRIPTION
This uses the raster type as the PDAL dimension type when we're creating data from a GDAL raster.  This ensures the that errors aren't thrown when reading a raster into a PDAL dimension and that no more memory is used than necessary.