### PR TITLE
tiledb: fix bbox option

### DIFF
--- a/plugins/tiledb/io/TileDBReader.cpp
+++ b/plugins/tiledb/io/TileDBReader.cpp
@@ -236,10 +236,10 @@ void TileDBReader::ready(PointTableRef)
     if (!m_bbox.empty())
     {
         if (numDims == 2)
-            m_query->set_subarray({m_bbox.minx, m_bbox.minx,
+            m_query->set_subarray({m_bbox.minx, m_bbox.maxx,
                 m_bbox.miny, m_bbox.maxy});
         else
-            m_query->set_subarray({m_bbox.minx, m_bbox.minx,
+            m_query->set_subarray({m_bbox.minx, m_bbox.maxx,
                 m_bbox.miny, m_bbox.maxy, m_bbox.minz, m_bbox.maxz});
     }
     else

--- a/plugins/tiledb/test/TileDBReaderTest.cpp
+++ b/plugins/tiledb/test/TileDBReaderTest.cpp
@@ -70,6 +70,24 @@ class TileDBReaderTest : public ::testing::Test
         EXPECT_TRUE(stage->pipelineStreamable());
     }
 
+    TEST_F(TileDBReaderTest, read_bbox)
+    {
+        tiledb::Context ctx;
+        tiledb::VFS vfs(ctx);
+        std::string pth(Support::datapath("tiledb/array"));
+        Options options;
+        options.add("array_name", pth);
+        options.add("bbox3d", "([0, 0.5], [0, 0.5], [0, 0.5])");
+
+        TileDBReader reader;
+        reader.setOptions(options);
+
+        FixedPointTable table(100);
+        reader.prepare(table);
+        reader.execute(table);
+        EXPECT_EQ(table.numPoints(), 50);
+    }
+
     TEST_F(TileDBReaderTest, read)
     {
         class Checker : public Filter, public Streamable


### PR DESCRIPTION
This PR fixes a typo and adds a test for the `bbox3d` option to the TileDB reader.