### PR TITLE
Read data from the metadata child "data" rather than the VLR node's data

### DIFF
--- a/io/LasReader.cpp
+++ b/io/LasReader.cpp
@@ -502,7 +502,6 @@ void LasReader::extractVlrMetadata(MetadataNode& forward, MetadataNode& m)
         std::ostringstream name;
         name << "vlr_" << i++;
         MetadataNode vlrNode(name.str());
-        m.add(vlrNode);
 
         vlrNode.addEncoded("data",
             (const uint8_t *)vlr.data(), vlr.dataLen(), vlr.description());
@@ -512,6 +511,7 @@ void LasReader::extractVlrMetadata(MetadataNode& forward, MetadataNode& m)
         vlrNode.add("record_id", vlr.recordId(),
             "Record ID specified by the user.");
         vlrNode.add("description", vlr.description());
+        m.add(vlrNode);
 
         if (vlr.userId() == TRANSFORM_USER_ID||
             vlr.userId() == LASZIP_USER_ID ||

--- a/io/LasWriter.cpp
+++ b/io/LasWriter.cpp
@@ -466,7 +466,8 @@ void LasWriter::addForwardVlrs()
         const MetadataNode& recordIdNode = n.findChild("record_id");
         if (recordIdNode.valid() && userIdNode.valid())
         {
-            data = Utils::base64_decode(n.value());
+            const MetadataNode& dataNode = n.findChild("data");
+            data = Utils::base64_decode(dataNode.value());
             uint16_t recordId = (uint16_t)std::stoi(recordIdNode.value());
             addVlr(userIdNode.value(), recordId, n.description(), data);
         }

--- a/test/unit/io/LasReaderTest.cpp
+++ b/test/unit/io/LasReaderTest.cpp
@@ -198,9 +198,11 @@ TEST(LasReaderTest, inspect)
 
     QuickInfo qi = reader.preview();
 
-    std::string testWkt = "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433],AUTHORITY[\"EPSG\",\"4326\"]]";
+    std::string testWkt {
+         R"(GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0],UNIT["degree",0.0174532925199433],AUTHORITY["EPSG","4326"]])"
+    };
 
-    EXPECT_EQ(qi.m_srs.getWKT(), testWkt);
+    EXPECT_TRUE(Utils::startsWith(qi.m_srs.getWKT(), testWkt));
     EXPECT_EQ(qi.m_pointCount, 5380u);
 
     BOX3D bounds(-94.683465399999989, 31.0367341, 39.081000199999998,
@@ -531,5 +533,4 @@ TEST(LasReaderTest, IgnoreVLRs)
         m = m.findChild("data");
         EXPECT_FALSE(!m.empty()) << "No value for node " << i;
     }
-
 }

--- a/test/unit/io/LasWriterTest.cpp
+++ b/test/unit/io/LasWriterTest.cpp
@@ -1235,9 +1235,22 @@ TEST(LasWriterTest, forward_spec_3)
             !temp.findChild(recPred).empty() &&
             !temp.findChild(userPred).empty();
     };
+    MetadataNode origRoot = reader.getMetadata();
+    MetadataNodeList origNodes = origRoot.findChildren(pred);
+    EXPECT_EQ(origNodes.size(), 1u);
+    MetadataNode origNode = origNodes[0];
+
     MetadataNode root = reader2.getMetadata();
     MetadataNodeList nodes = root.findChildren(pred);
     EXPECT_EQ(nodes.size(), 1u);
+    MetadataNode node = nodes[0];
+
+    // Also test that we're properly forwarding data.
+    origNode = origNode.findChild("data");
+    node = node.findChild("data");
+    EXPECT_EQ(origNode.value().size(), 28u);
+    EXPECT_EQ(node.value().size(), origNode.value().size());
+    EXPECT_EQ(node.value(), origNode.value());
 }
 
 TEST(LasWriterTest, oversize_vlr)


### PR DESCRIPTION
for forwarded VLRs.