### PR TITLE
Ability to add alternate dimension types other than float64 via the Python Filter stage

### DIFF
--- a/plugins/python/filters/PythonFilter.cpp
+++ b/plugins/python/filters/PythonFilter.cpp
@@ -37,6 +37,7 @@
 #include <nlohmann/json.hpp>
 
 #include <pdal/PointView.hpp>
+#include <pdal/DimUtil.hpp>
 #include <pdal/util/ProgramArgs.hpp>
 #include <pdal/util/FileUtils.hpp>
 
@@ -93,8 +94,17 @@ void PythonFilter::addArgs(ProgramArgs& args)
 
 void PythonFilter::addDimensions(PointLayoutPtr layout)
 {
-    for (const std::string& s : m_args->m_addDimensions)
-        layout->registerOrAssignDim(s, pdal::Dimension::Type::Double);
+    for (const std::string& s : m_args->m_addDimensions) {
+        std::size_t sep = s.find('=');
+        if (sep != std::string::npos)
+        {
+            std::string tval = s.substr(sep+1, s.length() - sep - 1),
+                        dval = s.substr(0, sep);
+            layout->registerOrAssignDim(dval, pdal::Dimension::type(tval));
+        } else {
+            layout->registerOrAssignDim(s, pdal::Dimension::Type::Double);
+        }
+    }
 }
 
 

--- a/plugins/python/filters/PythonFilter.cpp
+++ b/plugins/python/filters/PythonFilter.cpp
@@ -95,12 +95,20 @@ void PythonFilter::addArgs(ProgramArgs& args)
 void PythonFilter::addDimensions(PointLayoutPtr layout)
 {
     for (const std::string& s : m_args->m_addDimensions) {
-        StringList spec = Utils::split2(s, '=');
-        if (spec.size() > 1)
+        StringList spec = Utils::split(s, '=');
+        Utils::trim(spec[0]);
+        if (spec.size() == 2)
         {
-            layout->registerOrAssignDim(spec[0], pdal::Dimension::type(spec[1]));
-        } else {
+            Utils::trim(spec[1]);
+            auto type = pdal::Dimension::type(spec[1]);
+            if (type == pdal::Dimension::Type::None)
+                throwError("Invalid dimension type specified '" + spec[1] + "'.  See "
+                           "documentation for valid dimension types");
+            layout->registerOrAssignDim(spec[0], type);
+        } else if (spec.size() == 1){
             layout->registerOrAssignDim(s, pdal::Dimension::Type::Double);
+        } else {
+          throwError("Invalid dimension specified '" + s + "'.  Need <dimension> or <dimension>=<data_type>.");
         }
     }
 }

--- a/plugins/python/filters/PythonFilter.cpp
+++ b/plugins/python/filters/PythonFilter.cpp
@@ -95,12 +95,10 @@ void PythonFilter::addArgs(ProgramArgs& args)
 void PythonFilter::addDimensions(PointLayoutPtr layout)
 {
     for (const std::string& s : m_args->m_addDimensions) {
-        std::size_t sep = s.find('=');
-        if (sep != std::string::npos)
+        StringList spec = Utils::split2(s, '=');
+        if (spec.size() > 1)
         {
-            std::string tval = s.substr(sep+1, s.length() - sep - 1),
-                        dval = s.substr(0, sep);
-            layout->registerOrAssignDim(dval, pdal::Dimension::type(tval));
+            layout->registerOrAssignDim(spec[0], pdal::Dimension::type(spec[1]));
         } else {
             layout->registerOrAssignDim(s, pdal::Dimension::Type::Double);
         }


### PR DESCRIPTION
Related to the github issue #2755, this implements @abellgithub's suggestion to use the syntax `newDimension=dataType` to specify types of dimensions added via the Python filter stage.  If a type isn't specified, the current behavior is maintained (ie creating a float64 dimension).