### PR TITLE
Remove pdal::Config::lazPerfEnabled() declaration

### DIFF
--- a/pdal/pdal_config.hpp
+++ b/pdal/pdal_config.hpp
@@ -58,7 +58,6 @@ enum class Feature
 };
 
 PDAL_DLL bool hasFeature(Feature f);
-PDAL_DLL bool lazPerfEnabled();
 PDAL_DLL std::string fullVersionString();
 PDAL_DLL std::string versionString();
 PDAL_DLL int versionInteger();


### PR DESCRIPTION
This function has been replaced by `pdal::Config::hasFeature()` with the `pdal::Config::LAZPERF argument`. See comment in #2078.