### PR TITLE
Pass parameters by const reference (cppcheck)

### DIFF
--- a/filters/StatsFilter.hpp
+++ b/filters/StatsFilter.hpp
@@ -57,7 +57,7 @@ typedef std::map<double, point_count_t> EnumMap;
 typedef std::vector<double> DataVector;
 
 public:
-    Summary(std::string name, EnumType enumerate) :
+    Summary(const std::string& name, EnumType enumerate) :
         m_name(name), m_enumerate(enumerate)
     { reset(); }
 

--- a/filters/StreamCallbackFilter.hpp
+++ b/filters/StreamCallbackFilter.hpp
@@ -52,7 +52,7 @@ public:
     {}
 
     typedef std::function<bool(PointRef&)> CallbackFunc;
-    void setCallback(CallbackFunc cb)
+    void setCallback(const CallbackFunc& cb)
         { m_callback = cb; }
 
 private:

--- a/filters/private/DimRange.hpp
+++ b/filters/private/DimRange.hpp
@@ -49,7 +49,7 @@ struct DimRange
         {}
     };
 
-    DimRange(const std::string name,
+    DimRange(const std::string& name,
         double lower_bound,
         double upper_bound,
         bool inclusive_lower_bound,

--- a/filters/private/pnp/Comparison.hpp
+++ b/filters/private/pnp/Comparison.hpp
@@ -140,7 +140,7 @@ class FloatingPoint {
   // Reinterprets a bit pattern as a floating-point number.
   //
   // This function is needed to test the AlmostEquals() method.
-  static RawType ReinterpretBits(const Bits bits) {
+  static RawType ReinterpretBits(const Bits& bits) {
     FloatingPoint fp(0);
     fp.u_.bits_ = bits;
     return fp.u_.value_;

--- a/filters/private/pnp/GridPnp.hpp
+++ b/filters/private/pnp/GridPnp.hpp
@@ -157,9 +157,9 @@ private:
     };
 
 
-    Point& point1(EdgeId id)
+    Point& point1(const EdgeId& id)
         { return m_rings[id]; }
-    Point& point2(EdgeId id)
+    Point& point2(const EdgeId& id)
         { return m_rings[id + 1]; }
     double xval(const Point& p)
         { return p.first; }
@@ -327,7 +327,7 @@ private:
 
 
     // Determine if a point is collinear with an edge.
-    bool pointCollinear(double x, double y, EdgeId edgeId)
+    bool pointCollinear(double x, double y, const EdgeId& edgeId)
     {
         Point& p1 = point1(edgeId);
         Point& p2 = point2(edgeId);

--- a/io/HeaderVal.hpp
+++ b/io/HeaderVal.hpp
@@ -155,7 +155,7 @@ public:
     StringHeaderVal(const std::string& s) : BaseHeaderVal(s)
     {}
 
-    bool setVal(std::string val)
+    bool setVal(const std::string& val)
     {
         m_valSet = true;
         m_val = val;

--- a/io/Ilvis2MetadataReader.cpp
+++ b/io/Ilvis2MetadataReader.cpp
@@ -37,7 +37,7 @@
 namespace pdal
 {
 
-void Ilvis2MetadataReader::readMetadataFile(std::string filename,
+void Ilvis2MetadataReader::readMetadataFile(const std::string& filename,
     MetadataNode* m)
 {
     xmlDocPtr doc;
@@ -549,7 +549,7 @@ void Ilvis2MetadataReader::parsePSA(xmlNodePtr node, MetadataNode * m)
 
 // Since the Browse, PH, QA, and MP product nodes have the same structure
 // just differing prefixes, they can share this code.
-void Ilvis2MetadataReader::parseXXProduct(std::string type, xmlNodePtr node,
+void Ilvis2MetadataReader::parseXXProduct(const std::string& type, xmlNodePtr node,
     MetadataNode * m)
 {
     std::string fullBase = type + "Product";
@@ -630,7 +630,7 @@ xmlNodePtr Ilvis2MetadataReader::getFirstChildElementNode(xmlNodePtr node)
 }
 
 // Verifies the name of the node matches what's expected
-bool Ilvis2MetadataReader::nodeElementIs(xmlNodePtr node, std::string expected)
+bool Ilvis2MetadataReader::nodeElementIs(xmlNodePtr node, const std::string& expected)
 {
     if (!node)
     {
@@ -643,7 +643,7 @@ bool Ilvis2MetadataReader::nodeElementIs(xmlNodePtr node, std::string expected)
 
 
 // Throws an error if the next element is not what it expects
-void Ilvis2MetadataReader::assertElementIs(xmlNodePtr node, std::string expected)
+void Ilvis2MetadataReader::assertElementIs(xmlNodePtr node, const std::string& expected)
 {
     if (!node || !nodeElementIs(node, expected))
         throw error("Expected element '" + expected + "', found '" +
@@ -662,7 +662,7 @@ void Ilvis2MetadataReader::assertEndOfElements(xmlNodePtr node)
 
 // Counts the number of child element nodes with a given name
 int Ilvis2MetadataReader::countChildElements(xmlNodePtr node,
-    std::string childName)
+    const std::string& childName)
 {
     xmlNodePtr child = getFirstChildElementNode(node);
     int ctr = 0;

--- a/io/Ilvis2MetadataReader.hpp
+++ b/io/Ilvis2MetadataReader.hpp
@@ -55,7 +55,7 @@ public:
         {}
     };
 
-    void readMetadataFile(std::string filename, MetadataNode* m);
+    void readMetadataFile(const std::string& filename, MetadataNode* m);
 
 protected:
     // These methods are written to parse specific nodes.  It doesn't
@@ -77,7 +77,7 @@ protected:
     void parseCampaign(xmlNodePtr node, MetadataNode* m);
     void parsePSAs(xmlNodePtr node, MetadataNode* m);
     void parsePSA(xmlNodePtr node, MetadataNode* m);
-    void parseXXProduct(std::string type, xmlNodePtr node, MetadataNode* m);
+    void parseXXProduct(const std::string& type, xmlNodePtr node, MetadataNode* m);
 
     void parseSpatialDomainContainer(xmlNodePtr node, MetadataNode* m);
     void parseGPolygon(xmlNodePtr node, MetadataNode* m);
@@ -102,10 +102,10 @@ private:
     xmlNodePtr getNextElementNode(xmlNodePtr node);
     xmlNodePtr getFirstChildElementNode(xmlNodePtr node);
 
-    bool nodeElementIs(xmlNodePtr node, std::string expected);
-    void assertElementIs(xmlNodePtr node, std::string expected);
+    bool nodeElementIs(xmlNodePtr node, const std::string& expected);
+    void assertElementIs(xmlNodePtr node, const std::string& expected);
     void assertEndOfElements(xmlNodePtr node);
-    int countChildElements(xmlNodePtr node, std::string childName);
+    int countChildElements(xmlNodePtr node, const std::string& childName);
 };
 
 }

--- a/io/Ilvis2Reader.hpp
+++ b/io/Ilvis2Reader.hpp
@@ -45,7 +45,7 @@ namespace pdal
   class Ilvis2MetadataReader
   {
   public:
-      inline void readMetadataFile(std::string filename, pdal::MetadataNode* m) {};
+      inline void readMetadataFile(const std::string& filename, pdal::MetadataNode* m) {};
   };
 }
 #else

--- a/io/LasReader.cpp
+++ b/io/LasReader.cpp
@@ -284,7 +284,7 @@ namespace
 {
 
 void addForwardMetadata(MetadataNode& forward, MetadataNode& m,
-    const std::string& name, double val, const std::string description,
+    const std::string& name, double val, const std::string& description,
     size_t precision)
 {
     MetadataNode n = m.add(name, val, description, precision);
@@ -309,7 +309,7 @@ void addForwardMetadata(MetadataNode& forward, MetadataNode& m,
 // lasforward metadata node.
 template <typename T>
 void addForwardMetadata(MetadataNode& forward, MetadataNode& m,
-    const std::string& name, T val, const std::string description)
+    const std::string& name, T val, const std::string& description)
 {
     MetadataNode n = m.add(name, val, description);
 

--- a/io/LasUtils.hpp
+++ b/io/LasUtils.hpp
@@ -79,7 +79,7 @@ inline std::ostream& operator<<(std::ostream& out, const LasCompression& c)
 
 struct ExtraDim
 {
-    ExtraDim(const std::string name, Dimension::Type type,
+    ExtraDim(const std::string& name, Dimension::Type type,
             double scale = 1.0, double offset = 0.0) :
         m_name(name), m_dimType(Dimension::Id::Unknown, type, scale, offset),
         m_size(0)

--- a/io/PlyReader.hpp
+++ b/io/PlyReader.hpp
@@ -106,7 +106,7 @@ private:
 
     struct Element
     {
-        Element(const std::string name, size_t count) :
+        Element(const std::string& name, size_t count) :
             m_name(name), m_count(count)
         {}
 

--- a/pdal/EigenUtils.cpp
+++ b/pdal/EigenUtils.cpp
@@ -52,7 +52,7 @@ namespace pdal
 namespace eigen
 {
 
-Eigen::Vector3d computeCentroid(PointView& view, std::vector<PointId> ids)
+Eigen::Vector3d computeCentroid(PointView& view, const std::vector<PointId>& ids)
 {
     using namespace Eigen;
     
@@ -80,7 +80,7 @@ Eigen::Vector3d computeCentroid(PointView& view, std::vector<PointId> ids)
     return centroid;
 }
 
-Eigen::Matrix3f computeCovariance(PointView& view, std::vector<PointId> ids)
+Eigen::Matrix3f computeCovariance(PointView& view, const std::vector<PointId>& ids)
 {
     using namespace Eigen;
 
@@ -102,7 +102,7 @@ Eigen::Matrix3f computeCovariance(PointView& view, std::vector<PointId> ids)
     return A * A.transpose() / (ids.size()-1);
 }
 
-uint8_t computeRank(PointView& view, std::vector<PointId> ids, double threshold)
+uint8_t computeRank(PointView& view, const std::vector<PointId>& ids, double threshold)
 {
     using namespace Eigen;
 

--- a/pdal/EigenUtils.hpp
+++ b/pdal/EigenUtils.hpp
@@ -76,7 +76,7 @@ namespace eigen
   \return the 3D centroid of the XYZ dimensions.
 */
 PDAL_DLL Eigen::Vector3d computeCentroid(PointView& view,
-        std::vector<PointId> ids);
+        const std::vector<PointId>& ids);
 
 /**
   Compute the covariance matrix of a collection of points.
@@ -101,7 +101,7 @@ PDAL_DLL Eigen::Vector3d computeCentroid(PointView& view,
   \return the covariance matrix of the XYZ dimensions.
 */
 PDAL_DLL Eigen::Matrix3f computeCovariance(PointView& view,
-        std::vector<PointId> ids);
+        const std::vector<PointId>& ids);
 
 /**
   Compute second derivative in X direction using central difference method.
@@ -232,7 +232,7 @@ PDAL_DLL Eigen::MatrixXd cleanDSM(Eigen::MatrixXd data);
   \param ids a vector of PointIds specifying a subset of points.
   \return the estimated rank.
 */
-PDAL_DLL uint8_t computeRank(PointView& view, std::vector<PointId> ids,
+PDAL_DLL uint8_t computeRank(PointView& view, const std::vector<PointId>& ids,
                              double threshold);
 
 /**

--- a/pdal/PDALUtils.cpp
+++ b/pdal/PDALUtils.cpp
@@ -192,7 +192,7 @@ std::string tempFilename(const std::string& path)
 class TempFile
 {
 public:
-    TempFile(const std::string path) : m_filename(path)
+    TempFile(const std::string& path) : m_filename(path)
     {}
 
     virtual ~TempFile()

--- a/pdal/compression/DeflateCompression.cpp
+++ b/pdal/compression/DeflateCompression.cpp
@@ -42,7 +42,7 @@ namespace pdal
 class DeflateCompressorImpl
 {
 public:
-    DeflateCompressorImpl(BlockCb cb) : m_cb(cb)
+    DeflateCompressorImpl(const BlockCb& cb) : m_cb(cb)
     {
         m_strm.zalloc = Z_NULL;
         m_strm.zfree = Z_NULL;
@@ -125,7 +125,7 @@ private:
 };
 
 
-DeflateCompressor::DeflateCompressor(BlockCb cb) :
+DeflateCompressor::DeflateCompressor(const BlockCb& cb) :
     m_impl(new DeflateCompressorImpl(cb))
 {}
 
@@ -149,7 +149,7 @@ void DeflateCompressor::done()
 class DeflateDecompressorImpl
 {
 public:
-    DeflateDecompressorImpl(BlockCb cb) : m_cb(cb)
+    DeflateDecompressorImpl(const BlockCb& cb) : m_cb(cb)
     {
         m_strm.zalloc = Z_NULL;
         m_strm.zfree = Z_NULL;
@@ -230,7 +230,7 @@ private:
 };
 
 
-DeflateDecompressor::DeflateDecompressor(BlockCb cb) :
+DeflateDecompressor::DeflateDecompressor(const BlockCb& cb) :
     m_impl(new DeflateDecompressorImpl(cb))
 {}
 

--- a/pdal/compression/DeflateCompression.hpp
+++ b/pdal/compression/DeflateCompression.hpp
@@ -43,7 +43,7 @@ class DeflateCompressorImpl;
 class DeflateCompressor : public Compressor
 {
 public:
-    PDAL_DLL DeflateCompressor(BlockCb cb);
+    PDAL_DLL DeflateCompressor(const BlockCb& cb);
     PDAL_DLL ~DeflateCompressor();
 
     PDAL_DLL void compress(const char *buf, size_t bufsize);
@@ -59,7 +59,7 @@ class DeflateDecompressorImpl;
 class DeflateDecompressor : public Decompressor
 {
 public:
-    PDAL_DLL DeflateDecompressor(BlockCb cb);
+    PDAL_DLL DeflateDecompressor(const BlockCb& cb);
     PDAL_DLL ~DeflateDecompressor();
 
     PDAL_DLL void decompress(const char *buf, size_t bufsize);

--- a/pdal/compression/LazPerfCompression.cpp
+++ b/pdal/compression/LazPerfCompression.cpp
@@ -104,7 +104,7 @@ size_t addFields(LasZipEngine& engine, const DimTypeList& dims)
 class LazPerfCompressorImpl
 {
 public:
-    LazPerfCompressorImpl(BlockCb cb, const DimTypeList& dims) :
+    LazPerfCompressorImpl(const BlockCb& cb, const DimTypeList& dims) :
         m_cb(cb),
         m_encoder(*this),
         m_compressor(laszip::formats::make_dynamic_compressor(m_encoder)),
@@ -170,7 +170,7 @@ private:
 };
 
 
-LazPerfCompressor::LazPerfCompressor(BlockCb cb, const DimTypeList& dims) :
+LazPerfCompressor::LazPerfCompressor(const BlockCb& cb, const DimTypeList& dims) :
     m_impl(new LazPerfCompressorImpl(cb, dims))
 {}
 
@@ -194,7 +194,7 @@ void LazPerfCompressor::done()
 class LazPerfDecompressorImpl
 {
 public:
-    LazPerfDecompressorImpl(BlockCb cb, const DimTypeList& dims,
+    LazPerfDecompressorImpl(const BlockCb& cb, const DimTypeList& dims,
             size_t numPoints) :
         m_decoder(*this),
         m_decompressor(laszip::formats::make_dynamic_decompressor(m_decoder)),
@@ -248,7 +248,7 @@ private:
     size_t m_pointSize;
 };
 
-LazPerfDecompressor::LazPerfDecompressor(BlockCb cb, const DimTypeList& dims,
+LazPerfDecompressor::LazPerfDecompressor(const BlockCb& cb, const DimTypeList& dims,
         size_t numPoints) :
     m_impl(new LazPerfDecompressorImpl(cb, dims, numPoints))
 {}

--- a/pdal/compression/LazPerfCompression.hpp
+++ b/pdal/compression/LazPerfCompression.hpp
@@ -45,7 +45,7 @@ class LazPerfCompressorImpl;
 class LazPerfCompressor : public Compressor
 {
 public:
-    PDAL_DLL LazPerfCompressor(BlockCb cb, const DimTypeList& dims);
+    PDAL_DLL LazPerfCompressor(const BlockCb& cb, const DimTypeList& dims);
     PDAL_DLL ~LazPerfCompressor();
 
     PDAL_DLL void compress(const char *buf, size_t bufsize);
@@ -64,7 +64,7 @@ class LazPerfDecompressorImpl;
 class LazPerfDecompressor : public Decompressor
 {
 public:
-    PDAL_DLL LazPerfDecompressor(BlockCb cb, const DimTypeList& dims,
+    PDAL_DLL LazPerfDecompressor(const BlockCb& cb, const DimTypeList& dims,
         size_t numPoints);
     PDAL_DLL ~LazPerfDecompressor();
 

--- a/pdal/compression/LzmaCompression.cpp
+++ b/pdal/compression/LzmaCompression.cpp
@@ -42,7 +42,7 @@ namespace pdal
 class Lzma
 {
 protected:
-    Lzma(BlockCb cb) : m_cb(cb)
+    Lzma(const BlockCb& cb) : m_cb(cb)
     {
         m_strm = LZMA_STREAM_INIT;
     }
@@ -95,7 +95,7 @@ private:
 class LzmaCompressorImpl : public Lzma
 {
 public:
-    LzmaCompressorImpl(BlockCb cb) : Lzma(cb)
+    LzmaCompressorImpl(const BlockCb& cb) : Lzma(cb)
     {
         if (lzma_easy_encoder(&m_strm, 2, LZMA_CHECK_CRC64) != LZMA_OK)
             throw compression_error("Can't create compressor");
@@ -113,7 +113,7 @@ public:
 };
 
 
-LzmaCompressor::LzmaCompressor(BlockCb cb) :
+LzmaCompressor::LzmaCompressor(const BlockCb& cb) :
     m_impl(new LzmaCompressorImpl(cb))
 {}
 
@@ -137,7 +137,7 @@ void LzmaCompressor::done()
 class LzmaDecompressorImpl : public Lzma
 {
 public:
-    LzmaDecompressorImpl(BlockCb cb) : Lzma(cb)
+    LzmaDecompressorImpl(const BlockCb& cb) : Lzma(cb)
     {
         if (lzma_auto_decoder(&m_strm, std::numeric_limits<uint32_t>::max(),
             LZMA_TELL_UNSUPPORTED_CHECK))
@@ -155,7 +155,7 @@ public:
     }
 };
 
-LzmaDecompressor::LzmaDecompressor(BlockCb cb) :
+LzmaDecompressor::LzmaDecompressor(const BlockCb& cb) :
     m_impl(new LzmaDecompressorImpl(cb))
 {}
 

--- a/pdal/compression/LzmaCompression.hpp
+++ b/pdal/compression/LzmaCompression.hpp
@@ -42,7 +42,7 @@ class LzmaCompressorImpl;
 class LzmaCompressor : public Compressor
 {
 public:
-    PDAL_DLL LzmaCompressor(BlockCb cb);
+    PDAL_DLL LzmaCompressor(const BlockCb& cb);
     PDAL_DLL ~LzmaCompressor();
 
     PDAL_DLL void compress(const char *buf, size_t bufsize);
@@ -58,7 +58,7 @@ class LzmaDecompressorImpl;
 class LzmaDecompressor : public Decompressor
 {
 public:
-    PDAL_DLL LzmaDecompressor(BlockCb cb);
+    PDAL_DLL LzmaDecompressor(const BlockCb& cb);
     PDAL_DLL ~LzmaDecompressor();
 
     PDAL_DLL void decompress(const char *buf, size_t bufsize);

--- a/pdal/compression/ZstdCompression.cpp
+++ b/pdal/compression/ZstdCompression.cpp
@@ -47,7 +47,7 @@ public:
     char m_tmpbuf[CHUNKSIZE];
     BlockCb m_cb;
 
-    ZstdCompressorImpl(BlockCb cb) : m_cb(cb)
+    ZstdCompressorImpl(const BlockCb& cb) : m_cb(cb)
     {
         m_strm = ZSTD_createCStream();
         ZSTD_initCStream(m_strm, 15);
@@ -91,7 +91,7 @@ public:
     }
 };
 
-ZstdCompressor::ZstdCompressor(BlockCb cb) :
+ZstdCompressor::ZstdCompressor(const BlockCb& cb) :
     m_impl(new ZstdCompressorImpl(cb))
 {}
 
@@ -115,7 +115,7 @@ void ZstdCompressor::done()
 class ZstdDecompressorImpl
 {
 public:
-    ZstdDecompressorImpl(BlockCb cb) : m_cb(cb)
+    ZstdDecompressorImpl(const BlockCb& cb) : m_cb(cb)
     {
         m_strm = ZSTD_createDStream();
         ZSTD_initDStream(m_strm);
@@ -153,7 +153,7 @@ private:
     char m_tmpbuf[CHUNKSIZE];
 };
 
-ZstdDecompressor::ZstdDecompressor(BlockCb cb) :
+ZstdDecompressor::ZstdDecompressor(const BlockCb& cb) :
     m_impl(new ZstdDecompressorImpl(cb))
 {}
 

--- a/pdal/compression/ZstdCompression.hpp
+++ b/pdal/compression/ZstdCompression.hpp
@@ -43,7 +43,7 @@ class ZstdCompressorImpl;
 class ZstdCompressor : public Compressor
 {
 public:
-    PDAL_DLL ZstdCompressor(BlockCb cb);
+    PDAL_DLL ZstdCompressor(const BlockCb& cb);
     PDAL_DLL ~ZstdCompressor();
 
     PDAL_DLL void compress(const char *buf, size_t bufsize);
@@ -58,7 +58,7 @@ class ZstdDecompressorImpl;
 class ZstdDecompressor : public Decompressor
 {
 public:
-    PDAL_DLL ZstdDecompressor(BlockCb cb);
+    PDAL_DLL ZstdDecompressor(const BlockCb& cb);
     PDAL_DLL ~ZstdDecompressor();
 
     PDAL_DLL void decompress(const char *buf, size_t bufsize);

--- a/pdal/util/FileUtils.cpp
+++ b/pdal/util/FileUtils.cpp
@@ -280,7 +280,7 @@ std::string toAbsolutePath(const std::string& filename)
 //
 // note: if base dir is not absolute, first make it absolute via
 // toAbsolutePath(base)
-std::string toAbsolutePath(const std::string& filename, const std::string base)
+std::string toAbsolutePath(const std::string& filename, const std::string& base)
 {
     const std::string newbase = toAbsolutePath(base);
     return pdalboost::filesystem::absolute(filename, newbase).string();

--- a/pdal/util/FileUtils.hpp
+++ b/pdal/util/FileUtils.hpp
@@ -213,7 +213,7 @@ namespace FileUtils
       \return  Absolute version of provided filename relative to base.
     */
     PDAL_DLL std::string toAbsolutePath(const std::string& filename,
-        const std::string base);
+        const std::string& base);
     
     /**
       Get the file creation and modification times.

--- a/plugins/greyhound/io/GreyhoundCommon.hpp
+++ b/plugins/greyhound/io/GreyhoundCommon.hpp
@@ -115,7 +115,7 @@ class GreyhoundParams
 public:
     GreyhoundParams() { }
     GreyhoundParams(const GreyhoundArgs& args);
-    GreyhoundParams(std::string resourceRoot, Json::Value params)
+    GreyhoundParams(const std::string& resourceRoot, Json::Value params)
         : m_url(resourceRoot)
         , m_params(params)
     {

--- a/plugins/hexbin/kernel/OGR.cpp
+++ b/plugins/hexbin/kernel/OGR.cpp
@@ -55,7 +55,7 @@ namespace hexdensity
 namespace writer
 {
 
-OGR::OGR(std::string const& filename, std::string srs, std::string driver, std::string layerName)
+OGR::OGR(std::string const& filename, const std::string& srs, const std::string& driver, const std::string& layerName)
     : m_filename(filename)
     , m_driver(driver)
     , m_srs(srs)

--- a/plugins/hexbin/kernel/OGR.hpp
+++ b/plugins/hexbin/kernel/OGR.hpp
@@ -56,7 +56,7 @@ class OGR
 
 
 public:
-    OGR(std::string const& filename, std::string srs, std::string driver = "ESRI Shapefile", std::string layerName ="");
+    OGR(std::string const& filename, const std::string& srs, const std::string& driver = "ESRI Shapefile", const std::string& layerName ="");
     ~OGR();
 
     void writeBoundary(hexer::HexGrid *grid);

--- a/plugins/icebridge/io/IcebridgeReader.hpp
+++ b/plugins/icebridge/io/IcebridgeReader.hpp
@@ -44,7 +44,7 @@ namespace pdal
   class Ilvis2MetadataReader
   {
   public:
-      inline void readMetadataFile(std::string filename, MetadataNode* m) {};
+      inline void readMetadataFile(const std::string& filename, MetadataNode* m) {};
   };
 }
 #else

--- a/plugins/oci/io/OciCommon.cpp
+++ b/plugins/oci/io/OciCommon.cpp
@@ -42,7 +42,7 @@
 namespace pdal
 {
 
-Connection connect(std::string connSpec)
+Connection connect(const std::string& connSpec)
 {
     using namespace std;
 
@@ -133,7 +133,7 @@ XMLSchema fetchSchema(Statement stmt, BlockPtr block)
 }
 
 
-Block::Block(Connection connection) : num_points(0), m_connection(connection),
+Block::Block(const Connection& connection) : num_points(0), m_connection(connection),
     m_num_remaining(0), m_fetched(false)
 {
     m_connection->CreateType(&blk_extent);

--- a/plugins/oci/io/OciCommon.hpp
+++ b/plugins/oci/io/OciCommon.hpp
@@ -60,7 +60,7 @@ public:
 class Block
 {
 public:
-    Block(Connection connection);
+    Block(const Connection& connection);
     ~Block();
 
     point_count_t numRemaining() const

--- a/plugins/rdb/io/RdbPointcloud.cpp
+++ b/plugins/rdb/io/RdbPointcloud.cpp
@@ -47,7 +47,7 @@ namespace pdal
 RdbPointcloud::AttributeBuffer::AttributeBuffer(
     const pdal::Dimension::Id   id,
     const pdal::Dimension::Type type,
-    const std::string           name,
+    const std::string&          name,
     const size_t                size
 ):
     id  (id),

--- a/plugins/rdb/io/RdbPointcloud.hpp
+++ b/plugins/rdb/io/RdbPointcloud.hpp
@@ -113,7 +113,7 @@ private:
         AttributeBuffer(
             const pdal::Dimension::Id   id,   //!< PDAL dimension ID
             const pdal::Dimension::Type type, //!< PDAL dimension type
-            const std::string           name, //!< PDAL dimension name
+            const std::string&          name, //!< PDAL dimension name
             const size_t                size  //!< number of points
         );
 

--- a/plugins/sqlite/io/SQLiteCommon.hpp
+++ b/plugins/sqlite/io/SQLiteCommon.hpp
@@ -55,7 +55,7 @@ public:
         data = Utils::toString(v);
     }
 
-    column(std::string v) : null(false), blobBuf(0), blobLen(0)
+    column(const std::string& v) : null(false), blobBuf(0), blobLen(0)
     {
         data = v;
     }

--- a/test/unit/FileUtilsTest.cpp
+++ b/test/unit/FileUtilsTest.cpp
@@ -96,12 +96,12 @@ static const std::string drive = "A:";
 static const std::string drive = "";
 #endif
 
-static std::string normalize(const std::string p)
+static std::string normalize(const std::string& p)
 {
     return Utils::replaceAll(p, "\\", "/");
 }
 
-static void compare_paths(const std::string a, const std::string b)
+static void compare_paths(const std::string& a, const std::string& b)
 {
     EXPECT_EQ(normalize(a), normalize(b));
 }

--- a/test/unit/io/LasReaderTest.cpp
+++ b/test/unit/io/LasReaderTest.cpp
@@ -396,7 +396,7 @@ TEST(LasReaderTest, lazperf)
 }
 #endif
 
-void streamTest(const std::string src, const std::string compression)
+void streamTest(const std::string& src, const std::string& compression)
 {
     Options ops1;
     ops1.add("filename", src);

--- a/tools/lasdump/Vlr.hpp
+++ b/tools/lasdump/Vlr.hpp
@@ -46,7 +46,7 @@ namespace lasdump
 class Vlr
 {
 public:
-    bool matches(std::string userId, uint16_t recordId)
+    bool matches(const std::string& userId, uint16_t recordId)
         { return userId == m_userId && recordId == m_recordId; }
     const char *data() const
         { return (const char *)m_data.data(); }


### PR DESCRIPTION
This fixes all cppcheck warnings
```(performance) Function parameter 'XXX' should be passed by const reference```
(except in vendor/ subdirectory)