### PR TITLE
add AzP/docs build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,6 @@
 jobs:
-    #  - template: ./scripts/azp/linux.yml
-    #  - template: ./scripts/azp/linux-conda.yml
-    #  - template: ./scripts/azp/win.yml
-    #  - template: ./scripts/azp/osx.yml
+  - template: ./scripts/azp/linux.yml
+  - template: ./scripts/azp/linux-conda.yml
+  - template: ./scripts/azp/win.yml
+  - template: ./scripts/azp/osx.yml
   - template: ./scripts/azp/doc.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,6 @@
 jobs:
-  - template: ./scripts/azp/linux.yml
-  - template: ./scripts/azp/linux-conda.yml
-  - template: ./scripts/azp/win.yml
-  - template: ./scripts/azp/osx.yml
+    #  - template: ./scripts/azp/linux.yml
+    #  - template: ./scripts/azp/linux-conda.yml
+    #  - template: ./scripts/azp/win.yml
+    #  - template: ./scripts/azp/osx.yml
+  - template: ./scripts/azp/doc.yml

--- a/scripts/azp/doc.yml
+++ b/scripts/azp/doc.yml
@@ -1,9 +1,9 @@
 # -*- mode: yaml -*-
 
-variables:
-  - group: aws-credentials
 jobs:
 - job: docs
+  variables:
+    - group: aws-credentials
   pool:
     vmImage: ubuntu-16.04
   container:

--- a/scripts/azp/doc.yml
+++ b/scripts/azp/doc.yml
@@ -1,7 +1,9 @@
 # -*- mode: yaml -*-
 
+variables:
+  - group: aws-credentials
 jobs:
-- job: linux
+- job: docs
   pool:
     vmImage: ubuntu-16.04
   container:
@@ -20,7 +22,13 @@ jobs:
     displayName: 'Make HTML'
   - script: |
       cd doc
-      make pdf
+      make latexpdf
       ninja
     displayName: 'Make PDF'
+  - script: |
+      export AWS_ACCESS_KEY_ID = variables['aws-credentials.AWS_ACCESS_KEY_ID']
+      export AWS_SECRET_ACCESS_KEY = variables['aws-credentials.AWS_SECRET_ACCESS_KEY']
+      cd doc/build
+      aws s3 sync . "s3://pdal/docs/$BUILD_SOURCEVERSION/" --acl public-read
+    displayName: 'Upload https://github.com/OSGeo/gdal/commit/$BUILD_SOURCEVERSION to https://pdal.s3.amazonaws.com/docs/$BUILD_SOURCEVERSION/html/'
 

--- a/scripts/azp/doc.yml
+++ b/scripts/azp/doc.yml
@@ -20,7 +20,7 @@ jobs:
       cd doc
       make html
     displayName: 'Make HTML'
-    - script: |
+  - script: |
       cd doc
       make latexpdf
     displayName: 'Make PDF'

--- a/scripts/azp/doc.yml
+++ b/scripts/azp/doc.yml
@@ -31,7 +31,7 @@ jobs:
       export AWS_SECRET_ACCESS_KEY = $(AWS_SECRET_ACCESS_KEY)
       cd doc/build
       aws s3 sync html --quiet "s3://pdal/docs/$(Build.SourceVersion)/html/" --acl public-read
-      aws s3 cp latex/PDAL.pdf "s3://pdal/docs/$(Build.SourceVersion)/html/" --acl public-read
+      aws s3 cp --quiet latex/PDAL.pdf "s3://pdal/docs/$(Build.SourceVersion)/html/" --acl public-read
       echo "PDF location: https://pdal.s3.amazonaws.com/docs/$(Build.SourceVersion)/html/PDAL.pdf"
       echo "HTML location: https://pdal.s3.amazonaws.com/docs/$(Build.SourceVersion)/html/index.html"
     displayName: 'Upload https://pdal.s3.amazonaws.com/docs/$(Build.SourceVersion)/html/index.html'

--- a/scripts/azp/doc.yml
+++ b/scripts/azp/doc.yml
@@ -30,5 +30,7 @@ jobs:
       cd doc/build
       aws s3 sync html "s3://pdal/docs/$(Build.SourceVersion)/html/" --acl public-read
       aws s3 cp latex/PDAL.pdf "s3://pdal/docs/$(Build.SourceVersion)/html/" --acl public-read
+      echo "PDF location: https://pdal.s3.amazonaws.com/docs/$(Build.SourceVersion)/html/PDAL.pdf"
+      echo "HTML location: https://pdal.s3.amazonaws.com/docs/$(Build.SourceVersion)/html/"
     displayName: 'Upload https://pdal.s3.amazonaws.com/docs/$(Build.SourceVersion)/html/'
 

--- a/scripts/azp/doc.yml
+++ b/scripts/azp/doc.yml
@@ -27,11 +27,11 @@ jobs:
   - script: |
       #export AWS_ACCESS_KEY_ID = variables['aws-credentials.AWS_ACCESS_KEY_ID']
       #export AWS_SECRET_ACCESS_KEY = variables['aws-credentials.AWS_SECRET_ACCESS_KEY']
-      export AWS_ACCESS_KEY_ID = $(AWS_ACCESS_KEY_ID)
-      export AWS_SECRET_ACCESS_KEY = $(AWS_SECRET_ACCESS_KEY)
+      export AWS_ACCESS_KEY_ID="$(AWS_ACCESS_KEY_ID)"
+      export AWS_SECRET_ACCESS_KEY="$(AWS_SECRET_ACCESS_KEY)"
       cd doc/build
-      aws s3 sync html --quiet "s3://pdal/docs/$(Build.SourceVersion)/html/" --acl public-read
-      aws s3 cp --quiet latex/PDAL.pdf "s3://pdal/docs/$(Build.SourceVersion)/html/" --acl public-read
+      aws s3 sync html "s3://pdal/docs/$(Build.SourceVersion)/html/" --acl public-read --quiet
+      aws s3 cp latex/PDAL.pdf "s3://pdal/docs/$(Build.SourceVersion)/html/" --acl public-read --quiet
       echo "PDF location: https://pdal.s3.amazonaws.com/docs/$(Build.SourceVersion)/html/PDAL.pdf"
       echo "HTML location: https://pdal.s3.amazonaws.com/docs/$(Build.SourceVersion)/html/index.html"
     displayName: 'Upload https://pdal.s3.amazonaws.com/docs/$(Build.SourceVersion)/html/index.html'

--- a/scripts/azp/doc.yml
+++ b/scripts/azp/doc.yml
@@ -1,0 +1,26 @@
+# -*- mode: yaml -*-
+
+jobs:
+- job: linux
+  pool:
+    vmImage: ubuntu-16.04
+  container:
+      image: osgeo/proj-docs:latest
+      options: --privileged
+  timeoutInMinutes: 60
+  steps:
+  - script: |
+      echo "current directory:" `pwd`
+      cd doc
+      make doxygen
+    displayName: 'Make Doxygen'
+  - script: |
+      cd doc
+      make html
+    displayName: 'Make HTML'
+  - script: |
+      cd doc
+      make pdf
+      ninja
+    displayName: 'Make PDF'
+

--- a/scripts/azp/doc.yml
+++ b/scripts/azp/doc.yml
@@ -20,8 +20,8 @@ jobs:
     #  make latexpdf
     #displayName: 'Make PDF'
   - script: |
-      export AWS_ACCESS_KEY_ID=variables["aws-credentials.AWS_ACCESS_KEY_ID"]
-      export AWS_SECRET_ACCESS_KEY=variables["aws-credentials.AWS_SECRET_ACCESS_KEY"]
+      export AWS_ACCESS_KEY_ID=variables['aws-credentials.AWS_ACCESS_KEY_ID']
+      export AWS_SECRET_ACCESS_KEY=variables['aws-credentials.AWS_SECRET_ACCESS_KEY']
       cd doc/build
       aws s3 sync html "s3://pdal/docs/$(Build.SourceVersion)/html/" --acl public-read
       aws s3 sync latexpdf/PDAL.pdf "s3://pdal/docs/$(Build.SourceVersion)/html/" --acl public-read

--- a/scripts/azp/doc.yml
+++ b/scripts/azp/doc.yml
@@ -12,6 +12,11 @@ jobs:
   timeoutInMinutes: 60
   steps:
   - script: |
+      echo "current directory:" `pwd`
+      cd doc
+      make doxygen
+    displayName: 'Make Doxygen'
+  - script: |
       cd doc
       make html
     displayName: 'Make HTML'
@@ -20,10 +25,10 @@ jobs:
     #  make latexpdf
     #displayName: 'Make PDF'
   - script: |
-      export AWS_ACCESS_KEY_ID=variables['aws-credentials.AWS_ACCESS_KEY_ID']
-      export AWS_SECRET_ACCESS_KEY=variables['aws-credentials.AWS_SECRET_ACCESS_KEY']
+      export AWS_ACCESS_KEY_ID = variables['aws-credentials.AWS_ACCESS_KEY_ID']
+      export AWS_SECRET_ACCESS_KEY = variables['aws-credentials.AWS_SECRET_ACCESS_KEY']
       cd doc/build
       aws s3 sync html "s3://pdal/docs/$(Build.SourceVersion)/html/" --acl public-read
-      aws s3 sync latexpdf/PDAL.pdf "s3://pdal/docs/$(Build.SourceVersion)/html/" --acl public-read
+      aws s3 cp latexpdf/PDAL.pdf "s3://pdal/docs/$(Build.SourceVersion)/html/" --acl public-read
     displayName: 'Upload https://pdal.s3.amazonaws.com/docs/$(Build.SourceVersion)/html/'
 

--- a/scripts/azp/doc.yml
+++ b/scripts/azp/doc.yml
@@ -28,10 +28,10 @@ jobs:
       export AWS_ACCESS_KEY_ID = variables['aws-credentials.AWS_ACCESS_KEY_ID']
       export AWS_SECRET_ACCESS_KEY = variables['aws-credentials.AWS_SECRET_ACCESS_KEY']
       cd doc/build
-      aws s3 sync html "s3://pdal/docs/$(Build.SourceVersion)/html/" --acl public-read
+      aws s3 sync html --quiet "s3://pdal/docs/$(Build.SourceVersion)/html/" --acl public-read
       aws s3 cp latex/PDAL.pdf "s3://pdal/docs/$(Build.SourceVersion)/html/" --acl public-read
       echo "PDF location: https://pdal.s3.amazonaws.com/docs/$(Build.SourceVersion)/html/PDAL.pdf"
-      echo "HTML location: https://pdal.s3.amazonaws.com/docs/$(Build.SourceVersion)/html/"
-    displayName: 'Upload https://pdal.s3.amazonaws.com/docs/$(Build.SourceVersion)/html/'
+      echo "HTML location: https://pdal.s3.amazonaws.com/docs/$(Build.SourceVersion)/html/index.html"
+    displayName: 'Upload https://pdal.s3.amazonaws.com/docs/$(Build.SourceVersion)/html/index.html'
     condition: in(variables['Build.Reason'], 'PullRequest')
 

--- a/scripts/azp/doc.yml
+++ b/scripts/azp/doc.yml
@@ -20,14 +20,14 @@ jobs:
       cd doc
       make html
     displayName: 'Make HTML'
+    #  - script: |
+    #  cd doc
+    #  make latexpdf
+    #displayName: 'Make PDF'
   - script: |
-      cd doc
-      make latexpdf
-    displayName: 'Make PDF'
-  - script: |
-      export AWS_ACCESS_KEY_ID = variables['aws-credentials.AWS_ACCESS_KEY_ID']
-      export AWS_SECRET_ACCESS_KEY = variables['aws-credentials.AWS_SECRET_ACCESS_KEY']
+      export AWS_ACCESS_KEY_ID=$(aws-credentials.AWS_ACCESS_KEY_ID)
+      export AWS_SECRET_ACCESS_KEY=$(aws-credentials.AWS_SECRET_ACCESS_KEY)
       cd doc/build
-      aws s3 sync . "s3://pdal/docs/$BUILD_SOURCEVERSION/" --acl public-read
-    displayName: 'Upload https://github.com/OSGeo/gdal/commit/$BUILD_SOURCEVERSION to https://pdal.s3.amazonaws.com/docs/$BUILD_SOURCEVERSION/html/'
+      aws s3 sync . "s3://pdal/docs/$(Build.SourceVersion)/" --acl public-read
+    displayName: 'Upload to https://pdal.s3.amazonaws.com/docs/$(Build.SourceVersion)/html/'
 

--- a/scripts/azp/doc.yml
+++ b/scripts/azp/doc.yml
@@ -23,7 +23,6 @@ jobs:
   - script: |
       cd doc
       make latexpdf
-      ninja
     displayName: 'Make PDF'
   - script: |
       export AWS_ACCESS_KEY_ID = variables['aws-credentials.AWS_ACCESS_KEY_ID']

--- a/scripts/azp/doc.yml
+++ b/scripts/azp/doc.yml
@@ -25,8 +25,10 @@ jobs:
       make latexpdf
     displayName: 'Make PDF'
   - script: |
-      export AWS_ACCESS_KEY_ID = variables['aws-credentials.AWS_ACCESS_KEY_ID']
-      export AWS_SECRET_ACCESS_KEY = variables['aws-credentials.AWS_SECRET_ACCESS_KEY']
+      #export AWS_ACCESS_KEY_ID = variables['aws-credentials.AWS_ACCESS_KEY_ID']
+      #export AWS_SECRET_ACCESS_KEY = variables['aws-credentials.AWS_SECRET_ACCESS_KEY']
+      export AWS_ACCESS_KEY_ID = $(AWS_ACCESS_KEY_ID)
+      export AWS_SECRET_ACCESS_KEY = $(AWS_SECRET_ACCESS_KEY)
       cd doc/build
       aws s3 sync html --quiet "s3://pdal/docs/$(Build.SourceVersion)/html/" --acl public-read
       aws s3 cp latex/PDAL.pdf "s3://pdal/docs/$(Build.SourceVersion)/html/" --acl public-read

--- a/scripts/azp/doc.yml
+++ b/scripts/azp/doc.yml
@@ -20,15 +20,15 @@ jobs:
       cd doc
       make html
     displayName: 'Make HTML'
-    #  - script: |
-    #  cd doc
-    #  make latexpdf
-    #displayName: 'Make PDF'
+    - script: |
+      cd doc
+      make latexpdf
+    displayName: 'Make PDF'
   - script: |
       export AWS_ACCESS_KEY_ID = variables['aws-credentials.AWS_ACCESS_KEY_ID']
       export AWS_SECRET_ACCESS_KEY = variables['aws-credentials.AWS_SECRET_ACCESS_KEY']
       cd doc/build
       aws s3 sync html "s3://pdal/docs/$(Build.SourceVersion)/html/" --acl public-read
-      aws s3 cp latexpdf/PDAL.pdf "s3://pdal/docs/$(Build.SourceVersion)/html/" --acl public-read
+      aws s3 cp latex/PDAL.pdf "s3://pdal/docs/$(Build.SourceVersion)/html/" --acl public-read
     displayName: 'Upload https://pdal.s3.amazonaws.com/docs/$(Build.SourceVersion)/html/'
 

--- a/scripts/azp/doc.yml
+++ b/scripts/azp/doc.yml
@@ -25,9 +25,11 @@ jobs:
     #  make latexpdf
     #displayName: 'Make PDF'
   - script: |
-      export AWS_ACCESS_KEY_ID=$(aws-credentials.AWS_ACCESS_KEY_ID)
-      export AWS_SECRET_ACCESS_KEY=$(aws-credentials.AWS_SECRET_ACCESS_KEY)
+      #      export AWS_ACCESS_KEY_ID=variables['aws-credentials.AWS_ACCESS_KEY_ID']
+      #export AWS_SECRET_ACCESS_KEY=variables['aws-credentials.AWS_SECRET_ACCESS_KEY']
+      export AWS_ACCESS_KEY_ID="$(aws-credentials.AWS_ACCESS_KEY_ID)"
+      export AWS_SECRET_ACCESS_KEY="$(aws-credentials.AWS_SECRET_ACCESS_KEY)"
       cd doc/build
       aws s3 sync . "s3://pdal/docs/$(Build.SourceVersion)/" --acl public-read
-    displayName: 'Upload to https://pdal.s3.amazonaws.com/docs/$(Build.SourceVersion)/html/'
+    displayName: 'Upload https://github.com/OSGeo/gdal/commit/$(Build.SourceVersion) to https://pdal.s3.amazonaws.com/docs/$(Build.SourceVersion)/html/'
 

--- a/scripts/azp/doc.yml
+++ b/scripts/azp/doc.yml
@@ -33,4 +33,5 @@ jobs:
       echo "PDF location: https://pdal.s3.amazonaws.com/docs/$(Build.SourceVersion)/html/PDAL.pdf"
       echo "HTML location: https://pdal.s3.amazonaws.com/docs/$(Build.SourceVersion)/html/"
     displayName: 'Upload https://pdal.s3.amazonaws.com/docs/$(Build.SourceVersion)/html/'
+    condition: in(variables['Build.Reason'], 'PullRequest')
 

--- a/scripts/azp/doc.yml
+++ b/scripts/azp/doc.yml
@@ -12,11 +12,6 @@ jobs:
   timeoutInMinutes: 60
   steps:
   - script: |
-      echo "current directory:" `pwd`
-      cd doc
-      make doxygen
-    displayName: 'Make Doxygen'
-  - script: |
       cd doc
       make html
     displayName: 'Make HTML'
@@ -25,11 +20,10 @@ jobs:
     #  make latexpdf
     #displayName: 'Make PDF'
   - script: |
-      #      export AWS_ACCESS_KEY_ID=variables['aws-credentials.AWS_ACCESS_KEY_ID']
-      #export AWS_SECRET_ACCESS_KEY=variables['aws-credentials.AWS_SECRET_ACCESS_KEY']
-      export AWS_ACCESS_KEY_ID="$(aws-credentials.AWS_ACCESS_KEY_ID)"
-      export AWS_SECRET_ACCESS_KEY="$(aws-credentials.AWS_SECRET_ACCESS_KEY)"
+      export AWS_ACCESS_KEY_ID="variables['aws-credentials.AWS_ACCESS_KEY_ID']"
+      export AWS_SECRET_ACCESS_KEY="variables['aws-credentials.AWS_SECRET_ACCESS_KEY']"
       cd doc/build
-      aws s3 sync . "s3://pdal/docs/$(Build.SourceVersion)/" --acl public-read
-    displayName: 'Upload https://github.com/OSGeo/gdal/commit/$(Build.SourceVersion) to https://pdal.s3.amazonaws.com/docs/$(Build.SourceVersion)/html/'
+      aws s3 sync html "s3://pdal/docs/$(Build.SourceVersion)/html/" --acl public-read
+      aws s3 sync latexpdf/PDAL.pdf "s3://pdal/docs/$(Build.SourceVersion)/html/" --acl public-read
+    displayName: 'Upload https://pdal.s3.amazonaws.com/docs/$(Build.SourceVersion)/html/'
 

--- a/scripts/azp/doc.yml
+++ b/scripts/azp/doc.yml
@@ -20,8 +20,8 @@ jobs:
     #  make latexpdf
     #displayName: 'Make PDF'
   - script: |
-      export AWS_ACCESS_KEY_ID="variables['aws-credentials.AWS_ACCESS_KEY_ID']"
-      export AWS_SECRET_ACCESS_KEY="variables['aws-credentials.AWS_SECRET_ACCESS_KEY']"
+      export AWS_ACCESS_KEY_ID=variables["aws-credentials.AWS_ACCESS_KEY_ID"]
+      export AWS_SECRET_ACCESS_KEY=variables["aws-credentials.AWS_SECRET_ACCESS_KEY"]
       cd doc/build
       aws s3 sync html "s3://pdal/docs/$(Build.SourceVersion)/html/" --acl public-read
       aws s3 sync latexpdf/PDAL.pdf "s3://pdal/docs/$(Build.SourceVersion)/html/" --acl public-read


### PR DESCRIPTION
Build the docs using Azure Pipelines and upload the output to S3 for public viewing.

* Upload should only happen for pull requests
* The s3 bucket deletes all content after 3 days
* It could be adapted to upload to pdal.io quite easily. We are currently doing that with Travis.
