### PR TITLE
Initialize LasWriter::m_forwardVlrs

### DIFF
--- a/io/LasWriter.hpp
+++ b/io/LasWriter.hpp
@@ -102,7 +102,7 @@ private:
     std::string m_curFilename;
     StringList m_forwardSpec;
     std::set<std::string> m_forwards;
-    bool m_forwardVlrs;
+    bool m_forwardVlrs = false;
     LasCompression m_compression;
     std::vector<char> m_pointBuf;
     SpatialReference m_aSrs;


### PR DESCRIPTION
Fixes the following Valgrind warning on FerryFilterTest

==17720== Conditional jump or move depends on uninitialised value(s)
==17720==    at 0x56E9B3A: pdal::LasWriter::addForwardVlrs() (LasWriter.cpp:441)
==17720==    by 0x56E85B2: pdal::LasWriter::readyTable(pdal::BasePointTable&) (LasWriter.cpp:307)
==17720==    by 0x56A727B: pdal::FlexWriter::ready(pdal::BasePointTable&) (FlexWriter.hpp:89)
==17720==    by 0x577046F: pdal::Stage::execute(pdal::BasePointTable&) (Stage.cpp:209)
==17720==    by 0x5782430: pdal::PipelineManager::execute() (PipelineManager.cpp:207)
==17720==    by 0x457957: FerryFilterTest_test_ferry_copy_json_Test::TestBody() (FerryFilterTest.cpp:104)
==17720==    by 0x493CE7: void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (gtest.cc:2078)
==17720==    by 0x48EC8A: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (gtest.cc:2114)
==17720==    by 0x4744B3: testing::Test::Run() (gtest.cc:2151)
==17720==    by 0x474D5B: testing::TestInfo::Run() (gtest.cc:2326)
==17720==    by 0x47544A: testing::TestCase::Run() (gtest.cc:2444)
==17720==    by 0x47C527: testing::internal::UnitTestImpl::RunAllTests() (gtest.cc:4315)
==17720==