### PR TITLE
TileDB: Add append option to writer

### DIFF
--- a/doc/stages/writers.tiledb.rst
+++ b/doc/stages/writers.tiledb.rst
@@ -56,6 +56,9 @@ compression
 compression_level
   TileDB compression level for chosen compression [Optional]
 
+append
+  Append to an existing TileDB array with the same schema [Optional]
+
 stats
   Dump query stats to stdout [Optional]
 

--- a/plugins/tiledb/io/TileDBWriter.hpp
+++ b/plugins/tiledb/io/TileDBWriter.hpp
@@ -80,6 +80,7 @@ private:
 
 
     bool m_stats;
+    bool m_append;
 
     BOX3D m_bbox;
 


### PR DESCRIPTION
This change adds the option to append to an existing TileDB array. This change is useful when merging datasets.