### PR TITLE
tiledb: use internal array metadata for pipeline serialization

### DIFF
--- a/plugins/tiledb/CMakeLists.txt
+++ b/plugins/tiledb/CMakeLists.txt
@@ -16,6 +16,7 @@ PDAL_ADD_PLUGIN(reader_libname reader tiledb
         ${TILEDB_LIBRARIES}
     INCLUDES
         ${TILEDB_INCLUDE_DIR}
+        ${NLOHMANN_INCLUDE_DIR}
 )
 
 if (WIN32)
@@ -63,6 +64,7 @@ if (BUILD_TILEDB_TESTS)
             test/TileDBReaderTest.cpp
         LINK_WITH
             ${reader_libname}
+            ${writer_libname}
             ${TILEDB_LIBRARIES}
     )
 

--- a/plugins/tiledb/CMakeLists.txt
+++ b/plugins/tiledb/CMakeLists.txt
@@ -43,8 +43,6 @@ endif()
 
 if (WITH_TESTS)
 
-if (BUILD_TILEDB_TESTS)
-
     # Need to fix this #2596
     IF (NOT APPLE)
         PDAL_ADD_TEST(pdal_io_tiledb_writer_test
@@ -73,5 +71,4 @@ if (WIN32)
     target_compile_definitions(pdal_io_tiledb_reader_test PRIVATE -DNONMINMAX)
 endif()
 
-endif()
 endif()

--- a/plugins/tiledb/io/TileDBReader.cpp
+++ b/plugins/tiledb/io/TileDBReader.cpp
@@ -308,9 +308,9 @@ void TileDBReader::localReady()
     {
         tiledb::VFS vfs(*m_ctx, m_ctx->config());
         tiledb::VFS::filebuf fbuf(vfs);
-        std::string metaFName = m_arrayName + pathSeparator + "pdal.json";
+        std::string metaFName = m_filename + pathSeparator + "pdal.json";
 
-        if (vfs.is_dir(m_arrayName))
+        if (vfs.is_dir(m_filename))
         {
             auto nBytes = vfs.file_size(metaFName);
             tiledb::VFS::filebuf fbuf(vfs);

--- a/plugins/tiledb/io/TileDBReader.cpp
+++ b/plugins/tiledb/io/TileDBReader.cpp
@@ -322,7 +322,9 @@ void TileDBReader::localReady()
         }
     }
 
-    if ((meta != nullptr) && (meta["writers.tiledb"].count("spatialreference") > 0))
+    if ((meta != nullptr) &&
+        (meta.count("writers.tiledb") > 0) &&
+        (meta["writers.tiledb"].count("spatialreference") > 0))
     {
         SpatialReference ref(meta["writers.tiledb"]["spatialreference"]);
         setSpatialReference(ref);

--- a/plugins/tiledb/io/TileDBReader.cpp
+++ b/plugins/tiledb/io/TileDBReader.cpp
@@ -34,8 +34,17 @@
 
 #include <algorithm>
 
+#include <nlohmann/json.hpp>
+
 #include "TileDBReader.hpp"
 
+
+const char pathSeparator =
+#ifdef _WIN32
+        '\\';
+#else
+        '/';
+#endif
 namespace pdal {
 
 static PluginInfo const s_info
@@ -281,6 +290,42 @@ void TileDBReader::localReady()
             subarray.push_back(kv.second.second);
         }
         m_query->set_subarray(subarray);
+    }
+
+    // read spatial reference
+    NL::json meta = nullptr;
+
+#if TILEDB_VERSION_MAJOR >= 1 && TILEDB_VERSION_MINOR >= 7
+    tiledb_datatype_t v_type = TILEDB_UINT8; // CPLSerializeXMLTree returns char*
+    const void* v_r;
+    uint32_t v_num;
+    m_array->get_metadata("_pdal", &v_type, &v_num, &v_r);
+    if (v_r != NULL)
+        meta = NL::json::parse(static_cast<const char*>(v_r));
+#endif
+
+    if (meta == nullptr)
+    {
+        tiledb::VFS vfs(*m_ctx, m_ctx->config());
+        tiledb::VFS::filebuf fbuf(vfs);
+        std::string metaFName = m_arrayName + pathSeparator + "pdal.json";
+
+        if (vfs.is_dir(m_arrayName))
+        {
+            auto nBytes = vfs.file_size(metaFName);
+            tiledb::VFS::filebuf fbuf(vfs);
+            fbuf.open(metaFName, std::ios::in);
+            std::istream is(&fbuf);
+            std::string s { std::istreambuf_iterator<char>(is), std::istreambuf_iterator<char>() };
+            fbuf.close();
+            meta = NL::json::parse(s);
+        }
+    }
+
+    if ((meta != nullptr) && (meta.count("spatialreference") > 0))
+    {
+        SpatialReference ref(meta["spatialreference"]);
+        setSpatialReference(ref);
     }
 
     // initialize read buffer variables

--- a/plugins/tiledb/io/TileDBReader.cpp
+++ b/plugins/tiledb/io/TileDBReader.cpp
@@ -296,7 +296,7 @@ void TileDBReader::localReady()
     NL::json meta = nullptr;
 
 #if TILEDB_VERSION_MAJOR >= 1 && TILEDB_VERSION_MINOR >= 7
-    tiledb_datatype_t v_type = TILEDB_UINT8; // CPLSerializeXMLTree returns char*
+    tiledb_datatype_t v_type = TILEDB_UINT8;
     const void* v_r;
     uint32_t v_num;
     m_array->get_metadata("_pdal", &v_type, &v_num, &v_r);

--- a/plugins/tiledb/io/TileDBReader.cpp
+++ b/plugins/tiledb/io/TileDBReader.cpp
@@ -322,9 +322,9 @@ void TileDBReader::localReady()
         }
     }
 
-    if ((meta != nullptr) && (meta.count("spatialreference") > 0))
+    if ((meta != nullptr) && (meta["writers.tiledb"].count("spatialreference") > 0))
     {
-        SpatialReference ref(meta["spatialreference"]);
+        SpatialReference ref(meta["writers.tiledb"]["spatialreference"]);
         setSpatialReference(ref);
     }
 

--- a/plugins/tiledb/io/TileDBWriter.cpp
+++ b/plugins/tiledb/io/TileDBWriter.cpp
@@ -495,7 +495,7 @@ void TileDBWriter::done(PointTableRef table)
                     std::ios::out);
             else
             {
-                std::string fname = m_arrayName + "/pdal.json";
+                std::string fname = m_args->m_arrayName + "/pdal.json";
                 vfs.touch(fname);
                 fbuf.open(fname, std::ios::out);
             }

--- a/plugins/tiledb/io/TileDBWriter.cpp
+++ b/plugins/tiledb/io/TileDBWriter.cpp
@@ -445,7 +445,6 @@ bool TileDBWriter::processOne(PointRef& point)
     m_coords.push_back(x);
     m_coords.push_back(y);
     m_coords.push_back(z);
-    m_bbox.grow(x, y, z);
 
     if (++m_current_idx == m_args->m_cache_size)
     {
@@ -474,49 +473,47 @@ void TileDBWriter::done(PointTableRef table)
 {
     if (flushCache(m_current_idx))
     {
-        // write pipeline metadata sidecar inside array
-        MetadataNode anon;
-        MetadataNode meta("pipeline");
-        anon.addList(meta);
-        // set output to tiledb reader
-        meta.add("type", "readers.tiledb");
-        if (!getSpatialReference().empty() && table.spatialReferenceUnique())
+        if (!m_args->m_append)
         {
-            // The point view takes on the spatial reference of that stage,
-            // if it had one.
-            anon.add("spatialreference", 
-                Utils::toString(getSpatialReference()));
-        }
-        anon.add("bounds", pdal::Utils::toString(m_bbox));
+            // write pipeline metadata sidecar inside array
+            MetadataNode node = getMetadata();
+            if (!getSpatialReference().empty() && table.spatialReferenceUnique())
+            {
+                // The point view takes on the spatial reference of that stage,
+                // if it had one.
+                node.add("spatialreference", 
+                    Utils::toString(getSpatialReference()));
+            }
 
-        // serialize metadata
+            // serialize metadata
 #if TILEDB_VERSION_MAJOR == 1 && TILEDB_VERSION_MINOR < 7
-        tiledb::VFS vfs(*m_ctx, m_ctx->config());
-        tiledb::VFS::filebuf fbuf(vfs);
+            tiledb::VFS vfs(*m_ctx, m_ctx->config());
+            tiledb::VFS::filebuf fbuf(vfs);
 
-        if (vfs.is_dir(m_args->m_arrayName))
-            fbuf.open(m_args->m_arrayName + pathSeparator + "pdal.json",
-                std::ios::out);
-        else
-        {
-            std::string fname = m_arrayName + "/pdal.json";
-            vfs.touch(fname);
-            fbuf.open(fname, std::ios::out);
-        }
+            if (vfs.is_dir(m_args->m_arrayName))
+                fbuf.open(m_args->m_arrayName + pathSeparator + "pdal.json",
+                    std::ios::out);
+            else
+            {
+                std::string fname = m_arrayName + "/pdal.json";
+                vfs.touch(fname);
+                fbuf.open(fname, std::ios::out);
+            }
 
-        std::ostream os(&fbuf);
+            std::ostream os(&fbuf);
 
-        if (!os.good())
-            throwError("Unable to create sidecar file for " +
-                m_args->m_arrayName);
+            if (!os.good())
+                throwError("Unable to create sidecar file for " +
+                    m_args->m_arrayName);
 
-        pdal::Utils::toJSON(anon, os);
+            pdal::Utils::toJSON(node, os);
 
-        fbuf.close();
+            fbuf.close();
 #else
-        std::string m = pdal::Utils::toJSON(anon);
-        m_array->put_metadata("_pdal", TILEDB_UINT8, m.length() + 1, m.c_str());
+            std::string m = pdal::Utils::toJSON(node);
+            m_array->put_metadata("_pdal", TILEDB_UINT8, m.length() + 1, m.c_str());
 #endif
+        }
         m_array->close();
     }
     else{

--- a/plugins/tiledb/io/TileDBWriter.hpp
+++ b/plugins/tiledb/io/TileDBWriter.hpp
@@ -75,7 +75,6 @@ private:
     struct Args;
     std::unique_ptr<TileDBWriter::Args> m_args;
 
-    BOX3D m_bbox;
     size_t m_current_idx;
 
     std::unique_ptr<tiledb::Context> m_ctx;

--- a/plugins/tiledb/test/TileDBReaderTest.cpp
+++ b/plugins/tiledb/test/TileDBReaderTest.cpp
@@ -188,7 +188,6 @@ class TileDBReaderTest : public ::testing::Test
         std::string pth = Support::temppath("tiledb_test_srs");
 
         Options options;
-        std::string sidecar = pth + "/pdal.json";
         options.add("array_name", pth);
         options.add("chunk_size", 80);
 

--- a/plugins/tiledb/test/TileDBReaderTest.cpp
+++ b/plugins/tiledb/test/TileDBReaderTest.cpp
@@ -147,7 +147,6 @@ class TileDBReaderTest : public ::testing::Test
         Options options;
         options.add("array_name", pth);
 
-
         tiledb::Array array(ctx, pth, TILEDB_READ);
         auto domain = array.non_empty_domain<double>();
         std::vector<double> subarray;

--- a/plugins/tiledb/test/TileDBReaderTest.cpp
+++ b/plugins/tiledb/test/TileDBReaderTest.cpp
@@ -40,14 +40,18 @@
 #include <pdal/PointView.hpp>
 #include <pdal/PipelineManager.hpp>
 #include <pdal/StageFactory.hpp>
+#include <io/FauxReader.hpp>
 
 #include "Support.hpp"
 
 #include "../io/TileDBReader.hpp"
+#include "../io/TileDBWriter.hpp"
 
 
 namespace pdal
 {
+
+const SpatialReference utm16("EPSG:26916");
 
 class TileDBReaderTest : public ::testing::Test
 {
@@ -172,6 +176,49 @@ class TileDBReaderTest : public ::testing::Test
         c.setInput(reader);
         c.prepare(table);
         c.execute(table);
+        // test using a sidecar file
+        EXPECT_EQ(reader.getSpatialReference(), utm16);
     }
+
+#if TILEDB_VERSION_MAJOR >= 1 && TILEDB_VERSION_MINOR >= 7
+    TEST_F(TileDBReaderTest, spatial_reference)
+    {
+        tiledb::Context ctx;
+        tiledb::VFS vfs(ctx);
+        std::string pth = Support::temppath("tiledb_test_srs");
+
+        Options options;
+        std::string sidecar = pth + "/pdal.json";
+        options.add("array_name", pth);
+        options.add("chunk_size", 80);
+
+        if (vfs.is_dir(pth))
+        {
+            vfs.remove_dir(pth);
+        }
+
+        FauxReader reader;
+        Options reader_options;
+        reader_options.add("mode", "ramp");
+        reader_options.add("count", 50);
+        reader.addOptions(reader_options);
+
+        TileDBWriter writer;
+        writer.setOptions(options);
+        writer.setInput(reader);
+        writer.setSpatialReference(utm16);
+
+        FixedPointTable table(100);
+        writer.prepare(table);
+        writer.execute(table);
+
+        TileDBReader rdr;
+        rdr.setOptions(options);
+        FixedPointTable table2(100);
+        rdr.prepare(table2);
+        rdr.execute(table2);
+        EXPECT_EQ(rdr.getSpatialReference(), utm16);
+    }
+#endif
 }
 

--- a/plugins/tiledb/test/TileDBWriterTest.cpp
+++ b/plugins/tiledb/test/TileDBWriterTest.cpp
@@ -107,7 +107,6 @@ namespace pdal
 
 #if TILEDB_VERSION_MAJOR == 1 && TILEDB_VERSION_MINOR < 7
         // check the sidecar exists
-        std::string sidecar = pth + "/pdal.json";
         EXPECT_TRUE(pdal::Utils::fileExists(sidecar));
 #else
         tiledb_datatype_t v_type = TILEDB_UINT8;
@@ -185,7 +184,6 @@ namespace pdal
 
 #if TILEDB_VERSION_MAJOR == 1 && TILEDB_VERSION_MINOR < 7
         // check the sidecar exists so that the execute has completed
-        std::string sidecar = pth + "/pdal.json";
         EXPECT_TRUE(pdal::Utils::fileExists(sidecar));
 #else
         tiledb_datatype_t v_type = TILEDB_UINT8;

--- a/plugins/tiledb/test/TileDBWriterTest.cpp
+++ b/plugins/tiledb/test/TileDBWriterTest.cpp
@@ -115,7 +115,7 @@ namespace pdal
         uint32_t v_num;
         array.get_metadata("_pdal", &v_type, &v_num, &v_r);
         NL::json meta = NL::json::parse(static_cast<const char*>(v_r));
-        EXPECT_TRUE(meta.count("pipeline") > 0);
+        EXPECT_TRUE(meta.count("writers.tiledb") > 0);
 #endif
 
         auto domain = array.non_empty_domain<double>();
@@ -193,7 +193,7 @@ namespace pdal
         uint32_t v_num;
         array.get_metadata("_pdal", &v_type, &v_num, &v_r);
         NL::json meta = NL::json::parse(static_cast<const char*>(v_r));
-        EXPECT_TRUE(meta.count("pipeline") > 0);
+        EXPECT_TRUE(meta.count("writers.tiledb") > 0);
 #endif
 
         for (const auto& kv: domain)

--- a/plugins/tiledb/test/TileDBWriterTest.cpp
+++ b/plugins/tiledb/test/TileDBWriterTest.cpp
@@ -114,7 +114,7 @@ namespace pdal
         const void* v_r;
         uint32_t v_num;
         array.get_metadata("_pdal", &v_type, &v_num, &v_r);
-        nlohmann::json meta = nlohmann::json::parse(static_cast<const char*>(v_r));
+        NL::json meta = NL::json::parse(static_cast<const char*>(v_r));
         EXPECT_TRUE(meta.count("pipeline") > 0);
 #endif
 
@@ -192,7 +192,7 @@ namespace pdal
         const void* v_r;
         uint32_t v_num;
         array.get_metadata("_pdal", &v_type, &v_num, &v_r);
-        nlohmann::json meta = nlohmann::json::parse(static_cast<const char*>(v_r));
+        NL::json meta = NL::json::parse(static_cast<const char*>(v_r));
         EXPECT_TRUE(meta.count("pipeline") > 0);
 #endif
 

--- a/test/data/tiledb/array/pdal.json
+++ b/test/data/tiledb/array/pdal.json
@@ -5,5 +5,6 @@
     {
       "type": "readers.tiledb"
     }
-  ]
+  ],
+  "spatialreference": "EPSG:26916"
 }

--- a/test/data/tiledb/array/pdal.json
+++ b/test/data/tiledb/array/pdal.json
@@ -6,5 +6,7 @@
       "type": "readers.tiledb"
     }
   ],
-  "spatialreference": "EPSG:26916"
+  "writers.tiledb": {
+    "spatialreference": "EPSG:26916"
+  }
 }


### PR DESCRIPTION
In TileDB 1.7+ we support internal array metadata which removes the need for a sidecar JSON file. This PR adds support for internal metadata and has backward support for sidecar files for older versions.

I have added a conditional test for this change.