### PR TITLE
Improve stage overview documentation

### DIFF
--- a/doc/references.rst
+++ b/doc/references.rst
@@ -7,13 +7,21 @@ References
 .. index:: References
 
 
+.. [Alexa2003] Alexa, Marc, et al. "Computing and rendering point set surfaces." Visualization and Computer Graphics, IEEE Transactions on 9.1 (2003): 3-15.
+
 .. [Chen2012] Chen, Ziyue et al. “Upward-Fusion Urban DTM Generating Method Using Airborne Lidar Data.” ISPRS Journal of Photogrammetry and Remote Sensing 72 (2012): 121–130.
 
 .. [Cook1986] Cook, Robert L. "Stochastic sampling in computer graphics." *ACM Transactions on Graphics (TOG)* 5.1 (1986): 51-72.
 
 .. [Dippe1985] Dippé, Mark AZ, and Erling Henry Wold. "Antialiasing through stochastic sampling." *ACM Siggraph Computer Graphics* 19.3 (1985): 69-78.
 
+.. [Kazhdan2006] Kazhdan, Michael, Matthew Bolitho, and Hugues Hoppe. "Poisson surface reconstruction." Proceedings of the fourth Eurographics symposium on Geometry processing. Vol. 7. 2006.
+
+.. [Li2010] Li, Ruosi, et al. "Polygonizing extremal surfaces with manifold guarantees." Proceedings of the 14th ACM Symposium on Solid and Physical Modeling. ACM, 2010.
+
 .. [Mesh2009] ALoopingIcon. "Meshing Point Clouds." *MESHLAB STUFF*. n.p., 7 Sept. 2009. Web. 13 Nov. 2015.
+
+.. [Mongus2012] Mongus, D., Zalik, B., 2012. Parameter-free ground filtering of LiDAR data for automatic DTM generation. ISPRS J. Photogramm. Remote Sens. 67, 1–12.
 
 .. [Pingel2013] Pingel, Thomas J., Keith C. Clarke, and William A. McBride. “An Improved Simple Morphological Filter for the Terrain Classification of Airborne LIDAR Data.” ISPRS Journal of Photogrammetry and Remote Sensing 77 (2013): 21–30.
 

--- a/doc/stages/filters.gridprojection.rst
+++ b/doc/stages/filters.gridprojection.rst
@@ -10,8 +10,6 @@ GridProjection algorithm.
 GridProjection is an implementation of the surface reconstruction method
 described in [Li2010]_.
 
-.. [Li2010] Li, Ruosi, et al. "Polygonizing extremal surfaces with manifold guarantees." Proceedings of the 14th ACM Symposium on Solid and Physical Modeling. ACM, 2010.
-
 .. _`PCL`: http://www.pointclouds.org
 
 .. plugin::

--- a/doc/stages/filters.mongus.rst
+++ b/doc/stages/filters.mongus.rst
@@ -23,8 +23,6 @@ Some warts about the current implementation:
 * We require specification of a max level, whereas the original paper
   automatically determined an appropriate max level.
 
-.. [Mongus2012] Mongus, D., Zalik, B., 2012. Parameter-free ground filtering of LiDAR data for automatic DTM generation. ISPRS J. Photogramm. Remote Sens. 67, 1–12.
-
 .. embed::
 
 Example

--- a/doc/stages/filters.movingleastsquares.rst
+++ b/doc/stages/filters.movingleastsquares.rst
@@ -12,8 +12,6 @@ algorithm for data smoothing and improved normal estimation described in
 [Alexa2003]_. It also contains methods for upsampling the resulting cloud based
 on the parametric fit.
 
-.. [Alexa2003] Alexa, Marc, et al. "Computing and rendering point set surfaces." Visualization and Computer Graphics, IEEE Transactions on 9.1 (2003): 3-15.
-
 .. _`PCL`: http://www.pointclouds.org
 
 .. plugin::

--- a/doc/stages/filters.poisson.rst
+++ b/doc/stages/filters.poisson.rst
@@ -19,8 +19,6 @@ limited ability to impute associated data.  However, if color dimensions
 (red, green and blue) are present in the input, colors will be reconstruced
 in the output point set.
 
-.. [Kazhdan2006] Kazhdan, Michael, Matthew Bolitho, and Hugues Hoppe. "Poisson surface reconstruction." Proceedings of the fourth Eurographics symposium on Geometry processing. Vol. 7. 2006.
-
 This integration of the algorithm with PDAL only supports a limited set of
 the options available to the implementation.  If you need support for further
 options, please let us know.
@@ -70,4 +68,3 @@ depth
   Maximum depth of the tree used for reconstruction. The output is sentsitve
   to this parameter.  Increase if the results appear unsatisfactory.
   [Default: **8**]
-

--- a/doc/stages/filters.rst
+++ b/doc/stages/filters.rst
@@ -3,14 +3,377 @@
 Filters
 =======
 
-Filters operate on data as inline operations. They can remove, modify, reorganize,
-and add points to the data stream as it goes by. Some filters can only operate on
-dimensions they understand (consider :ref:`filters.reprojection` doing geographic
-reprojection on XYZ coordinates), while others do not interrogate the point data at
-all and simply reorganize or split data.
+Filters operate on data as inline operations. They can remove, modify,
+reorganize, and add points to the data stream as it goes by. Some filters can
+only operate on dimensions they understand (consider :ref:`filters.reprojection`
+doing geographic reprojection on XYZ coordinates), while others do not
+interrogate the point data at all and simply reorganize or split data.
+
+Create
+------
+
+PDAL filters commonly create new dimensions (e.g., ``HeightAboveGround``) or
+alter existing ones (e.g., ``Classification``). These filters will not
+invalidate an existing KD-tree.
+
+.. note::
+
+  We treat those filters that alter XYZ coordinates separately.
+
+.. note::
+
+  When creating new dimensions, be mindful of the writer you are using and
+  whether or not the custom dimension can be written to disk if that is the
+  desired behavior.
 
 .. toctree::
    :maxdepth: 1
    :glob:
+   :hidden:
 
-   filters.*
+   filters.approximatecoplanar
+   filters.assign
+   filters.cluster
+   filters.colorinterp
+   filters.colorization
+   filters.eigenvalues
+   filters.estimaterank
+   filters.elm
+   filters.ferry
+   filters.hag
+   filters.kdistance
+   filters.lof
+   filters.mongus
+   filters.neighborclassifier
+   filters.normal
+   filters.outlier
+   filters.overlay
+   filters.pmf
+   filters.radialdensity
+   filters.smrf
+
+:ref:`filters.approximatecoplanar`
+    Estimate pointwise planarity, based on k-nearest neighbors. Returns a new
+    dimension ``Coplanar`` where a value of 1 indicates that a point is part of
+    a coplanar neighborhood (0 otherwise).
+
+:ref:`filters.assign`
+    Assign values for a dimension range to a specified value.
+
+:ref:`filters.cluster`
+    Extract and label clusters using Euclidean distance metric. Returns a new
+    dimension ``ClusterID`` that indicates the cluster that a point belongs
+    to. Points not belonging to a cluster are given a cluster ID of 0.
+
+:ref:`filters.colorinterp`
+    Assign RGB colors based on a dimension and a ramp
+
+:ref:`filters.colorization`
+    Fetch and assign RGB color information from a GDAL-readable datasource.
+
+:ref:`filters.eigenvalues`
+    Compute pointwise eigenvalues, based on k-nearest neighbors.
+
+:ref:`filters.estimaterank`
+    Compute pointwise rank, based on k-nearest neighbors.
+
+:ref:`filters.elm`
+    Marks low points as noise.
+
+:ref:`filters.ferry`
+    Copy data from one dimension to another.
+
+:ref:`filters.hag`
+    Compute pointwise height above ground estimate. Requires points to be
+    classified as ground/non-ground prior to estimating.
+
+:ref:`filters.kdistance`
+    Compute pointwise K-Distance (the Euclidean distance to a point's k-th
+    nearest neighbor).
+
+:ref:`filters.lof`
+    Compute pointwise Local Outlier Factor (along with K-Distance and Local
+    Reachability Distance).
+
+:ref:`filters.mongus`
+    Label ground/non-ground returns using [Mongus2012]_.
+
+:ref:`filters.neighborclassifier`
+    Update pointwise classification using k-nearest neighbor consensus voting.
+
+:ref:`filters.normal`
+    Compute pointwise normal and curvature, based on k-nearest neighbors.
+
+:ref:`filters.outlier`
+    Label noise points using either a statistical or radius outlier detection.
+
+:ref:`filters.overlay`
+    Assign values to a dimension based on the extent of an OGR-readable data
+    source or an OGR SQL query.
+
+:ref:`filters.pmf`
+    Label ground/non-ground returns using [Zhang2003]_.
+
+:ref:`filters.radialdensity`
+    Compute pointwise density of points within a given radius.
+
+:ref:`filters.smrf`
+    Label ground/non-ground returns using [Pingel2013]_.
+
+Order
+-----
+
+There are currently three PDAL filters that can be used to reorder points. These
+filters will invalidate an existing KD-tree.
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+   :hidden:
+
+   filters.mortonorder
+   filters.randomize
+   filters.sort
+
+:ref:`filters.mortonorder`
+    Sort XY data using Morton ordering (aka Z-order/Z-curve).
+
+:ref:`filters.randomize`
+    Randomize points in a view.
+
+:ref:`filters.sort`
+    Sort data based on a given dimension.
+
+Move
+----
+
+PDAL filters that move XYZ coordinates will invalidate an existing KD-tree.
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+   :hidden:
+
+   filters.cpd
+   filters.icp
+   filters.reprojection
+   filters.transformation
+
+:ref:`filters.cpd`
+    Compute and apply transformation between two point clouds using the
+    Coherent Point Drift algorithm.
+
+:ref:`filters.icp`
+    Compute and apply transformation between two point clouds using the
+    Iterative Closest Point algorithm.
+
+:ref:`filters.reprojection`
+    Reproject data using GDAL from one coordinate system to another.
+
+:ref:`filters.transformation`
+    Transform each point using a 4x4 transformation matrix.
+
+Cull
+----
+
+Some PDAL filters will cull points, returning a point cloud that is smaller than
+the input. These filters will invalidate an existing KD-tree.
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+   :hidden:
+
+   filters.crop
+   filters.decimation
+   filters.head
+   filters.iqr
+   filters.locate
+   filters.mad
+   filters.range
+   filters.sample
+   filters.tail
+   filters.voxelcenternearestneighbor
+   filters.voxelcentroidnearestneighbor
+
+:ref:`filters.crop`
+    Filter points inside or outside a bounding box or a polygon
+
+:ref:`filters.decimation`
+    Keep every Nth point.
+
+:ref:`filters.head`
+    Return N points from beginning of the point cloud.
+
+:ref:`filters.iqr`
+    Cull points falling outside the computed Interquartile Range for a given
+    dimension.
+
+:ref:`filters.locate`
+    Return a single point with min/max value in the named dimension.
+
+:ref:`filters.mad`
+    Cull points falling outside the computed Median Absolute Deviation for a
+    given dimension.
+
+:ref:`filters.range`
+    Pass only points given a dimension/range.
+
+:ref:`filters.sample`
+    Perform Poisson sampling and return only a subset of the input points.
+
+:ref:`filters.tail`
+    Return N points from end of the point cloud.
+
+:ref:`filters.voxelcenternearestneighbor`
+    Return the point within each voxel that is nearest the voxel center.
+
+:ref:`filters.voxelcentroidnearestneighbor`
+    Return the point within each voxel that is nearest the voxel centroid.
+
+New
+---
+
+PDAL filters can be used to split the incoming point cloud into subsets. These
+filters will invalidate an existing KD-tree.
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+   :hidden:
+
+   filters.chipper
+   filters.divider
+   filters.groupby
+   filters.returns
+   filters.splitter
+
+:ref:`filters.chipper`
+    Organize points into spatially contiguous, squarish, and non-overlapping
+    chips.
+
+:ref:`filters.divider`
+    Divide points into approximately equal sized groups based on a simple
+    scheme.
+
+:ref:`filters.groupby`
+    Split data categorically by dimension.
+
+:ref:`filters.returns`
+    Split data by return order (e.g., 'first', 'last', 'intermediate', 'only').
+
+:ref:`filters.splitter`
+    Split data based on a X/Y box length.
+
+Join
+----
+
+Multiple point clouds can be joined to form a single point cloud. These filters
+will invalidate an existing KD-tree.
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+   :hidden:
+
+   filters.merge
+
+:ref:`filters.merge`
+    Merge data from two different readers into a single stream.
+
+Metadata
+--------
+
+PDAL filters can be used to create new metadata. These filters will not
+invalidate an existing KD-tree.
+
+.. note::
+
+  :ref:`filters.cpd` and :ref:`filters.icp` can optionally create metadata as
+  well, inserting the computed transformation matrix.
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+   :hidden:
+
+   filters.hexbin
+   filters.stats
+
+:ref:`filters.hexbin`
+    Tessellate XY domain and determine point density and/or point boundary.
+
+:ref:`filters.stats`
+    Compute statistics about each dimension (mean, min, max, etc.).
+
+Mesh
+----
+
+Meshes can be computed from point clouds. These filters will invalidate an
+existing KD-tree.
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+   :hidden:
+
+   filters.greedyprojection
+   filters.gridprojection
+   filters.movingleastsquares
+   filters.poisson
+
+:ref:`filters.greedyprojection`
+    Create mesh using the Greedy Projection Triangulation approach.
+
+:ref:`filters.gridprojection`
+    Create mesh using the Grid Projection approach [Li2010]_.
+
+:ref:`filters.movingleastsquares`
+    Data smoothing and normal estimation using the approach of [Alexa2003]_.
+
+:ref:`filters.poisson`
+    Create mesh using the Poisson surface reconstruction algorithm
+    [Kazhdan2006]_.
+
+Languages
+---------
+
+PDAL has two filters than can be used to pass point clouds to other languages.
+These filters will invalidate an existing KD-tree.
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+   :hidden:
+
+   filters.matlab
+   filters.pclblock
+   filters.python
+
+:ref:`filters.matlab`
+    Embed MATLAB software in a pipeline.
+
+:ref:`filters.pclblock`
+    Embed select PCL filters in a pipeline.
+
+:ref:`filters.python`
+    Embed Python software in a pipeline.
+
+Other
+-----
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+   :hidden:
+
+   filters.streamcallback
+   filters.voxelgrid
+
+:ref:`filters.streamcallback`
+    Provide a hook for a simple point-by-point callback.
+
+:ref:`filters.voxelgrid`
+    Create a new point cloud composed of voxel centroids computed from the 
+    input point cloud. All incoming dimension data (e.g., intensity, RGB) will
+    be lost.

--- a/doc/stages/readers.rst
+++ b/doc/stages/readers.rst
@@ -14,6 +14,117 @@ like :ref:`readers.oci`, or a network service like :ref:`readers.greyhound`.
 .. toctree::
    :maxdepth: 1
    :glob:
+   :hidden:
 
-   readers.*
+   readers.bpf
+   readers.buffer
+   readers.faux
+   readers.gdal
+   readers.geowave
+   readers.greyhound
+   readers.ilvis2
+   readers.las
+   readers.matlab
+   readers.mbio
+   readers.mrsid
+   readers.nitf
+   readers.oci
+   readers.optech
+   readers.pcd
+   readers.pgpointcloud
+   readers.ply
+   readers.pts
+   readers.qfit
+   readers.rxp
+   readers.sbet
+   readers.sqlite
+   readers.terrasolid
+   readers.text
+   readers.tindex
 
+:ref:`readers.bpf`
+    Read BPF files encoded as version 1, 2, or 3. BPF is an NGA specification
+    for point cloud data.
+
+:ref:`readers.buffer`
+    Special stage that allows you to read data from your own PointView rather
+    than fetching data from a specific reader.
+
+:ref:`readers.faux`
+    Used for testing pipelines. It does not read from a file or database, but
+    generates synthetic data to feed into the pipeline.
+
+:ref:`readers.gdal`
+    Read GDAL readable raster data sources as point clouds.
+
+:ref:`readers.geowave`
+    Read point cloud data from Accumulo.
+
+:ref:`readers.greyhound`
+    Query point cloud data from a Greyhound server.
+
+:ref:`readers.ilvis2`
+    Read from files in the ILVIS2 format.
+
+:ref:`readers.las`
+    Read ASPRS LAS versions 1.0 - 1.4. Does not support point formats
+    containing waveform data. LASzip support is also enabled through this
+    driver if LASzip  or LAZperf are found during compilation.
+
+:ref:`readers.matlab`
+    Read point cloud data from MATLAB .mat files where dimensions are stored as
+    arrays in a MATLAB struct.
+
+:ref:`readers.mbio`
+    Read sonar bathymetry data from formats supported by the MB-System library.
+
+:ref:`readers.mrsid`
+    Read data compressed by the MrSID 4.0 LiDAR Compressor. Requires the
+    LizardTech Lidar_DSDK.
+
+:ref:`readers.nitf`
+    Read point cloud data (LAS or LAZ) wrapped in NITF 2.1 files.
+
+:ref:`readers.oci`
+    Read data from Oracle point cloud databases.
+
+:ref:`readers.optech`
+    Read Optech Corrected Sensor Data (.csd) files.
+
+:ref:`readers.pcd`
+    Read files in the PCD format.
+
+:ref:`readers.pgpointcloud`
+    Read point cloud data from a PostgreSQL database with the PostgreSQL
+    Pointcloud extension enabled.
+
+:ref:`readers.ply`
+    Read points and vertices from either ASCII or binary PLY files.
+
+:ref:`readers.pts`
+    Read data from Leica Cyclone PTS files.
+
+:ref:`readers.qfit`
+    Read data in the QFIT format originated for NASA's Airborne Topographic
+    Mapper project.
+
+:ref:`readers.rxp`
+    Read data in the RXP format, the in-house streaming format used by RIEGL.
+    The reader requires a copy of RiVLib during compilation.
+
+:ref:`readers.sbet`
+    Read the SBET format.
+
+:ref:`readers.sqlite`
+    Read data stored in a SQLite database.
+
+:ref:`readers.terrasolid`
+    TerraSolid Reader
+
+:ref:`readers.text`
+    Read point clouds from ASCII text files.
+
+:ref:`readers.tindex`
+    The tindex (tile index) reader allows you to automatically merge and query
+    data described in tile index files that have been generated using the PDAL
+    tindex command.

--- a/doc/stages/writers.bpf.rst
+++ b/doc/stages/writers.bpf.rst
@@ -34,7 +34,7 @@ Options
 -------
 
 filename
-    BPF file to read.  The writer will accept a filename containing
+    BPF file to write.  The writer will accept a filename containing
     a single placeholder character ('#').  If input to the writer consists
     of multiple PointViews, each will be written to a separate file, where
     the placeholder will be replaced with an incrementing integer.  If no

--- a/doc/stages/writers.rst
+++ b/doc/stages/writers.rst
@@ -14,6 +14,76 @@ dimension type, while others only understand fixed dimension names.
 .. toctree::
    :maxdepth: 1
    :glob:
+   :hidden:
 
-   writers.*
+   writers.bpf
+   writers.gdal
+   writers.geowave
+   writers.greyhound
+   writers.las
+   writers.matlab
+   writers.nitf
+   writers.null
+   writers.oci
+   writers.ogr
+   writers.pcd
+   writers.pgpointcloud
+   writers.ply
+   writers.sbet
+   writers.sqlite
+   writers.text
 
+:ref:`writers.bpf`
+    Write BPF version 3 files. BPF is an NGA specification for point cloud data.
+
+:ref:`writers.gdal`
+    Create a raster from a point cloud using an interpolation algorithm.
+
+:ref:`writers.geowave`
+    Write point cloud data to Accumulo.
+
+:ref:`writers.greyhound`
+    Append new dimensions (or update existing dimensions) onto a Greyhound
+    resource. Must be used along with a Greyhound reader, and intermediate
+    filters that cull points are not allowed.
+
+:ref:`writers.las`
+    Write ASPRS LAS versions 1.0 - 1.4 formatted data. LAZ support is also
+    available if enabled at compile-time. Note that LAZ does not provide LAS
+    1.4 support at this time.
+
+:ref:`writers.matlab`
+    Write MATLAB .mat files. The output has a single array struct.
+
+:ref:`writers.nitf`
+    Write LAS and LAZ point cloud data, wrapped in a NITF 2.1 file.
+
+:ref:`writers.null`
+    Provides a sink for points in a pipeline. It's the same as sending pipeline
+    output to /dev/null.
+
+:ref:`writers.oci`
+    Write data to Oracle point cloud databases.
+
+:ref:`writers.ogr`
+    Write a point cloud as a set of OGR points/multipoints
+
+:ref:`writers.pcd`
+    Write PCD-formatted files in the ASCII, binary, or compressed format.
+
+:ref:`writers.pgpointcloud`
+    Write to a PostgreSQL database that has the PostgreSQL Pointcloud extension
+    enabled.
+
+:ref:`writers.ply`
+    Write points as PLY vertices. Can also emit a mesh as a set of faces.
+
+:ref:`writers.sbet`
+    Write data in the SBET format.
+
+:ref:`writers.sqlite`
+    Write point cloud data in a scheme that matches the approach used in the
+    PostgreSQL Pointcloud and OCI readers.
+
+:ref:`writers.text`
+    Write points in a text file. GeoJSON and CSV formats are supported.

--- a/doc/stages/writers.sbet.rst
+++ b/doc/stages/writers.sbet.rst
@@ -1,0 +1,30 @@
+.. _writers.sbet:
+
+writers.sbet
+============
+
+The **SBET writer** writes files in the SBET format, used for exchange data from interital measurement units (IMUs).
+
+.. embed::
+
+.. streamable::
+
+Example
+-------
+
+
+.. code-block:: json
+
+    {
+      "pipeline":[
+        "input.sbet",
+        "output.sbet"
+      ]
+    }
+
+
+Options
+-------
+
+filename
+  File to write. [Required]

--- a/filters/ApproximateCoplanarFilter.cpp
+++ b/filters/ApproximateCoplanarFilter.cpp
@@ -49,7 +49,7 @@ namespace pdal
 static StaticPluginInfo const s_info
 {
     "filters.approximatecoplanar",
-    "ApproximateCoplanar Filter",
+    "Estimates the planarity of a neighborhood of points using eigenvalues.",
     "http://pdal.io/stages/filters.approximatecoplanar.html"
 };
 

--- a/filters/AssignFilter.cpp
+++ b/filters/AssignFilter.cpp
@@ -45,7 +45,7 @@ namespace pdal
 static StaticPluginInfo const s_info
 {
     "filters.assign",
-    "Assign values for a dimension using a specified value.",
+    "Assign values for a dimension range to a specified value.",
     "http://pdal.io/stages/filters.assign.html"
 };
 
@@ -160,4 +160,3 @@ void AssignFilter::filter(PointView& view)
 }
 
 } // namespace pdal
-

--- a/filters/ClusterFilter.cpp
+++ b/filters/ClusterFilter.cpp
@@ -44,7 +44,7 @@ namespace pdal
 static StaticPluginInfo const s_info
 {
     "filters.cluster",
-    "Label clusters",
+    "Extract and label clusters using Euclidean distance.",
     "http://pdal.io/stages/filters.cluster.html"
 };
 

--- a/filters/ELMFilter.cpp
+++ b/filters/ELMFilter.cpp
@@ -48,7 +48,7 @@ namespace pdal
 static StaticPluginInfo const s_info
 {
     "filters.elm",
-    "Extended Local Minimum Filter",
+    "Marks low points as noise.",
     "http://pdal.io/stages/filters.elm.html"
 };
 

--- a/filters/EigenvaluesFilter.cpp
+++ b/filters/EigenvaluesFilter.cpp
@@ -49,7 +49,7 @@ namespace pdal
 static StaticPluginInfo const s_info
 {
     "filters.eigenvalues",
-    "Eigenvalues Filter",
+    "Returns the eigenvalues for a given point, based on its k-nearest neighbors.",
     "http://pdal.io/stages/filters.eigenvalues.html"
 };
 

--- a/filters/EstimateRankFilter.cpp
+++ b/filters/EstimateRankFilter.cpp
@@ -47,7 +47,7 @@ namespace pdal
 static StaticPluginInfo const s_info
 {
     "filters.estimaterank",
-    "EstimateRank Filter",
+    "Computes the rank of a neighborhood of points.",
     "http://pdal.io/stages/filters.estimaterank.html"
 };
 

--- a/filters/HAGFilter.cpp
+++ b/filters/HAGFilter.cpp
@@ -45,7 +45,7 @@ namespace pdal
 static StaticPluginInfo const s_info
 {
     "filters.hag",
-    "HAG Filter",
+    "Computes height above ground using ground-classified returns.",
     "http://pdal.io/stages/filters.hag.html"
 };
 


### PR DESCRIPTION
Convert from bulleted TOC stage listings to definition lists, whereby the
filter name and link are shown as the "term" and a brief stage description is
provided as the definition. The intent is to provide a simpler overview of our
growing list of stages.

Filters are also broken into some categories that attempt to capture what they
do to the data (like creating new dimensions, culling points, etc.).