### PR TITLE
Fix linking to libdl for dlopen().

### DIFF
--- a/pdal/util/CMakeLists.txt
+++ b/pdal/util/CMakeLists.txt
@@ -27,7 +27,7 @@ target_include_directories(${PDAL_UTIL_LIB_NAME} PRIVATE
 
 if (UNIX AND NOT APPLE)
     target_link_libraries(${PDAL_UTIL_LIB_NAME}
-        PRIVATE
+        PUBLIC
             dl
     )
 endif()


### PR DESCRIPTION
Fixes build failure:
```
[100%] Linking CXX executable ../../../bin/pdal_io_numpy_test
cd /build/pdal-1.7.0/obj-x86_64-linux-gnu/plugins/python/io && /usr/bin/cmake -E cmake_link_script CMakeFiles/pdal_io_numpy_test.dir/link.txt --verbose=1
/usr/bin/c++  -g -O2 -fdebug-prefix-map=/build/pdal-1.7.0=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -Wno-error=maybe-uninitialized -Wdate-time -D_FORTIFY_SOURCE=2 -O2 -g -DNDEBUG  -Wl,-z,relro -Wl,-z,now -rdynamic CMakeFiles/pdal_io_numpy_test.dir/__/test/NumpyReaderTest.cpp.o CMakeFiles/pdal_io_numpy_test.dir/__/plang/Environment.cpp.o CMakeFiles/pdal_io_numpy_test.dir/__/plang/Redirector.cpp.o ../../../test/unit/CMakeFiles/pdal_test_support.dir/Support.cpp.o  -o ../../../bin/pdal_io_numpy_test -Wl,-rpath,/build/pdal-1.7.0/obj-x86_64-linux-gnu/lib ../../../lib/libgtest.a ../../../lib/libpdal_plugin_reader_numpy.so.7.0.0 -lpython2.7 ../../../lib/libpdal_base.so.7.0.0 -lpthread -lgdal -lgeos_c -lgeotiff -lxml2 -lz -lcurl -ljsoncpp ../../../lib/libpdal_util.so.7.0.0
/usr/bin/ld: CMakeFiles/pdal_io_numpy_test.dir/__/plang/Environment.cpp.o: undefined reference to symbol 'dlopen@@GLIBC_2.2.5'
//lib/x86_64-linux-gnu/libdl.so.2: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
```