### PR TITLE
Add StreamPointTable::setNumPoints

### DIFF
--- a/pdal/PointTable.hpp
+++ b/pdal/PointTable.hpp
@@ -208,6 +208,11 @@ public:
     /// when all dimensions are known.
     virtual void finalize()
     {}
+    /// Called before the StreamPointTable is reset indicating the number of
+    /// points that were populated, which must be less than or equal to its
+    /// capacity.
+    virtual void setNumPoints(PointId n)
+    {}
     /// Called when the contents of StreamPointTable have been consumed and
     /// the point data will be potentially overwritten.
     virtual void reset()

--- a/pdal/Streamable.cpp
+++ b/pdal/Streamable.cpp
@@ -246,6 +246,7 @@ void Streamable::execute(StreamPointTable& table,
         // Yes, vector<bool> is terrible.  Can do something better later.
         for (size_t i = 0; i < skips.size(); ++i)
             skips[i] = false;
+        table.setNumPoints(pointLimit);
         table.reset();
     }
 }

--- a/pdal/Streamable.hpp
+++ b/pdal/Streamable.hpp
@@ -84,7 +84,7 @@ protected:
         SrsMap& srsMap);
 
     /**
-      Process a single point (streaming mode).  Implement in sublcass.
+      Process a single point (streaming mode).  Implement in subclass.
 
       \param point  Point to process.
       \return  Readers return false when no more points are to be read.


### PR DESCRIPTION
For streaming point tables with a fixed capacity, it seemed unclear how to determine the number of points actually populated before a `reset`, which on the last `reset` may be less than the `capacity`.  This makes the count explicit without tight-loop bookkeeping within the table.