### PR TITLE
Fix rxp reader

### DIFF
--- a/plugins/rxp/io/RxpPointcloud.cpp
+++ b/plugins/rxp/io/RxpPointcloud.cpp
@@ -127,8 +127,9 @@ void RxpPointcloud::on_echo_transformed(echo_type echo)
     point_count_t idx = m_view->size();
     unsigned int returnNumber = 1;
     Id timeId = getTimeDimensionId(m_syncToPps);
-    for (const auto& t : targets)
+    for (scanlib::pointcloud::target_count_type i = 0; i < target_count; ++i)
     {
+        auto t = targets[i];
         m_view->setField(Id::X, idx, t.vertex[0]);
         m_view->setField(Id::Y, idx, t.vertex[1]);
         m_view->setField(Id::Z, idx, t.vertex[2]);
@@ -138,7 +139,7 @@ void RxpPointcloud::on_echo_transformed(echo_type echo)
             m_view->setField(Id::Amplitude, idx, t.amplitude);
             m_view->setField(Id::Reflectance, idx, t.reflectance);
             m_view->setField(Id::ReturnNumber, idx, returnNumber);
-            m_view->setField(Id::NumberOfReturns, idx, targets.size());
+            m_view->setField(Id::NumberOfReturns, idx, target_count);
             m_view->setField(Id::EchoRange, idx, t.echo_range);
             m_view->setField(Id::Deviation, idx, t.deviation);
             m_view->setField(Id::BackgroundRadiation, idx, t.background_radiation);

--- a/plugins/rxp/io/RxpPointcloud.cpp
+++ b/plugins/rxp/io/RxpPointcloud.cpp
@@ -127,7 +127,7 @@ void RxpPointcloud::on_echo_transformed(echo_type echo)
     point_count_t idx = m_view->size();
     unsigned int returnNumber = 1;
     Id timeId = getTimeDimensionId(m_syncToPps);
-    for (scanlib::pointcloud::target_count_type i = 0; i < target_count; ++i)
+    for (scanlib::pointcloud::target_count_type i = 0; i < target_count; ++i, ++idx, ++returnNumber)
     {
         auto t = targets[i];
         m_view->setField(Id::X, idx, t.vertex[0]);
@@ -157,7 +157,6 @@ void RxpPointcloud::on_echo_transformed(echo_type echo)
             }
             m_view->setField(Id::Intensity, idx, intensity);
         }
-        ++idx, ++returnNumber;
     }
 }
 

--- a/plugins/rxp/io/RxpPointcloud.cpp
+++ b/plugins/rxp/io/RxpPointcloud.cpp
@@ -151,7 +151,7 @@ void RxpPointcloud::on_echo_transformed(echo_type echo)
             } else if (t.reflectance < m_minReflectance) {
                 intensity = 0;
             } else {
-                intensity = uint16_t(std::roundf(double((std::numeric_limits<uint16_t>::max)()) * 
+                intensity = uint16_t(std::roundf(double((std::numeric_limits<uint16_t>::max)()) *
                         (t.reflectance - m_minReflectance) / (m_maxReflectance - m_minReflectance)));
             }
             m_view->setField(Id::Intensity, idx, intensity);

--- a/plugins/rxp/test/RxpReaderTest.cpp
+++ b/plugins/rxp/test/RxpReaderTest.cpp
@@ -116,9 +116,9 @@ TEST(RxpReaderTest, testRead)
     reader.prepare(table);
 
     PointViewSet viewSet = reader.execute(table);
-    EXPECT_EQ(viewSet.size(), 1);
+    EXPECT_EQ(viewSet.size(), 1u);
     PointViewPtr view = *viewSet.begin();
-    EXPECT_EQ(view->size(), 177208);
+    EXPECT_EQ(view->size(), 177208u);
 
     checkPoint(view, 0, 2.2630672454833984, -0.038407701998949051, -1.3249952793121338, 342656.34233957872,
             2.6865001276019029, 19.8699989, 5.70246553, 4, true, 1, 1);

--- a/plugins/rxp/test/RxpReaderTest.cpp
+++ b/plugins/rxp/test/RxpReaderTest.cpp
@@ -142,6 +142,7 @@ TEST(RxpReaderTest, testNoPpsSync)
     PointViewSet viewSet = reader.execute(table);
     PointViewPtr view = *viewSet.begin();
 
+    EXPECT_EQ(view->size(), 185925u);
     checkPoint(view, 0, 0.0705248788, -0.0417557284, 0.0304775704, 31.917255942733149,
             0.14050000667339191, 0.689999998, -14.4898596, 3, false, 1, 1);
 }


### PR DESCRIPTION
This fixes the broken rxp reader. The break was due to an improper usage of Riegl's scanlib API that just happened to work for a while, then broke at least in RiVLib version 2.5.7. The fix is in 6ef5582  and there are some additional housekeeping commits.

There were two issues raised in #2226:
1. Unable to read rxp data
2. Broken `rxptest`

This for sure fixes the second problem and it might fix the first. The improper API usage was causing overallocation of views in the reader that might have been exceeding OP's available memory.