### PR TITLE
Header skip

### DIFF
--- a/doc/stages/readers.text.rst
+++ b/doc/stages/readers.text.rst
@@ -71,13 +71,12 @@ filename
 separator
   Separator character to override that found in header line.
 
-header_override
-  String to override the first line in the file that would normally be used
-  as the header.
-
-header_insert
+header
   String to use as the file header.  All lines in the file as assumed to be
-  records containing point data.
+  records containing point data unless skipped with the 'skip' option.
+
+skip
+  Number of lines to ignore at the beginning of the file.
 
 count
   Maximum number of points to read [Optional]

--- a/io/LasReader.cpp
+++ b/io/LasReader.cpp
@@ -827,7 +827,6 @@ void LasReader::loadPointV10(PointRef& point, char *buf, size_t bufsize)
 #ifdef PDAL_HAVE_LASZIP
 void LasReader::loadPointV14(PointRef& point, laszip_point& p)
 {
-    std::cerr << "Load point 1.4!\n";
     const LasHeader& h = m_header;
 
     double x = p.X * h.scaleX() + h.offsetX();

--- a/io/TextReader.cpp
+++ b/io/TextReader.cpp
@@ -126,25 +126,29 @@ void TextReader::parseHeader(const std::string& header)
 
 void TextReader::initialize(PointTableRef table)
 {
-    if (m_headerInsert.size() && m_headerOverride.size())
-        throwError("Can't specify both 'header_insert' and 'header_override' "
-            "options.");
-
     m_istream = Utils::openFile(m_filename);
     if (!m_istream)
         throwError("Unable to open text file '" + m_filename + "'.");
 
+    // Skip lines requested.
+    std::string dummy;
+    for (size_t i = 0; i < m_skip; ++i)
+    {
+        std::getline(*m_istream, dummy);
+        m_line++;
+    }
+
     std::string header;
-    if (m_headerInsert.size())
-        header = m_headerInsert;
-    else if (m_headerOverride.size())
-        header = m_headerOverride;
+    if (m_header.size())
+        header = m_header;
     else
     {
         std::getline(*m_istream, header);
+        m_line++;
         checkHeader(header);
     }
 
+    m_dataStart = m_istream->tellg();
     parseHeader(header);
     Utils::closeFile(m_istream);
 }
@@ -154,10 +158,9 @@ void TextReader::addArgs(ProgramArgs& args)
 {
     args.add("separator", "Separator character that overrides special "
         "character found in header line", m_separator, ' ');
-    args.add("header_override", "Use this string as the header line.  Ignore "
-        "the first line in the file.", m_headerOverride);
-    args.add("header_insert", "Use this string as the header line. All "
-        "lines of the file are treated as data.", m_headerInsert);
+    args.add("header", "Use this string as the header line.", m_header);
+    args.add("skip", "Skip this number of lines before attempting to "
+        "read the header.", m_skip);
 }
 
 
@@ -183,15 +186,7 @@ void TextReader::ready(PointTableRef table)
     if (!m_istream)
         throwError("Unable to open text file '" + m_filename + "'.");
 
-    // Skip header line unless we're inserting one from the command line..
-    if (m_headerInsert.size())
-        m_line = 0;
-    else
-    {
-        std::string buf;
-        std::getline(*m_istream, buf);
-        m_line = 1;
-    }
+    m_istream->seekg(m_dataStart);
 }
 
 

--- a/io/TextReader.hpp
+++ b/io/TextReader.hpp
@@ -136,8 +136,9 @@ private:
     Dimension::IdList m_dims;
     StringList m_fields;
     size_t m_line;
-    std::string m_headerOverride;
-    std::string m_headerInsert;
+    std::string m_header;
+    size_t m_skip;
+    std::streampos m_dataStart;
 };
 
 } // namespace pdal

--- a/test/unit/io/TextReaderTest.cpp
+++ b/test/unit/io/TextReaderTest.cpp
@@ -225,11 +225,13 @@ TEST(TextReaderTest, warnMissingHeader)
         std::string::npos);
 }
 
+// Skip the file's header and use another in it's place.
 TEST(TextReaderTest, overrideHeader)
 {
     TextReader reader;
     Options options;
-    options.add("header_override", "A,B,C,G");
+    options.add("skip", 1);
+    options.add("header", "A,B,C,G");
     options.add("filename", Support::datapath("text/crlf_test.txt"));
     reader.setOptions(options);
 
@@ -250,7 +252,7 @@ TEST(TextReaderTest, insertHeader)
 {
     TextReader reader;
     Options options;
-    options.add("header_insert", "A,B,C,G");
+    options.add("header", "A,B,C,G");
     options.add("filename", Support::datapath("text/crlf_test.txt"));
     reader.setOptions(options);
 


### PR DESCRIPTION
Add ability to ignore lines at the head of the input file.
Change header option semantics.