### PR TITLE
Make EPT reader asynchronous in streaming mode

### DIFF
--- a/filters/private/pnp/GridPnp.hpp
+++ b/filters/private/pnp/GridPnp.hpp
@@ -53,11 +53,11 @@ public:
         setupGrid();
     }
 
-    bool inside(const Point& p) const
+    bool inside(const Point& p)
     { return inside(p.first, p.second); }
 
     // Determine if a point is inside the polygon attached to this class.
-    bool inside(double x, double y) const
+    bool inside(double x, double y)
     {
         // Find the index of the grid cell at the position.
         // If the position isn't in the grid, we're certainly outside.
@@ -105,7 +105,7 @@ private:
             { return m_edges.empty(); }
         void setPoint(double x, double y)
             { m_point = Point(x, y); }
-        bool computed() const
+        bool computed()
             { return !std::isnan(m_point.first); }
         GridPnp::Point point() const
             { return m_point; }
@@ -157,16 +157,16 @@ private:
     };
 
 
-    const Point& point1(EdgeId id) const
+    Point& point1(EdgeId id)
         { return m_rings[id]; }
-    const Point& point2(EdgeId id) const
+    Point& point2(EdgeId id)
         { return m_rings[id + 1]; }
-    double xval(const Point& p) const
+    double xval(const Point& p)
         { return p.first; }
-    double yval(const Point& p) const
+    double yval(const Point& p)
         { return p.second; }
 
-    void validateRing(const Ring& r) const
+    void validateRing(const Ring& r)
     {
         if (r.size() < 4)
             throw grid_error("Invalid ring. Ring must consist of at least "
@@ -267,9 +267,9 @@ private:
     // though, in preprocessing vs. actual pnp tests.  Hopefully more work
     // can be done on this later.  My stupid way of dealing with this is
     // to set a minimum grid size of 1000 cells.
-    XYIndex calcGridSize(double xAvgLen, double yAvgLen) const
+    XYIndex calcGridSize(double xAvgLen, double yAvgLen)
     {
-        // I'm setting a minimum number of cells as 1000, because, why not?
+        // I'm setting a minmum number of cells as 1000, because, why not?
         // m_rings isn't necessarily an exact count of edges, but it's close
         // enough for this purpose.
         size_t m = (std::max)((size_t)1000, m_rings.size());
@@ -313,8 +313,8 @@ private:
         for (EdgeIt it(m_rings); it; it.next())
         {
             EdgeId id = *it;
-            const Point& p1 = point1(id);
-            const Point& p2 = point2(id);
+            Point& p1 = point1(id);
+            Point& p2 = point2(id);
             Point origin = m_grid->origin();
             VoxelRayTrace vrt(m_grid->cellWidth(), m_grid->cellHeight(),
                 xval(origin), yval(origin),
@@ -327,14 +327,14 @@ private:
 
 
     // Determine if a point is collinear with an edge.
-    bool pointCollinear(double x, double y, EdgeId edgeId) const
+    bool pointCollinear(double x, double y, EdgeId edgeId)
     {
-        const Point& p1 = point1(edgeId);
-        const Point& p2 = point2(edgeId);
-        const double x1 = xval(p1);
-        const double x2 = xval(p2);
-        const double y1 = yval(p1);
-        const double y2 = yval(p2);
+        Point& p1 = point1(edgeId);
+        Point& p2 = point2(edgeId);
+        double x1 = xval(p1);
+        double x2 = xval(p2);
+        double y1 = yval(p1);
+        double y2 = yval(p2);
 
         // If p1 == p2, this will fail.
 
@@ -346,7 +346,7 @@ private:
 
     // Put a reference point in the cell.  Figure out if the reference point
     // is inside the polygon.
-    void computeCell(Cell& cell, XYIndex& pos) const
+    void computeCell(Cell& cell, XYIndex& pos)
     {
         generateRefPoint(cell, pos);
         determinePointStatus(cell, pos);
@@ -359,7 +359,7 @@ private:
     // a known status (inside or outside the polygon).  So we just pick a point
     // that isn't collinear with any of the segments in the cell.  Eliminating
     // collinearity eliminates special cases when counting crossings.
-    void generateRefPoint(Cell& cell, XYIndex& pos) const
+    void generateRefPoint(Cell& cell, XYIndex& pos)
     {
         // A test point is valid if it's not collinear with any segments
         // in the cell.
@@ -389,7 +389,7 @@ private:
     // If we're determining the status of the leftmost cell, choose a point
     // to the left of the leftmost cell, which is guaranteed to be outside
     // the polygon.
-    void determinePointStatus(Cell& cell, XYIndex& pos) const
+    void determinePointStatus(Cell& cell, XYIndex& pos)
     {
         Point p1(cell.point());
 
@@ -433,7 +433,7 @@ private:
     // Determine the number of intersections between an edge and
     // all edges indexes by the 'edges' list.
     template<typename EDGES>
-    size_t intersections(Edge& e1, const EDGES& edges) const
+    size_t intersections(Edge& e1, const EDGES& edges)
     {
         size_t isect = 0;
         for (auto& edgeId : edges)
@@ -449,7 +449,7 @@ private:
     // Determine if a point in a cell is inside the polygon or outside.
     // We're always calling a point that lies on an edge as 'inside'
     // the polygon.
-    bool testCell(Cell& cell, double x, double y) const
+    bool testCell(Cell& cell, double x, double y)
     {
         Edge tester({x, y}, cell.point());
 
@@ -474,7 +474,7 @@ private:
     // is one or 0 and the other factor is between 0 and 1.
     // This is standard math, but it's shown nicely on Stack Overflow
     // question 563198.  The variable names map to the good response there.
-    IntersectType intersects(Edge& e1, Edge& e2) const
+    IntersectType intersects(Edge& e1, Edge& e2)
     {
         using Vector = std::pair<double, double>;
 
@@ -512,7 +512,7 @@ private:
     }
 
     RingList m_rings;
-    mutable std::mt19937 m_ranGen;
+    std::mt19937 m_ranGen;
     std::unique_ptr<std::uniform_real_distribution<>> m_xDistribution;
     std::unique_ptr<std::uniform_real_distribution<>> m_yDistribution;
     std::unique_ptr<Grid<Cell>> m_grid;

--- a/filters/private/pnp/GridPnp.hpp
+++ b/filters/private/pnp/GridPnp.hpp
@@ -53,11 +53,11 @@ public:
         setupGrid();
     }
 
-    bool inside(const Point& p)
+    bool inside(const Point& p) const
     { return inside(p.first, p.second); }
 
     // Determine if a point is inside the polygon attached to this class.
-    bool inside(double x, double y)
+    bool inside(double x, double y) const
     {
         // Find the index of the grid cell at the position.
         // If the position isn't in the grid, we're certainly outside.
@@ -105,7 +105,7 @@ private:
             { return m_edges.empty(); }
         void setPoint(double x, double y)
             { m_point = Point(x, y); }
-        bool computed()
+        bool computed() const
             { return !std::isnan(m_point.first); }
         GridPnp::Point point() const
             { return m_point; }
@@ -157,16 +157,16 @@ private:
     };
 
 
-    Point& point1(EdgeId id)
+    const Point& point1(EdgeId id) const
         { return m_rings[id]; }
-    Point& point2(EdgeId id)
+    const Point& point2(EdgeId id) const
         { return m_rings[id + 1]; }
-    double xval(const Point& p)
+    double xval(const Point& p) const
         { return p.first; }
-    double yval(const Point& p)
+    double yval(const Point& p) const
         { return p.second; }
 
-    void validateRing(const Ring& r)
+    void validateRing(const Ring& r) const
     {
         if (r.size() < 4)
             throw grid_error("Invalid ring. Ring must consist of at least "
@@ -267,9 +267,9 @@ private:
     // though, in preprocessing vs. actual pnp tests.  Hopefully more work
     // can be done on this later.  My stupid way of dealing with this is
     // to set a minimum grid size of 1000 cells.
-    XYIndex calcGridSize(double xAvgLen, double yAvgLen)
+    XYIndex calcGridSize(double xAvgLen, double yAvgLen) const
     {
-        // I'm setting a minmum number of cells as 1000, because, why not?
+        // I'm setting a minimum number of cells as 1000, because, why not?
         // m_rings isn't necessarily an exact count of edges, but it's close
         // enough for this purpose.
         size_t m = (std::max)((size_t)1000, m_rings.size());
@@ -313,8 +313,8 @@ private:
         for (EdgeIt it(m_rings); it; it.next())
         {
             EdgeId id = *it;
-            Point& p1 = point1(id);
-            Point& p2 = point2(id);
+            const Point& p1 = point1(id);
+            const Point& p2 = point2(id);
             Point origin = m_grid->origin();
             VoxelRayTrace vrt(m_grid->cellWidth(), m_grid->cellHeight(),
                 xval(origin), yval(origin),
@@ -327,14 +327,14 @@ private:
 
 
     // Determine if a point is collinear with an edge.
-    bool pointCollinear(double x, double y, EdgeId edgeId)
+    bool pointCollinear(double x, double y, EdgeId edgeId) const
     {
-        Point& p1 = point1(edgeId);
-        Point& p2 = point2(edgeId);
-        double x1 = xval(p1);
-        double x2 = xval(p2);
-        double y1 = yval(p1);
-        double y2 = yval(p2);
+        const Point& p1 = point1(edgeId);
+        const Point& p2 = point2(edgeId);
+        const double x1 = xval(p1);
+        const double x2 = xval(p2);
+        const double y1 = yval(p1);
+        const double y2 = yval(p2);
 
         // If p1 == p2, this will fail.
 
@@ -346,7 +346,7 @@ private:
 
     // Put a reference point in the cell.  Figure out if the reference point
     // is inside the polygon.
-    void computeCell(Cell& cell, XYIndex& pos)
+    void computeCell(Cell& cell, XYIndex& pos) const
     {
         generateRefPoint(cell, pos);
         determinePointStatus(cell, pos);
@@ -359,7 +359,7 @@ private:
     // a known status (inside or outside the polygon).  So we just pick a point
     // that isn't collinear with any of the segments in the cell.  Eliminating
     // collinearity eliminates special cases when counting crossings.
-    void generateRefPoint(Cell& cell, XYIndex& pos)
+    void generateRefPoint(Cell& cell, XYIndex& pos) const
     {
         // A test point is valid if it's not collinear with any segments
         // in the cell.
@@ -389,7 +389,7 @@ private:
     // If we're determining the status of the leftmost cell, choose a point
     // to the left of the leftmost cell, which is guaranteed to be outside
     // the polygon.
-    void determinePointStatus(Cell& cell, XYIndex& pos)
+    void determinePointStatus(Cell& cell, XYIndex& pos) const
     {
         Point p1(cell.point());
 
@@ -433,7 +433,7 @@ private:
     // Determine the number of intersections between an edge and
     // all edges indexes by the 'edges' list.
     template<typename EDGES>
-    size_t intersections(Edge& e1, const EDGES& edges)
+    size_t intersections(Edge& e1, const EDGES& edges) const
     {
         size_t isect = 0;
         for (auto& edgeId : edges)
@@ -449,7 +449,7 @@ private:
     // Determine if a point in a cell is inside the polygon or outside.
     // We're always calling a point that lies on an edge as 'inside'
     // the polygon.
-    bool testCell(Cell& cell, double x, double y)
+    bool testCell(Cell& cell, double x, double y) const
     {
         Edge tester({x, y}, cell.point());
 
@@ -474,7 +474,7 @@ private:
     // is one or 0 and the other factor is between 0 and 1.
     // This is standard math, but it's shown nicely on Stack Overflow
     // question 563198.  The variable names map to the good response there.
-    IntersectType intersects(Edge& e1, Edge& e2)
+    IntersectType intersects(Edge& e1, Edge& e2) const
     {
         using Vector = std::pair<double, double>;
 
@@ -512,7 +512,7 @@ private:
     }
 
     RingList m_rings;
-    std::mt19937 m_ranGen;
+    mutable std::mt19937 m_ranGen;
     std::unique_ptr<std::uniform_real_distribution<>> m_xDistribution;
     std::unique_ptr<std::uniform_real_distribution<>> m_yDistribution;
     std::unique_ptr<Grid<Cell>> m_grid;

--- a/io/EptReader.cpp
+++ b/io/EptReader.cpp
@@ -62,7 +62,6 @@ namespace
         { "ept" }
     };
 
-    const std::size_t streamNodeCount(8);
     const std::string addonFilename { "ept-addon.json" };
 
     Dimension::Type getRemoteType(const NL::json& dim)
@@ -906,7 +905,7 @@ void EptReader::load()
     // Asynchronously trigger the fetching and point-view execution of
     // a lookahead buffer of nodes.
     while (
-        m_upcomingNodeBuffers.size() < streamNodeCount &&
+        m_upcomingNodeBuffers.size() < m_pool->size() &&
         m_overlapIt != m_overlaps.end())
     {
         const auto nodeId(m_nodeId++);

--- a/io/EptReader.cpp
+++ b/io/EptReader.cpp
@@ -996,7 +996,7 @@ bool EptReader::processOne(PointRef& point)
     auto& sourceView(m_currentNodeBuffer->view);
     const auto& layout(*m_currentNodeBuffer->table.layout());
 
-    for (const auto& id : m_currentNodeBuffer->table.layout()->dims())
+    for (const auto& id : layout.dims())
     {
         point.setField(
             id,
@@ -1004,10 +1004,7 @@ bool EptReader::processOne(PointRef& point)
             sourceView.getPoint(m_pointId) + layout.dimOffset(id));
     }
 
-    if (++m_pointId == m_currentNodeBuffer->view.size())
-    {
-        m_currentNodeBuffer.reset();
-    }
+    if (++m_pointId == sourceView.size()) m_currentNodeBuffer.reset();
 
     return true;
 }

--- a/io/EptReader.cpp
+++ b/io/EptReader.cpp
@@ -949,7 +949,8 @@ EptReader::NodeBufferIt EptReader::findBuffer()
     return std::find_if(
         m_upcomingNodeBuffers.begin(),
         m_upcomingNodeBuffers.end(),
-        [this](const NodeBufferPair& p) { return !!p.second; });
+        [this](const NodeBufferPair& p)
+            { return static_cast<bool>(p.second); });
 }
 
 bool EptReader::next()

--- a/io/EptReader.cpp
+++ b/io/EptReader.cpp
@@ -62,6 +62,7 @@ namespace
         { "ept" }
     };
 
+    const std::size_t streamNodeCount(8);
     const std::string addonFilename { "ept-addon.json" };
 
     Dimension::Type getRemoteType(const NL::json& dim)
@@ -142,7 +143,7 @@ public:
     NL::json m_headers;
 };
 
-EptReader::EptReader() : m_args(new EptReader::Args), m_currentIndex(0)
+EptReader::EptReader() : m_args(new EptReader::Args)
 {}
 
 EptReader::~EptReader()
@@ -522,15 +523,6 @@ void EptReader::addDimensions(PointLayoutPtr layout)
     {
         throwError(e.what());
     }
-
-    // Backup the layout for streamable pipeline.
-    // Will be used to restore m_bufferPointTable layout after flushing
-    // points from previous tile.
-    if (pipelineStreamable())
-    {
-    	m_bufferLayout = layout;
-        m_temp_buffer.reserve(layout->pointSize());
-	}
 }
 
 
@@ -626,6 +618,8 @@ void EptReader::overlaps()
         overlaps(addon->ep(), addon->hierarchy(), root, key);
         m_pool->await();
     }
+
+    m_overlapIt = m_overlaps.begin();
 }
 
 void EptReader::overlaps(const arbiter::Endpoint& ep,
@@ -687,9 +681,7 @@ PointViewSet EptReader::run(PointViewPtr view)
 
     for (auto& p : m_args->m_polys)
     {
-        std::unique_ptr<GridPnp> gridPnp(new GridPnp(
-            p.exteriorRing(), p.interiorRings()));
-        m_queryGrids.push_back(std::move(gridPnp));
+        m_queryGrids.emplace_back(p.exteriorRing(), p.interiorRings());
     }
 
     for (const auto& entry : m_overlaps)
@@ -810,8 +802,8 @@ void EptReader::process(PointView& dst, PointRef& pr, const uint64_t nodeId,
         if (m_queryGrids.empty())
             return true;
 
-        for (auto& grid: m_queryGrids)
-            if (grid->inside(x,y))
+        for (const auto& grid : m_queryGrids)
+            if (grid.inside(x, y))
                 return true;
         return false;
     };
@@ -902,86 +894,105 @@ Dimension::Type EptReader::getCoercedTypeTest(const NL::json& j)
     return getCoercedType(j);
 }
 
-void EptReader::loadNextOverlap()
+struct EptReader::NodeBuffer
 {
-    std::map<Key, uint64_t>::iterator itr = m_overlaps.begin();
-    std::advance(itr, m_nodeId-1);
-    Key key(itr->first);
-    log()->get(LogLevel::Debug)
-        << "Streaming Data " << m_nodeId << "/" << m_overlaps.size() << ": "
-        << key.toString() << std::endl;
+    NodeBuffer(PointLayout& layout) : table(layout), view(table) { }
+    VectorPointTable table;
+    PointView view;
+};
 
-    uint64_t startId(0);
+void EptReader::load()
+{
+    // Asynchronously trigger the fetching and point-view execution of
+    // a lookahead buffer of nodes.
+    while (
+        m_upcomingNodeBuffers.size() < streamNodeCount &&
+        m_overlapIt != m_overlaps.end())
+    {
+        const auto nodeId(m_nodeId++);
+        const auto key(m_overlapIt->first);
+        ++m_overlapIt;
 
-    // Reset PointTable to make sure all points from previous tile are flushed.
-    m_bufferPointTable.reset(new PointTable());
+        log()->get(LogLevel::Debug) << nodeId << "/" << m_overlaps.size() <<
+            std::endl;
 
-    // We did reset PointTable,
-    // So it will not have the dimensions registered to it.
-    // Register/Restore Dimensions for PointTable layout.
-    PointLayoutPtr layout = m_bufferPointTable->layout();
-    for (auto id : m_bufferLayout->dims())
-        layout->registerOrAssignDim(m_bufferLayout->dimName(id),
-                                    m_bufferLayout->dimType(id));
+        // Insert an empty placeholder node to keep track of the outstanding
+        // nodes that are currently being fetched/executed.
+        std::unique_lock<std::mutex> lock(m_mutex);
+        auto& loadingBuffer = m_upcomingNodeBuffers[nodeId];
+        lock.unlock();
 
-    // Reset PointView to have new point table.
-    m_bufferPointView.reset(new PointView(*m_bufferPointTable));
+        m_pool->add([this, &loadingBuffer, nodeId, key]()
+        {
+            std::unique_ptr<NodeBuffer> nodeBuffer(
+                new NodeBuffer(*m_remoteLayout));
 
-    if (m_info->dataType() == EptInfo::DataType::Laszip)
-        startId = readLaszip(*m_bufferPointView, key, m_nodeId);
-    else
-        startId = readBinary(*m_bufferPointView, key, m_nodeId);
+            if (m_info->dataType() == EptInfo::DataType::Laszip)
+                readLaszip(nodeBuffer->view, key, nodeId);
+            else
+                readBinary(nodeBuffer->view, key, nodeId);
 
-    log()->get(LogLevel::Debug) << "Points : "<< m_bufferPointView->size() <<
-        std::endl;
-    m_currentIndex = 0;
+            for (const auto& addon : m_addons)
+                readAddon(nodeBuffer->view, key, *addon);
 
-    // Read addon information after the native data, we'll possibly
-    // overwrite attributes.
-    for (const auto& addon : m_addons)
-        readAddon(*m_bufferPointView, key, *addon, startId);
+            loadingBuffer = std::move(nodeBuffer);
 
-    m_nodeId++;
+            // A node has been populated - notify our consumer thread.
+            m_cv.notify_one();
+        });
+    }
 }
 
-
-void EptReader::fillPoint(PointRef& point)
+bool EptReader::next()
 {
-    DimTypeList dims = m_bufferPointView->dimTypes();
-    m_bufferPointView->getPackedPoint(dims, m_currentIndex,
-        m_temp_buffer.data());
-    point.setPackedData(dims, m_temp_buffer.data());
-    m_currentIndex++;
-}
+    // Asynchronously trigger the loading of some nodes.
+    load();
 
+    // Now wait for a node to be populated, or for there to be no outstanding
+    // nodes left, in which case we're all done.
+    std::unique_lock<std::mutex> lock(m_mutex);
+    m_cv.wait(lock, [this]()
+    {
+        return m_upcomingNodeBuffers.empty() ||
+            std::any_of(
+                m_upcomingNodeBuffers.begin(),
+                m_upcomingNodeBuffers.end(),
+                [this](const NodeBufferPair& p) { return !!p.second; });
+    });
+
+    // Processing is complete.
+    if (m_upcomingNodeBuffers.empty()) return false;
+
+    // We know at least one node is populated from our `wait` predicate, so find
+    // the first one and transfer it out of our `upcoming` pool to make it the
+    // current active node.
+    const auto it = std::find_if(
+        m_upcomingNodeBuffers.begin(),
+        m_upcomingNodeBuffers.end(),
+        [](const NodeBufferPair& p) { return !!p.second; }
+    );
+
+    m_pointId = 0;
+    m_currentNodeBuffer = std::move(it->second);
+    m_upcomingNodeBuffers.erase(it);
+
+    return true;
+}
 
 bool EptReader::processOne(PointRef& point)
 {
-    // bufferView is not set if no tile has been read and
-    // currentIndex will be greater or equal to the view size when the
-    // whole tile has been read
-    bool finishedCurrentOverlap = !(m_bufferPointView &&
-        m_currentIndex < m_bufferPointView->size());
+    if (!m_currentNodeBuffer && !next()) return false;
 
-    // We're done with all overlaps, Its time to finish reading.
-    if (m_nodeId > m_overlaps.size() && finishedCurrentOverlap)
-        return false;
+    point.setPackedData(
+        m_remoteLayout->dimTypes(),
+        m_currentNodeBuffer->view.getPoint(m_pointId));
 
-    // Either this is a first overlap or we've streamed all points
-    // from current overlap. So its time to load new overlap.
-    if (finishedCurrentOverlap)
-        loadNextOverlap();
-
-    // In some rare cases there are 0 points in the overlap.
-    // If this happen, fillPoint() will crash while retriving point information.
-    // In that case proceed to load next overlap.
-    if (m_bufferPointView->size())
-        fillPoint(point);
-    else
-        return processOne(point);
+    if (++m_pointId == m_currentNodeBuffer->view.size())
+    {
+        m_currentNodeBuffer = nullptr;
+    }
 
     return true;
 }
 
 } // namespace pdal
-

--- a/io/EptReader.cpp
+++ b/io/EptReader.cpp
@@ -992,11 +992,15 @@ bool EptReader::processOne(PointRef& point)
         if (m_currentNodeBuffer->view.empty()) m_currentNodeBuffer.reset();
     }
 
+    auto& sourceView(m_currentNodeBuffer->view);
+    const auto& layout(*m_currentNodeBuffer->table.layout());
+
     for (const auto& id : m_currentNodeBuffer->table.layout()->dims())
     {
         point.setField(
             id,
-            m_currentNodeBuffer->view.getFieldAs<double>(id, m_pointId));
+            layout.dimType(id),
+            sourceView.getPoint(m_pointId) + layout.dimOffset(id));
     }
 
     if (++m_pointId == m_currentNodeBuffer->view.size())

--- a/io/EptReader.cpp
+++ b/io/EptReader.cpp
@@ -527,6 +527,8 @@ void EptReader::addDimensions(PointLayoutPtr layout)
 
 void EptReader::ready(PointTableRef table)
 {
+    m_userLayout = table.layout();
+
     // These may not exist, in general they are only needed to track point
     // origins and ordering for an EPT writer.
     m_nodeIdDim = table.layout()->findDim("EptNodeId");
@@ -680,7 +682,8 @@ PointViewSet EptReader::run(PointViewPtr view)
 
     for (auto& p : m_args->m_polys)
     {
-        m_queryGrids.emplace_back(p.exteriorRing(), p.interiorRings());
+        m_queryGrids.emplace_back(
+            new GridPnp(p.exteriorRing(), p.interiorRings()));
     }
 
     for (const auto& entry : m_overlaps)
@@ -802,16 +805,13 @@ void EptReader::process(PointView& dst, PointRef& pr, const uint64_t nodeId,
             return true;
 
         for (const auto& grid : m_queryGrids)
-            if (grid.inside(x, y))
+            if (grid->inside(x, y))
                 return true;
         return false;
     };
 
     if (selected && m_queryBounds.contains(x, y, z) && passesPolyFilter(x, y))
     {
-        // If we were given polys, check that our point is inside those
-        // polygons too.
-
         dst.setField(Dimension::Id::X, dstId, x);
         dst.setField(Dimension::Id::Y, dstId, y);
         dst.setField(Dimension::Id::Z, dstId, z);
@@ -924,7 +924,7 @@ void EptReader::load()
         m_pool->add([this, &loadingBuffer, nodeId, key]()
         {
             std::unique_ptr<NodeBuffer> nodeBuffer(
-                new NodeBuffer(*m_remoteLayout));
+                new NodeBuffer(*m_userLayout));
 
             if (m_info->dataType() == EptInfo::DataType::Laszip)
                 readLaszip(nodeBuffer->view, key, nodeId);
@@ -993,9 +993,12 @@ bool EptReader::processOne(PointRef& point)
         if (m_currentNodeBuffer->view.empty()) m_currentNodeBuffer.reset();
     }
 
-    point.setPackedData(
-        m_remoteLayout->dimTypes(),
-        m_currentNodeBuffer->view.getPoint(m_pointId));
+    for (const auto& id : m_currentNodeBuffer->table.layout()->dims())
+    {
+        point.setField(
+            id,
+            m_currentNodeBuffer->view.getFieldAs<double>(id, m_pointId));
+    }
 
     if (++m_pointId == m_currentNodeBuffer->view.size())
     {

--- a/io/EptReader.cpp
+++ b/io/EptReader.cpp
@@ -966,13 +966,11 @@ bool EptReader::next()
             findBuffer() != m_upcomingNodeBuffers.end();
     });
 
-    // Processing is complete.
-    if (m_upcomingNodeBuffers.empty()) return false;
-
-    // We know at least one node is populated from our `wait` predicate, so find
-    // the first one and transfer it out of our `upcoming` pool to make it the
-    // current active node.
+    // Grab the first completed buffer from our list and transfer it out of our
+    // `upcoming` pool to make it the current active node.  If there are no
+    // completed buffers in the list, then we're done with processing.
     const auto it = findBuffer();
+    if (it == m_upcomingNodeBuffers.end()) return false;
 
     m_pointId = 0;
     m_currentNodeBuffer = std::move(it->second);

--- a/io/EptReader.hpp
+++ b/io/EptReader.hpp
@@ -131,7 +131,7 @@ private:
     std::unique_ptr<Args> m_args;
 
     BOX3D m_queryBounds;
-    std::vector<GridPnp> m_queryGrids;
+    std::vector<std::unique_ptr<GridPnp>> m_queryGrids;
     int64_t m_queryOriginId = -1;
     std::unique_ptr<Pool> m_pool;
     std::vector<std::unique_ptr<Addon>> m_addons;
@@ -156,6 +156,8 @@ private:
     Dimension::Id m_pointIdDim = Dimension::Id::Unknown;
 
     // The below are for streaming operation only.
+    PointLayout* m_userLayout = nullptr;
+
     struct NodeBuffer;
     using NodeBufferMap = std::map<uint64_t, std::unique_ptr<NodeBuffer>>;
     using NodeBufferIt = NodeBufferMap::const_iterator;

--- a/io/EptReader.hpp
+++ b/io/EptReader.hpp
@@ -36,8 +36,12 @@
 
 #include <array>
 #include <condition_variable>
+#include <list>
+#include <map>
 #include <memory>
 #include <mutex>
+#include <string>
+#include <vector>
 
 #include <pdal/JsonFwd.hpp>
 #include <pdal/Polygon.hpp>
@@ -111,9 +115,8 @@ private:
 
     // For streaming operation.
     struct NodeBuffer;
-    using NodeBufferMap = std::map<uint64_t, std::unique_ptr<NodeBuffer>>;
-    using NodeBufferIt = NodeBufferMap::iterator;
-    using NodeBufferPair = NodeBufferMap::value_type;
+    using NodeBufferList = std::list<std::unique_ptr<NodeBuffer>>;
+    using NodeBufferIt = NodeBufferList::iterator;
 
     virtual bool processOne(PointRef& point) override;
     void load();    // Asynchronously fetch EPT nodes for streaming use.
@@ -167,7 +170,7 @@ private:
     // These represent a lookahead of asynchronously loaded nodes, when we have
     // finished processing a streaming node we will wait for something to be
     // loaded here.
-    NodeBufferMap m_upcomingNodeBuffers;
+    NodeBufferList m_upcomingNodeBuffers;
 
     // This is the node we are currently processing in streaming mode, which is
     // plucked out of our upcoming node buffers when we have finished our

--- a/io/EptReader.hpp
+++ b/io/EptReader.hpp
@@ -109,10 +109,16 @@ private:
     static Dimension::Type getRemoteTypeTest(const NL::json& dimInfo);
     static Dimension::Type getCoercedTypeTest(const NL::json& dimInfo);
 
-    // For streamable pipeline.
+    // For streaming operation.
+    struct NodeBuffer;
+    using NodeBufferMap = std::map<uint64_t, std::unique_ptr<NodeBuffer>>;
+    using NodeBufferIt = NodeBufferMap::iterator;
+    using NodeBufferPair = NodeBufferMap::value_type;
+
     virtual bool processOne(PointRef& point) override;
     void load();    // Asynchronously fetch EPT nodes for streaming use.
     bool next();    // Acquire an already-fetched node for processing.
+    NodeBufferIt findBuffer();  // Find a fully acquired node.
 
     // Data fetching - these forward user-specified query/header params.
     std::string get(std::string path) const;
@@ -157,11 +163,6 @@ private:
 
     // The below are for streaming operation only.
     PointLayout* m_userLayout = nullptr;
-
-    struct NodeBuffer;
-    using NodeBufferMap = std::map<uint64_t, std::unique_ptr<NodeBuffer>>;
-    using NodeBufferIt = NodeBufferMap::const_iterator;
-    using NodeBufferPair = NodeBufferMap::value_type;
 
     // These represent a lookahead of asynchronously loaded nodes, when we have
     // finished processing a streaming node we will wait for something to be

--- a/io/private/EptSupport.hpp
+++ b/io/private/EptSupport.hpp
@@ -308,6 +308,32 @@ protected:
     }
 };
 
+class PDAL_DLL VectorPointTable : public SimplePointTable
+{
+public:
+    VectorPointTable(PointLayout& layout) : SimplePointTable(layout) { }
+    virtual bool supportsView() const override { return true; }
+    void clear() { m_buffer.clear(); }
+    std::size_t numPoints() const
+    {
+        return m_buffer.size() / m_layoutRef.pointSize();
+    }
+
+protected:
+    virtual PointId addPoint() override
+    {
+        m_buffer.resize(m_buffer.size() + m_layoutRef.pointSize(), 0);
+        return numPoints() - 1;
+    }
+
+    virtual char* getPoint(PointId id) override
+    {
+        return m_buffer.data() + pointsToBytes(id);
+    }
+
+    std::vector<char> m_buffer;
+};
+
 class PDAL_DLL ShallowPointTable : public BasePointTable
 {
     // PointTable semantics around a raw buffer of data matching the specified


### PR DESCRIPTION
The current streaming implementation for the EPT reader (#2603) is synchronous, so it is many times slower than the non-streaming version which loads many buffers at once.  This PR adds asynchronous look-ahead buffering to the streaming mode of the EPT reader (the number of which respects the existing `threads` option) which is significantly faster.

The diff is very noisy since it replaces the existing implementation - the relevant bits are `load`, `next`, and `processOne` in the EPT reader.