### PR TITLE
Add prefiltering options to ground kernel

### DIFF
--- a/kernels/GroundKernel.hpp
+++ b/kernels/GroundKernel.hpp
@@ -66,6 +66,8 @@ private:
     double m_initialDistance;
     double m_cellSize;
     bool m_extract;
+    bool m_reset;
+    bool m_denoise;
 };
 
 } // namespace pdal


### PR DESCRIPTION
- Add a switch to optionally reset classifications prior to segmenting ground returns
- Add a switch to optionally denoise prior to segmenting ground returns

Fixes #1579