### PR TITLE
tiledb: Fix name clash with filters

### DIFF
--- a/doc/stages/writers.tiledb.rst
+++ b/doc/stages/writers.tiledb.rst
@@ -62,7 +62,7 @@ append
 stats
   Dump query stats to stdout [Optional]
 
-filters
+attr_filters
   JSON array or object of compression filters for either `coords` or `attributes` of the form {coords/attributename : {"compression": name, compression_options: value, ...}} [Optional]
 
 

--- a/plugins/tiledb/io/TileDBWriter.cpp
+++ b/plugins/tiledb/io/TileDBWriter.cpp
@@ -244,7 +244,7 @@ void TileDBWriter::addArgs(ProgramArgs& args)
         m_args->m_compressor);
     args.add("compression_level", "TileDB compression level",
         m_args->m_compressionLevel, -1);
-    args.add("filters", "Specify filter and level per dimension/attribute",
+    args.add("attr_filters", "Specify filter and level per dimension/attribute",
         m_args->m_filters);
     args.add("append", "Append to existing TileDB array",
         m_args->m_append, false);

--- a/plugins/tiledb/test/TileDBWriterTest.cpp
+++ b/plugins/tiledb/test/TileDBWriterTest.cpp
@@ -247,7 +247,7 @@ namespace pdal
         jsonOptions["OffsetTime"]["compression"] = "rle";
 
         options.add("array_name", pth);
-        options.add("filters", jsonOptions);
+        options.add("attr_filters", jsonOptions);
 
         if (vfs.is_dir(pth))
         {
@@ -300,7 +300,7 @@ namespace pdal
         options.add("array_name", pth);
         options.add("compression", "zstd");
         options.add("compression_level", 50);
-        options.add("filters", jsonOptions);
+        options.add("attr_filters", jsonOptions);
 
         if (vfs.is_dir(pth))
         {


### PR DESCRIPTION
In the `TileDBWriter` we had an option called `filters` which was fine in code usage (as exercised by the tests), but clashed with the CLI. This PR changes the filter option name and updates the tests.