### PR TITLE
Document crop filter behavior with outside true

### DIFF
--- a/doc/stages/filters.crop.rst
+++ b/doc/stages/filters.crop.rst
@@ -49,12 +49,18 @@ bounds
 
 polygon
   The clipping polygon, expressed in a well-known text string,
-  eg: "POLYGON((0 0, 5000 10000, 10000 0, 0 0))".  This option can be
-  specified more than once by placing values in an array.
+  e.g.: "POLYGON((0 0, 5000 10000, 10000 0, 0 0))".  Multiple polygons can be
+  specified by providing an array of such WKT strings, in which case the
+  filter will let through points falling within the union of the provided
+  polygons.
 
 outside
-  Invert the cropping logic and only take points outside the cropping
-  bounds or polygon. [Default: false]
+  Include only points that fall outside, rather than inside, the cropping
+  bounds or polygon.  Note that when multiple polygons are provided, this will
+  let through points falling outside *any* of the polygons.  To correctly
+  invert a filter using multiple polygons, the crop filter must be used
+  multiple times in succession, using one polygon at a time with
+  ``"outside": true``. [Default: false]
 
 _`point`
   An array of WKT or GeoJSON 2D or 3D points. Requires distance_.


### PR DESCRIPTION
Well, I am unsure if the "outside" behavior of the crop filter with multiple polygons is intended, but in any case I've found it to be a bit of a gotcha. This PR documents the actual behavior of the filter.

Specifically, when providing an array of polygons, it is not correct that `"outside": true` gives the inverse crop compared to that from `"outside": false`.