### PR TITLE
NitfWrap: Fix compilation error 'pdal::Log::Log(const string&, const string&, bool) is private within this context'

### DIFF
--- a/tools/nitfwrap/NitfWrap.cpp
+++ b/tools/nitfwrap/NitfWrap.cpp
@@ -254,7 +254,7 @@ bool NitfWrap::verifyBpf(ILeStream& in, BOX3D& bounds)
 {
     BpfHeader h;
     BpfDimensionList dims;
-    LogPtr l(new Log("nitfwrap", "devnull"));
+    LogPtr l(Log::makeLog("nitfwrap", "devnull"));
 
     h.setLog(l);
 


### PR DESCRIPTION
This is to fix the compilation error when `BUILD_TOOLS_NITFWRAP` is enabled:
```
/home/nick/Code/Git/github.com/PDAL/tools/nitfwrap/NitfWrap.cpp: In member function ‘bool pdal::nitfwrap::NitfWrap::verifyBpf(pdal::ILeStream&, pdal::BOX3D&)’:
/home/nick/Code/Git/github.com/PDAL/tools/nitfwrap/NitfWrap.cpp:257:43: error: ‘pdal::Log::Log(const string&, const string&, bool)’ is private within this context
  257 |     LogPtr l(new Log("nitfwrap", "devnull"));
```