### PR TITLE
PMF classification fix

### DIFF
--- a/filters/PMFFilter.cpp
+++ b/filters/PMFFilter.cpp
@@ -176,40 +176,43 @@ PointViewSet PMFFilter::run(PointViewPtr input)
                    "1.");
 
     // Segment kept view into two views
-    PointViewPtr firstView = keptView->makeNew();
-    PointViewPtr secondView = keptView->makeNew();
+    PointViewPtr modifiedReturnsView = keptView->makeNew();
+    PointViewPtr staticReturnsView = keptView->makeNew();
     if (nrAllZero && rnAllZero)
     {
         log()->get(LogLevel::Warning)
             << "Both NumberOfReturns and ReturnNumber are filled with 0's. "
                "Proceeding without any further return filtering.\n";
-        firstView->append(*keptView);
+        modifiedReturnsView->append(*keptView);
     }
     else
     {
-        Segmentation::segmentReturns(keptView, firstView, secondView,
-                                     m_args->m_returns);
+        Segmentation::segmentReturns(keptView, modifiedReturnsView,
+                                     staticReturnsView, m_args->m_returns);
     }
 
-    if (!firstView->size())
+    if (!modifiedReturnsView->size())
     {
         throwError("No returns to process.");
     }
 
     // Classify remaining points with value of 1. processGround will mark ground
     // returns as 2.
-    for (PointId i = 0; i < firstView->size(); ++i)
-        firstView->setField(Dimension::Id::Classification, i,
-                            ClassLabel::Unclassified);
+    for (PointId i = 0; i < modifiedReturnsView->size(); ++i)
+        modifiedReturnsView->setField(Dimension::Id::Classification, i,
+                                      ClassLabel::Unclassified);
 
     // Run the actual PMF algorithm.
-    processGround(firstView);
+    processGround(modifiedReturnsView);
 
     // Prepare the output PointView.
     PointViewPtr outView = input->makeNew();
+    // ignoredView and staticReturnsView are appended to the output untouched.
     outView->append(*ignoredView);
-    outView->append(*secondView);
-    outView->append(*firstView);
+    outView->append(*staticReturnsView);
+    // modifiedReturnsView is appended to the output, the only PointView whose
+    // classifications may have been altered.
+    outView->append(*modifiedReturnsView);
     viewSet.insert(outView);
 
     return viewSet;

--- a/filters/PMFFilter.cpp
+++ b/filters/PMFFilter.cpp
@@ -1,5 +1,5 @@
 /******************************************************************************
- * Copyright (c) 2015-2017, Bradley J Chambers (brad.chambers@gmail.com)
+ * Copyright (c) 2015-2017, 2020 Bradley J Chambers (brad.chambers@gmail.com)
  *
  * All rights reserved.
  *
@@ -49,12 +49,9 @@
 namespace pdal
 {
 
-static StaticPluginInfo const s_info
-{
-    "filters.pmf",
-    "Progressive morphological filter",
-    "http://pdal.io/stages/filters.pmf.html"
-};
+static StaticPluginInfo const s_info{"filters.pmf",
+                                     "Progressive morphological filter",
+                                     "http://pdal.io/stages/filters.pmf.html"};
 
 struct PMFArgs
 {
@@ -70,11 +67,9 @@ struct PMFArgs
 
 CREATE_STATIC_STAGE(PMFFilter, s_info)
 
-PMFFilter::PMFFilter() : m_args(new PMFArgs)
-{}
+PMFFilter::PMFFilter() : m_args(new PMFArgs) {}
 
-PMFFilter::~PMFFilter()
-{}
+PMFFilter::~PMFFilter() {}
 
 std::string PMFFilter::getName() const
 {
@@ -203,8 +198,9 @@ PointViewSet PMFFilter::run(PointViewPtr input)
 
     // Classify remaining points with value of 1. processGround will mark ground
     // returns as 2.
-    for (PointId i = 0; i < secondView->size(); ++i)
-        secondView->setField(Dimension::Id::Classification, i, ClassLabel::Unclassified);
+    for (PointId i = 0; i < firstView->size(); ++i)
+        firstView->setField(Dimension::Id::Classification, i,
+                            ClassLabel::Unclassified);
 
     // Run the actual PMF algorithm.
     processGround(firstView);

--- a/test/unit/filters/PMFFilterTest.cpp
+++ b/test/unit/filters/PMFFilterTest.cpp
@@ -99,5 +99,6 @@ TEST(PMFFilterTEst, classOneAndTwoOnly)
         if (cl == ClassLabel::CreatedNeverClassified)
             classZero++;
     }
+    EXPECT_EQ(v->size(), 110000u);
     EXPECT_EQ(classZero, 0u);
 }

--- a/test/unit/filters/PMFFilterTest.cpp
+++ b/test/unit/filters/PMFFilterTest.cpp
@@ -1,39 +1,42 @@
 /******************************************************************************
-* Copyright (c) 2018, Bradley J Chambers (brad.chambers@gmail.com)
-*
-* All rights reserved.
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following
-* conditions are met:
-*
-*     * Redistributions of source code must retain the above copyright
-*       notice, this list of conditions and the following disclaimer.
-*     * Redistributions in binary form must reproduce the above copyright
-*       notice, this list of conditions and the following disclaimer in
-*       the documentation and/or other materials provided
-*       with the distribution.
-*     * Neither the name of Hobu, Inc. or Flaxen Geo Consulting nor the
-*       names of its contributors may be used to endorse or promote
-*       products derived from this software without specific prior
-*       written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-* FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-* COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-* BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
-* OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
-* AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
-* OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
-* OF SUCH DAMAGE.
-****************************************************************************/
+ * Copyright (c) 2018, 2020 Bradley J Chambers (brad.chambers@gmail.com)
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of Hobu, Inc. or Flaxen Geo Consulting nor the
+ *       names of its contributors may be used to endorse or promote
+ *       products derived from this software without specific prior
+ *       written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ ****************************************************************************/
 
-#include <pdal/pdal_test_main.hpp>
 #include <filters/PMFFilter.hpp>
+#include <pdal/StageFactory.hpp>
+#include <pdal/pdal_test_main.hpp>
+
+#include "Support.hpp"
 
 using namespace pdal;
 
@@ -59,4 +62,42 @@ TEST(PMFFilterTest, validReturns)
 
     PointTable table;
     EXPECT_NO_THROW(filter.prepare(table));
+}
+
+TEST(PMFFilterTEst, classOneAndTwoOnly)
+{
+    StageFactory f;
+
+    Stage* reader(f.createStage("readers.las"));
+    Options rOpts;
+    rOpts.add("filename", Support::datapath("las/autzen_trim.las"));
+    reader->setOptions(rOpts);
+
+    Stage* assign(f.createStage("filters.assign"));
+    Options aOpts;
+    aOpts.add("assignment", "Classification[:]=0");
+    assign->setInput(*reader);
+    assign->setOptions(aOpts);
+
+    Stage* filter(f.createStage("filters.pmf"));
+    Options fOpts;
+    fOpts.add("returns", "first,last,intermediate,only");
+    filter->setInput(*assign);
+    filter->setOptions(fOpts);
+
+    PointTable t;
+    filter->prepare(t);
+    PointViewSet s = filter->execute(t);
+
+    EXPECT_EQ(s.size(), 1U);
+    PointViewPtr v = *s.begin();
+
+    size_t classZero{0};
+    for (PointId id = 0; id < v->size(); ++id)
+    {
+        uint8_t cl = v->getFieldAs<uint8_t>(Dimension::Id::Classification, id);
+        if (cl == ClassLabel::CreatedNeverClassified)
+            classZero++;
+    }
+    EXPECT_EQ(classZero, 0u);
 }

--- a/test/unit/filters/PMFFilterTest.cpp
+++ b/test/unit/filters/PMFFilterTest.cpp
@@ -64,7 +64,7 @@ TEST(PMFFilterTest, validReturns)
     EXPECT_NO_THROW(filter.prepare(table));
 }
 
-TEST(PMFFilterTEst, classOneAndTwoOnly)
+TEST(PMFFilterTest, classOneAndTwoOnly)
 {
     StageFactory f;
 


### PR DESCRIPTION
- Do not touch classification of points exluded by return information

- Initialize all points passed to processGround() by setting
  classification to ClassLabel::Unclassified

- Apply clang-format

Fix #2898