### PR TITLE
Fixed normal dimension names

### DIFF
--- a/pdal/Dimension.json
+++ b/pdal/Dimension.json
@@ -349,13 +349,13 @@
     },
     {
     "name": "NormalY",
-    "alt_names": ["nz", "normal_z", "normalz" ],
+    "alt_names": ["ny", "normal_y", "normaly" ],
     "type": "double",
     "description": "Y component of a vector normal to surface at this point"
     },
     {
     "name": "NormalZ",
-    "alt_names": "nz",
+    "alt_names": ["nz", "normal_z", "normalz"],
     "type": "double",
     "description": "Z component of a vector normal to surface at this point"
     },


### PR DESCRIPTION
The names for the NormalY dimension are currently mapping to names for the NormalZ dimension. Also the NormalZ dimension is missing the alternate names?

Very cool work on alt_names support! :clap: 