### PR TITLE
Fix memleak in ReprojectionFilter

### DIFF
--- a/filters/ReprojectionFilter.hpp
+++ b/filters/ReprojectionFilter.hpp
@@ -74,7 +74,7 @@ private:
     ReferencePtr m_in_ref_ptr;
     ReferencePtr m_out_ref_ptr;
     TransformPtr m_transform_ptr;
-    gdal::ErrorHandler* m_errorHandler;
+    std::unique_ptr<gdal::ErrorHandler> m_errorHandler;
 
     ReprojectionFilter& operator=(const ReprojectionFilter&); // not implemented
     ReprojectionFilter(const ReprojectionFilter&); // not implemented


### PR DESCRIPTION
Fixes following Valgrind warning:
==22366== 72 bytes in 1 blocks are definitely lost in loss record 610 of 701
==22366==    at 0x4C2E0EF: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==22366==    by 0x560B2EE: pdal::ReprojectionFilter::ReprojectionFilter() (ReprojectionFilter.cpp:65)
==22366==    by 0x453131: ReprojectionFilterTest_ReprojectionFilterTest_test_1_Test::TestBody() (ReprojectionFilterTest.cpp:82)
==22366==    by 0x48CCB1: void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (gtest.cc:2078)
==22366==    by 0x487C54: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (gtest.cc:2114)
==22366==    by 0x46D42F: testing::Test::Run() (gtest.cc:2151)
==22366==    by 0x46DCD7: testing::TestInfo::Run() (gtest.cc:2326)
==22366==    by 0x46E3C6: testing::TestCase::Run() (gtest.cc:2444)
==22366==    by 0x4754A3: testing::internal::UnitTestImpl::RunAllTests() (gtest.cc:4315)
==22366==    by 0x48E288: bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (gtest.cc:2078)
==22366==    by 0x488ACC: bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (gtest.cc:2114)
==22366==    by 0x473F41: testing::UnitTest::Run() (gtest.cc:3926)