### PR TITLE
Use map find instead of at (#2721)

### DIFF
--- a/plugins/e57/io/E57Reader.cpp
+++ b/plugins/e57/io/E57Reader.cpp
@@ -103,13 +103,13 @@ void E57Reader::ChunkReader::setPoint(point_count_t pointIndex, PointRef point,
         {
             double value;
             // Rescale the value if needed so that if fits Pdal expectations
-            try
+            std::pair<double, double> minmax;
+            if (m_scan->getLimits(pdalDimension, minmax))
             {
-                auto minmax = m_scan->getLimits(pdalDimension);
                 value = e57plugin::rescaleE57ToPdalValue(keyValue.first,
                     keyValue.second[index], minmax);
             }
-            catch (std::out_of_range &)
+            else
             {
                 value = keyValue.second[index];
             }

--- a/plugins/e57/io/Scan.cpp
+++ b/plugins/e57/io/Scan.cpp
@@ -59,9 +59,16 @@ e57::CompressedVectorNode Scan::getPoints() const
     return *m_rawPoints;
 }
 
-std::pair<double,double> Scan::getLimits(pdal::Dimension::Id pdalId) const
+bool Scan::getLimits(pdal::Dimension::Id pdalId, std::pair<double, double>& minMax) const
 {
-    return m_valueBounds.at(pdalId);
+    auto itMinMax = m_valueBounds.find(pdalId);
+    if (itMinMax != m_valueBounds.end())
+    {
+        minMax = itMinMax->second;
+        return true;
+    }
+
+    return false;
 }
 
 bool Scan::hasPose() const

--- a/plugins/e57/io/Scan.hpp
+++ b/plugins/e57/io/Scan.hpp
@@ -54,7 +54,7 @@ public:
 
     e57::CompressedVectorNode getPoints() const;
 
-    std::pair<double,double> getLimits(pdal::Dimension::Id pdalId) const;
+    bool getLimits(pdal::Dimension::Id pdalId, std::pair<double, double>& minMax) const;
 
     bool hasPose() const;
     void transformPoint(pdal::PointRef pt) const;


### PR DESCRIPTION
Fixes performance issues on Windows caused by exceptions.