### PR TITLE
Fix warning about unused formal parameter in Streamable.hpp

### DIFF
--- a/pdal/Streamable.hpp
+++ b/pdal/Streamable.hpp
@@ -99,7 +99,7 @@ protected:
 
        \param srs  New spatial reference.
     */
-    virtual void spatialReferenceChanged(const SpatialReference& srs)
+    virtual void spatialReferenceChanged(const SpatialReference& /*srs*/)
     {}
 };
 


### PR DESCRIPTION
Follows convention already used in the file.

----

OS: Windows
Compiler: `cl.exe /W4` from VS2017

```
streamable.hpp(102): warning C4100: 'srs': unreferenced formal parameter 
```