### PR TITLE
Ignore CMakeSettings.json for CMake integration with VS2017

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ Debug/
 Release/
 RelWithDebInfo/
 ipch/
+CMakeSettings.json
 *.sln
 *.vcxproj
 *.vcxproj.filters


### PR DESCRIPTION
CMakeSettings.json is an auxiliary file used to customize [CMake configuration while building from within VS2017](https://go.microsoft.com//fwlink//?linkid=834763).
