### PR TITLE
Use raster width rather than block width when iterating source raster

### DIFF
--- a/pdal/GDALUtils.hpp
+++ b/pdal/GDALUtils.hpp
@@ -487,7 +487,7 @@ private:
             int partialRowElts = m_xBlockSize * x;
 
             auto si = sourceBegin + (wholeRowElts + partialRowElts);
-            std::transform(si, si + m_xBlockSize, di,
+            std::transform(si, si + xWidth, di,
                 [srcNoData, dstNoData](ITER_VAL<SOURCE_ITER> s){
                     T t;
 


### PR DESCRIPTION
in case of raster/block width mismatch.
Close #2448