### PR TITLE
Show if stage is streamable in pdal --options

### DIFF
--- a/apps/pdal.cpp
+++ b/apps/pdal.cpp
@@ -164,13 +164,15 @@ void App::outputDrivers()
         StageExtensions& extensions = PluginManager<Stage>::extensions();
         for (auto name : stages)
         {
+            Stage *s = f.createStage(name);
             std::string description = PluginManager<Stage>::description(name);
             std::string link = PluginManager<Stage>::link(name);
             j.push_back(
                 { { "name", name },
                   { "description", description },
                   { "link", link },
-                  { "extensions", extensions.extensions(name) }
+                  { "extensions", extensions.extensions(name) },
+                  { "streamable", s->pipelineStreamable()}
                 }
             );
         }
@@ -210,13 +212,11 @@ void App::outputOptions(std::string const& stageName, std::ostream& strm)
 
     if (!m_showJSON)
     {
-        const size_t indentSize = 2;
-        strm << stageName << " -- " << PluginManager<Stage>::link(stageName) <<
-             std::endl;
-        strm << headline << std::endl;
-        strm << std::string(indentSize, ' ') << "Streamable: " <<
-             (s->pipelineStreamable() ? "Yes" : "No") << "\n\n";
-        args.dump2(strm, indentSize, 6, headline.size());
+        strm  << stageName << " -- " << PluginManager<Stage>::link(stageName) <<
+            std::endl;
+        strm  << headline << std::endl;
+
+        args.dump2(strm , 2, 6, headline.size());
     }
     else
     {

--- a/apps/pdal.cpp
+++ b/apps/pdal.cpp
@@ -210,11 +210,13 @@ void App::outputOptions(std::string const& stageName, std::ostream& strm)
 
     if (!m_showJSON)
     {
-        strm  << stageName << " -- " << PluginManager<Stage>::link(stageName) <<
-            std::endl;
-        strm  << headline << std::endl;
-
-        args.dump2(strm , 2, 6, headline.size());
+        const size_t indentSize = 2;
+        strm << stageName << " -- " << PluginManager<Stage>::link(stageName) <<
+             std::endl;
+        strm << headline << std::endl;
+        strm << std::string(indentSize, ' ') << "Streamable: " <<
+             (s->pipelineStreamable() ? "Yes" : "No") << "\n\n";
+        args.dump2(strm, indentSize, 6, headline.size());
     }
     else
     {


### PR DESCRIPTION
Add the code to ouput wether a stage supports streaming in `pdal --options`. (#2480)
I did not change the outputed json by the `--showjson` switch.

And i'm not too sure about the placement of the text as it could look like an option 

![streamable](https://user-images.githubusercontent.com/15125341/57942114-f0344980-78d0-11e9-9819-068b0a5dcf78.png)
