### PR TITLE
fixed tiledb writer typo

### DIFF
--- a/doc/stages/writers.tiledb.rst
+++ b/doc/stages/writers.tiledb.rst
@@ -1,6 +1,6 @@
 .. _writers.tiledb:
 
-readers.tiledb
+writers.tiledb
 ==============
 
 Implements `TileDB`_ 1.4.1+ reads from an array.


### PR DESCRIPTION
Typo in `writers.tiledb` header