### PR TITLE
Add outlier detection criterion and make minor edit to filters.lof documentation

### DIFF
--- a/doc/references.rst
+++ b/doc/references.rst
@@ -34,6 +34,8 @@ Reference
 
 .. [Alexa2003] Alexa, Marc, et al. "Computing and rendering point set surfaces." Visualization and Computer Graphics, IEEE Transactions on 9.1 (2003): 3-15.
 
+.. [Breunig2000] Breunig, M.M., Kriegel, H.-P., Ng, R.T., Sander, J., 2000. LOF: Identifying Density-Based Local Outliers. Proc. 2000 Acm Sigmod Int. Conf. Manag. Data 1–12.
+
 .. [Chen2012] Chen, Ziyue et al. “Upward-Fusion Urban DTM Generating Method Using Airborne Lidar Data.” ISPRS Journal of Photogrammetry and Remote Sensing 72 (2012): 121–130.
 
 .. [Cook1986] Cook, Robert L. "Stochastic sampling in computer graphics." *ACM Transactions on Graphics (TOG)* 5.1 (1986): 51-72.
@@ -41,6 +43,8 @@ Reference
 .. [Demantke2011] Demantké J., Mallet C., David N., Vallet, B. "Dimensionality Based Scale Selection in 3d LIDAR Point Clouds."  Int. Arch. Photogramm. Remote Sens. Spatial Inf. Sci, XXXVIII-5/W12, 97-102, 2011
 
 .. [Dippe1985] Dippé, Mark AZ, and Erling Henry Wold. "Antialiasing through stochastic sampling." *ACM Siggraph Computer Graphics* 19.3 (1985): 69-78.
+
+.. [Fischer2010] Fischer, Kaspar, Bernd Gärtner, and Martin Kutz. “Fast Smallest-Enclosing-Ball Computation in High Dimensions.” 26473 (2010): 630–641. Web.
 
 .. [Guinard2017] Guinard S., Landrieu L. "Weakly Supervised Segmented-Aided Classification of Urban Scenes From 3D LIDAR Point Clouds." Int. Arch. Photogramm. Remote Sens. Spatial Inf. Sci., XLII-1/W1, 151-157, 2017
 
@@ -55,5 +59,7 @@ Reference
 .. [Pingel2013] Pingel, Thomas J., Keith C. Clarke, and William A. McBride. “An Improved Simple Morphological Filter for the Terrain Classification of Airborne LIDAR Data.” ISPRS Journal of Photogrammetry and Remote Sensing 77 (2013): 21–30.
 
 .. [Rusu2008] Rusu, Radu Bogdan, et al. "Towards 3D point cloud based object maps for household environments." Robotics and Autonomous Systems 56.11 (2008): 927-941.
+
+.. [Weyrich2004] Weyrich, T et al. “Post-Processing of Scanned 3D Surface Data.” Proceedings of Eurographics Symposium on Point-Based Graphics 2004 (2004): 85–94. Print.
 
 .. [Zhang2003] Zhang, Keqi, et al. "A progressive morphological filter for removing nonground measurements from airborne LIDAR data." Geoscience and Remote Sensing, IEEE Transactions on 41.4 (2003): 872-882.

--- a/doc/stages/filters.lof.rst
+++ b/doc/stages/filters.lof.rst
@@ -37,9 +37,9 @@ users of this filter should find instructive.
 Example
 -------
 
-The sample pipeline below uses computes the LOF with a neighborhood of 20
-neighbors, followed by a range filter to crop out points whose
-``LocalOutlierFactor`` exceeds 1.2 before writing the output.
+The sample pipeline below computes the LOF with a neighborhood of 20 neighbors,
+followed by a range filter to crop out points whose ``LocalOutlierFactor``
+exceeds 1.2 before writing the output.
 
 .. code-block:: json
 
@@ -61,6 +61,4 @@ Options
 
 _`minpts`
   The number of k nearest neighbors. [Default: 10]
-
-.. [Breunig2000] Breunig, M.M., Kriegel, H.-P., Ng, R.T., Sander, J., 2000. LOF: Identifying Density-Based Local Outliers. Proc. 2000 Acm Sigmod Int. Conf. Manag. Data 1–12.
 

--- a/doc/stages/filters.miniball.rst
+++ b/doc/stages/filters.miniball.rst
@@ -1,0 +1,53 @@
+.. _filters.miniball:
+
+filters.miniball
+===============================================================================
+
+The **Miniball Criterion** was introduced in [Weyrich2004]_ and is based on the
+assumption that points that are distant to the cluster built by their
+k-neighborhood are likely to be outliers. First, the smallest enclosing ball is
+computed for the k-neighborhood, giving a center point and radius
+[Fischer2010]_. The miniball criterion is then computed by comparing the
+distance (from the current point to the miniball center) to the radius of the
+miniball.
+
+The author suggests that the Miniball Criterion is more robust than the
+:ref:`Plane Fit Criterion <filters.planefit>` around high-frequency details,
+but demonstrates poor outlier detection for points close to a smooth surface.
+
+The filter creates a single new dimension, ``Miniball``, that records the
+Miniball criterion for the current point.
+
+.. note::
+
+  To inspect the newly created, non-standard dimensions, be sure to write to an
+  output format that can support arbitrary dimensions, such as BPF.
+
+.. embed::
+
+Example
+-------
+
+The sample pipeline below computes the Miniball criterion with a neighborhood
+of 8 neighbors. We do not apply a fixed threshold to single out outliers based
+on the Miniball criterion as the range of values can vary from one dataset to
+another. In general, higher values indicate the likelihood of a point being an
+outlier.
+
+.. code-block:: json
+
+  [
+      "input.las",
+      {
+          "type":"filters.miniball",
+          "knn":8
+      }
+      "output.laz"
+  ]
+
+Options
+-------------------------------------------------------------------------------
+
+knn
+  The number of k nearest neighbors. [Default: 8]
+

--- a/doc/stages/filters.planefit.rst
+++ b/doc/stages/filters.planefit.rst
@@ -1,0 +1,58 @@
+.. _filters.planefit:
+
+filters.planefit
+===============================================================================
+
+The **Plane Fit Criterion** was introduced in [Weyrich2004]_ and computes the
+deviation of a point from a manifold approximating its neighbors.  First, a
+plane is fit to each point's k-neighborhood by performing an eigenvalue
+decomposition. Next, the mean point to plane distance is computed by
+considering all points within the neighborhood. This is compared to the point
+to plane distance of the current point giving rise to the k-neighborhood. As
+the mean distance of the k-neighborhood approaches 0, the Plane Fit criterion
+will tend toward 1. As point to plane distance of the current point approaches
+0, the Plane Fit criterion will tend toward 0.
+
+The author suggests that the Plane Fit Criterion is well suited to outlier
+detection when considering noisy reconstructions of smooth surfaces, but
+produces poor results around small features and creases.
+
+The filter creates a single new dimension, ``PlaneFit``, that records the
+Plane Fit criterion for the current point.
+
+.. note::
+
+  To inspect the newly created, non-standard dimensions, be sure to write to an
+  output format that can support arbitrary dimensions, such as BPF.
+
+.. embed::
+
+Example
+-------
+
+The sample pipeline below computes the Plane Fit criterion with a neighborhood
+of 8 neighbors. We do not apply a fixed threshold to single out outliers based
+on the Plane Fit criterion as the range of values can vary from one dataset to
+another. In general, higher values indicate the likelihood of a point being an
+outlier.
+
+.. code-block:: json
+
+  [
+      "input.las",
+      {
+          "type":"filters.planefit",
+          "knn":8
+      }
+      "output.laz"
+  ]
+
+Options
+-------------------------------------------------------------------------------
+
+knn
+  The number of k nearest neighbors. [Default: 8]
+
+threads
+  The number of threads used for computing the plane fit criterion. [Default: 1]
+

--- a/doc/stages/filters.reciprocity.rst
+++ b/doc/stages/filters.reciprocity.rst
@@ -1,0 +1,55 @@
+.. _filters.reciprocity:
+
+filters.reciprocity
+===============================================================================
+
+The **Nearest-Neighbor Reciprocity Criterion** was introduced in [Weyrich2004]_
+and is based on a simple assumption, that valid points may be in the
+k-neighborhood of an outlier, but the outlier will most likely not be part of
+the valid point's k-neighborhood.
+
+The author suggests that the Nearest-Neighbor Reciprocity Criterion is more
+robust than both the :ref:`Plane Fit <filters.planefit>` and :ref:`Miniball
+<filters.miniball>` Criterion, being equally sensitive around smooth and
+detailed regions. The criterion does however produce invalid reslts near
+manifold borders.
+
+The filter creates a single new dimension, ``Reciprocity``, that records the
+percentage of points(in the range 0 to 100) that are considered uni-directional
+neighbors of the current point. 
+
+.. note::
+
+  To inspect the newly created, non-standard dimensions, be sure to write to an
+  output format that can support arbitrary dimensions, such as BPF.
+
+.. embed::
+
+Example
+-------
+
+The sample pipeline below computes reciprocity with a neighborhood of 8
+neighbors, followed by a range filter to crop out points whose ``Reciprocity``
+percentage is less than 98% before writing the output.
+
+.. code-block:: json
+
+  [
+      "input.las",
+      {
+          "type":"filters.reciprocity",
+          "knn":8
+      },
+      {
+          "type":"filters.range",
+          "limits":"Reciprocity[:98.0]"
+      },
+      "output.laz"
+  ]
+
+Options
+-------------------------------------------------------------------------------
+
+knn
+  The number of k nearest neighbors. [Default: 8]
+

--- a/filters/MiniballFilter.cpp
+++ b/filters/MiniballFilter.cpp
@@ -1,0 +1,151 @@
+/******************************************************************************
+ * Copyright (c) 2019, Bradley J Chambers (brad.chambers@gmail.com)
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of Hobu, Inc. or Flaxen Geo Consulting nor the
+ *       names of its contributors may be used to endorse or promote
+ *       products derived from this software without specific prior
+ *       written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ ****************************************************************************/
+
+// PDAL implementation of the miniball criterion presented in T. Weyrich, M.
+// Pauly, R. Keiser, S. Heinzle, S. Scandella, and M. Gross, “Post-processing
+// of Scanned 3D Surface Data,” Proc. Eurographics Symp.  Point-Based Graph.
+// 2004, pp. 85–94, 2004.
+
+#include "MiniballFilter.hpp"
+
+#include <pdal/KDIndex.hpp>
+#include <pdal/util/ProgramArgs.hpp>
+
+#include "private/miniball/Seb.h"
+
+#include <cmath>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace pdal
+{
+
+using namespace Dimension;
+
+static StaticPluginInfo const s_info
+{
+    "filters.miniball",
+    "Miniball (Kutz et al., 2003)",
+    "http://pdal.io/stages/filters.miniball.html"
+};
+
+CREATE_STATIC_STAGE(MiniballFilter, s_info)
+
+std::string MiniballFilter::getName() const
+{
+    return s_info.name;
+}
+
+void MiniballFilter::addArgs(ProgramArgs& args)
+{
+    args.add("knn", "k-Nearest neighbors", m_knn, 8);
+    args.add("threads", "Number of threads used to run this filter", m_threads,
+             1);
+}
+
+void MiniballFilter::addDimensions(PointLayoutPtr layout)
+{
+    m_miniball =
+        layout->registerOrAssignDim("Miniball", Dimension::Type::Double);
+}
+
+void MiniballFilter::filter(PointView& view)
+{
+    KD3Index& kdi = view.build3dIndex();
+
+    point_count_t nloops = view.size();
+    std::vector<std::thread> threadPool(m_threads);
+    for (int t = 0; t < m_threads; t++)
+    {
+        threadPool[t] = std::thread(std::bind(
+            [&](const PointId start, const PointId end, const PointId t) {
+                for (PointId i = start; i < end; i++)
+                    setMiniball(view, i, kdi);
+            },
+            t * nloops / m_threads,
+            (t + 1) == m_threads ? nloops : (t + 1) * nloops / m_threads, t));
+    }
+    for (auto& t : threadPool)
+        t.join();
+}
+
+void MiniballFilter::setMiniball(PointView& view, const PointId& i,
+                                 const KD3Index& kdi)
+{
+    typedef double FT;
+    typedef Seb::Point<FT> Point;
+    typedef std::vector<Point> PointVector;
+    typedef Seb::Smallest_enclosing_ball<FT> Miniball;
+
+    double X = view.getFieldAs<double>(Dimension::Id::X, i);
+    double Y = view.getFieldAs<double>(Dimension::Id::Y, i);
+    double Z = view.getFieldAs<double>(Dimension::Id::Z, i);
+
+    // Find k-nearest neighbors of i.
+    auto ni = kdi.neighbors(i, m_knn + 1);
+
+    PointVector S;
+    std::vector<double> coords(3);
+    for (auto const& j : ni)
+    {
+        if (j == i)
+            continue;
+        coords[0] = view.getFieldAs<double>(Dimension::Id::X, j);
+        coords[1] = view.getFieldAs<double>(Dimension::Id::Y, j);
+        coords[2] = view.getFieldAs<double>(Dimension::Id::Z, j);
+        S.push_back(Point(3, coords.begin()));
+    }
+
+    // add neighbors to Miniball mb(3, S)
+    Miniball mb(3, S);
+
+    // obtain radius r = mb.radius();
+    FT radius = mb.radius();
+
+    // obtain center = mb.center_begin()
+    Miniball::Coordinate_iterator center_it = mb.center_begin();
+    double x = center_it[0];
+    double y = center_it[1];
+    double z = center_it[2];
+
+    // compute distance d from p to center
+    double d =
+        std::sqrt((X - x) * (X - x) + (Y - y) * (Y - y) + (Z - z) * (Z - z));
+
+    double miniball = d / (d + 2 * radius / (std::sqrt(3)));
+    view.setField(m_miniball, i, miniball);
+}
+
+} // namespace pdal

--- a/filters/MiniballFilter.hpp
+++ b/filters/MiniballFilter.hpp
@@ -1,0 +1,67 @@
+/******************************************************************************
+ * Copyright (c) 2019, Bradley J Chambers (brad.chambers@gmail.com)
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of Hobu, Inc. or Flaxen Geo Consulting nor the
+ *       names of its contributors may be used to endorse or promote
+ *       products derived from this software without specific prior
+ *       written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ ****************************************************************************/
+
+#pragma once
+
+#include <pdal/Filter.hpp>
+
+#include <memory>
+#include <string>
+
+namespace pdal
+{
+
+class PDAL_DLL MiniballFilter : public Filter
+{
+public:
+    MiniballFilter()
+    {}
+    MiniballFilter& operator=(const MiniballFilter&) = delete;
+    MiniballFilter(const MiniballFilter&) = delete;
+
+    std::string getName() const;
+
+private:
+    int m_knn;
+    int m_threads;
+    Dimension::Id m_miniball;
+
+    virtual void addArgs(ProgramArgs& args);
+    virtual void addDimensions(PointLayoutPtr layout);
+    virtual void filter(PointView& view);
+
+    void setMiniball(PointView& view, const PointId& i, const KD3Index& kdi);
+};
+
+} // namespace pdal

--- a/filters/PlaneFitFilter.cpp
+++ b/filters/PlaneFitFilter.cpp
@@ -1,0 +1,157 @@
+/******************************************************************************
+ * Copyright (c) 2019, Bradley J Chambers (brad.chambers@gmail.com)
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of Hobu, Inc. or Flaxen Geo Consulting nor the
+ *       names of its contributors may be used to endorse or promote
+ *       products derived from this software without specific prior
+ *       written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ ****************************************************************************/
+
+// PDAL implementation of the plane fit criterion presented in T. Weyrich, M.
+// Pauly, R. Keiser, S. Heinzle, S. Scandella, and M. Gross, “Post-processing
+// of Scanned 3D Surface Data,” Proc. Eurographics Symp.  Point-Based Graph.
+// 2004, pp. 85–94, 2004.
+
+#include "PlaneFitFilter.hpp"
+
+#include <pdal/EigenUtils.hpp>
+#include <pdal/KDIndex.hpp>
+#include <pdal/util/ProgramArgs.hpp>
+
+#include <Eigen/Dense>
+
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace pdal
+{
+
+using namespace Dimension;
+
+static StaticPluginInfo const s_info
+{
+    "filters.planefit",
+    "Plane Fit (Kutz et al., 2003)",
+    "http://pdal.io/stages/filters.planefit.html"
+};
+
+CREATE_STATIC_STAGE(PlaneFitFilter, s_info)
+
+std::string PlaneFitFilter::getName() const
+{
+    return s_info.name;
+}
+
+void PlaneFitFilter::addArgs(ProgramArgs& args)
+{
+    args.add("knn", "k-Nearest neighbors", m_knn, 8);
+    args.add("threads", "Number of threads used to run this filter", m_threads,
+             1);
+}
+
+void PlaneFitFilter::addDimensions(PointLayoutPtr layout)
+{
+    m_planefit =
+        layout->registerOrAssignDim("PlaneFit", Dimension::Type::Double);
+}
+
+void PlaneFitFilter::filter(PointView& view)
+{
+    KD3Index& kdi = view.build3dIndex();
+
+    point_count_t nloops = view.size();
+    std::vector<std::thread> threadPool(m_threads);
+    for (int t = 0; t < m_threads; t++)
+    {
+        threadPool[t] = std::thread(std::bind(
+            [&](const PointId start, const PointId end, const PointId t) {
+                for (PointId i = start; i < end; i++)
+                    setPlaneFit(view, i, kdi);
+            },
+            t * nloops / m_threads,
+            (t + 1) == m_threads ? nloops : (t + 1) * nloops / m_threads, t));
+    }
+    for (auto& t : threadPool)
+        t.join();
+}
+
+double PlaneFitFilter::absDistance(PointView& view, const PointId& i,
+                                   Eigen::Vector3d& centroid,
+                                   Eigen::Vector3f& normal)
+{
+    double x = view.getFieldAs<double>(Dimension::Id::X, i);
+    double y = view.getFieldAs<double>(Dimension::Id::Y, i);
+    double z = view.getFieldAs<double>(Dimension::Id::Z, i);
+    Eigen::Vector3f p;
+    p << x - centroid[0], y - centroid[1], z - centroid[2];
+    double d = normal.dot(p);
+    return std::fabs(d);
+}
+
+void PlaneFitFilter::setPlaneFit(PointView& view, const PointId& i,
+                                 const KD3Index& kdi)
+{
+    // Find k-nearest neighbors of i.
+    std::vector<PointId> ni = kdi.neighbors(i, m_knn + 1);
+
+    // Normal based only on neighbors, so exclude first point.
+    std::vector<PointId> neighbors(ni.begin() + 1, ni.end());
+
+    // Covariance and normal are based off demeaned coordinates, so we record
+    // the centroid to properly offset the coordinates when computing point to
+    // plance distance.
+    auto centroid = eigen::computeCentroid(view, neighbors);
+
+    // Compute covariance of the neighbors.
+    auto B = eigen::computeCovariance(view, neighbors);
+
+    // Perform the eigen decomposition, using the eigenvector of the smallest
+    // eigenvalue as the normal.
+    Eigen::SelfAdjointEigenSolver<Eigen::Matrix3f> solver(B);
+    if (solver.info() != Eigen::Success)
+        throwError("Cannot perform eigen decomposition.");
+    auto eval = solver.eigenvalues();
+    Eigen::Vector3f normal = solver.eigenvectors().col(0);
+
+    // Compute point to plane distance of the query point.
+    double d = absDistance(view, i, centroid, normal);
+
+    // Compute mean point to plane distance of neighbors.
+    double d_sum(0.0);
+    for (auto const& j : neighbors)
+    {
+        d_sum += absDistance(view, j, centroid, normal);
+    }
+    double d_bar(d_sum / m_knn);
+
+    // Compute and set the plane fit criterion.
+    view.setField(m_planefit, i, d / (d + d_bar));
+}
+
+} // namespace pdal

--- a/filters/PlaneFitFilter.cpp
+++ b/filters/PlaneFitFilter.cpp
@@ -103,12 +103,12 @@ void PlaneFitFilter::filter(PointView& view)
 
 double PlaneFitFilter::absDistance(PointView& view, const PointId& i,
                                    Eigen::Vector3d& centroid,
-                                   Eigen::Vector3f& normal)
+                                   Eigen::Vector3d& normal)
 {
     double x = view.getFieldAs<double>(Dimension::Id::X, i);
     double y = view.getFieldAs<double>(Dimension::Id::Y, i);
     double z = view.getFieldAs<double>(Dimension::Id::Z, i);
-    Eigen::Vector3f p;
+    Eigen::Vector3d p;
     p << x - centroid[0], y - centroid[1], z - centroid[2];
     double d = normal.dot(p);
     return std::fabs(d);
@@ -133,11 +133,11 @@ void PlaneFitFilter::setPlaneFit(PointView& view, const PointId& i,
 
     // Perform the eigen decomposition, using the eigenvector of the smallest
     // eigenvalue as the normal.
-    Eigen::SelfAdjointEigenSolver<Eigen::Matrix3f> solver(B);
+    Eigen::SelfAdjointEigenSolver<Eigen::Matrix3d> solver(B);
     if (solver.info() != Eigen::Success)
         throwError("Cannot perform eigen decomposition.");
     auto eval = solver.eigenvalues();
-    Eigen::Vector3f normal = solver.eigenvectors().col(0);
+    Eigen::Vector3d normal = solver.eigenvectors().col(0);
 
     // Compute point to plane distance of the query point.
     double d = absDistance(view, i, centroid, normal);

--- a/filters/PlaneFitFilter.hpp
+++ b/filters/PlaneFitFilter.hpp
@@ -1,0 +1,72 @@
+/******************************************************************************
+ * Copyright (c) 2019, Bradley J Chambers (brad.chambers@gmail.com)
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of Hobu, Inc. or Flaxen Geo Consulting nor the
+ *       names of its contributors may be used to endorse or promote
+ *       products derived from this software without specific prior
+ *       written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ ****************************************************************************/
+
+#pragma once
+
+#include <pdal/Filter.hpp>
+
+#include <Eigen/Dense>
+
+#include <memory>
+#include <string>
+
+namespace pdal
+{
+
+class PDAL_DLL PlaneFitFilter : public Filter
+{
+public:
+    PlaneFitFilter()
+    {
+    }
+    PlaneFitFilter& operator=(const PlaneFitFilter&) = delete;
+    PlaneFitFilter(const PlaneFitFilter&) = delete;
+
+    std::string getName() const;
+
+private:
+    int m_knn;
+    int m_threads;
+    Dimension::Id m_planefit;
+
+    virtual void addArgs(ProgramArgs& args);
+    virtual void addDimensions(PointLayoutPtr layout);
+    virtual void filter(PointView& view);
+
+    void setPlaneFit(PointView& view, const PointId& i, const KD3Index& kdi);
+    double absDistance(PointView& view, const PointId& i,
+                       Eigen::Vector3d& centroid, Eigen::Vector3f& normal);
+};
+
+} // namespace pdal

--- a/filters/PlaneFitFilter.hpp
+++ b/filters/PlaneFitFilter.hpp
@@ -66,7 +66,7 @@ private:
 
     void setPlaneFit(PointView& view, const PointId& i, const KD3Index& kdi);
     double absDistance(PointView& view, const PointId& i,
-                       Eigen::Vector3d& centroid, Eigen::Vector3f& normal);
+                       Eigen::Vector3d& centroid, Eigen::Vector3d& normal);
 };
 
 } // namespace pdal

--- a/filters/ReciprocityFilter.cpp
+++ b/filters/ReciprocityFilter.cpp
@@ -1,0 +1,132 @@
+/******************************************************************************
+ * Copyright (c) 2019, Bradley J Chambers (brad.chambers@gmail.com)
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of Hobu, Inc. or Flaxen Geo Consulting nor the
+ *       names of its contributors may be used to endorse or promote
+ *       products derived from this software without specific prior
+ *       written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ ****************************************************************************/
+
+// PDAL implementation of the nearest-neighbor reciprocity criterion presented
+// in T. Weyrich, M. Pauly, R. Keiser, S. Heinzle, S. Scandella, and M. Gross,
+// “Post-processing of Scanned 3D Surface Data,” Proc. Eurographics Symp.
+// Point-Based Graph. 2004, pp. 85–94, 2004.
+
+#include "ReciprocityFilter.hpp"
+
+#include <pdal/KDIndex.hpp>
+#include <pdal/util/ProgramArgs.hpp>
+
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace pdal
+{
+
+static StaticPluginInfo const s_info
+{
+    "filters.reciprocity",
+    "Returns the percentage of neighbors that do NOT have the query point as a "
+    "neighbor",
+    "http://pdal.io/stages/filters.reciprocity.html"
+};
+
+CREATE_STATIC_STAGE(ReciprocityFilter, s_info)
+
+std::string ReciprocityFilter::getName() const
+{
+    return s_info.name;
+}
+
+void ReciprocityFilter::addArgs(ProgramArgs& args)
+{
+    args.add("knn", "k-Nearest neighbors", m_knn, 8);
+    args.add("threads", "Number of threads used to run this filter", m_threads,
+             1);
+}
+
+void ReciprocityFilter::addDimensions(PointLayoutPtr layout)
+{
+    m_reciprocity =
+        layout->registerOrAssignDim("Reciprocity", Dimension::Type::Double);
+}
+
+void ReciprocityFilter::filter(PointView& view)
+{
+    KD3Index& kdi = view.build3dIndex();
+
+    point_count_t nloops = view.size();
+    std::vector<std::thread> threadPool(m_threads);
+    for (int t = 0; t < m_threads; t++)
+    {
+        threadPool[t] = std::thread(std::bind(
+            [&](const PointId start, const PointId end, const PointId t) {
+                for (PointId i = start; i < end; i++)
+                    setReciprocity(view, i, kdi);
+            },
+            t * nloops / m_threads,
+            (t + 1) == m_threads ? nloops : (t + 1) * nloops / m_threads, t));
+    }
+    for (auto& t : threadPool)
+        t.join();
+}
+
+void ReciprocityFilter::setReciprocity(PointView& view, const PointId& i,
+                                       const KD3Index& kdi)
+{
+    // Find k-nearest neighbors of i.
+    auto ni = kdi.neighbors(i, m_knn + 1);
+
+    // Initialize number of unidirectional neighbors to 0.
+    point_count_t uni(0);
+
+    // Visit each neighbor of i, finding its k-nearest neighbors. If i is
+    // not a nearest neighbor of one of its neighbors, increment uni.
+    for (auto const& j : ni)
+    {
+        // The query point itself will always show up as a neighbor and can
+        // be skipped.
+        if (j == i)
+            continue;
+
+        // Find k-nearest neighbors of j.
+        auto nj = kdi.neighbors(j, m_knn + 1);
+
+        // If i is not a neighbor of j, increment uni.
+        if (std::find(nj.begin(), nj.end(), i) == nj.end())
+            ++uni;
+    }
+
+    // Compute reciprocity as percentage of neighbors that do NOT contain
+    // id as a neighbor.
+    double reciprocity = 100.0 * uni / m_knn;
+    view.setField(m_reciprocity, i, reciprocity);
+}
+
+} // namespace pdal

--- a/filters/ReciprocityFilter.hpp
+++ b/filters/ReciprocityFilter.hpp
@@ -1,0 +1,73 @@
+/******************************************************************************
+ * Copyright (c) 2019, Bradley J Chambers (brad.chambers@gmail.com)
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of Hobu, Inc. or Flaxen Geo Consulting nor the
+ *       names of its contributors may be used to endorse or promote
+ *       products derived from this software without specific prior
+ *       written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ ****************************************************************************/
+
+#pragma once
+
+#include <pdal/Filter.hpp>
+
+#include <cstdint>
+#include <memory>
+#include <string>
+
+namespace pdal
+{
+
+class Options;
+class PointLayout;
+class PointView;
+
+class PDAL_DLL ReciprocityFilter : public Filter
+{
+public:
+    ReciprocityFilter() : Filter()
+    {}
+    ReciprocityFilter& operator=(const ReciprocityFilter&) = delete;
+    ReciprocityFilter(const ReciprocityFilter&) = delete;
+
+    std::string getName() const;
+
+private:
+    int m_knn;
+    int m_threads;
+    Dimension::Id m_reciprocity;
+
+    virtual void addDimensions(PointLayoutPtr layout);
+    virtual void addArgs(ProgramArgs& args);
+    virtual void filter(PointView& view);
+
+    void setReciprocity(PointView& view, const PointId& i,
+                        const KD3Index& kdi);
+};
+
+} // namespace pdal

--- a/filters/private/miniball/Seb-inl.h
+++ b/filters/private/miniball/Seb-inl.h
@@ -1,0 +1,453 @@
+// Synopsis: Library to find the smallest enclosing ball of points
+//
+// Authors: Martin Kutz <kutz@math.fu-berlin.de>,
+//          Kaspar Fischer <kf@iaeth.ch>
+
+#ifndef SEB_SEB_INL_H
+#define SEB_SEB_INL_H
+
+#include <algorithm>
+#include <numeric>
+
+#include "Seb.h" // Note: header included for better syntax highlighting in some IDEs.
+
+namespace SEB_NAMESPACE {
+  
+  template<typename Float, class Pt, class PointAccessor>
+  void Smallest_enclosing_ball<Float, Pt, PointAccessor>::allocate_resources()
+  {
+    center            = new Float[dim];
+    center_to_aff     = new Float[dim];
+    center_to_point   = new Float[dim];
+    lambdas           = new Float[dim+1];
+  }
+  
+  template<typename Float, class Pt, class PointAccessor>
+  void Smallest_enclosing_ball<Float, Pt, PointAccessor>::deallocate_resources()
+  {
+    delete[] center;
+    delete[] center_to_aff;
+    delete[] center_to_point;
+    delete[] lambdas;
+    
+    if (support != NULL)
+      delete support;
+  }
+  
+  template<typename Float, class Pt, class PointAccessor>
+  void Smallest_enclosing_ball<Float, Pt, PointAccessor>::init_ball()
+  // Precondition: |S| > 0
+  // Sets up the search ball with an arbitrary point of S as center
+  // and with with exactly one of the points farthest from center in
+  // support, which is instantiated here.
+  // So the current ball contains all points of S and has radius at
+  // most twice as large as the minball.
+  {
+    SEB_ASSERT(S.size() > 0);
+    
+    // set center to the first point in S:
+    for (unsigned int i = 0; i < dim; ++i)
+      center[i] = S[0][i];
+    
+    // find farthest point:
+    radius_square = 0;
+    unsigned int farthest = 0; // Note: assignment prevents compiler warnings.
+    for (unsigned int j = 1; j < S.size(); ++j) {
+      // compute squared distance from center to S[j]:
+      Float dist = 0;
+      for (unsigned int i = 0; i < dim; ++i)
+        dist += sqr(S[j][i] - center[i]);
+      
+      // enlarge radius if needed:
+      if (dist >= radius_square) {
+        radius_square = dist;
+        farthest = j;
+      }
+      radius_ = sqrt(radius_square);
+    }
+    
+    // initialize support to the farthest point:
+    if (support != NULL)
+      delete support;
+    support = new Subspan<Float, Pt, PointAccessor>(dim,S,farthest);
+    
+    // statistics:
+    // initialize entry-counters to zero:
+    SEB_STATS(entry_count = std::vector<int>(S.size(),0));
+  }
+  
+  template<typename Float, class Pt, class PointAccessor>
+  bool Smallest_enclosing_ball<Float, Pt, PointAccessor>::successful_drop()
+  // Precondition: center lies in aff(support).
+  // If center doesn't already lie in conv(support) and is thus
+  // not optimal yet, successful_drop() elects a suitable point k to
+  // be removed from support -- and returns true.
+  // If center lies in the convex hull, however, false is returned
+  // (and support remains unaltered).
+  {
+    // find coefficients of the affine combination of center:
+    support->find_affine_coefficients(center,lambdas);
+    
+    // find a non-positive coefficient:
+    unsigned int smallest = 0; // Note: assignment prevents compiler warnings.
+    Float minimum(1);
+    for (unsigned int i=0; i<support->size(); ++i)
+      if (lambdas[i] < minimum) {
+        minimum = lambdas[i];
+        smallest = i;
+      }
+    
+    // drop a point with non-positive coefficient, if any:
+    if (minimum <= 0) {
+      SEB_LOG ("debug","  removing local point #" << smallest << std::endl);
+      support->remove_point(smallest);
+      return true;
+    }
+    return false;
+  }
+  
+  template<typename Float, class Pt, class PointAccessor>
+  Float Smallest_enclosing_ball<Float, Pt, PointAccessor>::find_stop_fraction(int& stopper)
+  // Given the center of the current enclosing ball and the
+  // walking direction center_to_aff, determine how much we can walk
+  // into this direction without losing a point from S.  The (positive)
+  // factor by which we can walk along center_to_aff is returned.
+  // Further, stopper is set to the index of the most restricting point
+  // and to -1 if no such point was found.
+  {
+    using std::inner_product;
+    
+    // We would like to walk the full length of center_to_aff ...
+    Float scale =  1;
+    stopper     = -1;
+    
+    SEB_DEBUG (Float margin = 0;)
+    
+    // ... but one of the points in S might hinder us:
+    for (unsigned int j = 0; j < S.size(); ++j)
+      if (!support->is_member(j)) {
+        
+        // compute vector center_to_point from center to the point S[i]:
+        for (unsigned int i = 0; i < dim; ++i)
+          center_to_point[i] = S[j][i] - center[i];
+        
+        const Float dir_point_prod
+        = inner_product(center_to_aff,center_to_aff+dim,
+                        center_to_point,Float(0));
+        
+        // we can ignore points beyond support since they stay
+        // enclosed anyway:
+        if (dist_to_aff_square - dir_point_prod
+            // make new variable 'radius_times_dist_to_aff'? !
+            < Eps * radius_ * dist_to_aff)
+          continue;
+        
+        // compute the fraction we can walk along center_to_aff until
+        // we hit point S[i] on the boundary:
+        // (Better don't try to understand this calculus from the code,
+        //  it needs some pencil-and-paper work.)
+        Float bound = radius_square;
+        bound -= inner_product(center_to_point,center_to_point+dim,
+                               center_to_point,Float(0));
+        bound /= 2 * (dist_to_aff_square - dir_point_prod);
+        
+        // watch for numerical instability - if bound=0 then we are
+        // going to walk by zero units, and thus hit an infinite loop.
+        //
+        // If we are walking < 0, then we are going the wrong way,
+        // which can happen if we were to disable the test just above
+        // (the "dist_to_aff_square-dir_point_prod" test)
+        
+        // take the smallest fraction:
+        if (bound > 0 && bound < scale) {
+          scale   = bound;
+          stopper = j;
+          SEB_DEBUG (margin = dist_to_aff - dir_point_prod / dist_to_aff;)
+        }
+      }
+    
+    SEB_LOG ("debug","  margin = " << margin << std::endl);
+    
+    return scale;
+  }
+  
+  
+  template<typename Float, class Pt, class PointAccessor>
+  void Smallest_enclosing_ball<Float, Pt, PointAccessor>::update()
+  // The main function containing the main loop.
+  // Iteratively, we compute the point in support that is closest
+  // to the current center and then walk towards this target as far
+  // as we can, i.e., we move until some new point touches the
+  // boundary of the ball and must thus be inserted into support.
+  // In each of these two alternating phases, we always have to check
+  // whether some point must be dropped from support, which is the
+  // case when the center lies in aff(support).
+  // If such an attempt to drop fails, we are done;  because then
+  // the center lies even conv(support).
+  {
+    SEB_DEBUG (int iteration = 0;)
+    
+    SEB_TIMER_START("computation");
+    
+    // optimistically, we set this flag now;
+    // on return from this function it will be true:
+    up_to_date = true;
+    
+    init_ball();
+    
+    // Invariant:  The ball B(center,radius_) always contains the whole
+    // point set S and has the points in support on its boundary.
+    
+    while (true) {
+      
+      SEB_LOG ("debug","  iteration " << ++iteration << std::endl);
+      
+      SEB_LOG ("debug","  " << support->size()
+               << " points on boundary" << std::endl);
+      
+      // Compute a walking direction and walking vector,
+      // and check if the former is perhaps too small:
+      while ((dist_to_aff
+              = sqrt(dist_to_aff_square
+                     = support->shortest_vector_to_span(center,
+                                                        center_to_aff)))
+             <= Eps * radius_)
+        // We are closer than Eps * radius_square, so we try a drop:
+        if (!successful_drop()) {
+          // If that is not possible, the center lies in the convex hull
+          // and we are done.
+          SEB_TIMER_PRINT("computation");
+          return;
+        }
+      
+      SEB_LOG ("debug","  distance to affine hull = "
+               << dist_to_aff << std::endl);
+      
+      // determine how far we can walk in direction center_to_aff
+      // without losing any point ('stopper', say) in S:
+      int stopper;
+      Float scale = find_stop_fraction(stopper);
+      SEB_LOG ("debug","  stop fraction = " << scale << std::endl);
+      
+      // Note: In theory, the following if-statement should simply read
+      //
+      //  if (stopper >= 0) {
+      //    // ...
+      //
+      // However, due to rounding errors, it may happen in practice that
+      // stopper is nonnegative and the support is already full (see #14);
+      // in this casev we cannot add yet another point to the support.
+      //
+      // Therefore, the condition reads:
+      if (stopper >= 0 && support->size() <= dim) {
+        // stopping point exists
+        
+        // walk as far as we can
+        for (unsigned int i = 0; i < dim; ++i)
+          center[i] += scale * center_to_aff[i];
+        
+        // update the radius
+        const Pt& stop_point = S[support->any_member()];
+        radius_square = 0;
+        for (unsigned int i = 0; i < dim; ++i)
+          radius_square += sqr(stop_point[i] - center[i]);
+        radius_ = sqrt(radius_square);
+        SEB_LOG ("debug","  current radius = "
+                 << std::setiosflags(std::ios::scientific)
+                 << std::setprecision(17) << radius_
+                 << std::endl << std::endl);
+        
+        // and add stopper to support
+        support->add_point(stopper);
+        SEB_STATS (++entry_count[stopper]);
+        SEB_LOG ("debug","  adding global point #" << stopper << std::endl);
+      }
+      else {
+        //  we can run unhindered into the affine hull
+        SEB_LOG ("debug","  moving into affine hull" << std::endl);
+        for (unsigned int i=0; i<dim; ++i)
+          center[i] += center_to_aff[i];
+        
+        // update the radius:
+        const Pt& stop_point = S[support->any_member()];
+        radius_square = 0;
+        for (unsigned int i = 0; i < dim; ++i)
+          radius_square += sqr(stop_point[i] - center[i]);
+        radius_ = sqrt(radius_square);
+        SEB_LOG ("debug","  current radius = "
+                 << std::setiosflags(std::ios::scientific)
+                 << std::setprecision(17) << radius_
+                 << std::endl << std::endl);
+        
+        // Theoretically, the distance to the affine hull is now zero
+        // and we would thus drop a point in the next iteration.
+        // For numerical stability, we don't rely on that to happen but
+        // try to drop a point right now:
+        if (!successful_drop()) {
+          // Drop failed, so the center lies in conv(support) and is thus
+          // optimal.
+          SEB_TIMER_PRINT("computation");
+          return;
+        }
+      }
+    }
+  }
+  
+  template<typename Float, class Pt, class PointAccessor>
+  void Smallest_enclosing_ball<Float, Pt, PointAccessor>::verify()
+  {
+    using std::inner_product;
+    using std::abs;
+    using std::cout;
+    using std::endl;
+    
+    Float  min_lambda      = 1;  // for center-in-convex-hull check
+    Float  max_overlength  = 0;  // for all-points-in-ball check
+    Float  min_underlength = 0;  // for all-boundary-points-on-boundary
+    Float  ball_error;
+    Float  qr_error = support->representation_error();
+    
+    // center really in convex hull?
+    support->find_affine_coefficients(center,lambdas);
+    for (unsigned int k = 0; k < support->size(); ++k)
+      if (lambdas[k] <= min_lambda)
+        min_lambda = lambdas[k];
+    
+    // all points in ball, all support points really on boundary?
+    for (unsigned int k = 0; k < S.size(); ++k) {
+      
+      // compare center-to-point distance with radius
+      for (unsigned int i = 0; i < dim; ++i)
+        center_to_point[i] = S[k][i] - center[i];
+      ball_error = sqrt(inner_product(center_to_point,center_to_point+dim,
+                                      center_to_point,Float(0)))
+      - radius_;
+      
+      // check for sphere violations
+      if (ball_error > max_overlength) max_overlength = ball_error;
+      
+      // check for boundary violations
+      if (support->is_member(k))
+        if (ball_error < min_underlength) min_underlength = ball_error;
+    }
+    
+    cout << "Solution errors (relative to radius, nonsquared)" << endl
+    << "  final QR inconsistency     : " << qr_error << endl
+    << "  minimal convex coefficient : ";
+    if (min_lambda >= 0) cout << "positive";
+    else cout << (-min_lambda);
+    cout << endl
+    << "  maximal overlength         : "
+    << (max_overlength / radius_) << endl
+    << "  maximal underlength        : "
+    << (abs(min_underlength / radius_))
+    << endl;
+    
+    
+#ifdef SEB_STATS_MODE
+    // And let's print some statistics about the rank changes
+    cout << "=====================================================" << endl
+    << "Statistics" << endl;
+    
+    // determine how often a single point entered support at most
+    int max_enter = 0;
+    for (int i = 0; i < S.size(); ++i)
+      if (entry_count[i] > max_enter)
+        max_enter = entry_count[i];
+    ++max_enter;
+    
+    // compute a histogram from the entry data ...
+    std::vector<int> histogram(max_enter+1);
+    for (int j = 0; j <= max_enter; ++j)
+      histogram[j] = 0;
+    for (int i = 0; i < S.size(); ++i)
+      histogram[entry_count[i]]++;
+    // ... and print it
+    for (int j = 0; j <= max_enter; j++)
+      if (histogram[j])
+        cout << histogram[j] << " points entered " << j << " times" << endl;
+#endif // SEB_STATS MODE
+  }
+  
+  
+  template<typename Float, class Pt, class PointAccessor>
+  void Smallest_enclosing_ball<Float, Pt, PointAccessor>::test_affine_stuff()
+  {
+    using std::cout;
+    using std::endl;
+    
+    Float *direction;
+    Float  error;
+    Float  max_representation_error = 0;
+    
+    cout << S.size() << " points in " << dim << " dimensions" << endl;
+    
+    if (!is_empty()) {
+      support = new Subspan<Float,PointAccessor,Pt>(dim,S,0);
+      cout << "initializing affine subspace with point S[0]" << endl;
+      
+      direction = new Float[dim];
+    }
+    else return;
+    
+    for (int loop = 0; loop < 5; ++loop) {
+      
+      // Try to fill each point of S into aff
+      for (int i = 0; i < S.size(); ++i) {
+        
+        cout << endl << "Trying new point #" << i << endl;
+        
+        Float dist = sqrt(support->shortest_vector_to_span(S[i],direction));
+        cout << "dist(S[" << i << "],affine_hull) = "
+        << dist << endl;
+        
+        if (dist > 1.0E-8) {
+          cout << "inserting point S["<<i<<"] into affine hull"
+          << endl;
+          support->add_point(i);
+          
+          cout << "representation error: "
+          << (error = support->representation_error()) << endl;
+          if (error > max_representation_error)
+            max_representation_error = error;
+        }
+      }
+      
+      //  Throw out half of the points
+      while (support->size() > dim/2) {
+        
+        //  throw away the origin or point at position r/2,
+        //  depending on whether size is odd or even:
+        int k = support->size()/2;
+        if (2 * k == support->size()) {
+          //  size even
+          cout << endl << "Throwing out local point #" << k << endl;
+          support->remove_point(k);
+        } else {
+          //  size odd
+          cout << endl << "Throughing out the origin" << endl;
+          support->remove(support->size()-1);
+        }
+        
+        cout << "representation error: "
+        << (error = support->representation_error()) << endl;
+        if (error > max_representation_error)
+          max_representation_error = error;
+      }
+    }
+    
+    cout << "maximal representation error: "
+    << max_representation_error << endl
+    << "End of test." << endl;
+    
+    delete support;
+    delete direction;
+  }
+  
+  
+  template<typename Float, class Pt, class PointAccessor>
+  const Float Smallest_enclosing_ball<Float, Pt, PointAccessor>::Eps = Float(1e-14);
+  
+} // namespace SEB_NAMESPACE
+
+#endif // SEB_SEB_INL_H

--- a/filters/private/miniball/Seb.h
+++ b/filters/private/miniball/Seb.h
@@ -1,0 +1,180 @@
+// Synopsis: Library to find the smallest enclosing ball of points
+//
+// Authors: Martin Kutz <kutz@math.fu-berlin.de>,
+//          Kaspar Fischer <kf@iaeth.ch>
+
+#ifndef SEB_SEB_H
+#define SEB_SEB_H
+
+#include <vector>
+#include "Seb_configure.h"
+#include "Seb_point.h"
+#include "Subspan.h"
+
+namespace SEB_NAMESPACE {
+
+  // template arguments:
+  // Float must be a floating point data type for which * / - + are defined
+  // Pt[i] must return the i-th coordinate as a Float
+  // PointAccessor[j] must return the j-th point in the data set as Pt and
+  // size_t size() returns the size of the data set
+  
+  template<typename Float, class Pt = Point<Float>, class PointAccessor = std::vector<Pt> >
+  class Smallest_enclosing_ball
+  // An instance of class Smallest_enclosing_ball<Float> represents
+  // the smallest enclosing ball of a set S of points.  Initially, the
+  // set S is empty; you can add points by calling insert().
+  {
+  public: // iterator-type to iterate over the center coordinates of
+	  // the miniball (cf. center_begin() below):
+    typedef Float *Coordinate_iterator;
+    
+  public: // construction and destruction:
+
+    Smallest_enclosing_ball(unsigned int d, const PointAccessor &P)
+    // Constructs an instance representing the miniball of points from
+    // set S.  The dimension of the ambient space is fixed to d for
+    // lifetime of the instance.
+    : dim(d), S(P), up_to_date(true), support(NULL)
+    {
+      allocate_resources();
+      SEB_ASSERT(!is_empty());
+      update();
+    }
+    
+    ~Smallest_enclosing_ball()
+    {
+      deallocate_resources();
+    }
+    
+  public: // modification:
+    
+    void invalidate()
+    // Notifies the instance that the underlying point set S (passed to the constructor
+    // of this instance as parameter P) has changed. This will cause the miniball to
+    // be recomputed lazily (i.e., when you call for example radius(), the recalculation
+    // will be triggered).
+    {
+      up_to_date = false;
+    }
+    
+  public: // access:
+    
+    bool is_empty()
+    // Returns whether the miniball is empty, i.e., if no point has
+    // been inserted so far.
+    {
+      return S.size() == 0;
+    }
+    
+    Float squared_radius()
+    // Returns the squared radius of the miniball.
+    // Precondition: !is_empty()
+    {
+      if (!up_to_date)
+        update();
+      
+      SEB_ASSERT(!is_empty());
+      return radius_square;
+    }
+    
+    Float radius()
+    // Returns the radius of the miniball.
+    // This is equivalent to std:sqrt(squared_radius())
+    // Precondition: !is_empty()
+    {
+      if (!up_to_date)
+        update();
+      
+      SEB_ASSERT(!is_empty());
+      return radius_;
+    }
+    
+    Coordinate_iterator center_begin()
+    // Returns an iterator to the first Cartesian coordinate of the
+    // center of the miniball.
+    // Precondition: !is_empty()
+    {
+      if (!up_to_date)
+        update();
+      
+      SEB_ASSERT(!is_empty());
+      return center;
+    }
+    
+    Coordinate_iterator center_end()
+    // Returns the past-the-end iterator past the last Cartesian
+    // coordinate of the center of the miniball.
+    // Precondition: !is_empty
+    {
+      if (!up_to_date)
+        update();
+      
+      SEB_ASSERT(!is_empty());
+      return center+dim;
+    }
+    
+  public: // testing:
+    
+    void verify();
+    //  Verifies whether center lies really in affine hull,
+    //  determines the consistency of the QR decomposition,
+    //  and check whether all points of Q lie on the ball
+    //  and all others within;
+    //  prints the respective errors.
+    
+    void test_affine_stuff();
+    // Runs some testing routines on the affine hull layer,
+    // using the points in S.
+    // Creates a new Q, so better use before or after actual computations.
+    // Prints the accumulated error.
+    
+    
+  private: // internal routines concerning storage:
+    void allocate_resources();
+    void deallocate_resources();
+    
+  private: // internal helper routines for the actual algorithm:
+    void init_ball();
+    Float find_stop_fraction(int& hinderer);
+    bool successful_drop();
+    
+    void update();
+    
+  private: // we forbid copying (since we have dynamic storage):
+    Smallest_enclosing_ball(const Smallest_enclosing_ball&);
+    Smallest_enclosing_ball& operator=(const Smallest_enclosing_ball&);
+    
+  private: // member fields:
+    unsigned int dim;                 // dimension of the amient space
+    const PointAccessor &S;           // set S of inserted points
+    bool up_to_date;                  // whether the miniball has
+                                      // already been computed
+    Float *center;                    // center of the miniball
+    Float radius_, radius_square;     // squared radius of the miniball
+    Subspan<Float, Pt, PointAccessor> *support;          // the points that lie on the current
+    // boundary and "support" the ball;
+    // the essential structure for update()
+    
+  private: // member fields for temporary use:
+    Float *center_to_aff;
+    Float *center_to_point;
+    Float *lambdas;
+    Float  dist_to_aff, dist_to_aff_square;
+    
+#ifdef SEB_STATS_MODE
+  private: // memeber fields for statistics
+    std::vector<int> entry_count;     // counts how often a point enters
+    // the support; only available in
+    // stats mode
+#endif // SEB_STATS_MODE
+    
+  private: // constants:
+    static const Float Eps;
+  };
+  
+} // namespace SEB_NAMESPACE
+
+#include "Seb-inl.h"
+
+#endif // SEB_SEB_H

--- a/filters/private/miniball/Seb_configure.h
+++ b/filters/private/miniball/Seb_configure.h
@@ -1,0 +1,127 @@
+// Synopsis: Switches to adapt the code
+//
+// Authors: Martin Kutz <kutz@math.fu-berlin.de>,
+//          Kaspar Fischer <kf@iaeth.ch>
+
+#ifndef SEB_CONFIGURE_H
+#define SEB_CONFIGURE_H
+
+#include <cassert>
+#include <iomanip>
+#include <iostream>
+
+#define SEB_NAMESPACE Seb              // namespace of the library
+// #define SEB_ASSERTION_MODE          // enables (cheap) assertions
+// #define SEB_DEBUG_MODE              // enables debugging checks (cheap and
+                                       // expensive ones) this enables
+                                       // assertion and timer mode as well
+// #define SEB_TIMER_MODE              // enables runtime measurements
+// #define SEB_STATS_MODE              // enables statistics
+
+#include "Seb_debug.h"
+
+// Fixes for GCC series 2.95.  (This fix is necessary for 2.95.2 at
+// least.  But I guess it is needed for any earlier version of the 2.95
+// series, too.)  Apparently, GCC doesn't come with a bitset and sstream
+// implementation, that's why we include them here.
+#if defined(__GNUC__) && __GNUC__==2 && \
+  __GNUC_MINOR__==95 && __GNUC_PATCHLEVEL__ <= 2
+  #include <gcc2-95-2_fix.h>
+#else
+  #include <sstream>
+#endif
+
+// We provide the following debugging routines:
+//
+// - SEB_DEBUG(expr): evaluates the expression expr when debugging mode
+//   is on (see SEB_DEBUG_MODE above), or does nothing otherwise.
+//
+// - SEB_LOG(channel,expr): Writes to file channel.log the string
+//   produced by the expression 's << expr' (where s it the stream for
+//   file channel.log).  This only happens when the debugging mode is
+//   enabled; nothing is done otherwise.
+//   Example: SEB_LOG("debug","Radius is " << radius_square << std::endl)
+//
+// - SEB_ASSERT(expr): Asserts that the Boolean expression expr evaluates
+//   to true.  This only happens when the assertion mode is enabled.  This
+//   macro should only be used for cheap assertions (which do not heavily
+//   affect the running time).
+//
+// - SEB_ASSERT_EXPENSIVE(expr): Asserts that the Boolean expression expr
+//   evaluates to true.  This only happens when the debugging mode is on,
+//   and not otherwise.  (The assertion mode alone doesn't enable such
+//   assertions.)
+//
+// - SEB_TIMER_START(timer): Restarts the timer with name timer.  Nothing
+//   happens when the timer mode is disabled (see SEB_TIMER_MODE above).
+//
+// - SEB_TIMER_PRINT(timer): Prints a string to std::cout telling how
+//   much time has elapsed since the last SEB_TIMER_START(timer).
+//
+// - SEB_TIMER_STRING(timer): Returns a string with the number of seconds
+//   elapsed since the last SEB_TIMER_START(timer).
+//
+// - SEB_STATS(expr): evaluates the expression when stats mode is
+//   enabled (see SEB_STATS_MODE above), or does nothing otherwise.
+//
+
+// Debugging mode:
+#ifdef SEB_DEBUG_MODE
+  // The debugging mode always enables the timer mode as well:
+  #ifndef SEB_TIMER_MODE
+  #define SEB_TIMER_MODE
+  #endif
+  #ifndef SEB_ASSERTION_MODE
+  #define SEB_ASSERTION_MODE
+  #endif
+
+  #define SEB_ASSERT_EXPENSIVE(expr) assert(expr)
+  #define SEB_DEBUG(expr) expr
+  #define SEB_LOG(channel,expr) \
+    { \
+      std::stringstream s; \
+      s << expr; \
+      SEB_NAMESPACE::Logger::instance().log(channel,s.str()); \
+    }
+#else // SEB_DEBUG_MODE not defined
+  #define SEB_ASSERT_EXPENSIVE(expr)
+  #define SEB_DEBUG(expr)
+  #define SEB_LOG(channel,expr)
+#endif // SEB_DEBUG_MODE
+
+// Assertion mode:
+#ifdef SEB_ASSERTION_MODE
+  #define SEB_ASSERT(expr) assert(expr)
+#else // SEB_ASSERTION_MODE
+  #define SEB_ASSERT(expr)
+#endif // SEB_ASSERTION_MODE
+
+// Timing mode:
+#ifdef SEB_TIMER_MODE
+  #define SEB_TIMER_START(timer) \
+    { \
+      SEB_NAMESPACE::Timer::instance().start(timer); \
+    }
+  #define SEB_TIMER_PRINT(timer) \
+    { \
+      std::cout << "Timer \'" << timer << "\': " \
+                << std::setprecision(5) \
+                << SEB_NAMESPACE::Timer::instance().lapse(timer) \
+                << 's' << std::endl; \
+    }
+  #define SEB_TIMER_STRING(timer) \
+    SEB_NAMESPACE::Timer::instance().lapse(timer)
+#else // SEB_TIMER_MOD
+  #define SEB_TIMER_START(timer)
+  #define SEB_TIMER_PRINT(timer)
+  #define SEB_TIMER_STRING(timer)
+#endif // SEB_TIMER_MODE
+
+// Stats mode:
+#ifdef SEB_STATS_MODE
+  #define SEB_STATS(expr) { expr; }
+#else // SEB_STATS_MODE
+  #define SEB_STATS(expr)
+#endif // SEB_STATS_MODE
+
+#endif // SEB_CONFIGURE_H

--- a/filters/private/miniball/Seb_configure.h
+++ b/filters/private/miniball/Seb_configure.h
@@ -18,7 +18,7 @@
 // #define SEB_TIMER_MODE              // enables runtime measurements
 // #define SEB_STATS_MODE              // enables statistics
 
-#include "Seb_debug.h"
+// #include "Seb_debug.h"
 
 // Fixes for GCC series 2.95.  (This fix is necessary for 2.95.2 at
 // least.  But I guess it is needed for any earlier version of the 2.95

--- a/filters/private/miniball/Seb_debug.C
+++ b/filters/private/miniball/Seb_debug.C
@@ -1,0 +1,123 @@
+// Synopsis: A simple class to save debugging comments to files
+//
+// Authors: Martin Kutz <kutz@math.fu-berlin.de>,
+//          Kaspar Fischer <kf@iaeth.ch>
+
+#include <cmath>
+#include <sys/resource.h>
+#include <sys/time.h>
+
+#include "Seb_configure.h"
+
+namespace SEB_NAMESPACE {
+  
+  // Implementation of class Logger:
+  
+  Logger::Logger()
+  {
+  }
+  
+  Logger::~Logger()
+  {
+    // we walk through the list of all opened files and close them:
+    for (Streams::iterator it = channels.begin();
+         it != channels.end(); ++it) {
+      (*it).second->close();
+      delete (*it).second;
+    }
+  }
+  
+  Logger& Logger::instance()
+  {
+    // Here's where we maintain the only instance: (Notice that it
+    // gets constructed automatically the first time instance() is
+    // called, and that it gets disposed of (if ever contructed) at
+    // program termination.)
+    static Logger instance;
+    return instance;
+  }
+  
+  void Logger::log(const char* ch,const std::string& msg)
+  {
+    const std::string name(ch);
+    Streams::iterator it = channels.find(name);
+    
+    // have we already opened this file?
+    if (it != channels.end()) {
+      // If so, then just append the message:
+      *(*it).second << msg;
+      (*it).second->flush();
+      
+    } else {
+      // If we haven't seen 'name' before, we create a new file:
+      using std::ofstream;
+      ofstream *o = new ofstream((name+".log").c_str(),
+                                 ofstream::out|ofstream::trunc);
+      channels[name] = o;
+      *o << msg;
+    }
+  }
+  
+  // Implementation of class Timer:
+  
+  // The following routine is taken from file mptimeval.h from
+  // "Matpack Library Release 1.7.1" which is copyright (C) 1991-2002
+  // by Berndt M. Gammel.  It works on the timeval struct defined in
+  // sys/time.h:
+  //
+  //       struct timeval {
+  //         long tv_sec;        /* seconds */
+  //         long tv_usec;       /* microseconds */
+  //       };
+  //
+  inline timeval& operator-=(timeval &t1,const timeval &t2)
+  {
+    t1.tv_sec -= t2.tv_sec;
+    if ( (t1.tv_usec -= t2.tv_usec) < 0 ) {
+      --t1.tv_sec;
+      t1.tv_usec += 1000000;
+    }
+    return t1;
+  }
+  
+  Timer::Timer()
+  {
+  }
+  
+  Timer& Timer::instance()
+  {
+    // Here's where we maintain the only instance: (Notice that it
+    // gets constructed automatically the first time instance() is
+    // called, and that it gets disposed of (if ever contructed) at
+    // program termination.)
+    static Timer instance;
+    return instance;
+  }
+  
+  void Timer::start(const char *timer_name)
+  {
+    // fetch current usage:
+    rusage now;
+    int status = getrusage(RUSAGE_SELF,&now);
+    SEB_ASSERT(status == 0);
+    
+    // save it:
+    timers[std::string(timer_name)] = now.ru_utime;
+  }
+  
+  float Timer::lapse(const char *name)
+  {
+    // assert that start(name) has been called before:
+    SEB_ASSERT(timers.find(std::string(name)) != timers.end());
+    
+    // get current usage:
+    rusage now;
+    int status = getrusage(RUSAGE_SELF,&now);
+    SEB_ASSERT(status == 0);
+    
+    // compute elapsed usage:
+    now.ru_utime -= (*timers.find(std::string(name))).second;
+    return now.ru_utime.tv_sec + now.ru_utime.tv_usec * 1e-6;
+  }
+  
+} // namespace SEB_NAMESPACE

--- a/filters/private/miniball/Seb_debug.h
+++ b/filters/private/miniball/Seb_debug.h
@@ -1,0 +1,88 @@
+// Synopsis: A simple class to save debugging comments to files
+//
+// Authors: Martin Kutz <kutz@math.fu-berlin.de>,
+//          Kaspar Fischer <kf@iaeth.ch>
+
+#ifndef SEB_DEBUG_H
+#define SEB_DEBUG_H
+
+#include <fstream>
+#include <map>
+#include <string>
+#include <sys/resource.h>
+#include <sys/time.h>
+
+namespace SEB_NAMESPACE {
+  
+  class Logger
+  // A singleton class which sends debugging comments to log files.
+  // (A class is called a "singleton" if at most one instance of it
+  // may ever exist.)  By calling void log(channel,msg) you can send
+  // the string msg to the file with name channel.
+  {
+  private: // (Construction and destruction are private to prevent
+    // more than one instantiation.)
+    
+    Logger();
+    Logger(const Logger&);
+    Logger& operator=(const Logger&);
+    ~Logger();
+    
+  public: // access and routines:
+    
+    static Logger& instance();
+    // Returns a reference to the only existing instance of this class:
+    
+    void log(const char *channel,const std::string& msg);
+    // If this is the first call to log with string channel as the
+    // first parameter, then the file with name channel.log is
+    // opened (at the beginning) for writing and msg is written to
+    // it.  Otherwise, the string msg is opened to the already open
+    // file channel.log.
+    
+  private: // private members:
+    typedef std::map<std::string,std::ofstream*> Streams;
+    Streams channels;           // a collection of pairs (k,v) where
+    // k is the file-name and v is the
+    // (open) stream associated with k
+  };
+  
+  class Timer
+  // A singleton class which maintains a collection of named timers.
+  // (A class is called a "singleton" if at most one instance of it
+  // may ever exist.)  The following routines are provided:
+  //
+  // - start(name): If this is the first time start() has been
+  //   called with name as the first parameter, then a new timer is
+  //   created and started.  Otherwise, the timer with name name is
+  //   restarted.
+  //
+  // - lapse(name): Retuns the number of seconds which have elapsed
+  //   since start(name) was called last.
+  //   Precondition: start(name) has been called once.
+  {
+  private: // (Construction and destruction are private to prevent
+    // more than one instantiation.)
+    
+    Timer();
+    Timer(const Timer&);
+    Timer& operator=(const Timer&);
+    
+  public: // access and routines:
+    
+    static Timer& instance();
+    // Returns a reference to the only existing instance of this class:
+    
+    void start(const char *name);
+    float lapse(const char *name);
+    
+  private: // private members:
+    typedef std::map<std::string,timeval> Timers;
+    Timers timers;              // a collection of pairs (k,v) where
+    // k is the timer name and v is the
+    // (started) timer associated with k
+  };
+  
+} // namespace SEB_NAMESPACE
+
+#endif // SEB_DEBUG_H

--- a/filters/private/miniball/Seb_point.h
+++ b/filters/private/miniball/Seb_point.h
@@ -1,0 +1,72 @@
+// Synopsis: Simple point class
+//
+// Authors: Martin Kutz <kutz@math.fu-berlin.de>,
+//          Kaspar Fischer <kf@iaeth.ch>
+
+#ifndef SEB_POINT_H
+#define SEB_POINT_H
+
+#include <vector>
+#include "Seb_configure.h"
+
+namespace SEB_NAMESPACE {
+  
+  template<typename Float>
+  class Point
+  // A simple class representing a d-dimensional point.
+  {
+  public: // types:
+    typedef typename std::vector<Float>::const_iterator Const_iterator;
+    typedef typename std::vector<Float>::iterator Iterator;
+    
+  public: // construction and destruction:
+    
+    Point(int d)
+    // Constructs a d-dimensional point with undefined coordinates.
+    : c(d)
+    {
+    }
+    
+    template<typename InputIterator>
+    Point(int d,InputIterator first)
+    // Constructs a d-dimensional point with Cartesian center
+    // coordinates [first,first+d).
+    : c(first,first+d)
+    {
+    }
+    
+  public: // access:
+    
+    const Float& operator[](unsigned int i) const
+    // Returns a const-reference to the i-th coordinate.
+    {
+      SEB_ASSERT(0 <= i && i < c.size());
+      return c[i];
+    }
+    
+    Float& operator[](unsigned int i)
+    // Returns a reference to the i-th coordinate.
+    {
+      SEB_ASSERT(0 <= i && i < c.size());
+      return c[i];
+    }
+    
+    Const_iterator begin() const
+    // Returns a const-iterator to the first of the d Cartesian coordinates.
+    {
+      return c.begin();
+    }
+    
+    Const_iterator end() const
+    // Returns the past-the-end iterator corresponding to begin().
+    {
+      return c.end();
+    }
+    
+  private: // member fields:
+    std::vector<Float> c;       // Cartesian center coordinates
+  };
+  
+} // namespace SEB_NAMESPACE
+
+#endif // SEB_POINT_H

--- a/filters/private/miniball/Subspan-inl.h
+++ b/filters/private/miniball/Subspan-inl.h
@@ -1,0 +1,374 @@
+// Synopsis: Class representing the affine hull of a point set.
+//
+// Authors: Martin Kutz <kutz@math.fu-berlin.de>,
+//          Kaspar Fischer <kf@iaeth.ch>
+
+#ifndef SEB_SUBSPAN_INL_H
+#define SEB_SUBSPAN_INL_H
+
+#include <cmath>
+#include <numeric>
+#include <ostream>
+#include "Seb_configure.h"
+
+#include "Subspan.h"  // Note: header included for better syntax highlighting in some IDEs.
+
+// The point members[r] is called the origin; we use the following macro
+// to increase the readibilty of the code:
+#define SEB_AFFINE_ORIGIN S[members[r]]
+
+namespace SEB_NAMESPACE {
+  
+  template<typename Float>
+  inline void givens(Float& c, Float& s, const Float a, const Float b)
+  //  Determine the Givens coefficients (c,s) satisfying
+  //
+  //     c * a + s * b = +/- (a^2 + b^2)
+  //     c * b - s * a = 0
+  //
+  //  We don't care about the signs here for efficiency,
+  //  so make sure not to rely on them anywhere.
+  //
+  //  Source: taken from "Matrix Computations" (2nd edition) by Gene
+  //  H. B. Golub & Charles F. B. Van Loan (Johns Hopkins University
+  //  Press, 1989), p. 216.
+  {
+    using std::abs;
+    using std::sqrt;
+    
+    if (b == 0) {
+      c = 1;
+      s = 0;
+    } else if (abs(b) > abs(a)) {
+      const Float t = a / b;
+      s = 1 / sqrt (1 + sqr(t));
+      c = s * t;
+    } else {
+      const Float t = b / a;
+      c = 1 / sqrt (1 + sqr(t));
+      s = c * t;
+    }
+  }
+  
+  template<typename Float, class Pt, class PointAccessor>
+  Subspan<Float, Pt, PointAccessor>::Subspan(unsigned int dim, const PointAccessor& S, int index)
+  : S(S), membership(S.size()), dim(dim), members(dim+1)
+  {
+    // allocate storage for Q, R, u, and w:
+    Q = new Float *[dim];
+    R = new Float *[dim];
+    for (unsigned int i=0; i<dim; ++i) {
+      Q[i] = new Float[dim];
+      R[i] = new Float[dim];
+    }
+    u = new Float[dim];
+    w = new Float[dim];
+    
+    // initialize Q to the identity matrix:
+    for (unsigned int i=0; i<dim; ++i)
+      for (unsigned int j=0; j<dim; ++j)
+        Q[i][j] = (i==j)? 1 : 0;
+    
+    members[r = 0] = index;
+    membership[index] = true;
+    
+    SEB_LOG ("ranks",r << std::endl);
+  }
+  
+  template<typename Float, class Pt, class PointAccessor>
+  Subspan<Float, Pt, PointAccessor>::~Subspan()
+  {
+    for (unsigned int i=0; i<dim; ++i) {
+      delete[] Q[i];
+      delete[] R[i];
+    }
+    delete[] Q;
+    delete[] R;
+    delete[] u;
+    delete[] w;
+  }
+  
+  template<typename Float, class Pt, class PointAccessor>
+  void Subspan<Float, Pt, PointAccessor>::add_point(int index) {
+    SEB_ASSERT(!is_member(index));
+    
+    // compute S[i] - origin into u:
+    for (unsigned int i=0; i<dim; ++i)
+      u[i] = S[index][i] - SEB_AFFINE_ORIGIN[i];
+    
+    // appends new column u to R and updates QR-decomposition,
+    // routine work with old r:
+    append_column();
+    
+    // move origin index and insert new index:
+    membership[index] = true;
+    members[r+1] = members[r];
+    members[r]   = index;
+    ++r;
+    
+    SEB_LOG ("ranks",r << std::endl);
+  }
+  
+  template<typename Float, class Pt, class PointAccessor>
+  void Subspan<Float, Pt, PointAccessor>::remove_point(const unsigned int local_index) {
+    SEB_ASSERT(is_member(global_index(local_index)) && size() > 1);
+    
+    membership[global_index(local_index)] = false;
+    
+    if (local_index == r) {
+      // origin must be deleted
+      
+      // We choose the right-most member of Q, i.e., column r-1 of R,
+      // as the new origin.  So all relative vectors (i.e., the
+      // columns of "A = QR") have to be updated by u:= old origin -
+      // S[global_index(r-1)]:
+      for (unsigned int i=0; i<dim; ++i)
+        u[i] = SEB_AFFINE_ORIGIN[i] - S[global_index(r-1)][i];
+      
+      --r;
+      
+      SEB_LOG ("ranks",r << std::endl);
+      
+      special_rank_1_update();
+      
+    } else {
+      // general case: delete column from R
+      
+      //  shift higher columns of R one step to the left
+      Float *dummy = R[local_index];
+      for (unsigned int j = local_index+1; j < r; ++j) {
+        R[j-1] = R[j];
+        members[j-1] = members[j];
+      }
+      members[r-1] = members[r];  // shift down origin
+      R[--r] = dummy;             // relink trash column
+      
+      // zero out subdiagonal entries in R
+      hessenberg_clear(local_index);
+    }
+  }
+  
+  template<typename Float, class Pt, class PointAccessor>
+  template<typename RandomAccessIterator1,
+  typename RandomAccessIterator2>
+  Float Subspan<Float, Pt, PointAccessor>::
+  shortest_vector_to_span(RandomAccessIterator1 p,
+                          RandomAccessIterator2 w)
+  {
+    using std::inner_product;
+    
+    // compute vector from p to origin, i.e., w = origin - p:
+    for (unsigned int i=0; i<dim; ++i)
+      w[i] = SEB_AFFINE_ORIGIN[i] - p[i];
+    
+    // remove projections of w onto the affine hull:
+    for (unsigned int j = 0; j < r; ++j) {
+      const Float scale = inner_product(w,w+dim,Q[j],Float(0));
+      for (unsigned int i = 0; i < dim; ++i)
+        w[i] -= scale * Q[j][i];
+    }
+    
+    return inner_product(w,w+dim,w,Float(0));
+  }
+  
+  template<typename Float, class Pt, class PointAccessor>
+  Float Subspan<Float, Pt, PointAccessor>::representation_error()
+  {
+    using std::abs;
+    
+    std::vector<Float> lambdas(size());
+    Float max = 0;
+    Float error;
+    
+    // cycle through all points in hull
+    for (unsigned int j = 0; j < size(); ++j) {
+      // compute the affine representation:
+      find_affine_coefficients(S[global_index(j)],lambdas.begin());
+      
+      // compare coefficient of point #j to 1.0
+      error = abs(lambdas[j] - 1.0);
+      if (error > max) max = error;
+      
+      // compare the other coefficients against 0.0
+      for (unsigned int i = 0; i < j; ++i) {
+        error = abs(lambdas[i] - 0.0);
+        if (error > max) max = error;
+      }
+      for (unsigned int i = j+1; i < size(); ++i) {
+        error = abs(lambdas[i] - 0.0);
+        if (error > max) max = error;
+      }
+    }
+    
+    return max;
+  }
+  
+  template<typename Float, class Pt, class PointAccessor>
+  template<typename RandomAccessIterator1,
+  typename RandomAccessIterator2>
+  void Subspan<Float, Pt, PointAccessor>::
+  find_affine_coefficients(RandomAccessIterator1 p,
+                           RandomAccessIterator2 lambdas)
+  {
+    // compute relative position of p, i.e., u = p - origin:
+    for (unsigned int i=0; i<dim; ++i)
+      u[i] = p[i] - SEB_AFFINE_ORIGIN[i];
+    
+    // calculate Q^T u into w:
+    for (unsigned int i = 0; i < dim; ++i) {
+      w[i] = 0;
+      for (unsigned int k = 0; k < dim; ++k)
+        w[i] += Q[i][k] * u[k];
+    }
+    
+    // We compute the coefficients by backsubstitution.  Notice that
+    //
+    //     c = \sum_{i\in M} \lambda_i (S[i] - origin)
+    //       = \sum_{i\in M} \lambda_i S[i] + (1-s) origin
+    //
+    // where s = \sum_{i\in M} \lambda_i.-- We compute the coefficient
+    // (1-s) of the origin in the variable origin_lambda:
+    Float origin_lambda = 1;
+    for (int j = r-1; j>=0; --j) {
+      for (unsigned int k=j+1; k<r; ++k)
+        w[j] -= *(lambdas+k) * R[k][j];
+      origin_lambda -= *(lambdas+j) = w[j] / R[j][j];
+    }
+    // The r-th coefficient corresponds to the origin (cf. remove_point()):
+    *(lambdas+r) = origin_lambda;
+  }
+  
+  template<typename Float, class Pt, class PointAccessor>
+  void Subspan<Float, Pt, PointAccessor>::append_column()
+  // Appends the new column u (which is a member of this instance) to
+  // the right of "A = QR", updating Q and R.  It assumes r to still
+  // be the old value, i.e., the index of the column used now for
+  // insertion; r is not altered by this routine and should be changed
+  // by the caller afterwards.
+  // Precondition: r<dim
+  {
+    SEB_ASSERT(r < dim);
+    
+    //  compute new column R[r] = Q^T * u
+    for (unsigned int i = 0; i < dim; ++i) {
+      R[r][i] = 0;
+      for (unsigned int k = 0; k < dim; ++k)
+        R[r][i] += Q[i][k] * u[k];
+    }
+    
+    //  zero all entries R[r][dim-1] down to R[r][r+1]
+    for (unsigned int j = dim-1; j > r; --j) {
+      //  j is the index of the entry to be cleared
+      //  with the help of entry j-1
+      
+      //  compute Givens coefficients c,s
+      Float c, s;
+      givens (c,s,R[r][j-1],R[r][j]);
+      
+      //  rotate one R-entry (the other one is an implicit zero)
+      R[r][j-1] = c * R[r][j-1] + s * R[r][j];
+      
+      //  rotate two Q-columns
+      for (unsigned int i = 0; i < dim; ++i) {
+        const Float a = Q[j-1][i];
+        const Float b = Q[j][i];
+        Q[j-1][i] =  c * a + s * b;
+        Q[j][i]   =  c * b - s * a;
+      }
+    }
+  }
+  
+  template<typename Float, class Pt, class PointAccessor>
+  void Subspan<Float, Pt, PointAccessor>::hessenberg_clear (unsigned int pos)
+  // Given R in lower Hessenberg form with subdiagonal entries 0 to
+  // pos-1 already all zero, clears the remaining subdiagonal entries
+  // via Givens rotations.
+  {
+    //  clear new subdiagonal entries
+    for (; pos < r; ++pos) {
+      //  pos is the column index of the entry to be cleared
+      
+      //  compute Givens coefficients c,s
+      Float c, s;
+      givens (c,s,R[pos][pos],R[pos][pos+1]);
+      
+      //  rotate partial R-rows (of the first pair, only one entry is
+      //  needed, the other one is an implicit zero)
+      R[pos][pos] = c * R[pos][pos] + s * R[pos][pos+1];
+      //  (then begin at posumn pos+1)
+      for (unsigned int j = pos+1; j < r; ++j) {
+        const Float a = R[j][pos];
+        const Float b = R[j][pos+1];
+        R[j][pos]   =  c * a + s * b;
+        R[j][pos+1] =  c * b - s * a;
+      }
+      
+      //  rotate Q-columns
+      for (unsigned int i = 0; i < dim; ++i) {
+        const Float a = Q[pos][i];
+        const Float b = Q[pos+1][i];
+        Q[pos][i]   =  c * a + s * b;
+        Q[pos+1][i] =  c * b - s * a;
+      }
+    }
+  }
+  
+  template<typename Float, class Pt, class PointAccessor>
+  void Subspan<Float, Pt, PointAccessor>::special_rank_1_update ()
+  // Update current QR-decomposition "A = QR" to
+  // A + u * [1,...,1] = Q' R'.
+  {
+    //  compute w = Q^T * u
+    for (unsigned int i = 0; i < dim; ++i) {
+      w[i] = 0;
+      for (unsigned int k = 0; k < dim; ++k)
+        w[i] += Q[i][k] * u[k];
+    }
+    
+    //  rotate w down to a multiple of the first unit vector;
+    //  the operations have to be recorded in R and Q
+    for (unsigned int k = dim-1; k > 0; --k) {
+      //  k is the index of the entry to be cleared
+      //  with the help of entry k-1
+      
+      //  compute Givens coefficients c,s
+      Float c, s;
+      givens (c,s,w[k-1],w[k]);
+      
+      //  rotate w-entry
+      w[k-1] = c * w[k-1] + s * w[k];
+      
+      //  rotate two R-rows;
+      //  the first column has to be treated separately
+      //  in order to account for the implicit zero in R[k-1][k]
+      R[k-1][k]    = -s * R[k-1][k-1];
+      R[k-1][k-1] *=  c;
+      for (unsigned int j = k; j < r; ++j) {
+        const Float a = R[j][k-1];
+        const Float b = R[j][k];
+        R[j][k-1] =  c * a + s * b;
+        R[j][k]   =  c * b - s * a;
+      }
+      
+      //  rotate two Q-columns
+      for (unsigned int i = 0; i < dim; ++i) {
+        const Float a = Q[k-1][i];
+        const Float b = Q[k][i];
+        Q[k-1][i] =  c * a + s * b;
+        Q[k][i]   =  c * b - s * a;
+      }
+    }
+    
+    //  add w * (1,...,1)^T to new R
+    //  which means simply to add u[0] to each column
+    //  since the other entries of u have just been eliminated
+    for (unsigned int j = 0; j < r; ++j)
+      R[j][0] += w[0];
+    
+    //  clear subdiagonal entries
+    hessenberg_clear(0);
+  }
+  
+} // namespace SEB_NAMESPACE
+
+#endif // SEB_SUBSPAN_INL_H

--- a/filters/private/miniball/Subspan.h
+++ b/filters/private/miniball/Subspan.h
@@ -1,0 +1,179 @@
+// Synopsis: Class representing the affine hull of a point set.
+//
+// Authors: Martin Kutz <kutz@math.fu-berlin.de>,
+//          Kaspar Fischer <kf@iaeth.ch>
+
+#ifndef SEB_SUBSPAN_H
+#define SEB_SUBSPAN_H
+
+#include <vector>
+#include "Seb_configure.h"
+
+namespace SEB_NAMESPACE {
+  
+  template<typename Float>
+  inline Float sqr(const Float x)
+  {
+    return x * x;
+  }
+  
+  template<typename Float, class Pt, class PointAccessor>
+  class Subspan
+  // An instance of this class represents the affine hull of a
+  // non-empty set M of affinely independent points.  The set M is not
+  // represented explicity; when an instance of this class is
+  // constructed, you pass a list S of points to it (which the
+  // instance will never change and which is assumed to stay fixed for
+  // the lifetime of this instance): The set M is then a subset of S,
+  // and its members are identified by their (zero-based) indices in
+  // S.  The following routines are provided to query and change the
+  // set M:
+  //
+  // - int size() returns the size of the instance's set M, a number
+  //   between 0 and dim+1.
+  //   Complexity: O(1).
+  //
+  // - bool is_member(int global_index) returns true iff S[global_index]
+  //   is a member of M.
+  //   Complexity: O(1)
+  //
+  // - global_index(int local_index) returns the index (into S) of the
+  //   local_index-th point in M.  The points in M are internally
+  //   ordered (in an arbitrary way) and this order only changes when
+  //   add() or remove() (see below) is called.
+  //   Complexity: O(1)
+  //
+  // - void add_point(int global_index) adds the global_index-th point
+  //   of S to the instance's set M.
+  //   Precondition: !is_member(global_index)
+  //   Complexity: O(dim^2).
+  //
+  // - void remove_point(int local_index) removes the local_index-th
+  //   point in M.
+  //   Precondition: 0<=local_index<=size() and size()>1
+  //   Complexity: O(dim^2)
+  //
+  // - int any_member() returns the global index (into S) of an
+  //   arbitrary element of M.
+  //   Precondition: size()>0
+  //   Postcondition: is_member(any_member())
+  //
+  // The following routines are provided to query the affine hull of M:
+  //
+  // - void shortest_vector_to_span(p,w): Computes the vector w
+  //   directed from point p to v, where v is the point in aff(M) that
+  //   lies nearest to p.  Returned is the squared length of w.
+  //   Precondition: size()>0
+  //   Complexity: O(dim^2)
+  //
+  // - void find_affine_coefficients(c,coeffs):
+  //   Preconditions: c lies in the affine hull aff(M) and size() > 0.
+  //   Calculates the size()-many coefficients in the representation
+  //   of c as an affine combination of the points M.  The i-th computed
+  //   coefficient coeffs[i] corresponds to the i-th point in M, or,
+  //   in other words, to the point in S with index global_index(i).
+  //   Complexity: O(dim^2)
+  {
+  public: // construction and deletion:
+    
+    Subspan(unsigned int dim, const PointAccessor& S, int i);
+    // Constructs an instance representing the affine hull aff(M) of M={p},
+    // where p is the point S[i] from S.
+    //
+    // Notice that S must not changed as long as this instance of
+    // Subspan<Float> is in use.
+    
+    ~Subspan();
+    
+  public: // modification:
+    
+    void add_point(int global_index);
+    void remove_point(unsigned int local_index);
+    
+  public: // access:
+    
+    unsigned int size() const
+    {
+      return r+1;
+    }
+    
+    bool is_member(unsigned int i) const
+    {
+      SEB_ASSERT(i < S.size());
+      return membership[i];
+    }
+    
+    unsigned int global_index(unsigned int i) const
+    {
+      SEB_ASSERT(i < size());
+      return members[i];
+    }
+    
+    unsigned int any_member() const {
+      SEB_ASSERT(size()>0);
+      return members[r];
+    }
+    
+    template<typename RandomAccessIterator1,
+    typename RandomAccessIterator2>
+    Float shortest_vector_to_span(RandomAccessIterator1 p,
+                                  RandomAccessIterator2 w);
+    
+    template<typename RandomAccessIterator1,
+    typename RandomAccessIterator2>
+    void find_affine_coefficients(RandomAccessIterator1 c,
+                                  RandomAccessIterator2 coeffs);
+    
+  public: // debugging routines:
+    
+    Float representation_error();
+    // Computes the coefficient representations of all points in the
+    // (internally used) system (Q) and returns the maximal deviation
+    // from the theoretical values.
+    // Warning: This routine has running time O(dim^3).
+    
+  private: // private helper routines:
+    
+    void append_column();
+    // Appends the new column u (which is a member of this instance) to
+    // the right of "A = QR", updating Q and R.  It assumes r to still
+    // be the old value, i.e., the index of the column used now for
+    // insertion; r is not altered by this routine and should be changed
+    // by the caller afterwards.
+    // Precondition: r<dim
+    
+    void hessenberg_clear(unsigned int start);
+    // Given R in lower Hessenberg form with subdiagonal entries 0 to
+    // pos-1 already all zero, clears the remaining subdiagonal entries
+    // via Givens rotations.
+    
+    void special_rank_1_update();
+    // Update current QR-decomposition "A = QR" to
+    // A + u [1,...,1] = Q' R'.
+    
+  private: // member fields:
+    const PointAccessor &S;            // a const-reference to the set S
+    std::vector<bool> membership;      // S[i] in M iff membership[i]
+    const unsigned int dim;            // ambient dimension (not to be
+    // confused with the rank r,
+    // see below)
+    
+    // Entry i of members contains the index into S of the i-th point
+    // in M.  The point members[r] is called the "origin."
+    std::vector<unsigned int> members;
+    
+  private: // member fields for maintaining the QR-decomposition:
+    Float **Q, **R;                    // (dim x dim)-matrices Q
+    // (orthogonal) and R (upper
+    // triangular); notice that
+    // e.g.  Q[j][i] is the element
+    // in row i and column j
+    Float *u,*w;                       // needed for rank-1 update
+    unsigned int r;                    // the rank of R (i.e. #points - 1)
+  };
+  
+} // namespace SEB_NAMESPACE
+
+#include "Subspan-inl.h"
+
+#endif // SEB_SUBSPAN_H

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -246,6 +246,7 @@ PDAL_ADD_TEST(pdal_filters_reprojection_test FILES
     filters/ReprojectionFilterTest.cpp)
 PDAL_ADD_TEST(pdal_filters_range_test FILES filters/RangeFilterTest.cpp)
 PDAL_ADD_TEST(pdal_filters_randomize_test FILES filters/RandomizeFilterTest.cpp)
+PDAL_ADD_TEST(pdal_filters_reciprocity_test FILES filters/ReciprocityFilterTest.cpp)
 PDAL_ADD_TEST(pdal_filters_returns_test FILES filters/ReturnsFilterTest.cpp)
 PDAL_ADD_TEST(pdal_filters_shell_test FILES filters/ShellFilterTest.cpp)
 

--- a/test/unit/filters/ReciprocityFilterTest.cpp
+++ b/test/unit/filters/ReciprocityFilterTest.cpp
@@ -1,0 +1,85 @@
+/******************************************************************************
+ * Copyright (c) 2019, Bradley J. Chambers (brad.chambers@gmail.com)
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of Hobu, Inc. or Flaxen Geo Consulting nor the
+ *       names of its contributors may be used to endorse or promote
+ *       products derived from this software without specific prior
+ *       written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ ****************************************************************************/
+
+#include <filters/ReciprocityFilter.hpp>
+#include <io/BufferReader.hpp>
+#include <pdal/Dimension.hpp>
+#include <pdal/PointTable.hpp>
+#include <pdal/PointView.hpp>
+#include <pdal/pdal_test_main.hpp>
+
+using namespace pdal;
+
+TEST(ReciprocityFilterTest, BasicTest)
+{
+    using namespace Dimension;
+
+    PointTable table;
+    table.layout()->registerDims({Id::X, Id::Y, Id::Z});
+
+    BufferReader br;
+    ReciprocityFilter filter;
+    Options opts;
+    opts.add("knn", 3);
+    filter.setInput(br);
+    filter.setOptions(opts);
+    filter.prepare(table);
+
+    PointViewPtr src(new PointView(table));
+    src->setField(Dimension::Id::X, 0, 0.0);
+    src->setField(Dimension::Id::Y, 0, 0.0);
+    src->setField(Dimension::Id::Z, 0, 0.0);
+    src->setField(Dimension::Id::X, 1, 10.0);
+    src->setField(Dimension::Id::Y, 1, 10.0);
+    src->setField(Dimension::Id::Z, 1, 10.0);
+    src->setField(Dimension::Id::X, 2, 11.0);
+    src->setField(Dimension::Id::Y, 2, 11.0);
+    src->setField(Dimension::Id::Z, 2, 11.0);
+    src->setField(Dimension::Id::X, 3, 12.0);
+    src->setField(Dimension::Id::Y, 3, 12.0);
+    src->setField(Dimension::Id::Z, 3, 12.0);
+    src->setField(Dimension::Id::X, 4, 18.0);
+    src->setField(Dimension::Id::Y, 4, 18.0);
+    src->setField(Dimension::Id::Z, 4, 18.0);
+
+    br.addView(src);
+
+    PointViewSet viewSet = filter.execute(table);
+    PointViewPtr outView = *viewSet.begin();
+
+    Id reciprocity = table.layout()->findDim("Reciprocity");
+
+    ASSERT_FLOAT_EQ(100, outView->getFieldAs<double>(reciprocity, 0));
+    ASSERT_FLOAT_EQ(0, outView->getFieldAs<double>(reciprocity, 1));
+}


### PR DESCRIPTION
This commit adds three filters that are implementations of the outlier
detection criterion specified in Weyrich, T et al. “Post-Processing of Scanned
3D Surface Data.” Proceedings of Eurographics Symposium on Point-Based Graphics
2004 (2004): 85–94. Print.

* Nearest-Neighbor Reciprocity Criterion available as filters.reciprocity

* Miniball Criterion available as filters.miniball

* Plane Fit Criterion available as filters.planefit