### PR TITLE
Add pgpointcloud lazperf support

### DIFF
--- a/doc/stages/writers.pgpointcloud.rst
+++ b/doc/stages/writers.pgpointcloud.rst
@@ -66,6 +66,7 @@ compression
   * **none** applies no compression
   * **dimensional** applies dynamic compression to each dimension separately
   * **ght** applies a "geohash tree" compression by sorting the points into a prefix tree
+  * **lazperf** applies a "laz" compression (using the `laz-perf`_ library in PostgreSQL Pointcloud)
 
 overwrite
   To drop the table before writing set to 'true'. To append to the table set to 'false'. [Default: **false**]
@@ -95,3 +96,4 @@ output_dims
   are listed by name and separated by commas.
 
 .. _PostgreSQL Pointcloud: http://github.com/pramsey/pointcloud
+.. _laz-perf: https://github.com/hobu/laz-perf

--- a/plugins/pgpointcloud/io/PgCommon.hpp
+++ b/plugins/pgpointcloud/io/PgCommon.hpp
@@ -52,7 +52,7 @@ inline pdal::CompressionType getCompressionType(
         return CompressionType::Dimensional;
     else if (compression_type == "ght")
         return CompressionType::Ght;
-    else if (compression_type == "laszperf")
+    else if (compression_type == "lazperf")
         return CompressionType::Lazperf;
     return CompressionType::None;
 }

--- a/plugins/pgpointcloud/io/PgWriter.cpp
+++ b/plugins/pgpointcloud/io/PgWriter.cpp
@@ -219,6 +219,8 @@ uint32_t PgWriter::SetupSchema(uint32_t srid)
         compression = "dimensional";
     else if (m_patch_compression_type == CompressionType::Ght)
         compression = "ght";
+    else if (m_patch_compression_type == CompressionType::Lazperf)
+        compression = "laz";
 
     Metadata metadata;
     MetadataNode m = metadata.getNode();


### PR DESCRIPTION
Add pgpointcloud lazperf support, and clarify the description of the "compression" parameter in the pgpointcloud writer documentation.

Closes #2050.