### PR TITLE
Avoid overwriting a default SRS with an empty SRS.

### DIFF
--- a/pdal/Reader.cpp
+++ b/pdal/Reader.cpp
@@ -57,6 +57,9 @@ void Reader::readerAddArgs(ProgramArgs& args)
 
 void Reader::setSpatialReference(MetadataNode& m, const SpatialReference& srs)
 {
+    if (srs.empty() && !m_defaultSrs.empty())
+        return;
+
     if (getSpatialReference().empty() || m_overrideSrs.empty())
     {
         Stage::setSpatialReference(m, srs);

--- a/pdal/Reader.cpp
+++ b/pdal/Reader.cpp
@@ -58,7 +58,12 @@ void Reader::readerAddArgs(ProgramArgs& args)
 void Reader::setSpatialReference(MetadataNode& m, const SpatialReference& srs)
 {
     if (srs.empty() && !m_defaultSrs.empty())
+    {
+        // If an attempt comes in to clear the SRS but we have a default,
+        // revert to the default rather than clearing.
+        Stage::setSpatialReference(m, m_defaultSrs);
         return;
+    }
 
     if (getSpatialReference().empty() || m_overrideSrs.empty())
     {

--- a/test/unit/SpatialReferenceTest.cpp
+++ b/test/unit/SpatialReferenceTest.cpp
@@ -367,6 +367,19 @@ TEST(SpatialReferenceTest, readerOptions)
         r.prepare(t);
         EXPECT_EQ(r.getSpatialReference(), native);
     }
+
+    {
+        Options o;
+        // This file has no spatial reference.
+        o.add("filename", Support::datapath("las/100-points.las"));
+        o.add("default_srs", "EPSG:26916");
+        LasReader r;
+        r.setOptions(o);
+
+        PointTable t;
+        r.prepare(t);
+        EXPECT_EQ(r.getSpatialReference(), SpatialReference("EPSG:26916"));
+    }
 }
 
 TEST(SpatialReferenceTest, merge)


### PR DESCRIPTION
If a default SRS was set, and a reader called `setSpatialReference` with an empty SRS, it would end up clearing the SRS.  This PR makes it so that an empty SRS will not override an existing default SRS and adds a corresponding test.