### PR TITLE
Adds `RiVLib_INCLUDE_DIRS` to rivlib test includes

### DIFF
--- a/plugins/rxp/CMakeLists.txt
+++ b/plugins/rxp/CMakeLists.txt
@@ -29,6 +29,7 @@ if (BUILD_RIVLIB_TESTS)
         LINK_WITH
             ${libname}
         INCLUDES
+            ${RiVLib_INCLUDE_DIRS}
             ${PROJECT_BINARY_DIR}/plugins/rxp/test
             ${PROJECT_SOURCE_DIR}/plugins/rxp/io
     )


### PR DESCRIPTION
The `${libname}`'s target include directories are private, so they aren't passed on to the test executable -- we need to explicitly add the RiVLib include directories again.

Fixes #2359. Tests pass on my local rivlib-linked PDAL build.