### PR TITLE
JSON fixes in documentation codeblocks

### DIFF
--- a/doc/pipeline.rst
+++ b/doc/pipeline.rst
@@ -129,7 +129,7 @@ files from a single pipeline.  The crop filter creates two output point views
       "input.las",
       {
           "type" : "filters.crop",
-          "bounds" : [ "([0, 75], [0, 75])", "([50, 125], [50, 125])" ],
+          "bounds" : [ "([0, 75], [0, 75])", "([50, 125], [50, 125])" ]
       },
       "output#.las"
   ]

--- a/doc/python.rst
+++ b/doc/python.rst
@@ -73,15 +73,14 @@ results as `Numpy`_ arrays:
 
 
     json = """
-    {
-      "pipeline": [
+    [
         "1.2-with-color.las",
         {
             "type": "filters.sort",
             "dimension": "X"
         }
-      ]
-    }"""
+    ]
+    """
 
     import pdal
     pipeline = pdal.Pipeline(json)

--- a/doc/python.rst
+++ b/doc/python.rst
@@ -74,7 +74,7 @@ results as `Numpy`_ arrays:
 
     json = """
     {
-      [
+      "pipeline": [
         "1.2-with-color.las",
         {
             "type": "filters.sort",

--- a/doc/stages/filters.chipper.rst
+++ b/doc/stages/filters.chipper.rst
@@ -46,7 +46,7 @@ Example
       "example.las",
       {
           "type":"filters.chipper",
-          "capacity":"400",
+          "capacity":"400"
       },
       {
           "type":"writers.pgpointcloud",

--- a/doc/stages/filters.merge.rst
+++ b/doc/stages/filters.merge.rst
@@ -50,7 +50,7 @@ contains the points in "utm3.las".
 .. code-block:: json
 
   [
-      "utm1.las"
+      "utm1.las",
       "utm2.las",
       "utm3.las",
       "out#.las"
@@ -65,7 +65,7 @@ and "utm2.las", while "out2.las" contains the points from "utm3.las".
 .. code-block:: json
 
   [
-      "utm1.las"
+      "utm1.las",
       "utm2.las",
       {
           "type" : "filters.merge"

--- a/doc/stages/filters.miniball.rst
+++ b/doc/stages/filters.miniball.rst
@@ -41,7 +41,7 @@ outlier.
       {
           "type":"filters.miniball",
           "knn":8
-      }
+      },
       "output.laz"
   ]
 

--- a/doc/stages/filters.planefit.rst
+++ b/doc/stages/filters.planefit.rst
@@ -43,7 +43,7 @@ outlier.
       {
           "type":"filters.planefit",
           "knn":8
-      }
+      },
       "output.laz"
   ]
 

--- a/doc/stages/filters.shell.rst
+++ b/doc/stages/filters.shell.rst
@@ -55,7 +55,7 @@ command to construct overview bands for the data using average interpolation.
         {
           "type":"filters.shell",
           "command" : "gdaladdo -r average output-2m.tif 2 4 8 16"
-        }
+        },
         {
           "type":"filters.shell",
           "command" : "gdaladdo -r average output-5m.tif 2 4 8 16"

--- a/doc/stages/readers.gdal.rst
+++ b/doc/stages/readers.gdal.rst
@@ -48,8 +48,7 @@ RGB values of an `ASPRS LAS`_ file using :ref:`writers.las`.
       {
           "type":"readers.gdal",
           "filename":"./pdal/test/data/autzen/autzen.jpg",
-          "header", "Red, Green, Blue"
-
+          "header": "Red, Green, Blue"
       },
       {
           "type":"writers.text",

--- a/doc/stages/readers.las.rst
+++ b/doc/stages/readers.las.rst
@@ -63,7 +63,7 @@ Example
       },
       {
           "type":"writers.text",
-          "filename":"outputfile.txt",
+          "filename":"outputfile.txt"
       }
   ]
 

--- a/doc/stages/readers.pgpointcloud.rst
+++ b/doc/stages/readers.pgpointcloud.rst
@@ -25,7 +25,7 @@ Example
           "table":"lidar",
           "column":"pa",
           "spatialreference":"EPSG:26910",
-          "where":"PC_Intersects(pa, ST_MakeEnvelope(560037.36, 5114846.45, 562667.31, 5118943.24, 26910))",
+          "where":"PC_Intersects(pa, ST_MakeEnvelope(560037.36, 5114846.45, 562667.31, 5118943.24, 26910))"
       },
       {
           "type":"writers.text",

--- a/doc/stages/readers.tindex.rst
+++ b/doc/stages/readers.tindex.rst
@@ -43,7 +43,7 @@ merge the data.
           "type":"readers.tindex",
           "filter_srs":"+proj=lcc +lat_1=43 +lat_2=45.5 +lat_0=41.75 +lon_0=-120.5 +x_0=399999.9999999999 +y_0=0 +ellps=GRS80 +units=ft +no_defs",
           "filename":"index.sqlite",
-          "where":"location LIKE \'%nteresting.las%\'",
+          "where":"location LIKE \"%nteresting.las%\"",
           "wkt":"POLYGON ((635629.85000000 848999.70000000, 635629.85000000 853535.43000000, 638982.55000000 853535.43000000, 638982.55000000 848999.70000000, 635629.85000000 848999.70000000))"
       },
       {

--- a/doc/stages/readers.tindex.rst
+++ b/doc/stages/readers.tindex.rst
@@ -43,7 +43,7 @@ merge the data.
           "type":"readers.tindex",
           "filter_srs":"+proj=lcc +lat_1=43 +lat_2=45.5 +lat_0=41.75 +lon_0=-120.5 +x_0=399999.9999999999 +y_0=0 +ellps=GRS80 +units=ft +no_defs",
           "filename":"index.sqlite",
-          "where":"location LIKE \"%nteresting.las%\"",
+          "where":"location LIKE \'%nteresting.las%\'",
           "wkt":"POLYGON ((635629.85000000 848999.70000000, 635629.85000000 853535.43000000, 638982.55000000 853535.43000000, 638982.55000000 848999.70000000, 635629.85000000 848999.70000000))"
       },
       {

--- a/doc/stages/writers.bpf.rst
+++ b/doc/stages/writers.bpf.rst
@@ -19,7 +19,7 @@ Example
 
   [
       {
-          "type":"readers.bpf"
+          "type":"readers.bpf",
           "filename":"inputfile.las"
       },
       {

--- a/doc/stages/writers.e57.rst
+++ b/doc/stages/writers.e57.rst
@@ -40,7 +40,7 @@ Example
       {
           "type":"writers.e57",
           "filename":"outputfile.e57",
-	  "doublePrecision":false
+	        "doublePrecision":false
       }
   ]
 

--- a/doc/stages/writers.fbx.rst
+++ b/doc/stages/writers.fbx.rst
@@ -36,7 +36,7 @@ Example
 
   [
       {
-          "type":"readers.las"
+          "type":"readers.las",
           "filename":"inputfile.las"
       },
       {

--- a/doc/stages/writers.null.rst
+++ b/doc/stages/writers.null.rst
@@ -24,7 +24,7 @@ Example
           "type":"filters.hexbin"
       },
       {
-          "type":"writers.null",
+          "type":"writers.null"
       }
   ]
 


### PR DESCRIPTION
Several JSON code snippets in the documentation were not valid, i fixed them. Trailing commas on the last entry was the most common problem, which the JSON specification does not allow. 