### PR TITLE
Add raster option to HAGFilter

### DIFF
--- a/doc/stages/filters.hag.rst
+++ b/doc/stages/filters.hag.rst
@@ -21,7 +21,7 @@ also be referred to as *height above ground* (HAG) or *above ground level* (AGL)
 heights. In the end, it is simply a measure of a point's relative height as
 opposed to its raw elevation value.
 
-There are two modes of operation:
+There are three modes of operation:
 
 Weighted Nearest Point
 ----------------------
@@ -51,6 +51,19 @@ If, for example, all the ground points near a non-ground point lay on
 one side of that non-ground point, finding a containing triangle will fail.
 
 .. embed::
+
+DEM Raster Comparison
+---------------------
+Used when the `raster`_ option is set. The filter loads a GDAL readable raster
+specifying the DEM to calculate ``HeightAboveGround`` from. The ``Z`` value
+of each point is compared against the value at the corresponding X,Y point in
+the DEM raster.
+
+If `respect_ground_classification`_ is set, any points classified as ground will
+have their ``HeightAboveGround`` value set to 0 regardless of the raster.
+
+Any points that do not have a corresponding value in the raster DEM will not have
+a ``HeightAboveGround`` value set.
 
 Example #1
 ----------
@@ -158,6 +171,9 @@ _`delaunay`
     to aid in interpolation of a ground height to use as a difference to
     a point's non-ground height. [Default: false]
 
+_`raster`
+    GDAL-readable raster to use for DEM (uses band 1, starting from 1)
+
 max_distance
     Use only ground points within `max_distance` of non-ground point when
     performing neighbor interpolation.  Not used with the `delaunay`_
@@ -172,3 +188,8 @@ allow_extrapolation
     is false), extrapolation is used to assign the ``HeightAboveGround``
     value.
     [Default: false]
+
+respect_ground_classification
+    If true, set HAG of ground-classified points to 0 rather than comparing
+    ``Z`` value to raster DEM
+    [Default: true]

--- a/filters/HAGFilter.cpp
+++ b/filters/HAGFilter.cpp
@@ -196,12 +196,16 @@ void HAGFilter::addArgs(ProgramArgs& args)
 {
     args.add("count", "The number of points to fetch to determine the "
         "ground point [Default: 1].", m_count, point_count_t(1));
-    args.add("raster", "GDAL-readable raster to use for DEM (uses band 1)", m_rasterName, "NONE");
+    args.add("raster", "GDAL-readable raster to use for DEM (uses band 1, "
+        "starting from 1)", m_rasterName, "");
     args.add("max_distance", "Ground points beyond this distance will not "
         "influence nearest neighbor interpolation of height above ground."
         "[Default: None]", m_maxDistance);
     args.add("allow_extrapolation", "If true and count > 1, allow "
         "extrapolation [Default: true].", m_allowExtrapolation, true);
+    args.add("respect_ground_classification", "If true, set HAG of ground"
+        "-classified points to 0 rather than comparing Z value to raster DEM",
+        m_respectGroundClassification, true);
     args.add("delaunay", "Construct local Delaunay fans and infer heights "
         "from them. [Default: false].", m_delaunay, false);
 }
@@ -215,7 +219,7 @@ void HAGFilter::addDimensions(PointLayoutPtr layout)
 
 void HAGFilter::ready(PointTableRef table)
 {
-    if (m_rasterName != "NONE") {
+    if (m_rasterName != "") {
       gdal::registerDrivers();
       m_raster.reset(new gdal::Raster(m_rasterName));
       m_raster->open();
@@ -224,43 +228,57 @@ void HAGFilter::ready(PointTableRef table)
 
 void HAGFilter::prepared(PointTableRef table)
 {
-    if (m_delaunay && m_rasterName != "NONE")
+    if (m_delaunay && m_rasterName != "")
         throwError("'delaunay' option not compatible with 'raster' option");
-    if (m_count == 0 && m_rasterName == "NONE")
+    if (m_count == 0 && m_rasterName == "")
         throwError("Option 'count' must be a positive integer.");
     if (m_delaunay && m_count < 3)
         throwError("Option 'count' must be at least 3 when using the "
             "'delaunay' option.");
 
     const PointLayoutPtr layout(table.layout());
-    if (m_rasterName == "NONE" && !layout->hasDim(Dimension::Id::Classification))
+    if (m_rasterName == "" && !layout->hasDim(Dimension::Id::Classification))
         throwError("Missing Classification dimension in input PointView.");
 }
 
+void HAGFilter::set_HAG_from_raster(PointView& view)
+{
+    using namespace pdal::Dimension;
+    static std::vector<double> data;
+
+    for (PointId i = 0; i < view.size(); ++i)
+    {
+
+        // If "respect_ground_classification" option is set, all ground points get HAG of 0
+        if (m_respectGroundClassification && view.getFieldAs<uint8_t>(Id::Classification, i) == ClassLabel::Ground)
+        {
+            view.setField(Id::HeightAboveGround, i, 0);
+        }
+        else
+        {
+          double x = view.getFieldAs<double>(Id::X, i);
+          double y = view.getFieldAs<double>(Id::Y, i);
+          double z = view.getFieldAs<double>(Id::Z, i);
+
+          // If raster has a point at X, Y of pointcloud point, use it. Otherwise the HAG
+          // value is not set.
+          if (m_raster->read(x, y, data) == gdal::GDALError::None)
+          {
+              double hag = z - data[0];
+              view.setField(Dimension::Id::HeightAboveGround, i, hag);
+          }
+       }
+    }
+}
 
 void HAGFilter::filter(PointView& view)
 {
     using namespace pdal::Dimension;
 
-    // If using a raster as the DTM, check each point against it and write
+    // If using a raster as the DEM, check each point against it and write
     // the HAG dimension
-    if (m_rasterName != "NONE") {
-      static std::vector<double> data;
-      for (PointId i = 0; i < view.size(); ++i)
-      {
-        double x = view.getFieldAs<double>(Id::X, i);
-        double y = view.getFieldAs<double>(Id::Y, i);
-        double z = view.getFieldAs<double>(Id::Z, i);
-
-        if (m_raster->read(x, y, data) == gdal::GDALError::None)
-        {
-          double hag = z - data[0];
-          view.setField(Dimension::Id::HeightAboveGround, i, hag);
-        }
-      }
-      // We are done as raster-mode doesn't need to do any of the heavy
-      // lifting involved in generating an index from ground points
-      return;
+    if (m_rasterName != "") {
+      return set_HAG_from_raster(view);
     }
 
     PointViewPtr gView = view.makeNew();

--- a/filters/HAGFilter.hpp
+++ b/filters/HAGFilter.hpp
@@ -43,6 +43,7 @@
 namespace pdal
 {
 
+namespace gdal { class Raster; }
 class Options;
 class PointLayout;
 class PointView;
@@ -60,8 +61,11 @@ private:
     virtual void addArgs(ProgramArgs& args);
     virtual void addDimensions(PointLayoutPtr layout);
     virtual void prepared(PointTableRef table);
+    virtual void ready(PointTableRef table);
     virtual void filter(PointView& view);
 
+    std::unique_ptr<gdal::Raster> m_raster;
+    std::string m_rasterName;
     bool m_allowExtrapolation;
     bool m_delaunay;
     double m_maxDistance;

--- a/filters/HAGFilter.hpp
+++ b/filters/HAGFilter.hpp
@@ -63,10 +63,12 @@ private:
     virtual void prepared(PointTableRef table);
     virtual void ready(PointTableRef table);
     virtual void filter(PointView& view);
+    void set_HAG_from_raster(PointView& view);
 
     std::unique_ptr<gdal::Raster> m_raster;
     std::string m_rasterName;
     bool m_allowExtrapolation;
+    bool m_respectGroundClassification;
     bool m_delaunay;
     double m_maxDistance;
     point_count_t m_count;


### PR DESCRIPTION
I had a look at adding a test for this mode, but didn't understand the geometry used in the existing test suite (https://github.com/PDAL/PDAL/blob/master/test/data/filters/hagtest.jpg).

If this is likely to get accepted I'll go ahead and add documentation and try to figure out how to create a DEM raster to use in the test suite.