### PR TITLE
Defaulted CMake config LIB_INSTALL_DIR to PDAL_LIB_INSTALL_DIR

### DIFF
--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -1,5 +1,5 @@
 set(INCLUDE_INSTALL_DIR include/ CACHE PATH "include")
-set(LIB_INSTALL_DIR lib/ CACHE PATH "lib")
+set(LIB_INSTALL_DIR ${PDAL_LIB_INSTALL_DIR} CACHE PATH "lib")
 set(SYSCONFIG_INSTALL_DIR etc/pdal/ CACHE PATH "sysconfig")
 
 include(CMakePackageConfigHelpers)
@@ -7,7 +7,7 @@ include(CMakePackageConfigHelpers)
 set(PDAL_CONFIG_INCLUDE_DIRS
   "${CMAKE_INSTALL_PREFIX}/include")
 set(PDAL_CONFIG_LIBRARY_DIRS
-  "${CMAKE_INSTALL_PREFIX}/lib")
+  "${CMAKE_INSTALL_PREFIX}/${LIB_INSTALL_DIR}")
 
 configure_package_config_file(
   PDALConfig.cmake.in


### PR DESCRIPTION
I ran into this issue when trying to package PDAL in an RPM, that when I specified PDAL_LIB_INSTALL_DIR as lib64 (for Fedora), the CMake config was still going to /usr/lib. This makes it so it will also go to lib64 when the user specifies a PDAL_LIB_INSTALL_DIR by hand.