### PR TITLE
Configure targets to link libxml2 only if found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,6 +216,7 @@ if (NOT PDAL_HAVE_LIBXML2)
     file(GLOB XML_SRCS
         io/Ilvis2MetadataReader.cpp
         io/Ilvis2Metadata.cpp
+        io/Ilvis2Reader.cpp
         ${PDAL_SRC_DIR}/DbWriter.cpp
         ${PDAL_SRC_DIR}/DbReader.cpp
         ${PDAL_SRC_DIR}/XMLSchema.cpp)

--- a/cmake/libxml2.cmake
+++ b/cmake/libxml2.cmake
@@ -12,6 +12,11 @@ mark_as_advanced(CLEAR LIBXML2_INCLUDE_DIR)
 mark_as_advanced(CLEAR LIBXML2_LIBRARIES)
 if (LIBXML2_FOUND)
     set(PDAL_HAVE_LIBXML2 1)
+else()
+    unset(LIBXML2_INCLUDE_DIR CACHE)
+    unset(LIBXML2_LIBRARY CACHE)
+    unset(LIBXML2_XMLLINT_EXECUTABLE CACHE)
+    unset(LIBXML2_LIBRARIES) # Find-module output variable, not cache variable
 endif()
 
 set_property(GLOBAL PROPERTY _LIBXML2_INCLUDED TRUE)


### PR DESCRIPTION
Although according to the docs libxml2 is an optional dependency, main target unconditionally uses `LIBXML2_INCLUDE_DIR` and `LIBXML2_LIBRARIES` which are flagged as `-NOTFOUND`. That is not valid value for `target_*`   commands.
This makes libxml2 a required dependency leading to CMake configuration errors, if not found.
Remove Ilvis2Reader.cpp from sources if libxml2 if not found.

-----

CMake will fail if libxml2 is not found:

```
1> -- Could NOT find LibXml2 (missing: LIBXML2_LIBRARY LIBXML2_INCLUDE_DIR) 
...
1> CMake Error: The following variables are used in this project, but they are set to NOTFOUND.
1> -- Configuring incomplete, errors occurred!
1> See also "D:/PDAL/_build/x64-Debug/CMakeFiles/CMakeOutput.log".
1> See also "D:/PDAL/_build/x64-Debug/CMakeFiles/CMakeError.log".
1> Please set them or make sure they are set and tested correctly in the CMake files:
1> LIBXML2_LIBRARY (ADVANCED)
1>     linked by target "pdalcpp" in directory D:/PDAL
```

-----

Possibly, there may be more similar issues for other optional dependencies. I haven't checked them all.
This is just a very minimal patch that indicates the problem.
