### PR TITLE
Add definition of pdal::Config::lazPerfEnabled()

### DIFF
--- a/pdal/pdal_config.cpp
+++ b/pdal/pdal_config.cpp
@@ -112,6 +112,12 @@ bool hasFeature(Feature f)
 }
 
 
+bool lazPerfEnabled()
+{
+    return hasFeature(Feature::LAZPERF);
+}
+
+
 int versionMajor()
 {
     return PDAL_VERSION_MAJOR;


### PR DESCRIPTION
Addresses #2077. The `pdal::Config::lazPerfEnabled()` function declared in pdal/pdal_config.hpp was not defined in pdal/pdal_config.cpp or elsewhere in PDAL. This pull request adds its definition to pdal/pdal_config.cpp.