### PR TITLE
Add enumerate option to info command

### DIFF
--- a/doc/apps/info.rst
+++ b/doc/apps/info.rst
@@ -29,6 +29,7 @@ Processing is performed with stream mode if possible.
   --stats                   Dump stats on all points (reads entire dataset)
   --boundary                Compute a hexagonal hull/boundary of dataset
   --dimensions              Dimensions on which to compute statistics
+  --enumerate               Dimensions whose values should be enumerated
   --schema                  Dump the schema
   --pipeline-serialization  Output filename for pipeline serialization
   --summary                 Dump summary of the info

--- a/kernels/InfoKernel.cpp
+++ b/kernels/InfoKernel.cpp
@@ -140,6 +140,8 @@ void InfoKernel::addSwitches(ProgramArgs& args)
         m_boundary);
     args.add("dimensions", "Dimensions on which to compute statistics",
         m_dimensions);
+    args.add("enumerate", "Dimensions whose values should be enumerated",
+        m_enumerate);
     args.add("schema", "Dump the schema", m_showSchema);
     args.add("pipeline-serialization", "Output filename for pipeline "
         "serialization", m_pipelineFile);
@@ -310,6 +312,8 @@ void InfoKernel::setup(const std::string& filename)
         Options filterOptions;
         if (m_dimensions.size())
             filterOptions.add({"dimensions", m_dimensions});
+        if (m_enumerate.size())
+            filterOptions.add({"enumerate", m_enumerate});
         m_statsStage = &m_manager.makeFilter("filters.stats", *stage,
             filterOptions);
         stage = m_statsStage;

--- a/kernels/InfoKernel.hpp
+++ b/kernels/InfoKernel.hpp
@@ -82,6 +82,7 @@ private:
     bool m_boundary;
     std::string m_pointIndexes;
     std::string m_dimensions;
+    std::string m_enumerate;
     std::string m_queryPoint;
     std::string m_pipelineFile;
     bool m_showSummary;


### PR DESCRIPTION
This adds the "enumerate" option to "info" command in order to set the Dimensions whose values should be enumerated by StatsFilter.