### PR TITLE
Added support for not offsetting the nominal xyz values while writing las.

### DIFF
--- a/doc/stages/writers.las.rst
+++ b/doc/stages/writers.las.rst
@@ -166,6 +166,7 @@ scale_x, scale_y, scale_z
   dimensions to range from [0, 2147483647].  [Default: .01]
 
   Note: written value = (nominal value - offset) / scale.
+  ``transform_points_by_offset`` may change this.
 
 offset_x, offset_y, offset_z
    Offset to be subtracted from the X, Y and Z nominal values, respectively,
@@ -174,6 +175,14 @@ offset_x, offset_y, offset_z
    dimension.  [Default: 0]
 
    Note: written value = (nominal value - offset) / scale.
+   ``transform_points_by_offset`` may change this.
+
+transform_points_by_offset
+  If true the offset is only written to the header but not applied to the
+  X, Y and Z nominal values. The scaling is still applied.  [Default: false]
+
+  Note: If this is true, the written values is nominal value / scale.
+
 
 filesource_id
   The file source id number to use for this file (a value between

--- a/io/LasWriter.hpp
+++ b/io/LasWriter.hpp
@@ -126,6 +126,7 @@ private:
     StringHeaderVal<0> m_offsetX;
     StringHeaderVal<0> m_offsetY;
     StringHeaderVal<0> m_offsetZ;
+    bool m_transformPointsByOffset;
     MetadataNode m_forwardMetadata;
     bool m_writePDALMetadata;
     std::unique_ptr<NL::json> m_userVLRs;


### PR DESCRIPTION
This pr adds an additional parameter to the las writer which disables the offset when computing the output xyz coordinates. The offset is still written into the las header.
Using this new parameter las files with high offsets can be created without having to transform all points before writing the las file. For very high offsets (such as those creating when georeferencing pointclouds) this avoid floating point precision problems (which can reduce the accuracy of point positions down to half a meter or less). 