### PR TITLE
Fix CMake dependencies for Riegl RDB Plugin

### DIFF
--- a/plugins/rdb/CMakeLists.txt
+++ b/plugins/rdb/CMakeLists.txt
@@ -13,7 +13,6 @@ PDAL_ADD_PLUGIN(libname reader rdb
     ${PDAL_JSONCPP_LIB_NAME}
     rdbcpp)
 
-target_include_directories(${libname} PUBLIC ${RDB_INCLUDE_CPP_DIR})
 target_include_directories(${libname} PUBLIC ${EIGEN_INCLUDE_DIRS})
 
 
@@ -29,7 +28,6 @@ if (BUILD_RDBLIB_TESTS)
     PDAL_ADD_TEST(${RDB_TEST_NAME}
         FILES test/RdbReaderTest.cpp
         LINK_WITH ${libname})
-    target_include_directories(${RDB_TEST_NAME} PUBLIC ${RDB_INCLUDE_CPP_DIR})
     target_include_directories(${RDB_TEST_NAME} PRIVATE
         ${PROJECT_BINARY_DIR}/plugins/rdb/test
         ${PROJECT_SOURCE_DIR}/plugins/rdb/io)

--- a/plugins/rdb/CMakeLists.txt
+++ b/plugins/rdb/CMakeLists.txt
@@ -14,6 +14,7 @@ PDAL_ADD_PLUGIN(libname reader rdb
     rdbcpp)
 
 target_include_directories(${libname} PUBLIC "${PDAL_VENDOR_DIR}/eigen")
+target_include_directories(${libname} PRIVATE ${PDAL_JSONCPP_INCLUDE_DIR})
 
 
 

--- a/plugins/rdb/CMakeLists.txt
+++ b/plugins/rdb/CMakeLists.txt
@@ -13,7 +13,7 @@ PDAL_ADD_PLUGIN(libname reader rdb
     ${PDAL_JSONCPP_LIB_NAME}
     rdbcpp)
 
-target_include_directories(${libname} PUBLIC ${EIGEN_INCLUDE_DIRS})
+target_include_directories(${libname} PUBLIC "${PDAL_VENDOR_DIR}/eigen")
 
 
 


### PR DESCRIPTION
When I tried to build PDAL with RDB plugin on a relatively minimal Ubuntu (Bionic) Docker container the build failed due to missing Eigen and JSONCPP.
In a pristine Ubuntu container I installed only the following packages
- build-essential
- cmake
- libgdal-dev
- RIEGL RDB packages
and ran the following CMake commands:
```cmake
cmake -HPDAL -Bbuild -DBUILD_PLUGIN_RDBLIB=ON; cmake --build build
```
The RDB plugin was missing Eigen and JSONCPP libraries to build.
To fix these errors I
- Added missing include directory for JSONCPP: I made sure this change still works regardless of the JSONCPP library used (system install or PDAL vendor).
- Always use the Eigen library from PDAL vendor. That's what the other plugins using Eigen do.
- (And I removed a redundant include directory for RDB.)

@hobu Since from the history of these files you seemed to have troubles building with the RDB plugin, could you please confirm I did not break your build with these changes. I only tested on different Ubuntu flavors.