### PR TITLE
add 'memorycopy' option to readers.gdal

### DIFF
--- a/io/GDALReader.cpp
+++ b/io/GDALReader.cpp
@@ -150,7 +150,8 @@ void GDALReader::addDimensions(PointLayoutPtr layout)
 void GDALReader::addArgs(ProgramArgs& args)
 {
     args.add("header", "A comma-separated list of dimension IDs to map raster bands to dimension id", m_header);
-    args.add("memorycopy", "Load the given raster file entirely to memory", m_useMemoryCopy, false);
+    pdal::Arg& cp = args.add("memorycopy", "Load the given raster file entirely to memory", m_useMemoryCopy, false);
+    cp.setHidden(true);
 }
 
 

--- a/io/GDALReader.hpp
+++ b/io/GDALReader.hpp
@@ -54,6 +54,7 @@ public:
     std::string getName() const;
 
     GDALReader();
+    ~GDALReader();
 
 private:
     virtual void initialize();
@@ -70,6 +71,7 @@ private:
     std::vector<Dimension::Type> m_bandTypes;
     std::vector<Dimension::Id> m_bandIds;
     std::string m_header;
+    bool m_useMemoryCopy;
     point_count_t m_index;
     int m_row;
     int m_col;

--- a/io/GDALReader.hpp
+++ b/io/GDALReader.hpp
@@ -71,11 +71,12 @@ private:
     std::vector<Dimension::Type> m_bandTypes;
     std::vector<Dimension::Id> m_bandIds;
     std::string m_header;
+    int m_width;
+    int m_height;
     bool m_useMemoryCopy;
     point_count_t m_index;
     int m_row;
     int m_col;
-
 };
 
 } // namespace pdal

--- a/pdal/GDALUtils.hpp
+++ b/pdal/GDALUtils.hpp
@@ -554,6 +554,22 @@ public:
     ~Raster();
 
     /**
+      Constructor.
+
+      \param ds Pointer to existing GDALDataset
+      \param drivername  Optional name of driver to use to open raster file.
+      \param srs  SpatialReference of the raster.
+      \param pixelToPos  Transformation matrix to convert raster positions to
+        geolocations.
+    */
+    Raster(GDALDataset *ds) : m_ds (ds) {};
+
+    /**
+      Return a GDAL MEM driver copy of the raster
+    */
+    Raster* memoryCopy() const;
+
+    /**
       Open raster file for reading.
     */
     GDALError open();
@@ -802,6 +818,8 @@ private:
     GDALDataset *m_ds;
     Dimension::Type m_bandType;
     double m_dstNoData;
+
+    GDALError wake();
 
     std::string m_errorMsg;
     mutable std::vector<pdal::Dimension::Type> m_types;

--- a/test/unit/io/GDALReaderTest.cpp
+++ b/test/unit/io/GDALReaderTest.cpp
@@ -51,8 +51,7 @@ TEST(GDALReaderTest, badfile)
     gr.setOptions(ro);
 
     PointTable t;
-    gr.prepare(t);
-    EXPECT_THROW(gr.execute(t), pdal_error);
+    EXPECT_THROW(gr.prepare(t), pdal_error);
 }
 
 


### PR DESCRIPTION
We sometimes need to allow user to create a GDAL MEM driver copy of the given raster for situations where the format is degenerate for whatever reason. This is kind of yucky, but otherwise the user has to manually convert the data into something more friendly to our reading strategy.