### PR TITLE
Remove pgpointcloud GHT compression

### DIFF
--- a/doc/stages/writers.pgpointcloud.rst
+++ b/doc/stages/writers.pgpointcloud.rst
@@ -70,7 +70,6 @@ compression
 
   * **none** applies no compression
   * **dimensional** applies dynamic compression to each dimension separately
-  * **ght** applies a "geohash tree" compression by sorting the points into a prefix tree
   * **lazperf** applies a "laz" compression (using the `laz-perf`_ library in PostgreSQL Pointcloud)
 
 overwrite

--- a/pdal/compression/Compression.hpp
+++ b/pdal/compression/Compression.hpp
@@ -42,7 +42,7 @@ namespace pdal
 enum class CompressionType
 {
     None = 0,
-    Ght = 1,
+//    Ght = 1,   -- Removed compression type
     Dimensional = 2,
     Lazperf = 3,
     Unknown = 256

--- a/plugins/pgpointcloud/io/PgCommon.hpp
+++ b/plugins/pgpointcloud/io/PgCommon.hpp
@@ -50,8 +50,6 @@ inline pdal::CompressionType getCompressionType(
     compression_type = Utils::tolower(compression_type);
     if (compression_type == "dimensional")
         return CompressionType::Dimensional;
-    else if (compression_type == "ght")
-        return CompressionType::Ght;
     else if (compression_type == "lazperf")
         return CompressionType::Lazperf;
     return CompressionType::None;

--- a/plugins/pgpointcloud/io/PgWriter.cpp
+++ b/plugins/pgpointcloud/io/PgWriter.cpp
@@ -217,8 +217,6 @@ uint32_t PgWriter::SetupSchema(uint32_t srid)
     /* If the writer specifies a compression, we should set that */
     if (m_patch_compression_type == CompressionType::Dimensional)
         compression = "dimensional";
-    else if (m_patch_compression_type == CompressionType::Ght)
-        compression = "ght";
     else if (m_patch_compression_type == CompressionType::Lazperf)
         compression = "laz";
 


### PR DESCRIPTION
Remove pgpointcloud GHT compression, as the support for GHT compression has been removed in pgpointcloud v1.2.0. See https://github.com/pgpointcloud/pointcloud/pull/214.