### PR TITLE
Broaden PipelineManager::executeStream

### DIFF
--- a/pdal/PipelineManager.cpp
+++ b/pdal/PipelineManager.cpp
@@ -215,7 +215,7 @@ point_count_t PipelineManager::execute()
 }
 
 
-void PipelineManager::executeStream(FixedPointTable& table)
+void PipelineManager::executeStream(StreamPointTable& table)
 {
     validateStageOptions();
     Stage *s = getStage();

--- a/pdal/PipelineManager.hpp
+++ b/pdal/PipelineManager.hpp
@@ -118,7 +118,7 @@ public:
     QuickInfo preview() const;
     void prepare() const;
     point_count_t execute();
-    void executeStream(FixedPointTable& table);
+    void executeStream(StreamPointTable& table);
     void validateStageOptions() const;
     bool pipelineStreamable() const;
 


### PR DESCRIPTION
Currently this function takes a FixedPointTable, which is an implementation of the more generic StreamPointTable.  This switches `PipelineManager::executeStream` to accept the more generic type.