### PR TITLE
Work around initializer-list ambiguity in gcc 7.3 (again)

### DIFF
--- a/io/EptReader.cpp
+++ b/io/EptReader.cpp
@@ -412,8 +412,8 @@ void EptReader::addDimensions(PointLayoutPtr layout)
             const arbiter::Endpoint ep(m_arbiter->getEndpoint(root));
             try
             {
-                const NL::json addonInfo
-                    { NL::json::parse(ep.get(addonFilename)) };
+                const NL::json addonInfo(
+                    NL::json::parse(ep.get(addonFilename)));
                 const Dimension::Type type(getRemoteType(addonInfo));
                 const Dimension::Id id(
                     layout->registerOrAssignDim(dimName, type));


### PR DESCRIPTION
A different instance of the same issue as #2495 elsewhere in the EPT reader.  Also see #2501 which fixed one instance of this.