### PR TITLE
Add power parameter to GDAL writer

### DIFF
--- a/doc/stages/writers.gdal.rst
+++ b/doc/stages/writers.gdal.rst
@@ -112,6 +112,15 @@ radius
     Radius about cell center bounding points to use to calculate a cell value.
     [Default: resolution_ * sqrt(2)]
 
+power
+    Exponent of the distance when computing IDW. Close points have higher
+    significance than far points. [Default: 2.0]
+
+    .. note::
+	Power is a newly added, optional argument, only used when computing
+	IDW. The default value of 2.0 represents a change from the previous
+        implementation, in which the power would have always been 1.0.
+
 gdaldriver
     GDAL code of the `GDAL driver`_ to use to write the output.
     [Default: "GTiff"]

--- a/doc/stages/writers.gdal.rst
+++ b/doc/stages/writers.gdal.rst
@@ -114,12 +114,7 @@ radius
 
 power
     Exponent of the distance when computing IDW. Close points have higher
-    significance than far points. [Default: 2.0]
-
-    .. note::
-	Power is a newly added, optional argument, only used when computing
-	IDW. The default value of 2.0 represents a change from the previous
-        implementation, in which the power would have always been 1.0.
+    significance than far points. [Default: 1.0]
 
 gdaldriver
     GDAL code of the `GDAL driver`_ to use to write the output.

--- a/io/GDALWriter.cpp
+++ b/io/GDALWriter.cpp
@@ -68,7 +68,7 @@ void GDALWriter::addArgs(ProgramArgs& args)
     m_radiusArg = &args.add("radius", "Radius from cell center to use to locate"
         " influencing points", m_radius);
     args.add("power", "Power parameter for weighting points when using IDW",
-        m_power, 2.0);
+        m_power, 1.0);
     args.add("gdaldriver", "GDAL writer driver name", m_drivername, "GTiff");
     args.add("gdalopts", "GDAL driver options (name=value,name=value...)",
         m_options);

--- a/io/GDALWriter.cpp
+++ b/io/GDALWriter.cpp
@@ -67,6 +67,8 @@ void GDALWriter::addArgs(ProgramArgs& args)
         m_edgeLength).setPositional();
     m_radiusArg = &args.add("radius", "Radius from cell center to use to locate"
         " influencing points", m_radius);
+    args.add("power", "Power parameter for weighting points when using IDW",
+        m_power, 2.0);
     args.add("gdaldriver", "GDAL writer driver name", m_drivername, "GTiff");
     args.add("gdalopts", "GDAL driver options (name=value,name=value...)",
         m_options);
@@ -204,7 +206,7 @@ void GDALWriter::createGrid(BOX2D bounds)
     try
     {
         m_grid.reset(new GDALGrid(c.x + 1, c.y + 1, m_edgeLength,
-            m_radius, m_outputTypes, m_windowSize));
+            m_radius, m_outputTypes, m_windowSize, m_power));
     }
     catch (GDALGrid::error& err)
     {

--- a/io/GDALWriter.hpp
+++ b/io/GDALWriter.hpp
@@ -95,6 +95,7 @@ private:
     Arg *m_heightArg;
     Arg *m_widthArg;
     double m_radius;
+    double m_power;
     StringList m_options;
     StringList m_outputTypeString;
     size_t m_windowSize;

--- a/io/private/GDALGrid.cpp
+++ b/io/private/GDALGrid.cpp
@@ -52,9 +52,9 @@ namespace pdal
 //  moving data around every time the grid is resized.
 
 GDALGrid::GDALGrid(size_t width, size_t height, double edgeLength,
-        double radius, int outputTypes, size_t windowSize) :
+        double radius, int outputTypes, size_t windowSize, double power) :
     m_width(width), m_height(height), m_windowSize(windowSize),
-    m_edgeLength(edgeLength), m_radius(radius), m_outputTypes(outputTypes)
+    m_edgeLength(edgeLength), m_radius(radius), m_power(power), m_outputTypes(outputTypes)
 {
     if (width > (size_t)(std::numeric_limits<int>::max)() ||
         height > (size_t)(std::numeric_limits<int>::max)())
@@ -426,8 +426,8 @@ void GDALGrid::update(size_t i, size_t j, double val, double dist)
             }
             else
             {
-                idw += val / dist;
-                idwDist += 1 / dist;
+                idw += val / std::pow(dist, m_power);
+                idwDist += 1 / std::pow(dist, m_power);
             }
         }
     }

--- a/io/private/GDALGrid.hpp
+++ b/io/private/GDALGrid.hpp
@@ -62,7 +62,7 @@ public:
 
     // Exported for testing.
     PDAL_DLL GDALGrid(size_t width, size_t height,
-        double edgeLength, double radius, int outputTypes, size_t windowSize);
+        double edgeLength, double radius, int outputTypes, size_t windowSize, double power=2.0);
 
     void expand(size_t width, size_t height, size_t xshift, size_t yshift);
 
@@ -90,6 +90,7 @@ private:
     size_t m_windowSize;
     double m_edgeLength;
     double m_radius;
+    double m_power;
 
     typedef std::vector<double> DataVec;
     typedef std::unique_ptr<DataVec> DataPtr;

--- a/io/private/GDALGrid.hpp
+++ b/io/private/GDALGrid.hpp
@@ -62,7 +62,7 @@ public:
 
     // Exported for testing.
     PDAL_DLL GDALGrid(size_t width, size_t height,
-        double edgeLength, double radius, int outputTypes, size_t windowSize, double power=2.0);
+        double edgeLength, double radius, int outputTypes, size_t windowSize, double power);
 
     void expand(size_t width, size_t height, size_t xshift, size_t yshift);
 

--- a/test/unit/io/GDALWriterTest.cpp
+++ b/test/unit/io/GDALWriterTest.cpp
@@ -369,7 +369,6 @@ TEST(GDALWriterTest, idw)
     wo.add("output_type", "idw");
     wo.add("resolution", 1);
     wo.add("radius", .7071);
-    wo.add("power", 1);
     wo.add("filename", outfile);
 
     const std::string output =
@@ -392,7 +391,6 @@ TEST(GDALWriterTest, idwWindow)
     wo.add("output_type", "idw");
     wo.add("resolution", 1);
     wo.add("radius", .7071);
-    wo.add("power", 1);
     wo.add("filename", outfile);
     wo.add("window_size", 2);
 
@@ -742,7 +740,7 @@ TEST(GDALWriterTest, issue_2074)
 
 TEST(GDALWriterTest, issue_2095)
 {
-    GDALGrid grid(5, 5, 1, .7, GDALGrid::statCount | GDALGrid::statMin, 0);
+    GDALGrid grid(5, 5, 1, .7, GDALGrid::statCount | GDALGrid::statMin, 0, 1.0);
 
     EXPECT_EQ(grid.verticalIndex(0), 4);
     EXPECT_EQ(grid.verticalIndex(.5), 4);
@@ -767,7 +765,6 @@ TEST(GDALWriterTest, issue_2545)
     Options wOpts;
     wOpts.add("resolution", 1);
     wOpts.add("radius", 10);
-    wOpts.add("power", 1);
     wOpts.add("output_type", "idw");
     wOpts.add("gdaldriver", "GTiff");
     wOpts.add("origin_x", .5);

--- a/test/unit/io/GDALWriterTest.cpp
+++ b/test/unit/io/GDALWriterTest.cpp
@@ -369,6 +369,7 @@ TEST(GDALWriterTest, idw)
     wo.add("output_type", "idw");
     wo.add("resolution", 1);
     wo.add("radius", .7071);
+    wo.add("power", 1);
     wo.add("filename", outfile);
 
     const std::string output =
@@ -391,6 +392,7 @@ TEST(GDALWriterTest, idwWindow)
     wo.add("output_type", "idw");
     wo.add("resolution", 1);
     wo.add("radius", .7071);
+    wo.add("power", 1);
     wo.add("filename", outfile);
     wo.add("window_size", 2);
 
@@ -765,6 +767,7 @@ TEST(GDALWriterTest, issue_2545)
     Options wOpts;
     wOpts.add("resolution", 1);
     wOpts.add("radius", 10);
+    wOpts.add("power", 1);
     wOpts.add("output_type", "idw");
     wOpts.add("gdaldriver", "GTiff");
     wOpts.add("origin_x", .5);


### PR DESCRIPTION
IDW can be more heavily influenced by near points if desired. Default value of 2.0 represents a change from the previous behavior, when no power was considered.

Close #2550 