### PR TITLE
Deal with empty srs in ept.json

### DIFF
--- a/io/private/EptSupport.cpp
+++ b/io/private/EptSupport.cpp
@@ -46,7 +46,7 @@ EptInfo::EptInfo(const NL::json& info) : m_info(info)
     m_span = m_info["span"].get<uint64_t>();
 
     auto iSrs = m_info.find("srs");
-    if (iSrs != m_info.end())
+    if (iSrs != m_info.end() && iSrs->size())
     {
         std::string wkt;
         auto iWkt = iSrs->find("wkt");


### PR DESCRIPTION
Ept reader refuses to read the ept tiles in case the ept.json file contains an empty srs object. I believe it should be the same behaviour as when the srs object is not present. This issue arises with the latest entwine version. 