### PR TITLE
Fix warning: suggest braces around initialization of subobject.

### DIFF
--- a/pdal/Mesh.hpp
+++ b/pdal/Mesh.hpp
@@ -55,8 +55,8 @@ public:
 
 inline bool operator == (const Triangle& a, const Triangle& b)
 {
-    std::array<PointId, 3> aa {a.m_a, a.m_b, a.m_c};
-    std::array<PointId, 3> bb {b.m_a, b.m_b, b.m_c};
+    std::array<PointId, 3> aa { {a.m_a, a.m_b, a.m_c} };
+    std::array<PointId, 3> bb { {b.m_a, b.m_b, b.m_c} };
     std::sort(aa.begin(), aa.end());
     std::sort(bb.begin(), bb.end());
     return aa == bb;


### PR DESCRIPTION
Fix a flood of these warnings:
```
In file included from ../pdal/PointView.hpp:39:
../pdal/Mesh.hpp:58:32: warning: suggest braces around initialization of subobject [-Wmissing-braces]
    std::array<PointId, 3> aa {a.m_a, a.m_b, a.m_c};
                               ^~~~~~~~~~~~~~~~~~~
                               {                  }
../pdal/Mesh.hpp:59:32: warning: suggest braces around initialization of subobject [-Wmissing-braces]
    std::array<PointId, 3> bb {b.m_a, b.m_b, b.m_c};
                               ^~~~~~~~~~~~~~~~~~~
                               {                  }
```