### PR TITLE
Add a_srs, t_srs, and default_srs hidden options to 'pdal info'

### DIFF
--- a/kernels/InfoKernel.hpp
+++ b/kernels/InfoKernel.hpp
@@ -84,6 +84,10 @@ private:
     bool m_showSummary;
     bool m_needPoints;
     bool m_usestdin;
+    bool m_doReprojection;
+    std::string m_outSRS;
+    std::string m_inSRS;
+    std::string m_defaultSRS;
 
     Stage *m_statsStage;
     Stage *m_hexbinStage;


### PR DESCRIPTION
It is common to want to see coordinates in a different coordinate system if you are normalizing a bunch of different data to a common coordinate system, and having `pdal info` be able to apply a `filters.reprojection` eliminates a full i/o operation that writes a new file that was reprojected to get coordinate statistics and information. 

Having done this, I can see I'd want `filters.transformation` also, but no other filters are reasonable to inline with `pdal info`. There isn't a need to add a `--json` switch like `pdal translate` has that takes in a generic pipeline.