### PR TITLE
Expression support for AssignFilter

### DIFF
--- a/doc/stages/filters.assign.rst
+++ b/doc/stages/filters.assign.rst
@@ -30,11 +30,42 @@ This pipeline resets the ``Classification`` of all points with classifications
       }
   ]
 
+Example 2
+---------
+
+This pipeline sets some dimensions using arithmetic expressions even 
+fetching values from other attributes.
+
+.. code-block:: json
+
+    {
+      "pipeline":[
+        "autzen-dd.las",
+        {
+          "type":"filters.assign",
+          "assignment" : "Classification[1:1]=Classification * (Z > 1000 || (Z >= 10 && Z <= 20))",
+          "assignment" : "Red[:]=(Blue + Green)",
+          "assignment" : "Userdata[:]=1000 + (Classification * 2)",
+          "assignment" : "UserData[:]=PointSourceId IN (200,500,700)",
+          "assignment" : "Z[:]=Z + 100.0",
+        },
+        {
+          "filename":"attributed.las",
+        }
+      ]
+    }
+
+It supports the most common operators (``*,/,+,-,==,!=,<>,>,<,>=,<=,&&,||``), and ``( )`` 
+for priorizing them. It supports too ``IN`` function to check the presence of a value 
+e.g. ``"PointSourceId IN (2300,2301,2302)"``.
+
+
 Options
 -------
 
 assignment
-  A :ref:`range <ranges>` followed by an assignment of a value (see example).
+  A :ref:`range <ranges>` followed by an assignment of a value or arithmetic 
+  expression (see examples).
   Can be specified multiple times.  The assignments are applied sequentially
   to the dimension value as set when the filter began processing. [Required]
 

--- a/filters/private/expr/Lexer.cpp
+++ b/filters/private/expr/Lexer.cpp
@@ -61,6 +61,14 @@ Token Lexer::get(char c)
 {
     Token tok(TokenType::Error);
 
+    // Is really coming a negative number?
+    if ((c == '+' || c == '-') && 
+        m_pos + 1 < m_buf.size() && isdigit(m_buf[m_pos + 1]))
+    {
+        tok = number();
+        return tok;
+    }
+
     tok = getOperator(c);
     if (tok.valid())
         return tok;

--- a/filters/private/expr/Lexer.cpp
+++ b/filters/private/expr/Lexer.cpp
@@ -1,0 +1,156 @@
+/******************************************************************************
+* Copyright (c) 2019, Andrew Bell (andrew.bell.ia@gmail.com)
+*
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following
+* conditions are met:
+*
+*     * Redistributions of source code must retain the above copyright
+*       notice, this list of conditions and the following disclaimer.
+*     * Redistributions in binary form must reproduce the above copyright
+*       notice, this list of conditions and the following disclaimer in
+*       the documentation and/or other materials provided
+*       with the distribution.
+*     * The name of Andrew Bell may not be used to endorse or promote
+*       products derived from this software without specific prior
+*       written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+* FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+* COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+* BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+* OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+* AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+* OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+* OF SUCH DAMAGE.
+****************************************************************************/
+
+#include "Lexer.hpp"
+#include <pdal/DimUtil.hpp>
+
+namespace pdal
+{
+namespace expr
+{
+
+Token Lexer::get(TokenClass cls)
+{
+    while (isspace(m_buf[m_pos]))
+        m_pos++;
+
+    if (m_pos == m_buf.size())
+        return Token(TokenType::Eof);
+
+    Token tok;
+    if (cls == TokenClass::Operator)
+        tok = getOperator(m_buf[m_pos]);
+    else
+        tok = get(m_buf[m_pos]);
+    m_pos = tok.end();
+    return tok;
+}
+
+
+Token Lexer::get(char c)
+{
+    Token tok(TokenType::Error);
+
+    tok = getOperator(c);
+    if (tok.valid())
+        return tok;
+
+    if (c == '+' || c == '-' || isdigit(c))
+        tok = number();
+    else if (c == '(')
+        tok = Token(TokenType::Lparen, m_pos, m_pos + 1);
+    else if (c == ')')
+        tok = Token(TokenType::Rparen, m_pos, m_pos + 1);
+    else if (isalpha(c))
+        tok = dimension();
+
+    return tok;
+}
+
+
+Token Lexer::getOperator(char c)
+{
+    Token tok(TokenType::Error);
+
+    if (c == ')')
+        tok = Token(TokenType::Rparen, m_pos, m_pos + 1);
+    else if (c == ',')
+        tok = Token(TokenType::Comma, m_pos, m_pos + 1);
+    else if (c == '+')
+        tok = Token(TokenType::Plus, m_pos, m_pos + 1);
+    else if (c == '-')
+        tok = Token(TokenType::Minus, m_pos, m_pos + 1);
+    else if (c == '/')
+        tok = Token(TokenType::Divide, m_pos, m_pos + 1);
+    else if (c == '*')
+        tok = Token(TokenType::Multiply, m_pos, m_pos + 1);
+    else if (m_buf.size() > m_pos + 1)
+    {
+        char d = m_buf[m_pos + 1];
+
+        if (c == '>' && d == '=') 
+            tok = Token(TokenType::GreaterOrEqual, m_pos, m_pos + 2);
+        else if (c == '<' && d == '=') 
+            tok = Token(TokenType::LessOrEqual, m_pos, m_pos + 2);
+        else if (c == '=' && d == '=') 
+            tok = Token(TokenType::Equal, m_pos, m_pos + 2);
+        else if (c == '<' && d == '>') 
+            tok = Token(TokenType::Inequality, m_pos, m_pos + 2);
+        else if (c == '!' && d == '=') 
+            tok = Token(TokenType::Inequality, m_pos, m_pos + 2);
+        else if (c == '>') 
+            tok = Token(TokenType::Greater, m_pos, m_pos + 1);
+        else if (c == '<') 
+            tok = Token(TokenType::Less, m_pos, m_pos + 1);
+        else if (c == '&' && d == '&')
+            tok = Token(TokenType::And, m_pos, m_pos + 2);
+        else if (c == '|' && d == '|')
+            tok = Token(TokenType::Or, m_pos, m_pos + 2);
+        else if (m_buf.size() > m_pos + 2 
+            && std::toupper(c) == 'I' 
+            && std::toupper(d) == 'N')
+        {
+            size_t end_pos = m_pos + 2;
+
+            while (isspace(m_buf[end_pos]))
+                end_pos++;
+
+            if (end_pos < m_buf.size() && m_buf[end_pos] == '(')
+                tok = Token(TokenType::In, m_pos, end_pos);
+        }
+    }
+    return tok;
+}
+
+
+Token Lexer::number()
+{
+    const char *start = m_buf.data() + m_pos;
+    char *end;
+
+    double v = strtod(start, &end);
+    if (start == end)
+        return Token(TokenType::Error);
+    return Token(TokenType::Number, m_pos, end - m_buf.data(), v);
+}
+
+
+Token Lexer::dimension()
+{
+    size_t end = Dimension::extractName(m_buf, m_pos);
+    return Token(TokenType::Dimension, m_pos, m_pos + end,
+        m_buf.substr(m_pos, end));
+}
+
+} // namespace expr
+} // namespace pdal

--- a/filters/private/expr/Lexer.hpp
+++ b/filters/private/expr/Lexer.hpp
@@ -1,0 +1,71 @@
+/******************************************************************************
+* Copyright (c) 2019, Andrew Bell (andrew.bell.ia@gmail.com)
+*
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following
+* conditions are met:
+*
+*     * Redistributions of source code must retain the above copyright
+*       notice, this list of conditions and the following disclaimer.
+*     * Redistributions in binary form must reproduce the above copyright
+*       notice, this list of conditions and the following disclaimer in
+*       the documentation and/or other materials provided
+*       with the distribution.
+*     * The name of Andrew Bell may not be used to endorse or promote
+*       products derived from this software without specific prior
+*       written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+* FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+* COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+* BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+* OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+* AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+* OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+* OF SUCH DAMAGE.
+****************************************************************************/
+
+#pragma once
+
+#include <string>
+
+#include "Token.hpp"
+
+namespace pdal
+{
+namespace expr
+{
+
+class Lexer
+{
+public:
+    Lexer() : m_pos(0)
+    {}
+
+    void lex(const std::string& s)
+    {
+        m_buf = s;
+        m_pos = 0;
+    }
+
+    Token get(TokenClass cls = TokenClass::Any);
+
+private:
+    Token get(char c);
+    Token getOperator(char c);
+    Token number();
+    Token dimension();
+
+    std::string m_buf;
+    std::string::size_type m_pos;
+};
+
+} // namespace expr
+} // namespace pdal
+

--- a/filters/private/expr/Parser.cpp
+++ b/filters/private/expr/Parser.cpp
@@ -1,0 +1,442 @@
+/******************************************************************************
+* Copyright (c) 2019, Andrew Bell (andrew.bell.ia@gmail.com)
+*
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following
+* conditions are met:
+*
+*     * Redistributions of source code must retain the above copyright
+*       notice, this list of conditions and the following disclaimer.
+*     * Redistributions in binary form must reproduce the above copyright
+*       notice, this list of conditions and the following disclaimer in
+*       the documentation and/or other materials provided
+*       with the distribution.
+*     * The name of Andrew Bell may not be used to endorse or promote
+*       products derived from this software without specific prior
+*       written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+* FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+* COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+* BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+* OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+* AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+* OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+* OF SUCH DAMAGE.
+****************************************************************************/
+
+#include "Parser.hpp"
+
+namespace pdal
+{
+namespace expr
+{
+
+bool Parser::parse(const std::string& s)
+{
+    m_lexer.lex(s);
+    return expression();
+}
+
+
+void Parser::prepare(PointLayoutPtr l)
+{
+    if (m_nodes.size() != 1)
+    {
+        std::cerr << "Can't prepare.  Node tree not properly parsed.\n";
+        return;
+    }
+    m_nodes.top()->prepare(l);
+}
+
+
+double Parser::eval(PointRef& p) const
+{
+    if (m_nodes.size() != 1)
+    {
+        std::cerr << "Can't evaluate.  Node tree not properly parsed.\n";
+        return 0;
+    }
+    return m_nodes.top()->eval(p);
+}
+
+
+// ABELL - This needs reworking since we may pop as another class.
+Token Parser::popToken(TokenClass cls)
+{
+    if (m_tokens.empty())
+        return m_lexer.get(cls);
+    Token tok = m_tokens.top();
+    m_tokens.pop();
+    return tok;
+}
+
+void Parser::pushToken(const Token& tok)
+{
+    m_tokens.push(tok);
+}
+
+
+bool Parser::expression()
+{
+    if (!orexpr())
+        return false;
+    return true;
+}
+
+bool Parser::orexpr()
+{
+    if (!andexpr())
+        return false;
+
+    while (true)
+    {
+        Token tok = popToken(TokenClass::Operator);
+        NodeType type;
+        if (tok.type() == TokenType::Or)
+            type = NodeType::Or;
+        else
+        {
+            pushToken(tok);
+            return true;
+        }
+
+        if (!andexpr())
+        {
+            m_error = "Operator not followed by rvalue.";
+            return false;
+        }
+
+        NodePtr right = popNode();
+        NodePtr left = popNode();
+
+        ValNode *leftVal = dynamic_cast<ValNode *>(left.get());
+        ValNode *rightVal = dynamic_cast<ValNode *>(right.get());
+        if (leftVal && rightVal)
+        {
+            double v;
+            if (type == NodeType::Or)
+                v = leftVal->value() || rightVal->value();
+            else
+            {
+                m_error = "Unknown boolean operator.";
+                return false;
+            }
+            pushNode(NodePtr(new ValNode(v)));
+        }
+        else
+            pushNode(NodePtr(new BoolNode(type, std::move(left),
+                std::move(right))));
+    }
+    return true;
+}
+
+bool Parser::andexpr()
+{
+    if (!compareexpr())
+        return false;
+
+    while (true)
+    {
+        Token tok = popToken(TokenClass::Operator);
+        NodeType type;
+        if (tok.type() == TokenType::And)
+            type = NodeType::And;
+        else
+        {
+            pushToken(tok);
+            return true;
+        }
+
+        if (!compareexpr())
+        {
+            m_error = "Operator not followed by rvalue.";
+            return false;
+        }
+
+        NodePtr right = popNode();
+        NodePtr left = popNode();
+
+        ValNode *leftVal = dynamic_cast<ValNode *>(left.get());
+        ValNode *rightVal = dynamic_cast<ValNode *>(right.get());
+        if (leftVal && rightVal)
+        {
+            double v;
+            if (type == NodeType::And)
+                v = leftVal->value() && rightVal->value();
+            else
+            {
+                m_error = "Unknown boolean operator.";
+                return false;
+            }
+            pushNode(NodePtr(new ValNode(v)));
+        }
+        else
+            pushNode(NodePtr(new BoolNode(type, std::move(left),
+                std::move(right))));
+    }
+    return true;
+}
+
+bool Parser::compareexpr()
+{
+    if (!addexpr())
+        return false;
+
+    while (true)
+    {
+        Token tok = popToken(TokenClass::Operator);
+        NodeType type;
+        if (tok.type() == TokenType::Equal)
+            type = NodeType::Equal;
+        else if (tok.type() == TokenType::Inequality)
+            type = NodeType::Inequality;
+        else if (tok.type() == TokenType::Greater)
+            type = NodeType::Greater;
+        else if (tok.type() == TokenType::GreaterOrEqual)
+            type = NodeType::GreaterOrEqual;
+        else if (tok.type() == TokenType::Less)
+            type = NodeType::Less;
+        else if (tok.type() == TokenType::LessOrEqual)
+            type = NodeType::LessOrEqual;
+        else if (tok.type() == TokenType::In)
+            type = NodeType::In;
+        else
+        {
+            pushToken(tok);
+            return true;
+        }
+
+        if (type == NodeType::In)
+        {
+            NodePtr left = popNode();
+
+            if (!arrayexpr())
+            {
+                m_error = "In function not followed by array.";
+                return false;
+            }
+
+            std::vector<NodePtr> right;
+
+            while (m_nodes.size() > 1)
+            {
+                right.insert(right.begin(), popNode());
+            }
+            pushNode(NodePtr(new ValInNode(type, std::move(left), right)));
+            return true;
+        }
+        if (!addexpr())
+        {
+            m_error = "Operator not followed by rvalue.";
+            return false;
+        }
+
+        NodePtr right = popNode();
+        NodePtr left = popNode();
+
+        ValNode *leftVal = dynamic_cast<ValNode *>(left.get());
+        ValNode *rightVal = dynamic_cast<ValNode *>(right.get());
+        if (leftVal && rightVal)
+        {
+            double v;
+            if (type == NodeType::Equal)
+                v = leftVal->value() == rightVal->value();
+            else if (type == NodeType::Inequality)
+                v = leftVal->value() != rightVal->value();
+            else if (type == NodeType::Greater)
+                v = leftVal->value() > rightVal->value();
+            else if (type == NodeType::GreaterOrEqual)
+                v = leftVal->value() >= rightVal->value();
+            else if (type == NodeType::Less)
+                v = leftVal->value() < rightVal->value();
+            else if (type == NodeType::LessOrEqual)
+                v = leftVal->value() <= rightVal->value();
+            else
+            {
+                m_error = "Unknown comparison operator.";
+                return false;
+            }
+            pushNode(NodePtr(new ValNode(v)));
+        }
+        else
+            pushNode(NodePtr(new BinNode(type, std::move(left),
+                std::move(right))));
+    }
+    return true;
+}
+
+bool Parser::addexpr()
+{
+    if (!multexpr())
+        return false;
+
+    while (true)
+    {
+        Token tok = popToken(TokenClass::Operator);
+        NodeType type;
+        if (tok.type() == TokenType::Plus)
+            type = NodeType::Plus;
+        else if (tok.type() == TokenType::Minus)
+            type = NodeType::Minus;
+        else
+        {
+            pushToken(tok);
+            return true;
+        }
+
+        if (!multexpr())
+        {
+            m_error = "Operator not followed by rvalue.";
+            return false;
+        }
+
+        NodePtr right(popNode());
+        NodePtr left(popNode());
+
+        ValNode *leftVal = dynamic_cast<ValNode *>(left.get());
+        ValNode *rightVal = dynamic_cast<ValNode *>(right.get());
+        if (leftVal && rightVal)
+        {
+            double v =
+                (type == NodeType::Plus) ?
+                leftVal->value() + rightVal->value() :
+                leftVal->value() - rightVal->value();
+            pushNode(NodePtr(new ValNode(v)));
+        }
+        else
+            pushNode(NodePtr(new BinNode(type, std::move(left),
+                std::move(right))));
+    }
+    return true;
+}
+
+bool Parser::multexpr()
+{
+    if (!primary())
+        return false;
+
+    while (true)
+    {
+        Token tok = popToken(TokenClass::Operator);
+        NodeType type;
+        if (tok.type() == TokenType::Multiply)
+            type = NodeType::Multiply;
+        else if (tok.type() == TokenType::Divide)
+            type = NodeType::Divide;
+        else
+        {
+            pushToken(tok);
+            return true;
+        }
+
+        if (!primary())
+        {
+            m_error = "Operator not followed by rvalue.";
+            return false;
+        }
+
+        NodePtr right = popNode();
+        NodePtr left = popNode();
+
+        ValNode *leftVal = dynamic_cast<ValNode *>(left.get());
+        ValNode *rightVal = dynamic_cast<ValNode *>(right.get());
+        if (leftVal && rightVal)
+        {
+            double v;
+            if (type == NodeType::Multiply)
+                v = leftVal->value() * rightVal->value();
+            else
+            {
+                if (rightVal->value() == 0.0)
+                {
+                    m_error = "Divide by 0.";
+                    return false;
+                }
+                v = leftVal->value() / rightVal->value();
+            }
+            pushNode(NodePtr(new ValNode(v)));
+        }
+        else
+            pushNode(NodePtr(new BinNode(type, std::move(left),
+                std::move(right))));
+    }
+    return true;
+}
+
+bool Parser::primary()
+{
+    Token tok = popToken();
+    if (tok.type() == TokenType::Number)
+    {
+        pushNode(NodePtr(new ValNode(tok.dval())));
+        return true;
+    }
+    else if (tok.type() == TokenType::Dimension)
+    {
+        pushNode(NodePtr(new VarNode(tok.sval())));
+        return true;
+    }
+    else if (tok.type() == TokenType::Eof)
+        return true;
+
+    pushToken(tok);
+    return parexpr();
+}
+
+
+bool Parser::parexpr()
+{
+    Token tok = popToken();
+    if (tok.type() != TokenType::Lparen)
+    {
+        pushToken(tok);
+        return false;
+    }
+
+    if (!expression())
+        return false;
+
+    tok = popToken();
+    if (tok.type() != TokenType::Rparen)
+    {
+        pushToken(tok);
+        return false;
+    }
+    return true;
+}
+
+bool Parser::arrayexpr()
+{
+    Token tok = popToken();
+    if (tok.type() != TokenType::Lparen)
+    {
+        pushToken(tok);
+        return false;
+    }
+
+    while (expression() && (tok = popToken()).type() == TokenType::Comma)
+    {
+        if (m_error.size() > 0)
+        {
+            pushToken(tok);
+            return false;
+        }
+    }
+
+    if (tok.type() != TokenType::Rparen)
+    {
+        pushToken(tok);
+        return false;
+    }
+    return true;
+}
+
+} // namespace expr
+} // namespace pdal

--- a/filters/private/expr/Parser.hpp
+++ b/filters/private/expr/Parser.hpp
@@ -1,0 +1,286 @@
+/******************************************************************************
+* Copyright (c) 2019, Andrew Bell (andrew.bell.ia@gmail.com)
+*
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following
+* conditions are met:
+*
+*     * Redistributions of source code must retain the above copyright
+*       notice, this list of conditions and the following disclaimer.
+*     * Redistributions in binary form must reproduce the above copyright
+*       notice, this list of conditions and the following disclaimer in
+*       the documentation and/or other materials provided
+*       with the distribution.
+*     * The name of Andrew Bell may not be used to endorse or promote
+*       products derived from this software without specific prior
+*       written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+* FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+* COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+* BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+* OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+* AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+* OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+* OF SUCH DAMAGE.
+****************************************************************************/
+
+#pragma once
+
+#include <stack>
+
+#include <pdal/PointLayout.hpp>
+#include <pdal/PointRef.hpp>
+
+#include "Lexer.hpp"
+
+namespace pdal
+{
+namespace expr
+{
+
+enum class NodeType
+{
+    Plus,
+    Minus,
+    Multiply,
+    Divide,
+    Equal,
+    Inequality,
+    Greater,
+    GreaterOrEqual,
+    Less,
+    LessOrEqual,
+    In,
+    And,
+    Or,
+    Value,
+    Variable
+};
+
+class Node
+{
+protected:
+    Node(NodeType type) : m_type(type)
+    {}
+
+public:
+    virtual ~Node()
+    {}
+    NodeType type() const
+    { return m_type; }
+
+    virtual void prepare(PointLayoutPtr l) = 0;
+    virtual double eval(PointRef& p) const = 0;
+
+private:
+    NodeType m_type;
+};
+using NodePtr = std::unique_ptr<Node>;
+
+class BinNode : public Node
+{
+public:
+    BinNode(NodeType type, NodePtr left, NodePtr right) :
+        Node(type), m_left(std::move(left)), m_right(std::move(right))
+    {}
+
+    virtual void prepare(PointLayoutPtr l)
+    {
+        m_left->prepare(l);
+        m_right->prepare(l);
+    }
+
+    virtual double eval(PointRef& p) const
+    {
+        double l = m_left->eval(p);
+        double r = m_right->eval(p);
+        switch (type())
+        {
+        case NodeType::Plus:
+            return l + r;
+        case NodeType::Minus:
+            return l - r;
+        case NodeType::Multiply:
+            return l * r;
+        case NodeType::Divide:
+            return l / r;
+        case NodeType::Equal:
+            return l == r;
+        case NodeType::Inequality:
+            return l != r;
+        case NodeType::Greater:
+            return l > r;
+        case NodeType::GreaterOrEqual:
+            return l >= r;
+        case NodeType::Less:
+            return l < r;
+        case NodeType::LessOrEqual:
+            return l <= r;
+        default:
+            return 0;
+        }
+    }
+
+private:
+    NodePtr m_left;
+    NodePtr m_right;
+};
+
+class BoolNode : public Node
+{
+public:
+    BoolNode(NodeType type, NodePtr left, NodePtr right) :
+        Node(type), m_left(std::move(left)), m_right(std::move(right))
+    {}
+
+    virtual void prepare(PointLayoutPtr l)
+    {
+        m_left->prepare(l);
+        m_right->prepare(l);
+    }
+
+    virtual double eval(PointRef& p) const
+    {
+        switch (type())
+        {
+        case NodeType::And:
+            return m_left->eval(p) && m_right->eval(p);
+        case NodeType::Or:
+            return m_left->eval(p) || m_right->eval(p);
+        default:
+            return 0;
+        }
+    }
+
+private:
+    NodePtr m_left;
+    NodePtr m_right;
+};
+
+class ValNode : public Node
+{
+public:
+    ValNode(double d) : Node(NodeType::Value), m_val(d)
+    {}
+
+    virtual void prepare(PointLayoutPtr l)
+    {}
+
+    virtual double eval(PointRef&) const
+    { return m_val; }
+
+    double value() const
+    { return m_val; }
+
+private:
+    double m_val;
+};
+
+class ValInNode : public Node
+{
+public:
+    ValInNode(NodeType type, NodePtr left, std::vector<NodePtr>& right) :
+        Node(type), m_left(std::move(left))
+    {
+        for (NodePtr& r : right)
+        {
+            m_right.push_back(std::move(r));
+        }
+    }
+
+    virtual void prepare(PointLayoutPtr l)
+    {
+        m_left->prepare(l);
+
+        for (NodePtr& r : m_right)
+        {
+            r->prepare(l);
+        }
+    }
+
+    virtual double eval(PointRef& p) const
+    {
+        double v = m_left->eval(p);
+
+        for (const NodePtr& r : m_right)
+        {
+            if (v == r->eval(p))
+                return 1;
+        }
+        return 0;
+    }
+
+private:
+    NodePtr m_left;
+    std::vector<NodePtr> m_right;
+};
+
+class VarNode : public Node
+{
+public:
+    VarNode(const std::string& s) : Node(NodeType::Variable), m_name(s),
+        m_id(Dimension::Id::Unknown)
+    {}
+
+    virtual void prepare(PointLayoutPtr l)
+    {
+        m_id = l->findDim(m_name);
+        if (m_id == Dimension::Id::Unknown)
+            std::cerr << "Unknown dimension '" << m_name << "' in assigment.";
+    }
+
+    virtual double eval(PointRef& p) const
+    { return p.getFieldAs<double>(m_id); }
+
+private:
+    std::string m_name;
+    Dimension::Id m_id;
+};
+
+class Parser
+{
+public:
+    bool parse(const std::string& s);
+    std::string error() const
+    { return m_error; }
+    void prepare(PointLayoutPtr l);
+    double eval(PointRef& p) const;
+
+private:
+    void pushNode(std::unique_ptr<Node> node)
+    { m_nodes.push(std::move(node)); }
+
+    NodePtr popNode()
+    {
+        NodePtr n(std::move(m_nodes.top()));
+        m_nodes.pop();
+        return n;
+    }
+
+    Token popToken(TokenClass cls = TokenClass::Any);
+    void pushToken(const Token& tok);
+    bool expression();
+    bool orexpr();
+    bool andexpr();
+    bool compareexpr();
+    bool addexpr();
+    bool multexpr();
+    bool primary();
+    bool parexpr();
+    bool arrayexpr();
+
+    Lexer m_lexer;
+    std::stack<NodePtr> m_nodes;
+    std::stack<Token> m_tokens;
+    std::string m_error;
+};
+
+} // namespace expr
+} // namespace pdal

--- a/filters/private/expr/Token.hpp
+++ b/filters/private/expr/Token.hpp
@@ -1,0 +1,128 @@
+/******************************************************************************
+* Copyright (c) 2019, Andrew Bell (andrew.bell.ia@gmail.com)
+*
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following
+* conditions are met:
+*
+*     * Redistributions of source code must retain the above copyright
+*       notice, this list of conditions and the following disclaimer.
+*     * Redistributions in binary form must reproduce the above copyright
+*       notice, this list of conditions and the following disclaimer in
+*       the documentation and/or other materials provided
+*       with the distribution.
+*     * The name of Andrew Bell may not be used to endorse or promote 
+*       products derived from this software without specific prior 
+*       written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+* FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+* COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+* BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+* OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+* AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+* OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+* OF SUCH DAMAGE.
+****************************************************************************/
+
+#pragma once
+
+#include <string>
+
+namespace pdal
+{
+namespace expr
+{
+
+enum class TokenClass
+{
+    Operator,
+    Any
+};
+
+enum class TokenType
+{
+    Eof,
+    Error,
+    Plus,
+    Minus,
+    Divide,
+    Multiply,
+    Equal,
+    Inequality,
+    Greater,
+    GreaterOrEqual,
+    Less,
+    LessOrEqual,
+    In,
+    And,
+    Or,
+    Lparen,
+    Rparen,
+    Comma,
+    Number,
+    Dimension
+};
+
+class Token
+{
+    // Union with string requires a bunch of muck, so...
+    struct Value
+    {
+        double d;
+        std::string s;
+    };
+
+public:
+    Token(TokenType type, std::string::size_type start,
+            std::string::size_type end, double d) :
+        m_type(type), m_start(start), m_end(end)
+    { m_val.d = d; }
+
+    Token(TokenType type, std::string::size_type start,
+            std::string::size_type end, const std::string& s) :
+        m_type(type), m_start(start), m_end(end)
+    { m_val.s = s; }
+
+    Token(TokenType type, std::string::size_type start,
+            std::string::size_type end) :
+        m_type(type), m_start(start), m_end(end)
+    {}
+    Token(TokenType type) : m_type(type), m_start(0), m_end(0)
+    {}
+    Token() : m_type(TokenType::Error), m_start(0), m_end(0)
+    {}
+
+    TokenType type() const
+    { return m_type; }
+
+    std::string::size_type start() const
+    { return m_start; }
+
+    std::string::size_type end() const
+    { return m_end; }
+
+    bool valid() const
+    { return m_type != TokenType::Error; }
+
+    double dval() const
+    { return m_val.d; }
+
+    std::string sval() const
+    { return m_val.s; }
+
+private:
+    TokenType m_type;
+    std::string::size_type m_start;
+    std::string::size_type m_end;
+    Value m_val;
+};
+
+} // namespace expr
+} // namespace pdal

--- a/pdal/util/ProgramArgs.hpp
+++ b/pdal/util/ProgramArgs.hpp
@@ -765,7 +765,7 @@ public:
         }
         if (!m_set)
             m_var.clear();
-        m_var.push_back(var);
+        m_var.push_back(std::move(var));
         m_set = true;
     }
 

--- a/test/unit/filters/AssignFilterTest.cpp
+++ b/test/unit/filters/AssignFilterTest.cpp
@@ -52,12 +52,12 @@ TEST(AssignFilterTest, value)
     r.setOptions(ro);
 
     Options fo;
-    fo.add("assignment", "X[:]=27.5");
+    fo.add("assignment", "X[:]=-27.5");
     fo.add("assignment", "Classification[:]=200-199");
     fo.add("assignment", "GpsTime[:]=(3000)");
     fo.add("assignment", "Red[:]=GpsTime");
     fo.add("assignment", "Green[:]=(GpsTime * 3) + 4");
-    fo.add("assignment", "Blue[:]=(GpsTime >= 3000 + 1.5 - 1.5) && (Red + 4 == GpsTime + (10 - 8) * 2) && Red IN (1, 2.5, GpsTime, 4)");
+    fo.add("assignment", "Blue[:]=(GpsTime >= 3000 + 1.5 - +1.5) && (Red + 4 == GpsTime + (10 - 8) * 2) && Red IN (1, -2.5, GpsTime, 4)");
 
     Stage& f = *(factory.createStage("filters.assign"));
     f.setInput(r);
@@ -88,7 +88,7 @@ TEST(AssignFilterTest, value)
     PointViewPtr v = *s.begin();
     for (PointId i = 0; i < v->size(); ++i)
     {
-        EXPECT_DOUBLE_EQ(v->getFieldAs<double>(Dimension::Id::X, i), 27.5);
+        EXPECT_DOUBLE_EQ(v->getFieldAs<double>(Dimension::Id::X, i), -27.5);
         EXPECT_EQ(v->getFieldAs<uint16_t>(
             Dimension::Id::Classification, i), 1);
         EXPECT_DOUBLE_EQ(v->getFieldAs<double>(

--- a/test/unit/filters/AssignFilterTest.cpp
+++ b/test/unit/filters/AssignFilterTest.cpp
@@ -45,6 +45,7 @@ TEST(AssignFilterTest, value)
 {
     Options ro;
     ro.add("filename", Support::datapath("autzen/autzen-dd.las"));
+    ro.add("count", 10);
 
     StageFactory factory;
     Stage& r = *(factory.createStage("readers.las"));
@@ -52,9 +53,11 @@ TEST(AssignFilterTest, value)
 
     Options fo;
     fo.add("assignment", "X[:]=27.5");
-    fo.add("assignment", "Classification[:]=0");
-    fo.add("assignment", "GpsTime[:]=3000");
-    fo.add("assignment", "Red[:]=255");
+    fo.add("assignment", "Classification[:]=200-199");
+    fo.add("assignment", "GpsTime[:]=(3000)");
+    fo.add("assignment", "Red[:]=GpsTime");
+    fo.add("assignment", "Green[:]=(GpsTime * 3) + 4");
+    fo.add("assignment", "Blue[:]=(GpsTime >= 3000 + 1.5 - 1.5) && (Red + 4 == GpsTime + (10 - 8) * 2) && Red IN (1, 2.5, GpsTime, 4)");
 
     Stage& f = *(factory.createStage("filters.assign"));
     f.setInput(r);
@@ -87,11 +90,15 @@ TEST(AssignFilterTest, value)
     {
         EXPECT_DOUBLE_EQ(v->getFieldAs<double>(Dimension::Id::X, i), 27.5);
         EXPECT_EQ(v->getFieldAs<uint16_t>(
-            Dimension::Id::Classification, i), 0);
+            Dimension::Id::Classification, i), 1);
         EXPECT_DOUBLE_EQ(v->getFieldAs<double>(
             Dimension::Id::GpsTime, i), 3000.0);
         EXPECT_EQ(v->getFieldAs<int>(
-            Dimension::Id::Red, i), 255);
+            Dimension::Id::Red, i), 3000.0);
+        EXPECT_EQ(v->getFieldAs<int>(
+            Dimension::Id::Blue, i), 1.0);
+        EXPECT_EQ(v->getFieldAs<int>(
+            Dimension::Id::Green, i), 9004.0);
     }
 }
 


### PR DESCRIPTION
Hi, I would like propose that AssignFilter supports arithmetic expressions to assign the dimension values of points.

For example:
```
"assignment": "X[:]=X + 30",
"assignment": "Intensity[1:3]=(Classification IN (1,2,3)) || (Red >= 90 && Red <= 120)",
"assignment": "Z[:]=0.5 * Z + (HeightAboveGround + 100)"
```