### PR TITLE
Document filters.python feature to use equal for type

### DIFF
--- a/doc/stages/filters.python.rst
+++ b/doc/stages/filters.python.rst
@@ -59,6 +59,12 @@ filter and the ``outs`` array represents the points after filtering.
        "add_dimension": [ "NewDimensionOne", "NewDimensionTwo", "NewDimensionThree" ]
 
 
+   You can also specify the :ref:`type <types>` of the dimension using an ``=``.
+   ::
+
+       "add_dimension": "NewDimensionOne=uint8"
+
+
 Modification Example
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
This feature is useful but not documented. 🤷‍♂ 

https://github.com/PDAL/python/blob/80eea96fada65f734ed4dd26a08681d1c2d5c415/pdal/filters/PythonFilter.cpp#L97-L114