### PR TITLE
Add _SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING to gtest flags

### DIFF
--- a/vendor/gtest/cmake/internal_utils.cmake
+++ b/vendor/gtest/cmake/internal_utils.cmake
@@ -65,6 +65,9 @@ macro(config_compiler_and_linker)
       # Compatibility warnings not applicable to Google Test.
       # Resolved overload was found by argument-dependent lookup.
       set(cxx_base_flags "${cxx_base_flags} -wd4675")
+    elseif (MSVC_VERSION GREATER 1900)
+      # VS2017, https://github.com/google/googletest/issues/1111
+      set(cxx_base_flags "${cxx_base_flags} -D_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING")
     endif()
     set(cxx_base_flags "${cxx_base_flags} -D_UNICODE -DUNICODE -DWIN32 -D_WIN32")
     set(cxx_base_flags "${cxx_base_flags} -DSTRICT -DWIN32_LEAN_AND_MEAN")


### PR DESCRIPTION
gtest uses `std::tr1` which has been deprecated in VS 2017 - https://github.com/google/googletest/issues/1111

Without `_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING` define, MSVC generates warnings and, since warnings are treated as errors, compilation fails.

------

```
d:\pdal\vendor\gtest\include\gtest\gtest-printers.h(497): 
  error C2220: warning treated as error - no 'object' file generated 
d:\pdal\vendor\gtest\include\gtest\gtest-printers.h(497): 
  warning C4996: 'std::tr1': warning STL4002: The non-Standard std::tr1 namespace and TR1-only machinery are deprecated and will be REMOVED. You can define _SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING to acknowledge that you have received this warning. 
```
