### PR TITLE
cache TileDB attributes and remove extraneous call to schema

### DIFF
--- a/plugins/tiledb/io/TileDBWriter.cpp
+++ b/plugins/tiledb/io/TileDBWriter.cpp
@@ -241,9 +241,12 @@ void TileDBWriter::ready(pdal::BasePointTable &table)
         m_array.reset(new tiledb::Array(*m_ctx, m_arrayName, TILEDB_WRITE));
     }
     
+    auto attrs = m_array->schema->attributes();
+
     for (const auto& d : all)
     {
         std::string dimName = layout->dimName(d);
+
         if ((dimName != "X") && (dimName != "Y") && (dimName != "Z"))
         {
             Dimension::Type type = layout->dimType(d);
@@ -257,7 +260,6 @@ void TileDBWriter::ready(pdal::BasePointTable &table)
             else
             {
                 // check attribute exists in original tiledb array
-                auto attrs = m_array->schema().attributes();
                 auto it = attrs.find(dimName);
                 if (it == attrs.end())
                     throwError("Attribute " + dimName + " does not exist in original array.");
@@ -284,7 +286,6 @@ void TileDBWriter::ready(pdal::BasePointTable &table)
 
 bool TileDBWriter::processOne(PointRef& point)
 {
-    auto attrs = m_array->schema().attributes();
     double x = point.getFieldAs<double>(Dimension::Id::X);
     double y = point.getFieldAs<double>(Dimension::Id::Y);
     double z = point.getFieldAs<double>(Dimension::Id::Z);

--- a/plugins/tiledb/io/TileDBWriter.cpp
+++ b/plugins/tiledb/io/TileDBWriter.cpp
@@ -241,7 +241,7 @@ void TileDBWriter::ready(pdal::BasePointTable &table)
         m_array.reset(new tiledb::Array(*m_ctx, m_arrayName, TILEDB_WRITE));
     }
     
-    auto attrs = m_array->schema->attributes();
+    auto attrs = m_array->schema().attributes();
 
     for (const auto& d : all)
     {


### PR DESCRIPTION
Reviewing the `processOne` code there is a call to retrieve attributes that isn't required, this PR removes that and also caches the fetch of the attributes during the schema check in the `ready` function.