### PR TITLE
Read PLY coords as floats, write normalized PLY fields

### DIFF
--- a/doc/stages/readers.ply.rst
+++ b/doc/stages/readers.ply.rst
@@ -41,6 +41,9 @@ Options
 filename
   ply file to read [Required]
 
+force_double
+  Read all X,Y,Z coordinates with double precision, regardless of declared dimension type. [Default: false]
+
 .. include:: reader_opts.rst
 
 .. _polygon file format: http://paulbourke.net/dataformats/ply/

--- a/doc/stages/writers.ply.rst
+++ b/doc/stages/writers.ply.rst
@@ -48,6 +48,9 @@ faces
   Write a mesh as faces in addition to writing points as vertices.
   [Default: false]
 
+normalize_names
+  Attempt to normalize PLY field names. [Default: false]
+
 precision
   If specified, the number of digits to the right of the decimal place
   using f-style formatting.  Only permitted when 'storage_mode' is 'ascii'.

--- a/io/PlyReader.cpp
+++ b/io/PlyReader.cpp
@@ -58,6 +58,12 @@ PlyReader::PlyReader() : m_vertexElt(nullptr)
 {}
 
 
+void PlyReader::addArgs(ProgramArgs& args)
+{
+    args.add("force_double", "Read all X,Y,Z coordinates with double precision, regardless of declared dimension type.", m_forceDouble);
+}
+
+
 std::string PlyReader::readLine()
 {
     m_line.clear();
@@ -304,9 +310,11 @@ void PlyReader::initialize()
 void PlyReader::addDimensions(PointLayoutPtr layout)
 {
     // Override XYZ to doubles.
-    layout->registerDim(Dimension::Id::X);
-    layout->registerDim(Dimension::Id::Y);
-    layout->registerDim(Dimension::Id::Z);
+    if (m_forceDouble){
+        layout->registerDim(Dimension::Id::X);
+        layout->registerDim(Dimension::Id::Y);
+        layout->registerDim(Dimension::Id::Z);
+    }
 
     for (auto& elt : m_elements)
     {

--- a/io/PlyReader.hpp
+++ b/io/PlyReader.hpp
@@ -126,7 +126,9 @@ private:
     std::vector<Element> m_elements;
     PointId m_index;
     Element *m_vertexElt;
+    bool m_forceDouble;
 
+    virtual void addArgs(ProgramArgs& args);
     virtual void initialize();
     virtual void addDimensions(PointLayoutPtr layout);
     virtual void ready(PointTableRef table);

--- a/io/PlyWriter.cpp
+++ b/io/PlyWriter.cpp
@@ -66,6 +66,7 @@ void PlyWriter::addArgs(ProgramArgs& args)
     args.add("storage_mode", "PLY Storage Mode", m_format, Format::Ascii);
     args.add("dims", "Dimension names", m_dimNames);
     args.add("faces", "Write faces", m_faces);
+    args.add("normalize_names", "Attempt to normalize PLY field names", m_normFieldNames);
     m_precisionArg = &args.add("precision", "Output precision", m_precision, 3);
 }
 
@@ -99,14 +100,14 @@ std::string PlyWriter::getType(Dimension::Type type) const
 {
    static std::map<Dimension::Type, std::string> types =
     {
-        { Dimension::Type::Signed8, "int8" },
-        { Dimension::Type::Unsigned8, "uint8" },
-        { Dimension::Type::Signed16, "int16" },
-        { Dimension::Type::Unsigned16, "uint16" },
-        { Dimension::Type::Signed32, "int32" },
-        { Dimension::Type::Unsigned32, "uint32" },
-        { Dimension::Type::Float, "float32" },
-        { Dimension::Type::Double, "float64" }
+        { Dimension::Type::Signed8, "char" },
+        { Dimension::Type::Unsigned8, "uchar" },
+        { Dimension::Type::Signed16, "short" },
+        { Dimension::Type::Unsigned16, "ushort" },
+        { Dimension::Type::Signed32, "int" },
+        { Dimension::Type::Unsigned32, "uint" },
+        { Dimension::Type::Float, "float" },
+        { Dimension::Type::Double, "double" }
     };
 
     try
@@ -134,12 +135,23 @@ void PlyWriter::writeHeader(PointLayoutPtr layout) const
     {
         std::string name = *ni++;
         std::string typeString = getType(layout->dimType(dim));
+
+        if (m_normFieldNames){
+            if (name == "normalx" || name == "normal_x") name = "nx";
+            if (name == "normaly" || name == "normal_y") name = "ny";
+            if (name == "normalz" || name == "normal_z") name = "nz";
+
+            if (name == "diffuse_red") name = "red";
+            if (name == "diffuse_green") name = "green";
+            if (name == "diffuse_blue") name = "blue";
+        }
+
         *m_stream << "property " << typeString << " " << name << std::endl;
     }
     if (m_faces)
     {
         *m_stream << "element face " << faceCount() << std::endl;
-        *m_stream << "property list uint8 uint32 vertex_indices" << std::endl;
+        *m_stream << "property list uchar uint vertex_indices" << std::endl;
     }
     *m_stream << "end_header" << std::endl;
 }

--- a/io/PlyWriter.hpp
+++ b/io/PlyWriter.hpp
@@ -74,6 +74,7 @@ private:
     StringList m_dimNames;
     Dimension::IdList m_dims;
     int m_precision;
+    bool m_normFieldNames;
     Arg *m_precisionArg;
     std::vector<PointViewPtr> m_views;
 };


### PR DESCRIPTION
Hello PDALers :hand: 

I'm proposing the following changes in regard to the dreaded PLY format. These changes have been very helpful in dealing with different PLY inputs coming from several different programs and I think they would make PDAL much more friendly toward applications that need to read PDAL's PLY outputs. There's no PLY standard, so I can link you the "de-facto" page that defines the PLY "best naming conventions". All changes in this PR try to follow the information in this link: http://paulbourke.net/dataformats/ply/

1) Output fields in `writers.ply` have been renamed to follow:

```
name        type        number of bytes
---------------------------------------
char       character                 1
uchar      unsigned character        1
short      short integer             2
ushort     unsigned short integer    2
int        integer                   4
uint       unsigned integer          4
float      single-precision float    4
double     double-precision float    8
```

Many programs currently cannot understand PDAL's field namings.

2) Optional flag to cast values to double when reading a PLY in `readers.ply`:

Currently if I have a PLY file:

```
ply
format ascii 1.0
comment Generated by PDAL
element vertex 1058107
property float x
property float y
property float z
```

And I execute `pdal translate -i input.ply -o output.ply`.

The fields will turn to `double`. 

```
ply
format ascii 1.0
comment Generated by PDAL
element vertex 1058107
property double x
property double y
property double z
```

This is sometimes desirable, as subsequent filters might need double coordinate precision, but sometimes it just doubles the disk and memory usage. This PR adds a `force_double` parameter to control this behavior.

3) Other PLY writer programs outside of PDAL will happily call the normal and color fields however they please. There's no clear reference to the normal fields (for which we decided to go with `nx`, `ny` and `nz` as they seem to work with most programs we've tested). Color fields in PLY however from the link above should be clearly named `red`, `blue` and `green`, while the variants `diffuse_red`, `ambient_red`, etc. fall into the category of "user defined properties". Again, there's no standard, so this last change, the addition of a `normalize_names` option in `writers.ply` is a bit opinionated, but I think it will allow PDAL to play nicer with most programs out there.

For 3) I thought about using `filters.ferry`, however, I do not know in advance what field names I'm going to be thrown at (plus copying the dimension seems wasteful?).

Thank you for your review and consideration!
