### PR TITLE
Added average option in KDistanceFilter

### DIFF
--- a/doc/stages/filters.kdistance.rst
+++ b/doc/stages/filters.kdistance.rst
@@ -5,7 +5,7 @@ filters.kdistance
 ===============================================================================
 
 The K-Distance filter creates a new attribute ``KDistance`` that contains the
-Euclidean distance to a point's k-th nearest neighbor.
+Euclidean distance to a point's k-th nearest neighbor. It can also be set to compute the average distance of its k nearest neighbors.
 
 .. embed::
 
@@ -35,4 +35,6 @@ Options
 
 k
   The number of k nearest neighbors. [Default: **10**]
+average
+  Compute the average distance of the point's k nearest neighbors. [Default: **false**]
 

--- a/filters/KDistanceFilter.cpp
+++ b/filters/KDistanceFilter.cpp
@@ -59,6 +59,7 @@ std::string KDistanceFilter::getName() const
 void KDistanceFilter::addArgs(ProgramArgs& args)
 {
     args.add("k", "k neighbors", m_k, 10);
+    args.add("average", "Compute the average distance of the point's k nearest neighbors", m_average, false);
 }
 
 void KDistanceFilter::addDimensions(PointLayoutPtr layout)
@@ -88,7 +89,16 @@ void KDistanceFilter::filter(PointView& view)
         std::vector<PointId> indices(m_k);
         std::vector<double> sqr_dists(m_k);
         index.knnSearch(i, m_k, &indices, &sqr_dists);
-        view.setField(m_kdist, i, std::sqrt(sqr_dists[m_k-1]));
+
+        if (m_average){
+            double sqr_dists_sum = 0.0;
+            for (int j = 0; j < m_k; j++){
+                sqr_dists_sum += sqr_dists[j];
+            }
+            view.setField(m_kdist, i, std::sqrt(sqr_dists_sum / m_k));
+        }else{
+            view.setField(m_kdist, i, std::sqrt(sqr_dists[m_k-1]));
+        }
     }
 }
 

--- a/filters/KDistanceFilter.hpp
+++ b/filters/KDistanceFilter.hpp
@@ -56,6 +56,7 @@ public:
 private:
     Dimension::Id m_kdist;
     int m_k;
+    bool m_average;
 
     virtual void addArgs(ProgramArgs& args);
     virtual void addDimensions(PointLayoutPtr layout);


### PR DESCRIPTION
Recently I needed to compute the average distance of points to their k nearest neighbors. I noticed that PDAL's KDistanceFilter almost served my purpose, so I added a new parameter to choose whether a person wants the K-th distance or the average distance.

I hope this can helpful to others.

I assume that `m_k` is always > 0. Do I need to place an assertion?

Precision issues could happen for isolated points very far away from the rest if the coordinates are large, so I'm not sure if a different approach for computing the average is preferred.