### PR TITLE
GeotiffSrs constructor: fix memleak of GTIFGetOGISDefn() return

### DIFF
--- a/io/GeotiffSupport.cpp
+++ b/io/GeotiffSupport.cpp
@@ -39,6 +39,8 @@
 #include <geo_normalize.h>
 #include <geo_simpletags.h>
 
+#include <cpl_conv.h>
+
 PDAL_C_START
 
 // These functions are available from GDAL, but they
@@ -146,7 +148,10 @@ GeotiffSrs::GeotiffSrs(const std::vector<uint8_t>& directoryRec,
     {
         char *wkt = GTIFGetOGISDefn(ctx.gtiff, &sGTIFDefn);
         if (wkt)
+        {
             m_srs.set(wkt);
+            VSIFree(wkt);
+        }
     }
 }
 


### PR DESCRIPTION
This fixes the following Valgrind warning on pdal_filters_reprojection_test

==22366== 1,282 bytes in 2 blocks are definitely lost in loss record 675 of 701
==22366==    at 0x4C2DB8F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==22366==    by 0x7DE5D24: VSIMalloc (cpl_vsisimple.cpp:557)
==22366==    by 0x7D136F5: CPLMalloc (cpl_conv.cpp:184)
==22366==    by 0x8737AD8: OGR_SRSNode::exportToWkt(char**) const (ogr_srsnode.cpp:466)
==22366==    by 0x8724742: OGRSpatialReference::exportToWkt(char**) const (ogrspatialreference.cpp:737)
==22366==    by 0x75C8C4B: GTIFGetOGISDefn (gt_wkt_srs.cpp:1356)
==22366==    by 0x5696FA9: pdal::GeotiffSrs::GeotiffSrs(std::vector<unsigned char, std::allocator<unsigned char> > const&, std::vector<unsigned char, std::allocator<unsigned char> > const&, std::vector<unsigned char, std::allocator<unsigned char> > const&, std::shared_ptr<pdal::Log>) (GeotiffSupport.cpp:149)
==22366==    by 0x56B3C3B: pdal::LasHeader::setSrsFromGeotiff() (LasHeader.cpp:322)
==22366==    by 0x56B3243: pdal::LasHeader::setSrs() (LasHeader.cpp:219)
==22366==    by 0x56B468F: pdal::operator>>(pdal::ILeStream&, pdal::LasHeader&) (LasHeader.cpp:404)
==22366==    by 0x5680FF4: pdal::LasReader::initializeLocal(pdal::BasePointTable&, pdal::MetadataNode&) (LasReader.cpp:192)
==22366==    by 0x568972E: pdal::LasReader::initialize(pdal::BasePointTable&) (LasReader.hpp:134)