### PR TITLE
Add normal refinement via minimum spanning tree propagation

### DIFF
--- a/doc/stages/filters.normal.rst
+++ b/doc/stages/filters.normal.rst
@@ -23,10 +23,10 @@ stages for more advanced filtering.
 The eigenvalue decomposition is performed using Eigen's
 `SelfAdjointEigenSolver <https://eigen.tuxfamily.org/dox/classEigen_1_1SelfAdjointEigenSolver.html>`_.
 
-Normals will be automatically flipped towards the viewpoint to be consistent. By
-default the viewpoint is located at the midpoint of the X and Y extents, and
-1000 units above the max Z value. Users can override any of the XYZ coordinates,
-or set them all to zero to effectively disable the normal flipping.
+Normals will be automatically flipped towards positive Z, unless the always_up_
+flag is set to `false`. Users can optionally set any of the XYZ coordinates to
+specify a custom viewpoint_ or set them all to zero to effectively disable the
+normal flipping.
 
 .. note::
 
@@ -35,6 +35,14 @@ or set them all to zero to effectively disable the normal flipping.
   instead be inverted such that they are oriented towards the viewpoint,
   regardless of the always_up_ flag. To disable all normal flipping, do not
   provide a viewpoint_ and set `always_up`_ to false.
+
+In addition to always_up_ and viewpoint_, users can run a refinement step (on
+by default) that propagates normals using a minimum spanning tree. The
+propagated normals can lead to much more consistent results across the dataset.
+
+.. note::
+
+  To disable normal propagation, users can set refine_ to `false`.
 
 .. embed::
 
@@ -73,3 +81,7 @@ _`viewpoint`
 _`always_up`
   A flag indicating whether or not normals should be inverted only when the Z
   component is negative. [Default: true]
+
+_`refine`
+  A flag indicating whether or not to reorient normals using minimum spanning
+  tree propagation. [Default: true]

--- a/filters/NormalFilter.cpp
+++ b/filters/NormalFilter.cpp
@@ -32,6 +32,14 @@
  * OF SUCH DAMAGE.
  ****************************************************************************/
 
+// Normal refinement algorithm is presented in [1] and adapted to PDAL based on
+// the implementation provided in [2].
+//
+// [1] H. Hoppe, T.  DeRose, T. Duchamp, J. McDonald, and W. Stuetzle, "Surface
+// reconstruction from unorganized points," Computer Graphics, vol. 26. no. 2,
+// pp. 71-78, 1992.
+// [2] https://github.com/CloudCompare/CloudCompare.
+
 #include "NormalFilter.hpp"
 #include "private/Point.hpp"
 

--- a/filters/NormalFilter.cpp
+++ b/filters/NormalFilter.cpp
@@ -1,5 +1,5 @@
 /******************************************************************************
- * Copyright (c) 2016-2017, Bradley J Chambers (brad.chambers@gmail.com)
+ * Copyright (c) 2016, 2017, 2019, 2020 Bradley J Chambers (brad.chambers@gmail.com)
  *
  * All rights reserved.
  *
@@ -47,12 +47,32 @@
 namespace pdal
 {
 
-static StaticPluginInfo const s_info
+struct Edge
 {
-    "filters.normal",
-    "Normal Filter",
-    "http://pdal.io/stages/filters.normal.html"
+    PointId m_v0;
+    PointId m_v1;
+    float m_weight;
+
+    Edge(PointId i, PointId j, float weight)
+        : m_v0(i), m_v1(j), m_weight(weight)
+    {
+    }
 };
+
+struct CompareEdgeWeight
+{
+    bool operator()(Edge const& lhs, Edge const& rhs)
+    {
+        return lhs.m_weight > rhs.m_weight;
+    }
+};
+
+using namespace Eigen;
+using namespace Dimension;
+
+static StaticPluginInfo const s_info{
+    "filters.normal", "Normal Filter",
+    "http://pdal.io/stages/filters.normal.html"};
 
 CREATE_STATIC_STAGE(NormalFilter, s_info)
 
@@ -61,15 +81,12 @@ struct NormalArgs
     int m_knn;
     filter::Point m_viewpoint;
     bool m_up;
+    bool m_refine;
 };
 
-NormalFilter::NormalFilter() : m_args(new NormalArgs)
-{}
+NormalFilter::NormalFilter() : m_args(new NormalArgs) {}
 
-
-NormalFilter::~NormalFilter()
-{}
-
+NormalFilter::~NormalFilter() {}
 
 std::string NormalFilter::getName() const
 {
@@ -79,16 +96,17 @@ std::string NormalFilter::getName() const
 void NormalFilter::addArgs(ProgramArgs& args)
 {
     args.add("knn", "k-Nearest Neighbors", m_args->m_knn, 8);
-    m_viewpointArg = &args.add("viewpoint",
-        "Viewpoint as WKT or GeoJSON", m_args->m_viewpoint);
+    m_viewpointArg = &args.add("viewpoint", "Viewpoint as WKT or GeoJSON",
+                               m_args->m_viewpoint);
     args.add("always_up", "Normals always oriented with positive Z?",
-        m_args->m_up, true);
+             m_args->m_up, true);
+    args.add("refine",
+             "Refine normals using minimum spanning tree propagation?",
+             m_args->m_refine, true);
 }
 
 void NormalFilter::addDimensions(PointLayoutPtr layout)
 {
-    using namespace Dimension;
-
     layout->registerDims(
         {Id::NormalX, Id::NormalY, Id::NormalZ, Id::Curvature});
 }
@@ -112,53 +130,177 @@ void NormalFilter::prepared(PointTableRef table)
             << "Viewpoint provided. Ignoring always_up = TRUE." << std::endl;
         m_args->m_up = false;
     }
+
+    // The query point is returned as a neighbor of itself, so we must increase
+    // k by one to get the desired number of neighbors.
+    ++m_args->m_knn;
+}
+
+void NormalFilter::compute(PointView& view, KD3Index& kdi)
+{
+    log()->get(LogLevel::Debug) << "Computing normal vectors\n";
+    for (PointId idx = 0; idx < view.size(); ++idx)
+    {
+        PointRef p = view.point(idx);
+
+        // Perform eigen decomposition of covariance matrix computed from
+        // neighborhood composed of k-nearest neighbors.
+        PointIdList neighbors = kdi.neighbors(idx, m_args->m_knn);
+        auto B = computeCovariance(view, neighbors);
+        SelfAdjointEigenSolver<Matrix3d> solver(B);
+        if (solver.info() != Success)
+            throwError("Cannot perform eigen decomposition.");
+
+        // The curvature is computed as the ratio of the first (smallest)
+        // eigenvalue to the sum of all eigenvalues.
+        auto eval = solver.eigenvalues();
+        double sum = eval[0] + eval[1] + eval[2];
+        double curvature = sum ? std::fabs(eval[0] / sum) : 0;
+
+        // The normal is defined by the eigenvector corresponding to the
+        // smallest eigenvalue.
+        Vector3d normal = solver.eigenvectors().col(0);
+
+        if (m_viewpointArg->set())
+        {
+            // If a viewpoint has been specified, orient the normals to face the
+            // viewpoint by taking the dot product of the vector connecting the
+            // point with the viewpoint and the normal. Flip the normal, where
+            // the dot product is negative.
+            float dx = static_cast<float>(m_args->m_viewpoint.x() -
+                                          p.getFieldAs<double>(Id::X));
+            float dy = static_cast<float>(m_args->m_viewpoint.y() -
+                                          p.getFieldAs<double>(Id::Y));
+            float dz = static_cast<float>(m_args->m_viewpoint.z() -
+                                          p.getFieldAs<double>(Id::Z));
+            Vector3d vp(dx, dy, dz);
+            if (vp.dot(normal) < 0)
+                normal *= -1.0;
+        }
+        else if (m_args->m_up)
+        {
+            // If normals are expected to be upward facing, invert them when the
+            // Z component is negative.
+            if (normal[2] < 0)
+                normal *= -1.0;
+        }
+
+        // Set the computed normal and curvature dimensions.
+        p.setField(Id::NormalX, normal[0]);
+        p.setField(Id::NormalY, normal[1]);
+        p.setField(Id::NormalZ, normal[2]);
+        p.setField(Id::Curvature, curvature);
+    }
+}
+
+void NormalFilter::refine(PointView& view, KD3Index& kdi)
+{
+    log()->get(LogLevel::Debug)
+        << "Refining normals using minimum spanning tree\n";
+
+    typedef std::vector<Edge> EdgeList;
+    std::priority_queue<Edge, EdgeList, CompareEdgeWeight> edge_queue;
+    std::vector<bool> inMST(view.size(), false);
+    PointId nextIdx(0);
+    point_count_t count(0);
+    while (count < view.size())
+    {
+        // Find the PointId of the next point not currently part of the minimum
+        // spanning tree.
+        while (inMST[nextIdx])
+            ++nextIdx;
+
+        // Lambda to add the current PointId to the minimum spanning tree and
+        // update the edge queue.
+        auto update = [&](PointId updateIdx) {
+            // Add the current PointId to the minimum spanning tree.
+            inMST[updateIdx] = true;
+            ++count;
+
+            // Consider neighbors of the newly added PointId, adding them to
+            // the edge queue if they are not already part of the minimum
+            // spanning tree.
+            PointIdList neighbors = kdi.neighbors(updateIdx, m_args->m_knn);
+            PointRef p = view.point(updateIdx);
+            Vector3d N1(p.getFieldAs<double>(Id::NormalX),
+                        p.getFieldAs<double>(Id::NormalY),
+                        p.getFieldAs<double>(Id::NormalZ));
+            for (PointId const& neighborIdx : neighbors)
+            {
+                if (updateIdx != neighborIdx && !inMST[neighborIdx])
+                {
+                    PointRef q = view.point(neighborIdx);
+                    Vector3d N2(q.getFieldAs<double>(Id::NormalX),
+                                q.getFieldAs<double>(Id::NormalY),
+                                q.getFieldAs<double>(Id::NormalZ));
+                    float weight = std::max(
+                        0.0, 1.0 - static_cast<float>(std::fabs(N1.dot(N2))));
+                    edge_queue.emplace(updateIdx, neighborIdx, weight);
+                }
+            }
+        };
+
+        update(nextIdx);
+
+        // Iterate on the edge queue until empty (or all points have been added
+        // to the minimum spanning tree).
+        while (!edge_queue.empty() && (count < view.size()))
+        {
+            // Retrieve the edge with the smallest weight.
+            Edge edge(edge_queue.top());
+            edge_queue.pop();
+
+            // Record the PointId and normal of the PointId (if one exists)
+            // that is not already in the minimum spanning tree.
+            PointId newIdx(0);
+            Vector3d normal;
+            PointRef p = view.point(edge.m_v0);
+            Vector3d N1(p.getFieldAs<double>(Id::NormalX),
+                        p.getFieldAs<double>(Id::NormalY),
+                        p.getFieldAs<double>(Id::NormalZ));
+            PointRef q = view.point(edge.m_v1);
+            Vector3d N2(q.getFieldAs<double>(Id::NormalX),
+                        q.getFieldAs<double>(Id::NormalY),
+                        q.getFieldAs<double>(Id::NormalZ));
+            if (!inMST[edge.m_v0])
+            {
+                newIdx = edge.m_v0;
+                normal = N1;
+            }
+            else if (!inMST[edge.m_v1])
+            {
+                newIdx = edge.m_v1;
+                normal = N2;
+            }
+            else
+                continue;
+
+            // Where the dot product of the normals is less than 0, invert the
+            // normal of the selected PointId.
+            if (N1.dot(N2) < 0)
+            {
+                normal *= -1;
+                view.setField(Id::NormalX, newIdx, normal(0));
+                view.setField(Id::NormalY, newIdx, normal(1));
+                view.setField(Id::NormalZ, newIdx, normal(2));
+            }
+
+            update(newIdx);
+        }
+    }
 }
 
 void NormalFilter::filter(PointView& view)
 {
     KD3Index& kdi = view.build3dIndex();
 
-    for (PointId i = 0; i < view.size(); ++i)
-    {
-        // find the k-nearest neighbors
-        auto ids = kdi.neighbors(i, m_args->m_knn);
+    // Compute the normal/curvature and optionally orient toward viewpoint or
+    // positive Z.
+    compute(view, kdi);
 
-        // compute covariance of the neighborhood
-        auto B = computeCovariance(view, ids);
-
-        // perform the eigen decomposition
-        Eigen::SelfAdjointEigenSolver<Eigen::Matrix3d> solver(B);
-        if (solver.info() != Eigen::Success)
-            throwError("Cannot perform eigen decomposition.");
-        auto eval = solver.eigenvalues();
-        Eigen::Vector3d normal = solver.eigenvectors().col(0);
-
-        if (m_viewpointArg->set())
-        {
-            using namespace Dimension;
-
-            PointRef p = view.point(i);
-            Eigen::Vector3d vp(
-                (float)(m_args->m_viewpoint.x() - p.getFieldAs<double>(Id::X)),
-                (float)(m_args->m_viewpoint.y() - p.getFieldAs<double>(Id::Y)),
-                (float)(m_args->m_viewpoint.z() - p.getFieldAs<double>(Id::Z)));
-            if (vp.dot(normal) < 0)
-                normal *= -1.0;
-        }
-        else if (m_args->m_up)
-        {
-            if (normal[2] < 0)
-                normal *= -1.0;
-        }
-
-        view.setField(Dimension::Id::NormalX, i, normal[0]);
-        view.setField(Dimension::Id::NormalY, i, normal[1]);
-        view.setField(Dimension::Id::NormalZ, i, normal[2]);
-
-        double sum = eval[0] + eval[1] + eval[2];
-        view.setField(Dimension::Id::Curvature, i,
-                      sum ? std::fabs(eval[0] / sum) : 0);
-    }
+    // If requested, refine normals through minimum spanning tree propagation.
+    if (m_args->m_refine)
+        refine(view, kdi);
 }
 
 } // namespace pdal

--- a/filters/NormalFilter.cpp
+++ b/filters/NormalFilter.cpp
@@ -127,13 +127,11 @@ void NormalFilter::prepared(PointTableRef table)
 void NormalFilter::compute(PointView& view, KD3Index& kdi)
 {
     log()->get(LogLevel::Debug) << "Computing normal vectors\n";
-    for (PointId idx = 0; idx < view.size(); ++idx)
+    for (auto&& p : view)
     {
-        PointRef p = view.point(idx);
-
         // Perform eigen decomposition of covariance matrix computed from
         // neighborhood composed of k-nearest neighbors.
-        PointIdList neighbors = kdi.neighbors(idx, m_args->m_knn);
+        PointIdList neighbors = kdi.neighbors(p.pointId(), m_args->m_knn);
         auto B = computeCovariance(view, neighbors);
         SelfAdjointEigenSolver<Matrix3d> solver(B);
         if (solver.info() != Success)

--- a/filters/NormalFilter.hpp
+++ b/filters/NormalFilter.hpp
@@ -1,5 +1,5 @@
 /******************************************************************************
- * Copyright (c) 2016-2017, Bradley J Chambers (brad.chambers@gmail.com)
+ * Copyright (c) 2016, 2017, 2020 Bradley J Chambers (brad.chambers@gmail.com)
  *
  * All rights reserved.
  *
@@ -64,6 +64,9 @@ public:
 private:
     std::unique_ptr<NormalArgs> m_args;
     Arg* m_viewpointArg;
+
+    void compute(PointView& view, KD3Index& kdi);
+    void refine(PointView& view, KD3Index& kdi);
 
     virtual void addArgs(ProgramArgs& args);
     virtual void addDimensions(PointLayoutPtr layout);

--- a/filters/NormalFilter.hpp
+++ b/filters/NormalFilter.hpp
@@ -48,6 +48,28 @@ class PointLayout;
 class PointView;
 struct NormalArgs;
 
+struct Edge
+{
+    PointId m_v0;
+    PointId m_v1;
+    double m_weight;
+
+    Edge(PointId i, PointId j, double weight)
+        : m_v0(i), m_v1(j), m_weight(weight)
+    {
+    }
+};
+
+struct CompareEdgeWeight
+{
+    bool operator()(Edge const& lhs, Edge const& rhs)
+    {
+        return lhs.m_weight > rhs.m_weight;
+    }
+};
+
+typedef std::vector<Edge> EdgeList;
+
 class PDAL_DLL NormalFilter : public Filter
 {
 public:
@@ -63,10 +85,15 @@ public:
 
 private:
     std::unique_ptr<NormalArgs> m_args;
+    point_count_t m_count;
     Arg* m_viewpointArg;
 
     void compute(PointView& view, KD3Index& kdi);
     void refine(PointView& view, KD3Index& kdi);
+    void
+    update(PointView& view, KD3Index& kdi, std::vector<bool> inMST,
+           std::priority_queue<Edge, EdgeList, CompareEdgeWeight> edge_queue,
+           PointId updateIdx);
 
     virtual void addArgs(ProgramArgs& args);
     virtual void addDimensions(PointLayoutPtr layout);

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -279,6 +279,7 @@ PDAL_ADD_TEST(pdal_filters_additional_merge_test
     INCLUDES
         ${NLOHMANN_INCLUDE_DIR}
 )
+PDAL_ADD_TEST(pdal_filters_normal_test FILES filters/NormalFilterTest.cpp)
 PDAL_ADD_TEST(pdal_filters_overlay_test FILES filters/OverlayFilterTest.cpp)
 PDAL_ADD_TEST(pdal_filters_pmf_test FILES filters/PMFFilterTest.cpp)
 PDAL_ADD_TEST(pdal_filters_reprojection_test FILES

--- a/test/unit/filters/NormalFilterTest.cpp
+++ b/test/unit/filters/NormalFilterTest.cpp
@@ -72,9 +72,8 @@ TEST(NormalFilterTest, XYPlane)
     Dimension::Id nz = table.layout()->findDim("NormalZ");
     Dimension::Id c = table.layout()->findDim("Curvature");
 
-    for (point_count_t idx = 0; idx < outView->size(); ++idx)
+    for (auto const& p : *outView)
     {
-        PointRef p = outView->point(idx);
         ASSERT_FLOAT_EQ(p.getFieldAs<float>(nx), 0.0);
         ASSERT_FLOAT_EQ(p.getFieldAs<float>(ny), 0.0);
         ASSERT_FLOAT_EQ(p.getFieldAs<float>(nz), 1.0);
@@ -110,9 +109,8 @@ TEST(NormalFilterTest, XZPlane)
     Dimension::Id nz = table.layout()->findDim("NormalZ");
     Dimension::Id c = table.layout()->findDim("Curvature");
 
-    for (point_count_t idx = 0; idx < outView->size(); ++idx)
+    for (auto const& p : *outView)
     {
-        PointRef p = outView->point(idx);
         ASSERT_FLOAT_EQ(p.getFieldAs<float>(nx), 0.0);
         ASSERT_FLOAT_EQ(p.getFieldAs<float>(ny), 1.0);
         ASSERT_FLOAT_EQ(p.getFieldAs<float>(nz), 0.0);
@@ -148,9 +146,8 @@ TEST(NormalFilterTest, YZPlane)
     Dimension::Id nz = table.layout()->findDim("NormalZ");
     Dimension::Id c = table.layout()->findDim("Curvature");
 
-    for (point_count_t idx = 0; idx < outView->size(); ++idx)
+    for (auto const& p : *outView)
     {
-        PointRef p = outView->point(idx);
         ASSERT_FLOAT_EQ(p.getFieldAs<float>(nx), 1.0);
         ASSERT_FLOAT_EQ(p.getFieldAs<float>(ny), 0.0);
         ASSERT_FLOAT_EQ(p.getFieldAs<float>(nz), 0.0);
@@ -197,9 +194,8 @@ TEST(NormalFilterTest, RampPlane)
     Dimension::Id c = table.layout()->findDim("Curvature");
 
     double expected = std::sqrt(2.0) / 2.0;
-    for (point_count_t idx = 0; idx < outView->size(); ++idx)
+    for (auto const& p : *outView)
     {
-        PointRef p = outView->point(idx);
         ASSERT_FLOAT_EQ(p.getFieldAs<float>(nx), -expected);
         ASSERT_FLOAT_EQ(p.getFieldAs<float>(ny), 0.0);
         ASSERT_FLOAT_EQ(p.getFieldAs<float>(nz), expected);
@@ -246,9 +242,8 @@ TEST(NormalFilterTest, RampPlane2)
     Dimension::Id c = table.layout()->findDim("Curvature");
 
     double expected = std::sqrt(2.0) / 2.0;
-    for (point_count_t idx = 0; idx < outView->size(); ++idx)
+    for (auto const& p : *outView)
     {
-        PointRef p = outView->point(idx);
         ASSERT_FLOAT_EQ(p.getFieldAs<float>(nx), 0.0);
         ASSERT_FLOAT_EQ(p.getFieldAs<float>(ny), -expected);
         ASSERT_FLOAT_EQ(p.getFieldAs<float>(nz), expected);

--- a/test/unit/filters/NormalFilterTest.cpp
+++ b/test/unit/filters/NormalFilterTest.cpp
@@ -1,0 +1,160 @@
+/******************************************************************************
+ * Copyright (c) 2020 Bradley J Chambers (brad.chambers@gmail.com)
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of Helix Re Inc. nor the
+ *       names of its contributors may be used to endorse or promote
+ *       products derived from this software without specific prior
+ *       written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ ****************************************************************************/
+
+#include <pdal/pdal_test_main.hpp>
+
+#include <filters/NormalFilter.hpp>
+#include <io/FauxReader.hpp>
+#include <pdal/PointView.hpp>
+
+#include "Support.hpp"
+
+namespace pdal
+{
+
+TEST(NormalFilterTest, XYPlane)
+{
+    using namespace Dimension;
+
+    PointTable table;
+    table.layout()->registerDims({Id::X, Id::Y, Id::Z});
+
+    FauxReader reader;
+    Options readerOps;
+    readerOps.add("mode", "grid");
+    readerOps.add("bounds", "([0, 2], [0, 2], [0, 0])");
+    readerOps.add("count", 4);
+    reader.setOptions(readerOps);
+    NormalFilter filter;
+    Options filterOps;
+    filterOps.add("knn", 3);
+    filter.setInput(reader);
+    filter.setOptions(filterOps);
+    filter.prepare(table);
+
+    PointViewSet viewSet = filter.execute(table);
+    PointViewPtr outView = *viewSet.begin();
+
+    Dimension::Id nx = table.layout()->findDim("NormalX");
+    Dimension::Id ny = table.layout()->findDim("NormalY");
+    Dimension::Id nz = table.layout()->findDim("NormalZ");
+    Dimension::Id c = table.layout()->findDim("Curvature");
+
+    for (point_count_t idx = 0; idx < outView->size(); ++idx)
+    {
+        PointRef p = outView->point(idx);
+        ASSERT_FLOAT_EQ(p.getFieldAs<float>(nx), 0.0);
+        ASSERT_FLOAT_EQ(p.getFieldAs<float>(ny), 0.0);
+        ASSERT_FLOAT_EQ(p.getFieldAs<float>(nz), 1.0);
+        ASSERT_FLOAT_EQ(p.getFieldAs<float>(c), 0.0);
+    }
+}
+
+TEST(NormalFilterTest, XZPlane)
+{
+    using namespace Dimension;
+
+    PointTable table;
+    table.layout()->registerDims({Id::X, Id::Y, Id::Z});
+
+    FauxReader reader;
+    Options readerOps;
+    readerOps.add("mode", "grid");
+    readerOps.add("bounds", "([0, 2], [0, 0], [0, 2])");
+    readerOps.add("count", 4);
+    reader.setOptions(readerOps);
+    NormalFilter filter;
+    Options filterOps;
+    filterOps.add("knn", 3);
+    filter.setInput(reader);
+    filter.setOptions(filterOps);
+    filter.prepare(table);
+
+    PointViewSet viewSet = filter.execute(table);
+    PointViewPtr outView = *viewSet.begin();
+
+    Dimension::Id nx = table.layout()->findDim("NormalX");
+    Dimension::Id ny = table.layout()->findDim("NormalY");
+    Dimension::Id nz = table.layout()->findDim("NormalZ");
+    Dimension::Id c = table.layout()->findDim("Curvature");
+
+    for (point_count_t idx = 0; idx < outView->size(); ++idx)
+    {
+        PointRef p = outView->point(idx);
+        ASSERT_FLOAT_EQ(p.getFieldAs<float>(nx), 0.0);
+        ASSERT_FLOAT_EQ(p.getFieldAs<float>(ny), 1.0);
+        ASSERT_FLOAT_EQ(p.getFieldAs<float>(nz), 0.0);
+        ASSERT_FLOAT_EQ(p.getFieldAs<float>(c), 0.0);
+    }
+}
+
+TEST(NormalFilterTest, YZPlane)
+{
+    using namespace Dimension;
+
+    PointTable table;
+    table.layout()->registerDims({Id::X, Id::Y, Id::Z});
+
+    FauxReader reader;
+    Options readerOps;
+    readerOps.add("mode", "grid");
+    readerOps.add("bounds", "([0, 0], [0, 2], [0, 2])");
+    readerOps.add("count", 4);
+    reader.setOptions(readerOps);
+    NormalFilter filter;
+    Options filterOps;
+    filterOps.add("knn", 3);
+    filter.setInput(reader);
+    filter.setOptions(filterOps);
+    filter.prepare(table);
+
+    PointViewSet viewSet = filter.execute(table);
+    PointViewPtr outView = *viewSet.begin();
+
+    Dimension::Id nx = table.layout()->findDim("NormalX");
+    Dimension::Id ny = table.layout()->findDim("NormalY");
+    Dimension::Id nz = table.layout()->findDim("NormalZ");
+    Dimension::Id c = table.layout()->findDim("Curvature");
+
+    for (point_count_t idx = 0; idx < outView->size(); ++idx)
+    {
+        PointRef p = outView->point(idx);
+        ASSERT_FLOAT_EQ(p.getFieldAs<float>(nx), 1.0);
+        ASSERT_FLOAT_EQ(p.getFieldAs<float>(ny), 0.0);
+        ASSERT_FLOAT_EQ(p.getFieldAs<float>(nz), 0.0);
+        ASSERT_FLOAT_EQ(p.getFieldAs<float>(c), 0.0);
+    }
+}
+
+} // namespace pdal


### PR DESCRIPTION
Adds switch (default ~`false`~ `true`) to refine the normal orientation by implementing the method of minimum spanning tree normal propagation.