### PR TITLE
EPT reader headers/query parameters forwarding for HTTP-based endpoints

### DIFF
--- a/doc/stages/readers.ept.rst
+++ b/doc/stages/readers.ept.rst
@@ -110,3 +110,10 @@ threads
 .. _Plasio: http://speck.ly/?s=http%3A%2F%2Fc%5B0-7%5D.greyhound.io&r=ept%3A%2F%2Fna.entwine.io%2Fnyc&ca=-0&ce=49.06&ct=-8239196%2C4958509.308%2C337&cd=42640.943&cmd=125978.13&ps=2&pa=0.1&ze=1&c0s=remote%3A%2F%2Fimagery%3Furl%3Dhttp%3A%2F%2Fserver.arcgisonline.com%2FArcGIS%2Frest%2Fservices%2FWorld_Imagery%2FMapServer%2Ftile%2F%7B%7Bz%7D%7D%2F%7B%7By%7D%7D%2F%7B%7Bx%7D%7D.jpg
 .. _Schema: https://entwine.io/entwine-point-tile.html#schema
 
+headers
+    HTTP headers to forward for remote EPT endpoints, structured as a JSON
+    object of key/value string pairs.
+
+query
+    HTTP query parameters to forward for remote EPT endpoints, structured as a
+    JSON object of key/value string pairs.

--- a/io/EptReader.cpp
+++ b/io/EptReader.cpp
@@ -312,7 +312,7 @@ void EptReader::initializeHttpForwards()
         for (const auto& entry : obj.items())
         {
             if (!entry.value().is_string())
-                throwError("Invalid " + type + "parameters: "
+                throwError("Invalid " + type + " parameters: "
                     "expected string->string mapping");
             map[entry.key()] = entry.value().get<std::string>();
         }

--- a/io/EptReader.cpp
+++ b/io/EptReader.cpp
@@ -137,8 +137,10 @@ public:
     double m_resolution = 0;
     std::vector<Polygon> m_polys;
     NL::json m_addons;
-};
 
+    NL::json m_query;
+    NL::json m_headers;
+};
 
 EptReader::EptReader() : m_args(new EptReader::Args), m_currentIndex(0)
 {}
@@ -159,6 +161,38 @@ void EptReader::addArgs(ProgramArgs& args)
     args.add("polygon", "Bounding polygon(s) to crop requests",
         m_args->m_polys).setErrorText("Invalid polygon specification. "
             "Must be valid GeoJSON/WKT");
+    args.add("header", "Header fields to forward with HTTP requests",
+        m_args->m_headers);
+    args.add("query", "Query parameters to forward with HTTP requests",
+        m_args->m_query);
+}
+
+
+std::string EptReader::get(const std::string path) const
+{
+    if (m_ep->isLocal())
+        return m_ep->get(path);
+    else
+        return m_ep->get(path, m_headers, m_query);
+}
+
+
+std::vector<char> EptReader::getBinary(const std::string path) const
+{
+    if (m_ep->isLocal())
+        return m_ep->getBinary(path);
+    else
+        return m_ep->getBinary(path, m_headers, m_query);
+}
+
+
+std::unique_ptr<arbiter::LocalHandle> EptReader::getLocalHandle(
+    const std::string path) const
+{
+    if (m_ep->isLocal())
+        return m_ep->getLocalHandle(path);
+    else
+        return m_ep->getLocalHandle(path, m_headers, m_query);
 }
 
 
@@ -167,6 +201,8 @@ void EptReader::initialize()
     m_root = m_filename;
 
     auto& debug(log()->get(LogLevel::Debug));
+
+    initializeHttpForwards();
 
     const std::string prefix("ept://");
     const std::string postfix("ept.json");
@@ -196,7 +232,7 @@ void EptReader::initialize()
     debug << "Endpoint: " << m_ep->prefixedRoot() << std::endl;
     try
     {
-        m_info.reset(new EptInfo(parse(m_ep->get("ept.json"))));
+        m_info.reset(new EptInfo(parse(get("ept.json"))));
     }
     catch (std::exception& e)
     {
@@ -263,6 +299,36 @@ void EptReader::initialize()
 }
 
 
+void EptReader::initializeHttpForwards()
+{
+    const auto remap([&](StringMap& map, NL::json obj, std::string type)
+    {
+        if (obj.is_null())
+            return;
+
+        if (!obj.is_object())
+            throwError("Invalid " + type + " parameters: expected object");
+
+        for (const auto& entry : obj.items())
+        {
+            if (!entry.value().is_string())
+                throwError("Invalid " + type + "parameters: "
+                    "expected string->string mapping");
+            map[entry.key()] = entry.value().get<std::string>();
+        }
+    });
+
+    remap(m_headers, m_args->m_headers, "header");
+    remap(m_query, m_args->m_query, "query");
+
+    auto& debug(log()->get(LogLevel::Debug));
+    if (!m_headers.empty())
+        debug << "Using header parameters" << std::endl;
+    if (!m_query.empty())
+        debug << "Using query parameters" << std::endl;
+}
+
+
 void EptReader::handleOriginQuery()
 {
     const std::string search(m_args->m_origin);
@@ -273,7 +339,7 @@ void EptReader::handleOriginQuery()
     log()->get(LogLevel::Debug) << "Searching sources for " << search <<
         std::endl;
 
-    const NL::json sources(parse(m_ep->get("ept-sources/list.json")));
+    const NL::json sources(parse(get("ept-sources/list.json")));
     log()->get(LogLevel::Debug) << "Fetched sources list" << std::endl;
 
     if (!sources.is_array())
@@ -520,7 +586,7 @@ void EptReader::overlaps()
         NL::json j;
         try
         {
-            j = NL::json::parse(ep.get(file));
+            j = NL::json::parse(get(file));
         }
         catch (NL::json::parse_error&)
         {
@@ -652,13 +718,14 @@ PointViewSet EptReader::run(PointViewPtr view)
     return views;
 }
 
+
 PointId EptReader::readLaszip(PointView& dst, const Key& key,
         const uint64_t nodeId) const
 {
     // If the file is remote (HTTP, S3, Dropbox, etc.), getLocalHandle will
     // download the file and `localPath` will return the location of the
     // downloaded file in a temporary directory.  Otherwise it's a no-op.
-    auto handle(m_ep->getLocalHandle("ept-data/" + key.toString() + ".laz"));
+    auto handle(getLocalHandle("ept-data/" + key.toString() + ".laz"));
 
     PointTable table;
 
@@ -696,7 +763,7 @@ PointId EptReader::readLaszip(PointView& dst, const Key& key,
 PointId EptReader::readBinary(PointView& dst, const Key& key,
         const uint64_t nodeId) const
 {
-    auto data(m_ep->getBinary("ept-data/" + key.toString() + ".bin"));
+    auto data(getBinary("ept-data/" + key.toString() + ".bin"));
     ShallowPointTable table(*m_remoteLayout, data.data(), data.size());
     PointRef pr(table);
 

--- a/io/EptReader.hpp
+++ b/io/EptReader.hpp
@@ -51,6 +51,7 @@ namespace arbiter
 {
     class Arbiter;
     class Endpoint;
+    class LocalHandle;
 }
 
 class Addon;
@@ -78,6 +79,10 @@ private:
     virtual void ready(PointTableRef table) override;
     virtual PointViewSet run(PointViewPtr view) override;
 
+    // Users may supply header and query parameters to be forwarded with remote
+    // requests, deconstruct their JSON into our member maps.
+    void initializeHttpForwards();
+
     // If argument "origin" is specified, this function will clip the query
     // bounds to the bounds of the specified origin and set m_queryOriginId to
     // the selected OriginId value.  If the selected origin is not found, throw.
@@ -102,10 +107,16 @@ private:
     static Dimension::Type getRemoteTypeTest(const NL::json& dimInfo);
     static Dimension::Type getCoercedTypeTest(const NL::json& dimInfo);
 
-    //For streamable pipeline.
+    // For streamable pipeline.
     virtual bool processOne(PointRef& point) override;
     void loadNextOverlap();
     void fillPoint(PointRef& point);
+
+    // Data fetching - these forward user-specified query/header params.
+    std::string get(std::string path) const;
+    std::vector<char> getBinary(std::string path) const;
+    std::unique_ptr<arbiter::LocalHandle> getLocalHandle(std::string path)
+        const;
 
     std::string m_root;
 
@@ -121,6 +132,10 @@ private:
     int64_t m_queryOriginId = -1;
     std::unique_ptr<Pool> m_pool;
     std::vector<std::unique_ptr<Addon>> m_addons;
+
+    using StringMap = std::map<std::string, std::string>;
+    StringMap m_headers;
+    StringMap m_query;
 
     mutable std::mutex m_mutex;
 

--- a/pdal/StageFactory.cpp
+++ b/pdal/StageFactory.cpp
@@ -83,6 +83,10 @@ std::string StageFactory::inferReaderDriver(const std::string& filename)
     // Strip off '.' and make lowercase.
     if (ext.length())
         ext = Utils::tolower(ext.substr(1));
+
+    if (ext == "json" && Utils::endsWith(filename, "ept.json"))
+        return "readers.ept";
+
     return PluginManager<Stage>::extensions().defaultReader(ext);
 }
 

--- a/vendor/arbiter/arbiter.hpp
+++ b/vendor/arbiter/arbiter.hpp
@@ -1,7 +1,7 @@
 /// Arbiter amalgamated header (https://github.com/connormanning/arbiter).
 /// It is intended to be used with #include "arbiter.hpp"
 
-// Git SHA: 0d6fba8d4ec6a7805693b4fdce0cc0c31cd1e97b
+// Git SHA: 098ed60a28d9a612a125a26ec667569c0bc90c8e
 
 // //////////////////////////////////////////////////////////////////////
 // Beginning of content of file: LICENSE
@@ -3117,6 +3117,13 @@ inline std::string decompress(const char* data, std::size_t size)
 // //////////////////////////////////////////////////////////////////////
 
 
+
+
+
+
+#include <nlohmann/json.hpp>
+
+
 // //////////////////////////////////////////////////////////////////////
 // Beginning of content of file: arbiter/util/exports.hpp
 // //////////////////////////////////////////////////////////////////////
@@ -3263,7 +3270,9 @@ private:
 
 #pragma once
 
-#include <nlohmann/json.hpp>
+#ifndef ARBITER_IS_AMALGAMATION
+#include <arbiter/third/json/json.hpp>
+#endif
 
 #ifdef ARBITER_CUSTOM_NAMESPACE
 namespace ARBITER_CUSTOM_NAMESPACE
@@ -5149,7 +5158,10 @@ public:
     bool isHttpDerived() const;
 
     /** See Arbiter::getLocalHandle. */
-    std::unique_ptr<LocalHandle> getLocalHandle(std::string subpath) const;
+    std::unique_ptr<LocalHandle> getLocalHandle(
+            std::string subpath,
+            http::Headers headers = http::Headers(),
+            http::Query query = http::Query()) const;
 
     /** Passthrough to Driver::get. */
     std::string get(std::string subpath) const;


### PR DESCRIPTION
Adds `headers` and `query` options to the EPT reader, which will be forwarded to remote endpoints.  The typical use-case here is for authenticated endpoints.

Also adds capability for `filename` values ending with `"ept.json"` to be routed to the EPT reader, which can be more convenient than the alternative `ept://` protocol method.