### PR TITLE
Fix doc typo and dead URL

### DIFF
--- a/doc/stages/readers.ept.rst
+++ b/doc/stages/readers.ept.rst
@@ -98,7 +98,7 @@ threads
     Number of worker threads used to download and process EPT data.  A
     minimum of 4 will be used no matter what value is specified.
 
-.. _Entwine Point Tile: https://github.com/connormanning/entwine/blob/master/doc/entwine-point-tile.md
+.. _Entwine Point Tile: https://entwine.io/entwine-point-tile.html
 .. _Entwine: https://entwine.io/
 .. _Potree: http://potree.entwine.io/data/nyc.html
 .. _Plasio: http://speck.ly/?s=http%3A%2F%2Fc%5B0-7%5D.greyhound.io&r=ept%3A%2F%2Fna.entwine.io%2Fnyc&ca=-0&ce=49.06&ct=-8239196%2C4958509.308%2C337&cd=42640.943&cmd=125978.13&ps=2&pa=0.1&ze=1&c0s=remote%3A%2F%2Fimagery%3Furl%3Dhttp%3A%2F%2Fserver.arcgisonline.com%2FArcGIS%2Frest%2Fservices%2FWorld_Imagery%2FMapServer%2Ftile%2F%7B%7Bz%7D%7D%2F%7B%7By%7D%7D%2F%7B%7Bx%7D%7D.jpg

--- a/doc/stages/writers.sbet.rst
+++ b/doc/stages/writers.sbet.rst
@@ -3,7 +3,7 @@
 writers.sbet
 ============
 
-The **SBET writer** writes files in the SBET format, used for exchange data from interital measurement units (IMUs).
+The **SBET writer** writes files in the SBET format, used for exchange data from inertial measurement units (IMUs).
 
 .. embed::
 


### PR DESCRIPTION
This PR fixes a typo and a dead URL in the documentation.