### PR TITLE
Fix segmentation of last returns

### DIFF
--- a/filters/PMFFilter.cpp
+++ b/filters/PMFFilter.cpp
@@ -128,6 +128,12 @@ PointViewSet PMFFilter::run(PointViewPtr input)
     else
         lastView->append(*keptView);
 
+    if (!lastView->size())
+    {
+        log()->get(LogLevel::Error) << "No last returns found. Try running again with --filters.pmf.last=false.\n";
+        return viewSet;
+    }
+
     // Run the actual PMF algorithm.
     processGround(lastView);
 

--- a/filters/SMRFilter.cpp
+++ b/filters/SMRFilter.cpp
@@ -147,6 +147,12 @@ PointViewSet SMRFilter::run(PointViewPtr view)
     else
         lastView->append(*keptView);
 
+    if (!lastView->size())
+    {
+        log()->get(LogLevel::Error) << "No last returns found. Try running again with --filters.smrf.last=false.\n";
+        return viewSet;
+    }
+
     for (PointId i = 0; i < nonlastView->size(); ++i)
         nonlastView->setField(Dimension::Id::Classification, i, 1);
 

--- a/pdal/Segmentation.cpp
+++ b/pdal/Segmentation.cpp
@@ -130,12 +130,11 @@ void ignoreDimRange(DimRange dr, PointViewPtr input, PointViewPtr keep,
 void segmentLastReturns(PointViewPtr input, PointViewPtr last,
                         PointViewPtr other)
 {
-    PointRef point(*input, 0);
     for (PointId i = 0; i < input->size(); ++i)
     {
-        point.setPointId(i);
-        if (point.getFieldAs<uint8_t>(Dimension::Id::ReturnNumber) ==
-            point.getFieldAs<uint8_t>(Dimension::Id::NumberOfReturns))
+        uint8_t rn = input->getFieldAs<uint8_t>(Dimension::Id::ReturnNumber, i);
+        uint8_t nr = input->getFieldAs<uint8_t>(Dimension::Id::NumberOfReturns, i);
+        if ((rn == nr) && (nr > 1))
             last->appendPoint(*input, i);
         else
             other->appendPoint(*input, i);


### PR DESCRIPTION
segmentLastReturns now defines last returns as those points whose ReturnNumber
equals the NumberOfReturns when the NumberOfReturns is greater than 1.

This segmentation is used in both the SMRF and PMF ground segmentation filters,
so ground segmentation results may differ from what was previously returned.