### PR TITLE
Get the dimension Name even its Id has not a predefined value

### DIFF
--- a/pdal/PointView.cpp
+++ b/pdal/PointView.cpp
@@ -237,7 +237,7 @@ void PointView::dump(std::ostream& ostr) const
         {
             Dimension::Id d = *di;
             const Dimension::Detail *dd = layout->dimDetail(d);
-            ostr << Dimension::name(d) << " (" <<
+            ostr << layout->dimName(d) << " (" <<
                 Dimension::interpretationName(dd->type()) << ") : ";
 
             switch (dd->type())


### PR DESCRIPTION
This fix allows correctly trace the name of dimensions with no predefined values