### PR TITLE
Don't use a destructed value in GDALReader::inspect.

### DIFF
--- a/io/GDALReader.cpp
+++ b/io/GDALReader.cpp
@@ -84,19 +84,9 @@ void GDALReader::initialize()
     m_width = m_raster->width();
     m_height = m_raster->height();
     m_bandTypes = m_raster->getPDALDimensionTypes();
-    m_raster.reset();
-}
 
-
-QuickInfo GDALReader::inspect()
-{
-    QuickInfo qi;
     std::unique_ptr<PointLayout> layout(new PointLayout());
-
-    initialize();
     addDimensions(layout.get());
-
-    qi.m_pointCount = m_width * m_height;
 
     auto p = std::find(m_bandIds.begin(), m_bandIds.end(), Dimension::Id::Z);
 
@@ -107,13 +97,27 @@ QuickInfo GDALReader::inspect()
         nBand = (int) std::distance(m_bandIds.begin(), p) + 1;
     }
 
+    m_dimNames.clear();
     Dimension::IdList dims = layout->dims();
     for (auto di = dims.begin(); di != dims.end(); ++di)
-        qi.m_dimNames.push_back(layout->dimName(*di));
+        m_dimNames.push_back(layout->dimName(*di));
+    m_bounds = m_raster->bounds(nBand);
 
-    qi.m_bounds = m_raster->bounds(nBand);
-    qi.m_srs = m_raster->getSpatialRef();
+    m_raster.reset();
+}
+
+
+QuickInfo GDALReader::inspect()
+{
+    QuickInfo qi;
+
+    initialize();
+
+    qi.m_pointCount = m_width * m_height;
+    qi.m_srs = getSpatialReference();
+    qi.m_bounds = m_bounds;
     qi.m_valid = true;
+    qi.m_dimNames = m_dimNames;
 
     return qi;
 }

--- a/io/GDALReader.hpp
+++ b/io/GDALReader.hpp
@@ -35,7 +35,7 @@
 #pragma once
 
 #include <string>
-
+#include <vector>
 
 #include <pdal/Dimension.hpp>
 #include <pdal/Reader.hpp>
@@ -77,6 +77,9 @@ private:
     point_count_t m_index;
     int m_row;
     int m_col;
+
+    BOX3D m_bounds;
+    std::vector<std::string> m_dimNames;
 };
 
 } // namespace pdal

--- a/io/GDALReader.hpp
+++ b/io/GDALReader.hpp
@@ -79,7 +79,7 @@ private:
     int m_col;
 
     BOX3D m_bounds;
-    std::vector<std::string> m_dimNames;
+    StringList m_dimNames;
 };
 
 } // namespace pdal

--- a/pdal/QuickInfo.hpp
+++ b/pdal/QuickInfo.hpp
@@ -48,7 +48,7 @@ public:
     BOX3D m_bounds;
     SpatialReference m_srs;
     point_count_t m_pointCount;
-    std::vector<std::string> m_dimNames;
+    StringList m_dimNames;
     bool m_valid;
 
     QuickInfo() : m_pointCount(0), m_valid(false)


### PR DESCRIPTION
`inspect` currently segfaults since `m_raster` is reset at the end of `initialize` but still accessed afterward in `inspect`.