### PR TITLE
Tests: fix for GDAL with proj.5

### DIFF
--- a/test/unit/filters/FerryFilterTest.cpp
+++ b/test/unit/filters/FerryFilterTest.cpp
@@ -120,7 +120,9 @@ TEST(FerryFilterTest, test_ferry_copy_json)
     double y = view->getFieldAs<double>(state_plane_y, 0);
 
     EXPECT_DOUBLE_EQ(-117.2501328350574, lon);
-    EXPECT_DOUBLE_EQ(49.341077824192915, lat);
+    // proj 5 will consider +ellps=GRS80 +towgs84=0,0,0 to be slighly different
+    // than +datum=WGS84 and return 49.341077823260804.
+    EXPECT_NEAR(49.341077824192915, lat, 1e-9);
     EXPECT_DOUBLE_EQ(637012.24, x);
     EXPECT_DOUBLE_EQ(849028.31, y);
 }

--- a/test/unit/filters/ReprojectionFilterTest.cpp
+++ b/test/unit/filters/ReprojectionFilterTest.cpp
@@ -66,6 +66,9 @@ TEST(ReprojectionFilterTest, ReprojectionFilterTest_test_1)
 
     const double postX = -93.351563;
     const double postY = 41.577148;
+    // proj 4 transformed to 16 exactly, but proj 5 will consider
+    // +ellps=GRS80 +towgs84=0,0,0 to be slighly different than +datum=WGS84
+    // and return 15.999954
     const double postZ = 16.000000;
 
     {
@@ -93,7 +96,7 @@ TEST(ReprojectionFilterTest, ReprojectionFilterTest_test_1)
 
         EXPECT_FLOAT_EQ(x, postX);
         EXPECT_FLOAT_EQ(y, postY);
-        EXPECT_FLOAT_EQ(z, postZ);
+        EXPECT_NEAR(z, postZ, 5e-5);
     }
 }
 
@@ -120,13 +123,16 @@ TEST(ReprojectionFilterTest, stream_test_1)
         static int i = 0;
         const double x = -93.351563;
         const double y = 41.577148;
+        // proj 4 transformed to 16 exactly, but proj 5 will consider
+        // +ellps=GRS80 +towgs84=0,0,0 to be slighly different than +datum=WGS84
+        // and return 15.999954
         const double z = 16.000000;
 
         if (i == 0)
         {
             EXPECT_FLOAT_EQ(point.getFieldAs<float>(Dimension::Id::X), x);
             EXPECT_FLOAT_EQ(point.getFieldAs<float>(Dimension::Id::Y), y);
-            EXPECT_FLOAT_EQ(point.getFieldAs<float>(Dimension::Id::Z), z);
+            EXPECT_NEAR(point.getFieldAs<float>(Dimension::Id::Z), z, 5e-5);
         }
         ++i;
         return true;


### PR DESCRIPTION
There are slight different of behavioru in proj.5 vs proj.4
In particular reprojection from +ellps=GRS80 +towgs84=0,0,0 to
+datum=WGS84 now involves a helmert transform in proj.5
instead of being considered as a no-op in proj.4