### PR TITLE
Reset cells member to use Delaunay::set_vertices more than one time

### DIFF
--- a/plugins/delaunay/filters/Delaunay_psm.cpp
+++ b/plugins/delaunay/filters/Delaunay_psm.cpp
@@ -20554,6 +20554,7 @@ namespace GEO {
     void Delaunay::set_vertices(
         index_t nb_vertices, const double* vertices
     ) {
+        nb_cells_ = 0;
         nb_vertices_ = nb_vertices;
         vertices_ = vertices;
         if(nb_vertices_ < index_t(dimension()) + 1) {


### PR DESCRIPTION
`Delaunay::nb_cells()` returns a wrong value (it returns the last value assigned by a previous call) when you call `Delaunay::set_vertices` with vertices don't define a valid mesh and the method returns without success. 

[Example](https://github.com/PDAL/PDAL/blob/master/plugins/delaunay/filters/Delaunay_psm.cpp#L20560)