### PR TITLE
fix argument error message for true/false

### DIFF
--- a/io/LasReader.cpp
+++ b/io/LasReader.cpp
@@ -476,7 +476,7 @@ void LasReader::readExtraBytesVlr()
     }
     if (m_extraDims.size() && m_extraDims != extraDims)
         log()->get(LogLevel::Warning) << "Extra byte dimensions specified "
-            "in pineline and VLR don't match.  Ignoring pipeline-specified "
+            "in pipeline and VLR don't match.  Ignoring pipeline-specified "
             "dimensions";
     m_extraDims = extraDims;
 }

--- a/pdal/util/ProgramArgs.hpp
+++ b/pdal/util/ProgramArgs.hpp
@@ -1487,7 +1487,7 @@ private:
                 {
                     throw arg_error("Value '" + value +
                         "' provided for argument '" + name +
-                        "' when none is expected.");
+                        "' when 'true' or 'false' is expected.");
                 }
             }
             else


### PR DESCRIPTION
Fix the arg message when incorrectly specifying a true/false arg

For instance these two incorrect uses of use_eb_vlr produce confusing messages:

pdal translate  my.las --readers.las.use_eb_vlr -o my.bpf
PDAL: Stage option 'readers.las.use_eb_vlr' must be specified  as --readers.las.use_eb_vlr=<value>.

pdal translate  my.las --readers.las.use_eb_vlr=1 -o my.bpf
PDAL: readers.las: Value '1' provided for argument 'use_eb_vlr' when none is expected.
