### PR TITLE
Allow more flexible processing of return groups in ground filters

### DIFF
--- a/filters/PMFFilter.cpp
+++ b/filters/PMFFilter.cpp
@@ -62,22 +62,19 @@ struct PMFArgs
     bool m_exponential;
     DimRange m_ignored;
     double m_initialDistance;
-    bool m_lastOnly;
+    StringList m_returns;
     double m_maxDistance;
     double m_maxWindowSize;
     double m_slope;
 };
-
 
 CREATE_STATIC_STAGE(PMFFilter, s_info)
 
 PMFFilter::PMFFilter() : m_args(new PMFArgs)
 {}
 
-
 PMFFilter::~PMFFilter()
 {}
-
 
 std::string PMFFilter::getName() const
 {
@@ -88,14 +85,15 @@ void PMFFilter::addArgs(ProgramArgs& args)
 {
     args.add("cell_size", "Cell size", m_args->m_cellSize, 1.0);
     args.add("exponential", "Exponential growth of window size?",
-        m_args->m_exponential, true);
+             m_args->m_exponential, true);
     args.add("ignore", "Ignore values", m_args->m_ignored);
-    args.add("initial_distance", "Initial distance",
-        m_args->m_initialDistance, 0.15);
-    args.add("last", "Consider last returns only?", m_args->m_lastOnly, true);
+    args.add("initial_distance", "Initial distance", m_args->m_initialDistance,
+             0.15);
+    args.add("returns", "Include only returns?", m_args->m_returns,
+             {"last", "only"});
     args.add("max_distance", "Maximum distance", m_args->m_maxDistance, 2.5);
-    args.add("max_window_size", "Maximum window size",
-        m_args->m_maxWindowSize, 33.0);
+    args.add("max_window_size", "Maximum window size", m_args->m_maxWindowSize,
+             33.0);
     args.add("slope", "Slope", m_args->m_slope, 1.0);
 }
 
@@ -110,7 +108,7 @@ void PMFFilter::prepared(PointTableRef table)
 
     m_args->m_ignored.m_id = layout->findDim(m_args->m_ignored.m_name);
 
-    if (m_args->m_lastOnly)
+    if (m_args->m_returns.size())
     {
         if (!layout->hasDim(Dimension::Id::ReturnNumber) ||
             !layout->hasDim(Dimension::Id::NumberOfReturns))
@@ -119,7 +117,7 @@ void PMFFilter::prepared(PointTableRef table)
                                              "NumberOfReturns. Skipping "
                                              "segmentation of last returns and "
                                              "proceeding with all returns.\n";
-            m_args->m_lastOnly = false;
+            m_args->m_returns = {""};
         }
     }
 }
@@ -136,36 +134,35 @@ PointViewSet PMFFilter::run(PointViewPtr input)
     if (m_args->m_ignored.m_id == Dimension::Id::Unknown)
         keptView->append(*input);
     else
-        Segmentation::ignoreDimRange(m_args->m_ignored, input,
-            keptView, ignoredView);
+        Segmentation::ignoreDimRange(m_args->m_ignored, input, keptView,
+                                     ignoredView);
 
     // Classify remaining points with value of 1. processGround will mark ground
     // returns as 2.
     for (PointId i = 0; i < keptView->size(); ++i)
         keptView->setField(Dimension::Id::Classification, i, 1);
 
-    // Segment kept view into last/other-than-last return views.
-    PointViewPtr lastView = keptView->makeNew();
-    PointViewPtr nonlastView = keptView->makeNew();
-    if (m_args->m_lastOnly)
-        Segmentation::segmentLastReturns(keptView, lastView, nonlastView);
-    else
-        lastView->append(*keptView);
+    // Segment kept view into two views
+    PointViewPtr firstView = keptView->makeNew();
+    PointViewPtr secondView = keptView->makeNew();
+    Segmentation::segmentReturns(keptView, firstView, secondView,
+                                 m_args->m_returns);
 
-    if (!lastView->size())
+    if (!firstView->size())
     {
-        log()->get(LogLevel::Error) << "No last returns found. Try running again with --filters.pmf.last=false.\n";
+        log()->get(LogLevel::Error) << "No last returns found. Try running "
+                                       "again with --filters.pmf.last=false.\n";
         return viewSet;
     }
 
     // Run the actual PMF algorithm.
-    processGround(lastView);
+    processGround(firstView);
 
     // Prepare the output PointView.
     PointViewPtr outView = input->makeNew();
     outView->append(*ignoredView);
-    outView->append(*nonlastView);
-    outView->append(*lastView);
+    outView->append(*secondView);
+    outView->append(*firstView);
     viewSet.insert(outView);
 
     return viewSet;
@@ -267,8 +264,8 @@ void PMFFilter::processGround(PointViewPtr view)
         if (iter == 0)
             ht = m_args->m_initialDistance;
         else
-            ht = m_args->m_slope * (ws - wsvec[iter - 1]) *
-                m_args->m_cellSize + m_args->m_initialDistance;
+            ht = m_args->m_slope * (ws - wsvec[iter - 1]) * m_args->m_cellSize +
+                 m_args->m_initialDistance;
 
         // Enforce max distance on height threshold
         if (ht > m_args->m_maxDistance)
@@ -299,10 +296,10 @@ void PMFFilter::processGround(PointViewPtr view)
             double y = view->getFieldAs<double>(Dimension::Id::Y, p_idx);
             double z = view->getFieldAs<double>(Dimension::Id::Z, p_idx);
 
-            int c = static_cast<int>(floor((x - bounds.minx) /
-                m_args->m_cellSize));
-            int r = static_cast<int>(floor((y - bounds.miny) /
-                m_args->m_cellSize));
+            int c =
+                static_cast<int>(floor((x - bounds.minx) / m_args->m_cellSize));
+            int r =
+                static_cast<int>(floor((y - bounds.miny) / m_args->m_cellSize));
 
             if ((z - mo[c * rows + r]) < htvec[j])
                 groundNewIdx.push_back(p_idx);

--- a/filters/SMRFilter.cpp
+++ b/filters/SMRFilter.cpp
@@ -83,16 +83,14 @@ struct SMRArgs
     double m_cut;
     std::string m_dir;
     DimRange m_ignored;
-    bool m_lastOnly;
+    StringList m_returns;
 };
 
 SMRFilter::SMRFilter() : m_args(new SMRArgs)
 {}
 
-
 SMRFilter::~SMRFilter()
 {}
-
 
 std::string SMRFilter::getName() const
 {
@@ -109,7 +107,8 @@ void SMRFilter::addArgs(ProgramArgs& args)
     args.add("cut", "Cut net size?", m_args->m_cut, 0.0);
     args.add("dir", "Optional output directory for debugging", m_args->m_dir);
     args.add("ignore", "Ignore values", m_args->m_ignored);
-    args.add("last", "Consider last returns only?", m_args->m_lastOnly, true);
+    args.add("returns", "Include last returns?", m_args->m_returns,
+             {"last", "only"});
 }
 
 void SMRFilter::addDimensions(PointLayoutPtr layout)
@@ -123,7 +122,7 @@ void SMRFilter::prepared(PointTableRef table)
 
     m_args->m_ignored.m_id = layout->findDim(m_args->m_ignored.m_name);
 
-    if (m_args->m_lastOnly)
+    if (m_args->m_returns.size())
     {
         if (!layout->hasDim(Dimension::Id::ReturnNumber) ||
             !layout->hasDim(Dimension::Id::NumberOfReturns))
@@ -132,7 +131,7 @@ void SMRFilter::prepared(PointTableRef table)
                                              "NumberOfReturns. Skipping "
                                              "segmentation of last returns and "
                                              "proceeding with all returns.\n";
-            m_args->m_lastOnly = false;
+            m_args->m_returns = {""};
         }
     }
 }
@@ -159,33 +158,33 @@ PointViewSet SMRFilter::run(PointViewPtr view)
         keptView->append(*view);
     else
         Segmentation::ignoreDimRange(m_args->m_ignored, view, keptView,
-            ignoredView);
+                                     ignoredView);
 
-    // Segment kept view into last/other-than-last return views.
-    PointViewPtr lastView = keptView->makeNew();
-    PointViewPtr nonlastView = keptView->makeNew();
-    if (m_args->m_lastOnly)
-        Segmentation::segmentLastReturns(keptView, lastView, nonlastView);
-    else
-        lastView->append(*keptView);
+    // Segment kept view into two views
+    PointViewPtr firstView = keptView->makeNew();
+    PointViewPtr secondView = keptView->makeNew();
+    Segmentation::segmentReturns(keptView, firstView, secondView,
+                                 m_args->m_returns);
 
-    if (!lastView->size())
+    if (!firstView->size())
     {
-        log()->get(LogLevel::Error) << "No last returns found. Try running again with --filters.smrf.last=false.\n";
+        log()->get(LogLevel::Error)
+            << "No last returns found. Try running again with "
+               "--filters.smrf.last=false.\n";
         return viewSet;
     }
 
-    for (PointId i = 0; i < nonlastView->size(); ++i)
-        nonlastView->setField(Dimension::Id::Classification, i, 1);
+    for (PointId i = 0; i < secondView->size(); ++i)
+        secondView->setField(Dimension::Id::Classification, i, 1);
 
-    m_srs = lastView->spatialReference();
+    m_srs = firstView->spatialReference();
 
-    lastView->calculateBounds(m_bounds);
+    firstView->calculateBounds(m_bounds);
     m_cols = ((m_bounds.maxx - m_bounds.minx) / m_args->m_cell) + 1;
     m_rows = ((m_bounds.maxy - m_bounds.miny) / m_args->m_cell) + 1;
 
     // Create raster of minimum Z values per element.
-    std::vector<double> ZImin = createZImin(lastView);
+    std::vector<double> ZImin = createZImin(firstView);
 
     // Create raster mask of pixels containing low outlier points.
     std::vector<int> Low = createLowMask(ZImin);
@@ -205,16 +204,16 @@ PointViewSet SMRFilter::run(PointViewPtr view)
     // original ZImin (not ZInet), however the net cut mask will still force
     // interpolation at these pixels.
     std::vector<double> ZIpro =
-        createZIpro(lastView, ZImin, Low, isNetCell, Obj);
+        createZIpro(firstView, ZImin, Low, isNetCell, Obj);
 
     // Classify ground returns by comparing elevation values to the provisional
     // DEM.
-    classifyGround(lastView, ZIpro);
+    classifyGround(firstView, ZIpro);
 
     PointViewPtr outView = view->makeNew();
     outView->append(*ignoredView);
-    outView->append(*nonlastView);
-    outView->append(*lastView);
+    outView->append(*secondView);
+    outView->append(*firstView);
     viewSet.insert(outView);
 
     return viewSet;
@@ -244,31 +243,31 @@ void SMRFilter::classifyGround(PointViewPtr view, std::vector<double>& ZIpro)
                                     gsurfs.data() + gsurfs.size());
         std::vector<double> gsurfs_fillV = knnfill(view, gsurfsV);
         gsurfs = Map<MatrixXd>(gsurfs_fillV.data(), m_rows, m_cols);
-        thresh = (m_args->m_threshold + m_args->m_scalar *
-            gsurfs.array()).matrix();
+        thresh =
+            (m_args->m_threshold + m_args->m_scalar * gsurfs.array()).matrix();
 
         if (!m_args->m_dir.empty())
         {
-            std::string fname = FileUtils::toAbsolutePath("gx.tif",
-                m_args->m_dir);
+            std::string fname =
+                FileUtils::toAbsolutePath("gx.tif", m_args->m_dir);
             writeMatrix(gx, fname, "GTiff", m_args->m_cell, m_bounds, m_srs);
 
             fname = FileUtils::toAbsolutePath("gy.tif", m_args->m_dir);
             writeMatrix(gy, fname, "GTiff", m_args->m_cell, m_bounds, m_srs);
 
             fname = FileUtils::toAbsolutePath("gsurfs.tif", m_args->m_dir);
-            writeMatrix(gsurfs, fname, "GTiff", m_args->m_cell,
-                m_bounds, m_srs);
+            writeMatrix(gsurfs, fname, "GTiff", m_args->m_cell, m_bounds,
+                        m_srs);
 
             fname = FileUtils::toAbsolutePath("gsurfs_fill.tif", m_args->m_dir);
             MatrixXd gsurfs_fill =
                 Map<MatrixXd>(gsurfs_fillV.data(), m_rows, m_cols);
-            writeMatrix(gsurfs_fill, fname, "GTiff", m_args->m_cell,
-                m_bounds, m_srs);
+            writeMatrix(gsurfs_fill, fname, "GTiff", m_args->m_cell, m_bounds,
+                        m_srs);
 
             fname = FileUtils::toAbsolutePath("thresh.tif", m_args->m_dir);
-            writeMatrix(thresh, fname, "GTiff", m_args->m_cell,
-                m_bounds, m_srs);
+            writeMatrix(thresh, fname, "GTiff", m_args->m_cell, m_bounds,
+                        m_srs);
         }
     }
 
@@ -278,10 +277,10 @@ void SMRFilter::classifyGround(PointViewPtr view, std::vector<double>& ZIpro)
         double y = view->getFieldAs<double>(Id::Y, i);
         double z = view->getFieldAs<double>(Id::Z, i);
 
-        size_t c = static_cast<size_t>(std::floor(x - m_bounds.minx) /
-            m_args->m_cell);
-        size_t r = static_cast<size_t>(std::floor(y - m_bounds.miny) /
-            m_args->m_cell);
+        size_t c =
+            static_cast<size_t>(std::floor(x - m_bounds.minx) / m_args->m_cell);
+        size_t r =
+            static_cast<size_t>(std::floor(y - m_bounds.miny) / m_args->m_cell);
 
         // TODO(chambbj): We don't quite do this by the book and yet it seems to
         // work reasonably well:
@@ -324,11 +323,11 @@ std::vector<int> SMRFilter::createLowMask(std::vector<double> const& ZImin)
 
     if (!m_args->m_dir.empty())
     {
-        std::string fname = FileUtils::toAbsolutePath("zilow.tif",
-            m_args->m_dir);
+        std::string fname =
+            FileUtils::toAbsolutePath("zilow.tif", m_args->m_dir);
         MatrixXi Low = Map<MatrixXi>(LowV.data(), m_rows, m_cols);
         writeMatrix(Low.cast<double>(), fname, "GTiff", m_args->m_cell,
-            m_bounds, m_srs);
+                    m_bounds, m_srs);
     }
 
     return LowV;
@@ -372,16 +371,16 @@ std::vector<int> SMRFilter::createObjMask(std::vector<double> const& ZImin)
     // "The second stage of the ground identification algorithm involves the
     // application of a progressive morphological filter to the minimum surface
     // grid (ZImin)."
-    std::vector<int> ObjV = progressiveFilter(ZImin, m_args->m_slope,
-        m_args->m_window);
+    std::vector<int> ObjV =
+        progressiveFilter(ZImin, m_args->m_slope, m_args->m_window);
 
     if (!m_args->m_dir.empty())
     {
-        std::string fname = FileUtils::toAbsolutePath("ziobj.tif",
-            m_args->m_dir);
+        std::string fname =
+            FileUtils::toAbsolutePath("ziobj.tif", m_args->m_dir);
         MatrixXi Obj = Map<MatrixXi>(ObjV.data(), m_rows, m_cols);
-        writeMatrix(Obj.cast<double>(), fname, "GTiff",
-            m_args->m_cell, m_bounds, m_srs);
+        writeMatrix(Obj.cast<double>(), fname, "GTiff", m_args->m_cell,
+                    m_bounds, m_srs);
     }
 
     return ObjV;
@@ -418,14 +417,15 @@ std::vector<double> SMRFilter::createZImin(PointViewPtr view)
 
     if (!m_args->m_dir.empty())
     {
-        std::string fname = FileUtils::toAbsolutePath("zimin.tif",
-            m_args->m_dir);
+        std::string fname =
+            FileUtils::toAbsolutePath("zimin.tif", m_args->m_dir);
         MatrixXd ZImin = Map<MatrixXd>(ZIminV.data(), m_rows, m_cols);
         writeMatrix(ZImin, fname, "GTiff", m_args->m_cell, m_bounds, m_srs);
 
         fname = FileUtils::toAbsolutePath("zimin_fill.tif", m_args->m_dir);
         MatrixXd ZImin_fill = Map<MatrixXd>(ZImin_fillV.data(), m_rows, m_cols);
-        writeMatrix(ZImin_fill, fname, "GTiff", m_args->m_cell, m_bounds, m_srs);
+        writeMatrix(ZImin_fill, fname, "GTiff", m_args->m_cell, m_bounds,
+                    m_srs);
     }
 
     return ZImin_fillV;
@@ -463,8 +463,8 @@ std::vector<double> SMRFilter::createZInet(std::vector<double> const& ZImin,
 
     if (!m_args->m_dir.empty())
     {
-        std::string fname = FileUtils::toAbsolutePath("zinet.tif",
-            m_args->m_dir);
+        std::string fname =
+            FileUtils::toAbsolutePath("zinet.tif", m_args->m_dir);
         MatrixXd ZInet = Map<MatrixXd>(ZInetV.data(), m_rows, m_cols);
         writeMatrix(ZInet, fname, "GTiff", m_args->m_cell, m_bounds, m_srs);
     }
@@ -495,15 +495,15 @@ std::vector<double> SMRFilter::createZIpro(PointViewPtr view,
 
     if (!m_args->m_dir.empty())
     {
-        std::string fname = FileUtils::toAbsolutePath("zipro.tif",
-            m_args->m_dir);
+        std::string fname =
+            FileUtils::toAbsolutePath("zipro.tif", m_args->m_dir);
         MatrixXd ZIpro = Map<MatrixXd>(ZIproV.data(), m_rows, m_cols);
         writeMatrix(ZIpro, fname, "GTiff", m_args->m_cell, m_bounds, m_srs);
 
         fname = FileUtils::toAbsolutePath("zipro_fill.tif", m_args->m_dir);
         MatrixXd ZIpro_fill = Map<MatrixXd>(ZIpro_fillV.data(), m_rows, m_cols);
-        writeMatrix(ZIpro_fill, fname, "GTiff", m_args->m_cell,
-            m_bounds, m_srs);
+        writeMatrix(ZIpro_fill, fname, "GTiff", m_args->m_cell, m_bounds,
+                    m_srs);
     }
 
     return ZIpro_fillV;
@@ -524,10 +524,10 @@ std::vector<double> SMRFilter::knnfill(PointViewPtr view,
             if (std::isnan(cz[c * m_rows + r]))
                 continue;
 
-            temp->setField(Id::X, i, m_bounds.minx + (c + 0.5) *
-                m_args->m_cell);
-            temp->setField(Id::Y, i, m_bounds.miny + (r + 0.5) *
-                m_args->m_cell);
+            temp->setField(Id::X, i,
+                           m_bounds.minx + (c + 0.5) * m_args->m_cell);
+            temp->setField(Id::Y, i,
+                           m_bounds.miny + (r + 0.5) * m_args->m_cell);
             temp->setField(Id::Z, i, cz[c * m_rows + r]);
             i++;
         }

--- a/pdal/Segmentation.cpp
+++ b/pdal/Segmentation.cpp
@@ -166,7 +166,6 @@ void segmentReturns(PointViewPtr input, PointViewPtr first,
 
     for (PointId i = 0; i < input->size(); ++i)
     {
-        PointRef p = input->point(i);
         uint8_t rn = input->getFieldAs<uint8_t>(Dimension::Id::ReturnNumber, i);
         uint8_t nr = input->getFieldAs<uint8_t>(Dimension::Id::NumberOfReturns, i);
         if ((rn == 1) && (nr > 1))
@@ -200,7 +199,6 @@ void segmentReturns(PointViewPtr input, PointViewPtr first,
         else
             second->appendPoint(*input.get(), i);
     }
-    std::cerr << first->size() << ", " << second->size() << std::endl;
 }
 
 } // namespace Segmentation

--- a/pdal/Segmentation.cpp
+++ b/pdal/Segmentation.cpp
@@ -144,60 +144,40 @@ void segmentLastReturns(PointViewPtr input, PointViewPtr last,
 void segmentReturns(PointViewPtr input, PointViewPtr first,
                     PointViewPtr second, StringList returns)
 {
-    static const int returnFirst = 1;
-    static const int returnIntermediate = 2;
-    static const int returnLast = 4;
-    static const int returnOnly = 8;
-
-    int outputTypes = 0;
+    bool returnFirst = false;
+    bool returnIntermediate = false;
+    bool returnLast = false;
+    bool returnOnly = false;
 
     for (auto& r : returns)
     {
         Utils::trim(r);
         if (r == "first")
-            outputTypes |= returnFirst;
+            returnFirst = true;
         else if (r == "intermediate")
-            outputTypes |= returnIntermediate;
+            returnIntermediate = true;
         else if (r == "last")
-            outputTypes |= returnLast;
+            returnLast = true;
         else if (r == "only")
-            outputTypes |= returnOnly;
+            returnOnly = true;
     }
 
     for (PointId i = 0; i < input->size(); ++i)
     {
         uint8_t rn = input->getFieldAs<uint8_t>(Dimension::Id::ReturnNumber, i);
         uint8_t nr = input->getFieldAs<uint8_t>(Dimension::Id::NumberOfReturns, i);
-        if ((rn == 1) && (nr > 1))
+        
+        if ((((rn == 1) && (nr > 1)) && returnFirst) ||
+            (((rn > 1) && (rn < nr)) && returnIntermediate) ||
+            (((rn == nr) && (nr > 1)) && returnLast) ||
+            ((nr == 1) && returnOnly))
         {
-            if (outputTypes & returnFirst)
-                first->appendPoint(*input.get(), i);
-            else
-                second->appendPoint(*input.get(), i);
-        }
-        else if ((rn > 1) && (rn < nr))
-        {
-            if (outputTypes & returnIntermediate)
-                first->appendPoint(*input.get(), i);
-            else
-                second->appendPoint(*input.get(), i);
-        }
-        else if ((rn == nr) && (nr > 1))
-        {
-            if (outputTypes & returnLast)
-                first->appendPoint(*input.get(), i);
-            else
-                second->appendPoint(*input.get(), i);
-        }
-        else if (nr ==1)
-        {
-            if (outputTypes & returnOnly)
-                first->appendPoint(*input.get(), i);
-            else
-                second->appendPoint(*input.get(), i);
+            first->appendPoint(*input.get(), i);
         }
         else
+        {
             second->appendPoint(*input.get(), i);
+        }
     }
 }
 

--- a/pdal/Segmentation.hpp
+++ b/pdal/Segmentation.hpp
@@ -74,5 +74,8 @@ PDAL_DLL void ignoreDimRange(DimRange dr, PointViewPtr input, PointViewPtr keep,
 PDAL_DLL void segmentLastReturns(PointViewPtr input, PointViewPtr last,
                                  PointViewPtr other);
 
+PDAL_DLL void segmentReturns(PointViewPtr input, PointViewPtr first,
+                             PointViewPtr second, StringList returns);
+
 } // namespace Segmentation
 } // namespace pdal

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -174,6 +174,7 @@ PDAL_ADD_TEST(pdal_filters_reprojection_test FILES
     filters/ReprojectionFilterTest.cpp)
 PDAL_ADD_TEST(pdal_filters_range_test FILES filters/RangeFilterTest.cpp)
 PDAL_ADD_TEST(pdal_filters_randomize_test FILES filters/RandomizeFilterTest.cpp)
+PDAL_ADD_TEST(pdal_filters_smrf_test FILES filters/SMRFilterTest.cpp)
 PDAL_ADD_TEST(pdal_filters_sort_test FILES filters/SortFilterTest.cpp)
 target_include_directories(pdal_filters_sort_test PRIVATE ${PDAL_JSONCPP_INCLUDE_DIR})
 PDAL_ADD_TEST(pdal_filters_splitter_test FILES filters/SplitterTest.cpp)

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -169,6 +169,7 @@ PDAL_ADD_TEST(pdal_filters_additional_merge_test FILES
     filters/AdditionalMergeTest.cpp)
 target_include_directories(pdal_filters_additional_merge_test PRIVATE ${PDAL_JSONCPP_INCLUDE_DIR})
 PDAL_ADD_TEST(pdal_filters_overlay_test FILES filters/OverlayFilterTest.cpp)
+PDAL_ADD_TEST(pdal_filters_pmf_test FILES filters/PMFFilterTest.cpp)
 PDAL_ADD_TEST(pdal_filters_reprojection_test FILES
     filters/ReprojectionFilterTest.cpp)
 PDAL_ADD_TEST(pdal_filters_range_test FILES filters/RangeFilterTest.cpp)

--- a/test/unit/OldPCLBlockTest.cpp
+++ b/test/unit/OldPCLBlockTest.cpp
@@ -218,7 +218,10 @@ TEST(OldPCLBlockTests, PMF)
     fo.add("slope", 1.0);
     fo.add("initial_distance", 0.15);
     fo.add("max_distance", 2.5);
-    fo.add("last", false);
+    fo.add("returns", "first");
+    fo.add("returns", "intermediate");
+    fo.add("returns", "last");
+    fo.add("returns", "only");
 
     Stage* outlier(f.createStage("filters.pmf"));
     EXPECT_TRUE(outlier);

--- a/test/unit/filters/PMFFilterTest.cpp
+++ b/test/unit/filters/PMFFilterTest.cpp
@@ -1,0 +1,62 @@
+/******************************************************************************
+* Copyright (c) 2018, Bradley J Chambers (brad.chambers@gmail.com)
+*
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following
+* conditions are met:
+*
+*     * Redistributions of source code must retain the above copyright
+*       notice, this list of conditions and the following disclaimer.
+*     * Redistributions in binary form must reproduce the above copyright
+*       notice, this list of conditions and the following disclaimer in
+*       the documentation and/or other materials provided
+*       with the distribution.
+*     * Neither the name of Hobu, Inc. or Flaxen Geo Consulting nor the
+*       names of its contributors may be used to endorse or promote
+*       products derived from this software without specific prior
+*       written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+* FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+* COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+* BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+* OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+* AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+* OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+* OF SUCH DAMAGE.
+****************************************************************************/
+
+#include <pdal/pdal_test_main.hpp>
+#include <filters/PMFFilter.hpp>
+
+using namespace pdal;
+
+TEST(PMFFilterTest, invalidReturns)
+{
+    Options opts;
+    opts.add("returns", "foo");
+
+    PMFFilter filter;
+    filter.setOptions(opts);
+
+    PointTable table;
+    EXPECT_THROW(filter.prepare(table), pdal_error);
+}
+
+TEST(PMFFilterTest, validReturns)
+{
+    Options opts;
+    opts.add("returns", "last,first,intermediate,only");
+
+    PMFFilter filter;
+    filter.setOptions(opts);
+
+    PointTable table;
+    EXPECT_NO_THROW(filter.prepare(table));
+}

--- a/test/unit/filters/SMRFilterTest.cpp
+++ b/test/unit/filters/SMRFilterTest.cpp
@@ -1,0 +1,62 @@
+/******************************************************************************
+* Copyright (c) 2018, Bradley J Chambers (brad.chambers@gmail.com)
+*
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following
+* conditions are met:
+*
+*     * Redistributions of source code must retain the above copyright
+*       notice, this list of conditions and the following disclaimer.
+*     * Redistributions in binary form must reproduce the above copyright
+*       notice, this list of conditions and the following disclaimer in
+*       the documentation and/or other materials provided
+*       with the distribution.
+*     * Neither the name of Hobu, Inc. or Flaxen Geo Consulting nor the
+*       names of its contributors may be used to endorse or promote
+*       products derived from this software without specific prior
+*       written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+* FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+* COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+* BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+* OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+* AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+* OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+* OF SUCH DAMAGE.
+****************************************************************************/
+
+#include <pdal/pdal_test_main.hpp>
+#include <filters/SMRFilter.hpp>
+
+using namespace pdal;
+
+TEST(SMRFilterTest, invalidReturns)
+{
+    Options opts;
+    opts.add("returns", "foo");
+
+    SMRFilter filter;
+    filter.setOptions(opts);
+
+    PointTable table;
+    EXPECT_THROW(filter.prepare(table), pdal_error);
+}
+
+TEST(SMRFilterTest, validReturns)
+{
+    Options opts;
+    opts.add("returns", "last,first,intermediate,only");
+
+    SMRFilter filter;
+    filter.setOptions(opts);
+
+    PointTable table;
+    EXPECT_NO_THROW(filter.prepare(table));
+}


### PR DESCRIPTION
Continue to default to processing last and only returns, but allow users to
specify any combination of "last", "first", "intermediate", and "only".