### PR TITLE
Python object reference counting is incorrect

### DIFF
--- a/plugins/python/filters/PythonFilter.cpp
+++ b/plugins/python/filters/PythonFilter.cpp
@@ -78,7 +78,8 @@ void PythonFilter::ready(PointTableRef table)
         m_source = FileUtils::readFileIntoString(m_scriptFile);
     static_cast<plang::Environment*>(plang::Environment::get())->set_stdout(log()->getLogStream());
     m_script = new plang::Script(m_source, m_module, m_function);
-    m_pythonMethod = new plang::Invocation(*m_script);
+
+	m_pythonMethod = new plang::Invocation(*m_script);
     m_pythonMethod->compile();
     m_totalMetadata = table.metadata();
 }

--- a/plugins/python/plang/Environment.cpp
+++ b/plugins/python/plang/Environment.cpp
@@ -214,14 +214,14 @@ std::string getTraceback()
 #endif
         mssg << d;
     }
-    else
+     else
         mssg << "unknown error that we are unable to get a traceback for."
             "Was it already printed/taken?";
 
     Py_XDECREF(value);
     Py_XDECREF(type);
     Py_XDECREF(traceback);
-
+	PyErr_Clear();
     return mssg.str();
 }
 

--- a/plugins/python/plang/Environment.cpp
+++ b/plugins/python/plang/Environment.cpp
@@ -59,7 +59,7 @@
 // __attribute__ ((constructor)) this does nothing.  We'll have to deal with
 // those as they come up.
 #ifndef _WIN32
-__attribute__ ((constructor))
+__attribute__((constructor))
 static void loadPython()
 {
     ::dlopen(PDAL_PYTHON_LIBRARY, RTLD_LAZY | RTLD_GLOBAL);
@@ -74,8 +74,7 @@ namespace pdal
 {
 namespace plang
 {
-
-static Environment* g_environment=0;
+static Environment* g_environment = 0;
 //
 EnvironmentPtr Environment::get()
 {
@@ -108,10 +107,11 @@ Environment::Environment()
     {
         PyImport_AppendInittab(const_cast<char*>("redirector"), redirector_init);
         Py_Initialize();
-    } else
+    }
+    else
     {
         m_redirector.init();
-        PyObject* added  = PyImport_AddModule("redirector");
+        PyObject* added = PyImport_AddModule("redirector");
         if (!added)
             throw pdal_error("unable to add redirector module!");
     }
@@ -120,24 +120,20 @@ Environment::Environment()
     PyImport_ImportModule("redirector");
 }
 
-
 Environment::~Environment()
 {
     Py_Finalize();
 }
-
 
 void Environment::set_stdout(std::ostream* ostr)
 {
     m_redirector.set_stdout(ostr);
 }
 
-
 void Environment::reset_stdout()
 {
     m_redirector.reset_stdout();
 }
-
 
 std::string getTraceback()
 {
@@ -214,14 +210,14 @@ std::string getTraceback()
 #endif
         mssg << d;
     }
-     else
+    else
         mssg << "unknown error that we are unable to get a traceback for."
-            "Was it already printed/taken?";
+        "Was it already printed/taken?";
 
     Py_XDECREF(value);
     Py_XDECREF(type);
     Py_XDECREF(traceback);
-	PyErr_Clear();
+    PyErr_Clear();
     return mssg.str();
 }
 
@@ -233,10 +229,10 @@ PyObject *fromMetadata(MetadataNode m)
     std::string description = m.description();
 
     MetadataNodeList children = m.children();
-	PyObject *submeta(0);
+    PyObject *submeta(0);
     if (children.size())
     {
-		submeta = PyList_New(0);
+        submeta = PyList_New(0);
         for (MetadataNode& child : children)
             PyList_Append(submeta, fromMetadata(child));
     }
@@ -245,10 +241,10 @@ PyObject *fromMetadata(MetadataNode m)
     PyDict_SetItemString(data, "value", PyUnicode_FromString(value.data()));
     PyDict_SetItemString(data, "type", PyUnicode_FromString(type.data()));
     PyDict_SetItemString(data, "description", PyUnicode_FromString(description.data()));
-	if (children.size())
-	{
-		PyDict_SetItemString(data, "children", submeta);
-	}
+    if (children.size())
+    {
+        PyDict_SetItemString(data, "children", submeta);
+    }
     return data;
 }
 
@@ -279,13 +275,12 @@ std::string readPythonString(PyObject* dict, const std::string& key)
 }
 void addMetadata(PyObject *dict, MetadataNode m)
 {
-
-    if (! dict)
+    if (!dict)
     {
         return;
     }
 
-    if (!PyDict_Check(dict) )
+    if (!PyDict_Check(dict))
         throw pdal::pdal_error("'metadata' member must be a dictionary!");
 
     std::string name = readPythonString(dict, "name");
@@ -308,7 +303,7 @@ void addMetadata(PyObject *dict, MetadataNode m)
             PyObject* p = PyList_GetItem(submeta, i);
             addMetadata(p, m);
         }
-        MetadataNode child =  m.addWithType(name, value, type, description);
+        MetadataNode child = m.addWithType(name, value, type, description);
     }
 }
 
@@ -346,7 +341,6 @@ int Environment::getPythonDataType(Dimension::Type t)
     return -1;
 }
 
-
 Dimension::Type Environment::getPDALDataType(int t)
 {
     using namespace Dimension;
@@ -380,7 +374,5 @@ Dimension::Type Environment::getPDALDataType(int t)
 
     return Type::None;
 }
-
 } // namespace plang
 } // namespace pdal
-

--- a/plugins/python/plang/Invocation.cpp
+++ b/plugins/python/plang/Invocation.cpp
@@ -41,7 +41,6 @@
 
 namespace
 {
-
 int argCount(PyObject *function)
 {
     PyObject *module = PyImport_ImportModule("inspect");
@@ -53,16 +52,14 @@ int argCount(PyObject *function)
     PyTuple_SetItem(inArgs, 0, function);
     PyObject *outArgs = PyObject_CallObject(getargFunc, inArgs);
     PyObject *arglist = PyTuple_GetItem(outArgs, (Py_ssize_t)0);
-    return (int) PyList_Size(arglist);
+    return (int)PyList_Size(arglist);
 }
-
 }
 
 namespace pdal
 {
 namespace plang
 {
-
 Invocation::Invocation(const Script& script)
     : m_script(script)
     , m_bytecode(NULL)
@@ -82,7 +79,6 @@ Invocation::Invocation(const Script& script)
     resetArguments();
 }
 
-
 Invocation::~Invocation()
 {
     cleanup();
@@ -90,20 +86,20 @@ Invocation::~Invocation()
 
 void Printobject(PyObject* o)
 {
-	PyObject* r = PyObject_Repr(o);
-	if (!r)
-		throw pdal::pdal_error("couldn't make string representation of traceback value");
+    PyObject* r = PyObject_Repr(o);
+    if (!r)
+        throw pdal::pdal_error("couldn't make string representation of traceback value");
 #if PY_MAJOR_VERSION >= 3
-	Py_ssize_t size;
-	const char *d = PyUnicode_AsUTF8AndSize(r, &size);
+    Py_ssize_t size;
+    const char *d = PyUnicode_AsUTF8AndSize(r, &size);
 #else
-	const char *d = PyString_AsString(r);
+    const char *d = PyString_AsString(r);
 #endif
-	std::cout << "raw_json" << d << std::endl;
+    std::cout << "raw_json" << d << std::endl;
 }
 void Invocation::compile()
 {
-	Py_XDECREF(m_bytecode);
+    Py_XDECREF(m_bytecode);
     m_bytecode = Py_CompileString(m_script.source(), m_script.module(),
         Py_file_input);
     if (!m_bytecode)
@@ -111,28 +107,28 @@ void Invocation::compile()
 
     Py_INCREF(m_bytecode);
 
-	Py_XDECREF(m_module);
+    Py_XDECREF(m_module);
     m_module = PyImport_ExecCodeModule(const_cast<char*>(m_script.module()),
         m_bytecode);
     if (!m_module)
         throw pdal::pdal_error(getTraceback());
-	Py_INCREF(m_module);
+    Py_INCREF(m_module);
 
-	Py_XDECREF(m_dictionary);
+    Py_XDECREF(m_dictionary);
     m_dictionary = PyModule_GetDict(m_module);
-	if (!m_dictionary)
-	{
-		std::ostringstream oss;
-		oss << "unable to fetch module dictionary";
-		throw pdal::pdal_error(oss.str());
-	}
-	Py_INCREF(m_dictionary);
+    if (!m_dictionary)
+    {
+        std::ostringstream oss;
+        oss << "unable to fetch module dictionary";
+        throw pdal::pdal_error(oss.str());
+    }
+    Py_INCREF(m_dictionary);
 
-	// PyDict_GetItemString returns borrowed reference
-	// we need to increment the count after we fetch this 
-	// to keep it around
-    m_function = PyDict_GetItemString(m_dictionary, 
-									  m_script.function());
+    // PyDict_GetItemString returns borrowed reference
+    // we need to increment the count after we fetch this
+    // to keep it around
+    m_function = PyDict_GetItemString(m_dictionary,
+        m_script.function());
     if (!m_function)
     {
         std::ostringstream oss;
@@ -140,16 +136,14 @@ void Invocation::compile()
             "' in module.";
         throw pdal::pdal_error(oss.str());
     }
-	Py_INCREF(m_function);
+    Py_INCREF(m_function);
 
     if (!PyCallable_Check(m_function))
         throw pdal::pdal_error(getTraceback());
 }
 
-
 void Invocation::cleanup()
 {
-
     Py_XDECREF(m_varsIn);
     Py_XDECREF(m_varsOut);
     Py_XDECREF(m_scriptResult);
@@ -158,17 +152,15 @@ void Invocation::cleanup()
         Py_XDECREF(m_pyInputArrays[i]);
     m_pyInputArrays.clear();
     Py_XDECREF(m_bytecode);
-	Py_XDECREF(m_module);
+    Py_XDECREF(m_module);
 
-	//	Py_XDECREF(m_function);
-	Py_XDECREF(m_dictionary);
+    //	Py_XDECREF(m_function);
+    Py_XDECREF(m_dictionary);
 
-	Py_XDECREF(m_metadata_PyObject);
-	Py_XDECREF(m_srs_PyObject);
-	Py_XDECREF(m_pdalargs_PyObject);
-
+    Py_XDECREF(m_metadata_PyObject);
+    Py_XDECREF(m_srs_PyObject);
+    Py_XDECREF(m_pdalargs_PyObject);
 }
-
 
 void Invocation::resetArguments()
 {
@@ -176,7 +168,6 @@ void Invocation::resetArguments()
     m_varsIn = PyDict_New();
     m_varsOut = PyDict_New();
 }
-
 
 void Invocation::insertArgument(std::string const& name, uint8_t* data,
     Dimension::Type t, point_count_t count)
@@ -201,7 +192,6 @@ void Invocation::insertArgument(std::string const& name, uint8_t* data,
     PyDict_SetItemString(m_varsIn, name.c_str(), pyArray);
 }
 
-
 void *Invocation::extractResult(std::string const& name,
     Dimension::Type t, size_t& num_elements)
 {
@@ -224,7 +214,7 @@ void *Invocation::extractResult(std::string const& name,
     for (int i = 0; i < nDims; ++i)
         nPoints *= shape[i];
 
-    num_elements = (size_t) nPoints;
+    num_elements = (size_t)nPoints;
 
     if (static_cast<uint32_t>(dtype->elsize) != Dimension::size(t))
     {
@@ -265,7 +255,6 @@ void *Invocation::extractResult(std::string const& name,
     return PyArray_GetPtr(arr, &one);
 }
 
-
 void Invocation::getOutputNames(std::vector<std::string>& names)
 {
     names.clear();
@@ -286,37 +275,33 @@ void Invocation::getOutputNames(std::vector<std::string>& names)
     }
 }
 
-
 bool Invocation::hasOutputVariable(const std::string& name) const
 {
     return (PyDict_GetItemString(m_varsOut, name.c_str()) != NULL);
 }
 
-PyObject* addGlobalObject(PyObject* module, 
-						  PyObject* obj, 
-						  const std::string& name)
+PyObject* addGlobalObject(PyObject* module,
+    PyObject* obj,
+    const std::string& name)
 {
-	PyObject* output(NULL);
-	PyObject* mod_vars = PyModule_GetDict(module);
-	if (!mod_vars)
-		throw pdal::pdal_error("Unable to get module dictionary");
+    PyObject* output(NULL);
+    PyObject* mod_vars = PyModule_GetDict(module);
+    if (!mod_vars)
+        throw pdal::pdal_error("Unable to get module dictionary");
 
-
-	PyObject* nameObj = PyUnicode_FromString(name.c_str());
-	if (PyDict_Contains(mod_vars, nameObj) == 1)
-		output = PyDict_GetItem(mod_vars, nameObj);
-	else
-	{
-		int success = PyModule_AddObject(module, name.c_str(), obj);
-		if (success)
-			throw pdal::pdal_error("unable to set" + name + "global");
-		Py_INCREF(obj);
-		output = obj;
-	}
-	return output;
-
+    PyObject* nameObj = PyUnicode_FromString(name.c_str());
+    if (PyDict_Contains(mod_vars, nameObj) == 1)
+        output = PyDict_GetItem(mod_vars, nameObj);
+    else
+    {
+        int success = PyModule_AddObject(module, name.c_str(), obj);
+        if (success)
+            throw pdal::pdal_error("unable to set" + name + "global");
+        Py_INCREF(obj);
+        output = obj;
+    }
+    return output;
 }
-
 
 bool Invocation::execute()
 {
@@ -341,22 +326,22 @@ bool Invocation::execute()
 
     if (m_metadata_PyObject)
     {
-		addGlobalObject(m_module, m_metadata_PyObject, "metadata");
+        addGlobalObject(m_module, m_metadata_PyObject, "metadata");
     }
 
     if (m_schema_PyObject)
     {
-		addGlobalObject(m_module, m_schema_PyObject, "schema");
+        addGlobalObject(m_module, m_schema_PyObject, "schema");
     }
 
     if (m_srs_PyObject)
     {
-		addGlobalObject(m_module, m_srs_PyObject, "spatialreference");
-	}
+        addGlobalObject(m_module, m_srs_PyObject, "spatialreference");
+    }
 
     if (m_pdalargs_PyObject)
     {
-		addGlobalObject(m_module, m_pdalargs_PyObject, "pdalargs");
+        addGlobalObject(m_module, m_pdalargs_PyObject, "pdalargs");
     }
 
     m_scriptResult = PyObject_CallObject(m_function, m_scriptArgs);
@@ -365,20 +350,18 @@ bool Invocation::execute()
     if (!PyBool_Check(m_scriptResult))
         throw pdal::pdal_error("User function return value not a boolean type.");
 
-    PyObject* b =  PyUnicode_FromString("metadata");
+    PyObject* b = PyUnicode_FromString("metadata");
     if (PyDict_Contains(m_dictionary, PyUnicode_FromString("metadata")) == 1)
         m_metadata_PyObject = PyDict_GetItem(m_dictionary, b);
 
     return (m_scriptResult == Py_True);
 }
 
-
 PyObject* getPyJSON(std::string const& s)
 {
-
-    PyObject* raw_json =  PyUnicode_FromString(s.c_str());
-	if (!raw_json)
-		throw pdal::pdal_error(getTraceback());
+    PyObject* raw_json = PyUnicode_FromString(s.c_str());
+    if (!raw_json)
+        throw pdal::pdal_error(getTraceback());
 
     PyObject* json_module = PyImport_ImportModule("json");
     if (!json_module)
@@ -391,7 +374,7 @@ PyObject* getPyJSON(std::string const& s)
     PyObject* loads_func = PyDict_GetItemString(json_mod_dict, "loads");
     if (!loads_func)
         throw pdal::pdal_error(getTraceback());
-	Py_INCREF(loads_func);
+    Py_INCREF(loads_func);
 
     PyObject* json_args = PyTuple_New(1);
     if (!json_args)
@@ -401,13 +384,13 @@ PyObject* getPyJSON(std::string const& s)
     if (bFail)
         throw pdal::pdal_error(getTraceback());
 
-	PyObject* strict = PyDict_New();
-	if (!strict)
-		throw pdal::pdal_error(getTraceback());
+    PyObject* strict = PyDict_New();
+    if (!strict)
+        throw pdal::pdal_error(getTraceback());
 
-	bFail = PyDict_SetItemString(strict, "strict", Py_False);
-	if (bFail)
-		throw pdal::pdal_error(getTraceback());
+    bFail = PyDict_SetItemString(strict, "strict", Py_False);
+    if (bFail)
+        throw pdal::pdal_error(getTraceback());
 
     PyObject* json = PyObject_Call(loads_func, json_args, strict);
     if (!json)
@@ -444,7 +427,7 @@ void Invocation::begin(PointView& view, MetadataNode m)
 
     // Put pipeline 'metadata' variable into module scope
     Py_XDECREF(m_metadata_PyObject);
-    m_metadata_PyObject= plang::fromMetadata(m);
+    m_metadata_PyObject = plang::fromMetadata(m);
 
     // Put 'schema' dict into module scope
     Py_XDECREF(m_schema_PyObject);
@@ -460,7 +443,6 @@ void Invocation::begin(PointView& view, MetadataNode m)
     m_srs_PyObject = getPyJSON(ostrm.str());
     ostrm.str("");
 }
-
 
 void Invocation::end(PointView& view, MetadataNode m)
 {
@@ -495,7 +477,6 @@ void Invocation::end(PointView& view, MetadataNode m)
             view.setField(d, dd->type(), idx, (void *)p);
             p += size;
         }
-
     }
     for (auto bi = m_buffers.begin(); bi != m_buffers.end(); ++bi)
         free(*bi);
@@ -503,7 +484,5 @@ void Invocation::end(PointView& view, MetadataNode m)
     if (m_metadata_PyObject)
         addMetadata(m_metadata_PyObject, m);
 }
-
 } // namespace plang
 } // namespace pdal
-

--- a/plugins/python/test/PythonFilterTest.cpp
+++ b/plugins/python/test/PythonFilterTest.cpp
@@ -156,10 +156,10 @@ TEST_F(PythonFilterTest, add_dimension)
     FauxReader reader;
     reader.setOptions(ops);
 
-    Option source("source", "import numpy\n"
+    Option source("source", "import numpy as np\n"
         "def myfunc(ins,outs):\n"
-        "  outs['AddedIntensity'] = np.zeros(ins['X'].size, dtype=numpy.double) + 1\n"
-        "  outs['AddedPointSourceId'] = np.zeros(ins['X'].size, dtype=numpy.double) + 2\n"
+        "  outs['AddedIntensity'] = np.zeros(ins['X'].size, dtype=np.double) + 1\n"
+        "  outs['AddedPointSourceId'] = np.zeros(ins['X'].size, dtype=np.double) + 2\n"
         "  return True\n"
     );
     Option module("module", "MyModule");


### PR DESCRIPTION
The recent windows failures are due to Conda upgrading to Python 3.7 and exposing a bug in our object reference counting. 

We add some objects to the module and reference count them in Python. This is ok if only a single pipeline run happens, but our tests have multiple pipelines executing and assigning objects to the Python module. The reference counting is incorrect and Python segfaults when it tries to collect something that doesn't have a proper reference count. 

I do not yet know which object is improperly counted, but the code was messy so I started by trying to factor things out to make it easier to debug and see what was going on. I suspect it is related to the `m_pdalargs_PyObject` object, but I do not have proof.