### PR TITLE
Check if inView is empty before setting m_size

### DIFF
--- a/filters/DividerFilter.cpp
+++ b/filters/DividerFilter.cpp
@@ -109,11 +109,18 @@ void DividerFilter::initialize()
 
 PointViewSet DividerFilter::run(PointViewPtr inView)
 {
-    if (m_sizeMode == SizeMode::Capacity)
-	m_size = inView->empty() ? 1 : (((inView->size() - 1) / m_size) + 1);
-
-
     PointViewSet result;
+
+    if (inView->empty())
+    {
+	result.insert(inView);
+	return result;
+    }
+
+    if (m_sizeMode == SizeMode::Capacity)
+	m_size = ((inView->size() - 1) / m_size) + 1;
+
+
     std::vector<PointViewPtr> views;
     for (point_count_t i = 0; i < m_size; ++i)
     {

--- a/filters/DividerFilter.cpp
+++ b/filters/DividerFilter.cpp
@@ -110,7 +110,8 @@ void DividerFilter::initialize()
 PointViewSet DividerFilter::run(PointViewPtr inView)
 {
     if (m_sizeMode == SizeMode::Capacity)
-        m_size = ((inView->size() - 1) / m_size) + 1;
+	m_size = inView->empty() ? 1 : (((inView->size() - 1) / m_size) + 1);
+
 
     PointViewSet result;
     std::vector<PointViewPtr> views;


### PR DESCRIPTION
Check if inView is empty before setting m_size to avoid integer overflow

Fixes #2726 