### PR TITLE
Don't cast away const for SrsBounds ostreaming.

### DIFF
--- a/pdal/SrsBounds.cpp
+++ b/pdal/SrsBounds.cpp
@@ -82,7 +82,7 @@ void SrsBounds::parse(const std::string& s, std::string::size_type& pos)
 
 std::ostream& operator << (std::ostream& out, const SrsBounds& srsBounds)
 {
-    out << (Bounds&)srsBounds;
+    out << static_cast<const Bounds&>(srsBounds);
     out << " / " << srsBounds.m_srs;
     return out;
 }


### PR DESCRIPTION
Fixes warning on Ubuntu (reproducible via the Ubuntu Dockerfile):
```
[160/254] Building CXX object CMakeFiles/pdal_base.dir/pdal/SrsBounds.cpp.o
../pdal/SrsBounds.cpp: In function 'std::ostream& pdal::operator<<(std::ostream&, const pdal::SrsBounds&)':
../pdal/SrsBounds.cpp:85:21: warning: cast from type 'const pdal::SrsBounds*' to type 'pdal::Bounds*' casts away qualifiers [-Wcast-qual]
     out << (Bounds&)srsBounds;
                     ^~~~~~~~~
```