### PR TITLE
Use CMAKE_DL_LIBS

### DIFF
--- a/dimbuilder/CMakeLists.txt
+++ b/dimbuilder/CMakeLists.txt
@@ -31,11 +31,10 @@ target_include_directories(dimbuilder PRIVATE
 PDAL_TARGET_COMPILE_SETTINGS(dimbuilder)
 target_link_libraries(dimbuilder
     PRIVATE
-        ${EXECINFO_LIBRARY})
+        ${EXECINFO_LIBRARY}
+        ${CMAKE_DL_LIBS}
+)
 if (PDAL_HAVE_JSONCPP)
     target_link_libraries(dimbuilder ${JSON_CPP_LINK_TYPE}
         ${PDAL_JSONCPP_LIB_NAME})
-endif()
-if (UNIX AND NOT APPLE)
-    target_link_libraries(dimbuilder PRIVATE  ${CMAKE_DL_LIBS})
 endif()

--- a/pdal/util/CMakeLists.txt
+++ b/pdal/util/CMakeLists.txt
@@ -21,13 +21,10 @@ target_link_libraries(${PDAL_UTIL_LIB_NAME}
     PRIVATE
         ${EXECINFO_LIBRARY}
         ${PDAL_BOOST_LIB_NAME}
+        ${CMAKE_DL_LIBS}
 )
 target_include_directories(${PDAL_UTIL_LIB_NAME} PRIVATE
     ${PDAL_VENDOR_DIR}/pdalboost)
-
-if (UNIX AND NOT APPLE)
-    target_link_libraries(${PDAL_UTIL_LIB_NAME} PRIVATE ${CMAKE_DL_LIBS})
-endif()
 
 set_target_properties(${PDAL_UTIL_LIB_NAME} PROPERTIES
     VERSION "${PDAL_BUILD_VERSION}"

--- a/pdal/util/CMakeLists.txt
+++ b/pdal/util/CMakeLists.txt
@@ -26,10 +26,7 @@ target_include_directories(${PDAL_UTIL_LIB_NAME} PRIVATE
     ${PDAL_VENDOR_DIR}/pdalboost)
 
 if (UNIX AND NOT APPLE)
-    target_link_libraries(${PDAL_UTIL_LIB_NAME}
-        PRIVATE
-            dl
-    )
+    target_link_libraries(${PDAL_UTIL_LIB_NAME} PRIVATE ${CMAKE_DL_LIBS})
 endif()
 
 set_target_properties(${PDAL_UTIL_LIB_NAME} PROPERTIES


### PR DESCRIPTION
I believe we inadvertently removed `CMAKE_DL_LIBS` [here](https://github.com/PDAL/PDAL/commit/afbfccab6b2a06dab22b8b5e2e9d3e2bdd9e384b#diff-9df7bbdfc0579f4e154ab1226d9ffd7f), and then replaced it with `dl` [here](https://github.com/PDAL/PDAL/commit/95407c152bdc2afcc401578b1297d2bc2915d801#diff-9df7bbdfc0579f4e154ab1226d9ffd7f).

`CMAKE_DL_LIBS` is already used in the following locations:

https://github.com/PDAL/PDAL/blob/b6474df9cc58599509ec93e6d97d1ad4b6284541/dimbuilder/CMakeLists.txt#L40

https://github.com/PDAL/PDAL/blob/c709b5d118edd13f2871deb93620630241655d4d/plugins/python/filters/CMakeLists.txt#L12

https://github.com/PDAL/PDAL/blob/f22bffd723c530af57d89eb97609fcdda253bc4f/plugins/python/io/CMakeLists.txt#L9

We should probably be consistent and use it across the board (although clearly it hasn't seemed to cause any issues to date).