### PR TITLE
Remove E57 dependency from PDAL plugin headers

### DIFF
--- a/plugins/e57/CMakeLists.txt
+++ b/plugins/e57/CMakeLists.txt
@@ -49,8 +49,5 @@ if (WITH_TESTS)
         LINK_WITH
             ${e57plugin_reader}
             ${e57plugin_writer}
-            E57Format
-            ${XercesC_LIBRARY}
             )
-    target_include_directories(pdal_io_e57_write_test PRIVATE "libE57Format/include")
 endif()

--- a/plugins/e57/io/E57Reader.hpp
+++ b/plugins/e57/io/E57Reader.hpp
@@ -100,7 +100,7 @@ public:
     std::set<std::string> getDimensions();
 
     /// returns the scans
-   std::vector<std::shared_ptr<e57::Scan>> getScans() const;
+    std::vector<std::shared_ptr<e57::Scan>> getScans() const;
 
 private:
 

--- a/plugins/e57/io/E57Reader.hpp
+++ b/plugins/e57/io/E57Reader.hpp
@@ -88,7 +88,7 @@ public:
     E57Reader(const E57Reader &) = delete;
     E57Reader& operator=(const E57Reader&) = delete;
 
-    std::string getName() const;
+    std::string getName() const override;
 
     /// Get the total number of points in the scan
     point_count_t getNumberPoints() const;
@@ -105,11 +105,11 @@ public:
 private:
 
     /* Pdal section */
-    virtual void addDimensions(PointLayoutPtr layout);
-    virtual void initialize();
-    virtual bool processOne(PointRef& point);
-    virtual point_count_t read(PointViewPtr view, point_count_t count);
-    virtual QuickInfo inspect();
+    virtual void addDimensions(PointLayoutPtr layout) override;
+    virtual void initialize() override;
+    virtual bool processOne(PointRef& point) override;
+    virtual point_count_t read(PointViewPtr view, point_count_t count) override;
+    virtual QuickInfo inspect() override;
 
     void openFile(const std::string &filename);
     void closeFile();

--- a/plugins/e57/io/E57Reader.hpp
+++ b/plugins/e57/io/E57Reader.hpp
@@ -34,55 +34,30 @@
 
 #pragma once
 
-#include <string>
-
 #include <pdal/pdal_types.hpp>
-#include <E57Format.h>
 #include <pdal/Reader.hpp>
 #include <pdal/Streamable.hpp>
 
-#include "Scan.hpp"
+#include <memory>
+#include <set>
+#include <string>
+#include <vector>
+
+namespace e57
+{
+class ImageFile;
+class Scan;
+}
 
 namespace pdal
 {
 
 class PDAL_DLL E57Reader: public Reader, public Streamable
 {
-    class PDAL_DLL ChunkReader {
-    public:
-        ChunkReader(const point_count_t &pointOffset,
-            const point_count_t &maxPointRead,
-            const std::shared_ptr<e57::Scan> &scan,
-            const std::set<std::string> &e57Dimensions);
-
-        ~ChunkReader();
-
-        // returns false if the index falls out of the
-        // [pointOffset,pointOffset + m_maxPointRead] interval
-        bool isInScope(point_count_t index) const;
-
-        bool isInChunk(point_count_t index) const;
-
-        void setPoint(point_count_t pointIndex, PointRef point) const;
-
-        // Reads a new chunk of data
-        point_count_t read(point_count_t index);
-
-    private:
-        point_count_t m_startIndex;
-        point_count_t m_pointOffset;
-        point_count_t m_maxPointRead;
-        const point_count_t m_defaultChunkSize;
-        std::map<std::string, std::vector<double>> m_doubleBuffers;
-        std::vector<e57::SourceDestBuffer> m_e57buffers;
-        std::unique_ptr<e57::CompressedVectorReader> m_dataReader;
-        std::shared_ptr<e57::Scan> m_scan;
-    };
+    class PDAL_LOCAL ChunkReader;
 
 public:
-    E57Reader()
-    {}
-
+    E57Reader();
     E57Reader(std::string filename);
     ~E57Reader();
     E57Reader(const E57Reader &) = delete;

--- a/plugins/e57/io/E57Writer.cpp
+++ b/plugins/e57/io/E57Writer.cpp
@@ -33,6 +33,7 @@
 ****************************************************************************/
 
 #include <pdal/util/Algorithm.hpp>
+#include <E57Format.h>
 
 #include "E57Writer.hpp"
 #include "Utils.hpp"
@@ -49,6 +50,24 @@ static StaticPluginInfo const s_info
 };
 
 CREATE_SHARED_STAGE(E57Writer, s_info)
+
+class E57Writer::ChunkWriter
+{
+public:
+    ChunkWriter(const std::vector<std::string> &dimensionsToWrite,
+        e57::CompressedVectorNode &vectorNode);
+
+    void write(pdal::PointRef &point);
+
+    void finalise();
+
+private:
+    const pdal::point_count_t m_defaultChunkSize;
+    pdal::point_count_t m_currentIndex;
+    std::map<std::string, std::vector<double>> m_doubleBuffers;
+    std::vector<e57::SourceDestBuffer> m_e57buffers;
+    std::unique_ptr<e57::CompressedVectorWriter> m_dataWriter;
+};
 
 E57Writer::ChunkWriter::ChunkWriter
 (const std::vector<std::string>& dimensionsToWrite,

--- a/plugins/e57/io/E57Writer.hpp
+++ b/plugins/e57/io/E57Writer.hpp
@@ -67,15 +67,15 @@ public:
     E57Writer(const E57Writer &) = delete;
     E57Writer& operator=(const E57Writer&) = delete;
 
-    std::string getName() const;
+    std::string getName() const override;
 
 private:
-    virtual void addArgs(ProgramArgs &args);
-    virtual void initialize();
-    virtual bool processOne(PointRef & point);
-    virtual void ready(PointTableRef table);
-    virtual void write(const PointViewPtr view);
-    virtual void done(PointTableRef table);
+    virtual void addArgs(ProgramArgs &args) override;
+    virtual void initialize() override;
+    virtual bool processOne(PointRef & point) override;
+    virtual void ready(PointTableRef table) override;
+    virtual void write(const PointViewPtr view) override;
+    virtual void done(PointTableRef table) override;
 
     void setupFileHeader();
 

--- a/plugins/e57/io/E57Writer.hpp
+++ b/plugins/e57/io/E57Writer.hpp
@@ -35,31 +35,25 @@
 #pragma once
 
 #include <pdal/pdal_types.hpp>
-#include <E57Format.h>
 #include <pdal/Writer.hpp>
 #include <pdal/Streamable.hpp>
+#include <pdal/util/Bounds.hpp>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace e57
+{
+class ImageFile;
+class StructureNode;
+}
 
 namespace pdal
 {
-class PDAL_DLL E57Writer : public pdal::Writer, public pdal::Streamable 
+class PDAL_DLL E57Writer : public pdal::Writer, public pdal::Streamable
 {
-
-    class PDAL_DLL ChunkWriter {
-    public:
-        ChunkWriter(const std::vector<std::string> &dimensionsToWrite,
-            e57::CompressedVectorNode &vectorNode);
-
-        void write(pdal::PointRef &point);
-
-        void finalise();
-
-    private:
-        const pdal::point_count_t m_defaultChunkSize;
-        pdal::point_count_t m_currentIndex;
-        std::map<std::string, std::vector<double>> m_doubleBuffers;
-        std::vector<e57::SourceDestBuffer> m_e57buffers;
-        std::unique_ptr<e57::CompressedVectorWriter> m_dataWriter;
-    };
+    class PDAL_LOCAL ChunkWriter;
 
 public:
     E57Writer();

--- a/plugins/e57/io/Scan.hpp
+++ b/plugins/e57/io/Scan.hpp
@@ -34,16 +34,24 @@
 
 #pragma once
 
-#include <pdal/pdal_types.hpp>
-#include <pdal/Writer.hpp>
-#include <pdal/Dimension.hpp>
 #include <E57Format.h>
+
+#include <pdal/Dimension.hpp>
+#include <pdal/pdal_types.hpp>
+#include <pdal/PointRef.hpp>
+#include <pdal/util/Bounds.hpp>
+#include <pdal/util/pdal_util_export.hpp>
+
+#include <array>
+#include <map>
+#include <set>
+#include <string>
+#include <utility>
 
 namespace e57
 {
 class PDAL_DLL Scan
 {
-
 public:
     Scan(const e57::StructureNode& scanNode);
 

--- a/plugins/e57/io/Utils.cpp
+++ b/plugins/e57/io/Utils.cpp
@@ -36,6 +36,8 @@
 
 #include "Utils.hpp"
 
+#include <E57Format.h>
+
 namespace pdal
 {
 namespace e57plugin

--- a/plugins/e57/io/Utils.hpp
+++ b/plugins/e57/io/Utils.hpp
@@ -34,10 +34,18 @@
 
 #pragma once
 
-#include <string>
-#include <E57Format.h>
 #include <pdal/Dimension.hpp>
 #include <pdal/pdal_export.hpp>
+#include <pdal/pdal_types.hpp>
+
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace e57
+{
+class StructureNode;
+}
 
 namespace pdal
 {

--- a/plugins/e57/io/Uuid.cpp
+++ b/plugins/e57/io/Uuid.cpp
@@ -34,6 +34,10 @@
 
 #include "Uuid.hpp"
 
+#include <ios>
+#include <random>
+#include <sstream>
+
 namespace pdal {
     namespace uuidGenerator {
 unsigned char random_char()

--- a/plugins/e57/io/Uuid.hpp
+++ b/plugins/e57/io/Uuid.hpp
@@ -34,13 +34,6 @@
 
 #pragma once
 
-#include <vector>
-#include <iostream>
-#include <sstream>
-#include <random>
-#include <climits>
-#include <algorithm>
-#include <functional>
 #include <string>
 #include <pdal/pdal_export.hpp>
 

--- a/plugins/e57/test/E57ReaderTest.cpp
+++ b/plugins/e57/test/E57ReaderTest.cpp
@@ -36,6 +36,7 @@
 #include "Support.hpp"
 
 #include "plugins/e57/io/E57Reader.hpp"
+#include "plugins/e57/io/Scan.hpp"
 #include "plugins/e57/io/Utils.hpp"
 
 using namespace pdal;


### PR DESCRIPTION
As discussed with @abellgithub in #2707 the E57 reader/writer plugins included the E57Format library in the public headers and therefore required clients and tests to link against this library. In this PR I removed the depedencies on the E57Format library as much as possible (hopefully) without any major changes to functions exported by the plugins.

The only change I've (intentionally) made is that the (already previously) `private` internal classes `ChunkReader` & `ChunkWriter` are now only forward declared in header files and marked with `PDAL_LOCAL`. These classes depend on E57 library types and were therefore removed from the headers.

This change allows to remove the dependency on the E57Format library for the writer test. The dependency remains for the reader test, since this test uses the publicly exported `e57::Scan` class to directly access E57 types in the tests.
For users of the plugins (`E57Reader` & `E57Writer`) a dependency on `e57::Scan` and therefore the E57Format library is not required as long as scans stored in E57 are not accessed individually.

I ran the corresponding tests successfully on my computer (Ubuntu Bionic with Clang 8). For the tests I've built all e57 code (both plugins and the E57Format library) with default and inline visibility set to `hidden`. After removing all tests that required `e57::Scan` both tests could be built, linked and ran successfully *without* linking to E57Format.