### PR TITLE
Fix global symbol export for python

### DIFF
--- a/pdal/util/Utils.hpp
+++ b/pdal/util/Utils.hpp
@@ -64,15 +64,15 @@ namespace Utils
 {
 
 #if defined(__APPLE__) && defined(__MACH__)
-    const std::string dynamicLibExtension = ".dylib";
+    const char dynamicLibExtension[] = ".dylib";
     const char dirSeparator = '/';
     const char pathListSeparator = ':';
 #elif defined _WIN32
-    const std::string dynamicLibExtension = ".dll";
+    const char dynamicLibExtension[] = ".dll";
     const char dirSeparator = '\\';
     const char pathListSeparator = ';';
 #else
-    const std::string dynamicLibExtension = ".so";
+    const char dynamicLibExtension[] = ".so";
     const char dirSeparator = '/';
     const char pathListSeparator = ':';
 #endif

--- a/plugins/python/filters/CMakeLists.txt
+++ b/plugins/python/filters/CMakeLists.txt
@@ -12,7 +12,6 @@ PDAL_ADD_PLUGIN(python_libname filter python
         ${CMAKE_DL_LIBS}
     INCLUDES
         ${NLOHMANN_INCLUDE_DIR}
-        ${CMAKE_CURRENT_BINARY_DIR}/../plang/include
     SYSTEM_INCLUDES
         ${PYTHON_ALL_INCLUDE_DIRS}
 )

--- a/plugins/python/filters/CMakeLists.txt
+++ b/plugins/python/filters/CMakeLists.txt
@@ -12,9 +12,12 @@ PDAL_ADD_PLUGIN(python_libname filter python
         ${CMAKE_DL_LIBS}
     INCLUDES
         ${NLOHMANN_INCLUDE_DIR}
+        ${CMAKE_CURRENT_BINARY_DIR}/../plang/include
     SYSTEM_INCLUDES
         ${PYTHON_ALL_INCLUDE_DIRS}
 )
+target_compile_definitions(pdal_plugin_filter_python PRIVATE
+    PDAL_PYTHON_LIBRARY="${PYTHON_LIBRARY}")
 
 if (WITH_TESTS)
     PDAL_ADD_TEST(pdal_filters_python_test

--- a/plugins/python/io/CMakeLists.txt
+++ b/plugins/python/io/CMakeLists.txt
@@ -7,8 +7,6 @@ PDAL_ADD_PLUGIN(numpy_reader reader numpy
     LINK_WITH
         ${PYTHON_LIBRARY}
         ${CMAKE_DL_LIBS}
-    INCLUDES
-        ${CMAKE_CURRENT_BINARY_DIR}/include
     SYSTEM_INCLUDES
         ${PYTHON_ALL_INCLUDE_DIRS}
     )

--- a/plugins/python/io/CMakeLists.txt
+++ b/plugins/python/io/CMakeLists.txt
@@ -7,9 +7,13 @@ PDAL_ADD_PLUGIN(numpy_reader reader numpy
     LINK_WITH
         ${PYTHON_LIBRARY}
         ${CMAKE_DL_LIBS}
+    INCLUDES
+        ${CMAKE_CURRENT_BINARY_DIR}/include
     SYSTEM_INCLUDES
         ${PYTHON_ALL_INCLUDE_DIRS}
     )
+target_compile_definitions(pdal_plugin_reader_numpy PRIVATE
+    PDAL_PYTHON_LIBRARY="${PYTHON_LIBRARY}")
 
 # Install headers so Python extension
 # can use them later

--- a/plugins/python/plang/Environment.cpp
+++ b/plugins/python/plang/Environment.cpp
@@ -71,7 +71,6 @@ static void loadPython()
     if (libname.empty())
         libname = PDAL_PYTHON_LIBRARY;
     libname = pdal::FileUtils::getFilename(libname);
-    std::cerr << "Python library = " << libname << "!\n";
     ::dlopen(libname.data(), RTLD_LAZY | RTLD_GLOBAL);
 }
 #endif

--- a/plugins/python/plang/Environment.cpp
+++ b/plugins/python/plang/Environment.cpp
@@ -68,6 +68,10 @@ static void loadPython()
     std::string libname;
 
     pdal::Utils::getenv("PDAL_PYTHON_LIBRARY", libname);
+#
+# PDAL_PYTHON_LIBRARY below is the result of the cmake FindPython script's
+# PYTHON_LIBRARY.
+#
     if (libname.empty())
         libname = PDAL_PYTHON_LIBRARY;
     libname = pdal::FileUtils::getFilename(libname);

--- a/plugins/python/plang/Environment.cpp
+++ b/plugins/python/plang/Environment.cpp
@@ -38,9 +38,11 @@
 
 #include "Environment.hpp"
 #include "Redirector.hpp"
+
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #define PY_ARRAY_UNIQUE_SYMBOL PDAL_ARRAY_API
 #include <numpy/arrayobject.h>
+#include <pdal/util/FileUtils.hpp>
 #include <pdal/util/Utils.hpp>
 
 #include <sstream>
@@ -67,7 +69,9 @@ static void loadPython()
 
     pdal::Utils::getenv("PDAL_PYTHON_LIBRARY", libname);
     if (libname.empty())
-        libname = "libPython" + pdal::Utils::dynamicLibExtension;
+        libname = PDAL_PYTHON_LIBRARY;
+    libname = pdal::FileUtils::getFilename(libname);
+    std::cerr << "Python library = " << libname << "!\n";
     ::dlopen(libname.data(), RTLD_LAZY | RTLD_GLOBAL);
 }
 #endif


### PR DESCRIPTION
A change to improve flexibility (#2399) broke the loading of python symbols for Ubuntu.

Note: On ubuntu extension modules aren't liked with libpython3 (or whatever).  This means that when loaded from a dll, the python symbols aren't available.  In our case the extension is numpy, and it can't find python symbols because it hasn't been linked with python.  So we globally export the python symbols when our shared library is loaded so that they're available to satisfy the symbols in numpy.

This uses the base name from the compile-time python library as the source of the symbols.  It allows for override by setting the env variable PDAL_PYTHON_LIBRARY.