### PR TITLE
Allow a JSON pipeline to be an array

### DIFF
--- a/doc/pipeline.rst
+++ b/doc/pipeline.rst
@@ -33,10 +33,12 @@ a pipeline provides useful advantages for more complex things:
 Introduction
 --------------------------------------------------------------------------------
 
+A PDAL processing pipeline is represented in JSON.  The structure may either:
 
-A JSON object represents a PDAL processing pipeline.  The structure is always a
-JSON object, with the primary object called ``pipeline`` being an array of
-inferred or explicit PDAL :ref:`stage_object` representations.
+- a JSON object, with a key called ``pipeline`` whose value is an array of
+  inferred or explicit PDAL :ref:`stage_object` representations.
+- a JSON array, being the array described above without being encapsulated by a
+  JSON object.
 
 Simple Example
 ................................................................................

--- a/pdal/PipelineReaderJSON.cpp
+++ b/pdal/PipelineReaderJSON.cpp
@@ -148,10 +148,18 @@ void PipelineReaderJSON::readPipeline(std::istream& input)
         throw pdal_error(err);
     }
 
-    Json::Value& subtree = root["pipeline"];
-    if (!subtree)
+    if (root.isObject() && root.isMember("pipeline"))
+    {
+        parsePipeline(root["pipeline"]);
+    }
+    else if (root.isArray())
+    {
+        parsePipeline(root);
+    }
+    else
+    {
         throw pdal_error("JSON pipeline: Root element is not a Pipeline");
-    parsePipeline(subtree);
+    }
 }
 
 

--- a/test/data/pipeline/array-pipeline.json.in
+++ b/test/data/pipeline/array-pipeline.json.in
@@ -1,0 +1,5 @@
+[
+  "@CMAKE_SOURCE_DIR@/test/data/autzen/autzen-thin.las",
+  "@CMAKE_SOURCE_DIR@/test/temp/array-pipeline.las"
+]
+

--- a/test/unit/PipelineManagerTest.cpp
+++ b/test/unit/PipelineManagerTest.cpp
@@ -157,6 +157,35 @@ TEST(PipelineManagerTest, InputGlobbing)
     FileUtils::deleteFile(Support::temppath("globbed.las"));
 }
 
+TEST(PipelineManagerTest, arrayPipeline)
+{
+    std::string cmd = Support::binpath(Support::exename("pdal") +
+        " pipeline");
+
+    std::string file(Support::configuredpath("pipeline/array-pipeline.json"));
+
+    std::string output;
+    int stat = Utils::run_shell_command(cmd + " " + file, output);
+    EXPECT_EQ(stat, 0);
+
+    StageFactory f;
+    Stage *r = f.createStage("readers.las");
+
+    Options o;
+    o.add("filename", Support::temppath("array-pipeline.las"));
+    r->setOptions(o);
+
+    PointTable t;
+    r->prepare(t);
+    PointViewSet s = r->execute(t);
+    EXPECT_EQ(s.size(), 1U);
+    PointViewPtr v = *(s.begin());
+
+    EXPECT_EQ(v->size(), 10653U);
+
+    FileUtils::deleteFile(Support::temppath("array-pipeline.las"));
+}
+
 TEST(PipelineManagerTest, replace)
 {
     PipelineManager mgr;


### PR DESCRIPTION
The specification for a JSON pipeline to be an object with key `pipeline` may be useful in some contexts but it's almost always just extra noise.  This PR allows a pipeline to be specified simply as an array while maintaining the current functionality as well.  For example: `[ "in.las", "out.laz" ]`.