### PR TITLE
Purging Numpy breaks numpy support

### DIFF
--- a/scripts/docker/ubuntu/Dockerfile
+++ b/scripts/docker/ubuntu/Dockerfile
@@ -60,7 +60,6 @@ RUN    apt-get purge -y \
         libtiff5-dev \
         openssh-client \
         python-dev \
-        python-numpy \
         python-software-properties \
         software-properties-common \
         wget \


### PR DESCRIPTION
numyp should not be purged, when it is removed the 'npy' file extension no longer works for pdal.