### PR TITLE
Simplify os-specific #ifdefs

### DIFF
--- a/pdal/PluginDirectory.cpp
+++ b/pdal/PluginDirectory.cpp
@@ -45,12 +45,12 @@ namespace
 #if defined(__APPLE__) && defined(__MACH__)
     static const std::string dynamicLibraryExtension(".dylib");
     static const char pathSeparator(':');
-#elif defined(__linux__) || defined(__FreeBSD__) || defined(__DragonFly__) || defined(__FreeBSD_kernel__) || defined(__GNU__)
-    static const std::string dynamicLibraryExtension(".so");
-    static const char pathSeparator(':');
 #elif defined _WIN32
     static const std::string dynamicLibraryExtension(".dll");
     static const char pathSeparator(';');
+#else
+    static const std::string dynamicLibraryExtension(".so");
+    static const char pathSeparator(':');
 #endif
 
 StringList pluginSearchPaths()

--- a/plugins/sqlite/io/SQLiteCommon.hpp
+++ b/plugins/sqlite/io/SQLiteCommon.hpp
@@ -446,23 +446,19 @@ public:
     {
         std::string so_extension;
         std::string lib_extension;
-#ifdef __APPLE__
+#if defined(__APPLE__)
         so_extension = ".dylib";
         lib_extension = "mod_";
-#endif
-
-#if defined(__linux__) || defined(__FreeBSD_kernel__)
+#elif defined (_WIN32)
+        so_extension = ".dll";
+        lib_extension = "pdal";
+#else
         so_extension = ".so";
 #ifdef MOD_SPATIALITE
         lib_extension = "mod_";
 #else
         lib_extension = "lib";
 #endif
-#endif
-
-#ifdef _WIN32
-        so_extension = ".dll";
-        lib_extension = "pdal";
 #endif
 
 // #if !defined(sqlite3_enable_load_extension)

--- a/test/unit/PluginManagerTest.cpp
+++ b/test/unit/PluginManagerTest.cpp
@@ -121,11 +121,10 @@ TEST(PluginManagerTest, validnames)
 {
 #if defined(__APPLE__) && defined(__MACH__)
     static const std::string dlext(".dylib");
-#elif defined(__linux__) || defined(__FreeBSD__) || defined(__DragonFly__) || \
-      defined(__FreeBSD_kernel__) || defined(__GNU__)
-    static const std::string dlext(".so");
 #elif defined _WIN32
     static const std::string dlext(".dll");
+#else
+    static const std::string dlext(".so");
 #endif
 
     StringList type1 { "reader", "writer" };


### PR DESCRIPTION
Instead of manually listing all non-macos unix platforms, make it the fallback
case, this way all BSDs are included.

As a side effect, fixes OpenBSD and NetBSD for free :)