### PR TITLE
Update arbiter bundle

### DIFF
--- a/io/EptReader.cpp
+++ b/io/EptReader.cpp
@@ -191,8 +191,7 @@ std::vector<char> EptReader::getBinary(const std::string path) const
 }
 
 
-std::unique_ptr<arbiter::LocalHandle> EptReader::getLocalHandle(
-    const std::string path) const
+arbiter::LocalHandle EptReader::getLocalHandle(const std::string path) const
 {
     if (m_ep->isLocal())
         return m_ep->getLocalHandle(path);
@@ -765,7 +764,7 @@ PointId EptReader::readLaszip(PointView& dst, const Key& key,
     PointTable table;
 
     Options options;
-    options.add("filename", handle->localPath());
+    options.add("filename", handle.localPath());
     options.add("use_eb_vlr", true);
 
     LasReader reader;

--- a/io/EptReader.hpp
+++ b/io/EptReader.hpp
@@ -129,8 +129,7 @@ private:
     // Data fetching - these forward user-specified query/header params.
     std::string get(std::string path) const;
     std::vector<char> getBinary(std::string path) const;
-    std::unique_ptr<arbiter::LocalHandle> getLocalHandle(std::string path)
-        const;
+    arbiter::LocalHandle getLocalHandle(std::string path) const;
 
     std::string m_root;
 

--- a/vendor/arbiter/arbiter.cpp
+++ b/vendor/arbiter/arbiter.cpp
@@ -162,7 +162,7 @@ Arbiter::Arbiter(const std::string s)
 
 bool Arbiter::hasDriver(const std::string path) const
 {
-    return m_drivers.count(getType(path));
+    return m_drivers.count(getProtocol(path));
 }
 
 void Arbiter::addDriver(const std::string type, std::unique_ptr<Driver> driver)
@@ -173,42 +173,42 @@ void Arbiter::addDriver(const std::string type, std::unique_ptr<Driver> driver)
 
 std::string Arbiter::get(const std::string path) const
 {
-    return getDriver(path).get(stripType(path));
+    return getDriver(path).get(stripProtocol(path));
 }
 
 std::vector<char> Arbiter::getBinary(const std::string path) const
 {
-    return getDriver(path).getBinary(stripType(path));
+    return getDriver(path).getBinary(stripProtocol(path));
 }
 
 std::unique_ptr<std::string> Arbiter::tryGet(std::string path) const
 {
-    return getDriver(path).tryGet(stripType(path));
+    return getDriver(path).tryGet(stripProtocol(path));
 }
 
 std::unique_ptr<std::vector<char>> Arbiter::tryGetBinary(std::string path) const
 {
-    return getDriver(path).tryGetBinary(stripType(path));
+    return getDriver(path).tryGetBinary(stripProtocol(path));
 }
 
 std::size_t Arbiter::getSize(const std::string path) const
 {
-    return getDriver(path).getSize(stripType(path));
+    return getDriver(path).getSize(stripProtocol(path));
 }
 
 std::unique_ptr<std::size_t> Arbiter::tryGetSize(const std::string path) const
 {
-    return getDriver(path).tryGetSize(stripType(path));
+    return getDriver(path).tryGetSize(stripProtocol(path));
 }
 
 void Arbiter::put(const std::string path, const std::string& data) const
 {
-    return getDriver(path).put(stripType(path), data);
+    return getDriver(path).put(stripProtocol(path), data);
 }
 
 void Arbiter::put(const std::string path, const std::vector<char>& data) const
 {
-    return getDriver(path).put(stripType(path), data);
+    return getDriver(path).put(stripProtocol(path), data);
 }
 
 std::string Arbiter::get(
@@ -216,7 +216,7 @@ std::string Arbiter::get(
         const http::Headers headers,
         const http::Query query) const
 {
-    return getHttpDriver(path).get(stripType(path), headers, query);
+    return getHttpDriver(path).get(stripProtocol(path), headers, query);
 }
 
 std::unique_ptr<std::string> Arbiter::tryGet(
@@ -224,7 +224,7 @@ std::unique_ptr<std::string> Arbiter::tryGet(
         const http::Headers headers,
         const http::Query query) const
 {
-    return getHttpDriver(path).tryGet(stripType(path), headers, query);
+    return getHttpDriver(path).tryGet(stripProtocol(path), headers, query);
 }
 
 std::vector<char> Arbiter::getBinary(
@@ -232,7 +232,7 @@ std::vector<char> Arbiter::getBinary(
         const http::Headers headers,
         const http::Query query) const
 {
-    return getHttpDriver(path).getBinary(stripType(path), headers, query);
+    return getHttpDriver(path).getBinary(stripProtocol(path), headers, query);
 }
 
 std::unique_ptr<std::vector<char>> Arbiter::tryGetBinary(
@@ -240,7 +240,7 @@ std::unique_ptr<std::vector<char>> Arbiter::tryGetBinary(
         const http::Headers headers,
         const http::Query query) const
 {
-    return getHttpDriver(path).tryGetBinary(stripType(path), headers, query);
+    return getHttpDriver(path).tryGetBinary(stripProtocol(path), headers, query);
 }
 
 void Arbiter::put(
@@ -249,7 +249,7 @@ void Arbiter::put(
         const http::Headers headers,
         const http::Query query) const
 {
-    return getHttpDriver(path).put(stripType(path), data, headers, query);
+    return getHttpDriver(path).put(stripProtocol(path), data, headers, query);
 }
 
 void Arbiter::put(
@@ -258,7 +258,7 @@ void Arbiter::put(
         const http::Headers headers,
         const http::Query query) const
 {
-    return getHttpDriver(path).put(stripType(path), data, headers, query);
+    return getHttpDriver(path).put(stripProtocol(path), data, headers, query);
 }
 
 void Arbiter::copy(
@@ -343,7 +343,7 @@ void Arbiter::copyFile(
     {
         // If this copy is within the same driver domain, defer to the
         // hopefully specialized copy method.
-        getDriver(file).copy(stripType(file), stripType(dst));
+        getDriver(file).copy(stripProtocol(file), stripProtocol(dst));
     }
     else
     {
@@ -376,17 +376,17 @@ std::vector<std::string> Arbiter::resolve(
         const std::string path,
         const bool verbose) const
 {
-    return getDriver(path).resolve(stripType(path), verbose);
+    return getDriver(path).resolve(stripProtocol(path), verbose);
 }
 
 Endpoint Arbiter::getEndpoint(const std::string root) const
 {
-    return Endpoint(getDriver(root), stripType(root));
+    return Endpoint(getDriver(root), stripProtocol(root));
 }
 
 const Driver& Arbiter::getDriver(const std::string path) const
 {
-    const auto type(getType(path));
+    const auto type(getProtocol(path));
 
     if (!m_drivers.count(type))
     {
@@ -407,7 +407,7 @@ const drivers::Http& Arbiter::getHttpDriver(const std::string path) const
     else throw ArbiterError("Cannot get driver for " + path + " as HTTP");
 }
 
-std::unique_ptr<LocalHandle> Arbiter::getLocalHandle(
+LocalHandle Arbiter::getLocalHandle(
         const std::string path,
         const Endpoint& tempEndpoint) const
 {
@@ -415,52 +415,12 @@ std::unique_ptr<LocalHandle> Arbiter::getLocalHandle(
     return fromEndpoint.getLocalHandle(getBasename(path));
 }
 
-std::unique_ptr<LocalHandle> Arbiter::getLocalHandle(
+LocalHandle Arbiter::getLocalHandle(
         const std::string path,
         std::string tempPath) const
 {
     if (tempPath.empty()) tempPath = getTempPath();
     return getLocalHandle(path, getEndpoint(tempPath));
-}
-
-std::string Arbiter::getType(const std::string path)
-{
-    std::string type("file");
-    const std::size_t pos(path.find(delimiter));
-
-    if (pos != std::string::npos)
-    {
-        type = path.substr(0, pos);
-    }
-
-    return type;
-}
-
-std::string Arbiter::stripType(const std::string raw)
-{
-    std::string result(raw);
-    const std::size_t pos(raw.find(delimiter));
-
-    if (pos != std::string::npos)
-    {
-        result = raw.substr(pos + delimiter.size());
-    }
-
-    return result;
-}
-
-std::string Arbiter::getExtension(const std::string path)
-{
-    const std::size_t pos(path.find_last_of('.'));
-
-    if (pos != std::string::npos) return path.substr(pos + 1);
-    else return std::string();
-}
-
-std::string Arbiter::stripExtension(const std::string path)
-{
-    const std::size_t pos(path.find_last_of('.'));
-    return path.substr(0, pos);
 }
 
 } // namespace arbiter
@@ -631,14 +591,13 @@ namespace
         std::ofstream::app);
     std::string postfixSlash(std::string path)
     {
-        if (path.empty()) throw ArbiterError("Invalid root path");
-        if (path.back() != '/') path.push_back('/');
+        if (!path.empty() && path.back() != '/') path.push_back('/');
         return path;
     }
 }
 
 Endpoint::Endpoint(const Driver& driver, const std::string root)
-    : m_driver(driver)
+    : m_driver(&driver)
     , m_root(expandTilde(postfixSlash(root)))
 { }
 
@@ -654,12 +613,12 @@ std::string Endpoint::prefixedRoot() const
 
 std::string Endpoint::type() const
 {
-    return m_driver.type();
+    return m_driver->type();
 }
 
 bool Endpoint::isRemote() const
 {
-    return m_driver.isRemote();
+    return m_driver->isRemote();
 }
 
 bool Endpoint::isLocal() const
@@ -672,17 +631,15 @@ bool Endpoint::isHttpDerived() const
     return tryGetHttpDriver() != nullptr;
 }
 
-std::unique_ptr<LocalHandle> Endpoint::getLocalHandle(
+LocalHandle Endpoint::getLocalHandle(
         const std::string subpath,
         http::Headers headers,
         http::Query query) const
 {
-    std::unique_ptr<LocalHandle> handle;
-
     if (isRemote())
     {
         const std::string tmp(getTempPath());
-        const auto ext(Arbiter::getExtension(subpath));
+        const auto ext(getExtension(subpath));
         const std::string basename(
                 std::to_string(randomNumber()) +
                 (ext.size() ? "." + ext : ""));
@@ -727,59 +684,57 @@ std::unique_ptr<LocalHandle> Endpoint::getLocalHandle(
             fs.put(local, getBinary(subpath));
         }
 
-        handle.reset(new LocalHandle(local, true));
+        return LocalHandle(local, true);
     }
     else
     {
-        handle.reset(new LocalHandle(expandTilde(fullPath(subpath)), false));
+        return LocalHandle(expandTilde(fullPath(subpath)), false);
     }
-
-    return handle;
 }
 
 std::string Endpoint::get(const std::string subpath) const
 {
-    return m_driver.get(fullPath(subpath));
+    return m_driver->get(fullPath(subpath));
 }
 
 std::unique_ptr<std::string> Endpoint::tryGet(const std::string subpath)
     const
 {
-    return m_driver.tryGet(fullPath(subpath));
+    return m_driver->tryGet(fullPath(subpath));
 }
 
 std::vector<char> Endpoint::getBinary(const std::string subpath) const
 {
-    return m_driver.getBinary(fullPath(subpath));
+    return m_driver->getBinary(fullPath(subpath));
 }
 
 std::unique_ptr<std::vector<char>> Endpoint::tryGetBinary(
         const std::string subpath) const
 {
-    return m_driver.tryGetBinary(fullPath(subpath));
+    return m_driver->tryGetBinary(fullPath(subpath));
 }
 
 std::size_t Endpoint::getSize(const std::string subpath) const
 {
-    return m_driver.getSize(fullPath(subpath));
+    return m_driver->getSize(fullPath(subpath));
 }
 
 std::unique_ptr<std::size_t> Endpoint::tryGetSize(
         const std::string subpath) const
 {
-    return m_driver.tryGetSize(fullPath(subpath));
+    return m_driver->tryGetSize(fullPath(subpath));
 }
 
 void Endpoint::put(const std::string subpath, const std::string& data) const
 {
-    m_driver.put(fullPath(subpath), data);
+    m_driver->put(fullPath(subpath), data);
 }
 
 void Endpoint::put(
         const std::string subpath,
         const std::vector<char>& data) const
 {
-    m_driver.put(fullPath(subpath), data);
+    m_driver->put(fullPath(subpath), data);
 }
 
 std::string Endpoint::get(
@@ -879,7 +834,7 @@ std::string Endpoint::prefixedFullPath(const std::string& subpath) const
 
 Endpoint Endpoint::getSubEndpoint(std::string subpath) const
 {
-    return Endpoint(m_driver, m_root + subpath);
+    return Endpoint(*m_driver, m_root + subpath);
 }
 
 std::string Endpoint::softPrefix() const
@@ -889,7 +844,7 @@ std::string Endpoint::softPrefix() const
 
 const drivers::Http* Endpoint::tryGetHttpDriver() const
 {
-    return dynamic_cast<const drivers::Http*>(&m_driver);
+    return dynamic_cast<const drivers::Http*>(m_driver);
 }
 
 const drivers::Http& Endpoint::getHttpDriver() const
@@ -978,7 +933,6 @@ namespace
             if (homeDrive && homePath) s = *homeDrive + *homePath;
         }
 #endif
-        if (s.empty()) std::cout << "No home directory found" << std::endl;
 
         return s;
     }
@@ -1297,9 +1251,9 @@ std::vector<std::string> glob(std::string path)
 std::string expandTilde(std::string in)
 {
     std::string out(in);
-    static std::string home(getHome());
     if (!in.empty() && in.front() == '~')
     {
+        const std::string home = getHome();
         if (home.empty()) throw ArbiterError("No home directory found");
         out = home + in.substr(1);
     }
@@ -1563,7 +1517,7 @@ Response Http::internalPost(
 
 std::string Http::typedPath(const std::string& p) const
 {
-    if (Arbiter::getType(p) != "file") return p;
+    if (getProtocol(p) != "file") return p;
     else return type() + "://" + p;
 }
 
@@ -2114,7 +2068,7 @@ void S3::put(
     Headers headers(m_config->baseHeaders());
     headers.insert(userHeaders.begin(), userHeaders.end());
 
-    if (Arbiter::getExtension(rawPath) == "json")
+    if (getExtension(rawPath) == "json")
     {
         headers["Content-Type"] = "application/json";
     }
@@ -2566,10 +2520,10 @@ namespace
         std::string m_object;
 
     };
-    
+
     // https://cloud.google.com/storage/docs/json_api/#encoding
     const char GResource::exclusions[] = "!$&'()*+,;=:@";
-    
+
 } // unnamed namespace
 
 namespace drivers
@@ -2599,10 +2553,18 @@ std::unique_ptr<std::size_t> Google::tryGetSize(const std::string path) const
     const auto res(
             https.internalHead(resource.endpoint(), headers, altMediaQuery));
 
-    if (res.ok() && res.headers().count("Content-Length"))
+    if (res.ok())
     {
-        const auto& s(res.headers().at("Content-Length"));
-        return makeUnique<std::size_t>(std::stoull(s));
+        if (res.headers().count("Content-Length"))
+        {
+            const auto& s(res.headers().at("Content-Length"));
+            return makeUnique<std::size_t>(std::stoull(s));
+        }
+        else if (res.headers().count("content-length"))
+        {
+            const auto& s(res.headers().at("content-length"));
+            return makeUnique<std::size_t>(std::stoull(s));
+        }
     }
 
     return std::unique_ptr<std::size_t>();
@@ -3003,14 +2965,13 @@ Headers Dropbox::httpPostHeaders() const
     return headers;
 }
 
-std::unique_ptr<std::size_t> Dropbox::tryGetSize(
-        const std::string rawPath) const
+std::unique_ptr<std::size_t> Dropbox::tryGetSize(const std::string path) const
 {
     std::unique_ptr<std::size_t> result;
 
     Headers headers(httpPostHeaders());
 
-    json tx { { "path", "/" + sanitize(rawPath) } };
+    json tx { { "path", "/" + path } };
     const std::string f(tx.dump());
     const std::vector<char> postData(f.begin(), f.end());
 
@@ -3031,13 +2992,11 @@ std::unique_ptr<std::size_t> Dropbox::tryGetSize(
 }
 
 bool Dropbox::get(
-        const std::string rawPath,
+        const std::string path,
         std::vector<char>& data,
         const Headers userHeaders,
         const Query query) const
 {
-    const std::string path(sanitize(rawPath));
-
     Headers headers(httpGetHeaders());
 
     headers["Dropbox-API-Arg"] = json{{ "path", "/" + path }}.dump();
@@ -3100,13 +3059,11 @@ bool Dropbox::get(
 }
 
 void Dropbox::put(
-        const std::string rawPath,
+        const std::string path,
         const std::vector<char>& data,
         const Headers userHeaders,
         const Query query) const
 {
-    const std::string path(sanitize(rawPath));
-
     Headers headers(httpGetHeaders());
     headers["Dropbox-API-Arg"] = json{{ "path", "/" + path }}.dump();
     headers["Content-Type"] = "application/octet-stream";
@@ -4762,6 +4719,8 @@ namespace arbiter
 
 namespace
 {
+    const std::string protocolDelimiter("://");
+
     std::mutex randomMutex;
     std::random_device rd;
     std::mt19937 gen(rd());
@@ -4793,9 +4752,9 @@ std::string stripPostfixing(const std::string path)
 
 std::string getBasename(const std::string fullPath)
 {
-    std::string result(fullPath);
+    std::string result(stripProtocol(fullPath));
 
-    const std::string stripped(stripPostfixing(Arbiter::stripType(fullPath)));
+    const std::string stripped(stripPostfixing(stripProtocol(fullPath)));
 
     // Now do the real slash searching.
     std::size_t pos(stripped.rfind('/'));
@@ -4817,7 +4776,7 @@ std::string getDirname(const std::string fullPath)
 {
     std::string result("");
 
-    const std::string stripped(stripPostfixing(Arbiter::stripType(fullPath)));
+    const std::string stripped(stripPostfixing(stripProtocol(fullPath)));
 
     // Now do the real slash searching.
     const std::size_t pos(stripped.rfind('/'));
@@ -4828,8 +4787,8 @@ std::string getDirname(const std::string fullPath)
         result = sub;
     }
 
-    const std::string type(Arbiter::getType(fullPath));
-    if (type != "file") result = type + "://" + result;
+    const std::string protocol(getProtocol(fullPath));
+    if (protocol != "file") result = protocol + "://" + result;
 
     return result;
 }
@@ -4891,6 +4850,47 @@ std::string stripWhitespace(const std::string& in)
                 [](char c) { return std::isspace(c); }),
             out.end());
     return out;
+}
+
+std::string getProtocol(const std::string path)
+{
+    std::string type("file");
+    const std::size_t pos(path.find(protocolDelimiter));
+
+    if (pos != std::string::npos)
+    {
+        type = path.substr(0, pos);
+    }
+
+    return type;
+}
+
+std::string stripProtocol(const std::string raw)
+{
+    std::string result(raw);
+    const std::size_t pos(raw.find(protocolDelimiter));
+
+    if (pos != std::string::npos)
+    {
+        result = raw.substr(pos + protocolDelimiter.size());
+    }
+
+    return result;
+}
+
+std::string getExtension(std::string path)
+{
+    path = getBasename(path);
+    const std::size_t pos(path.find_last_of('.'));
+
+    if (pos != std::string::npos) return path.substr(pos + 1);
+    else return std::string();
+}
+
+std::string stripExtension(const std::string path)
+{
+    const std::size_t pos(path.find_last_of('.'));
+    return path.substr(0, pos);
 }
 
 } // namespace arbiter

--- a/vendor/arbiter/arbiter.hpp
+++ b/vendor/arbiter/arbiter.hpp
@@ -1,7 +1,7 @@
 /// Arbiter amalgamated header (https://github.com/connormanning/arbiter).
 /// It is intended to be used with #include "arbiter.hpp"
 
-// Git SHA: 098ed60a28d9a612a125a26ec667569c0bc90c8e
+// Git SHA: ca8bf63974b7614eec6dd3cb414a7e2b07345820
 
 // //////////////////////////////////////////////////////////////////////
 // Beginning of content of file: LICENSE
@@ -4070,6 +4070,22 @@ std::unique_ptr<T> maybeClone(const T* t)
 
 ARBITER_DLL uint64_t randomNumber();
 
+/** If no delimiter of "://" is found, returns "file".  Otherwise, returns
+ * the substring prior to but not including this delimiter.
+ */
+ARBITER_DLL std::string getProtocol(std::string path);
+
+/** Strip the type and delimiter `://`, if they exist. */
+ARBITER_DLL std::string stripProtocol(std::string path);
+
+/** Get the characters following the final instance of '.', or an empty
+ * string if there are no '.' characters. */
+ARBITER_DLL std::string getExtension(std::string path);
+
+/** Strip the characters following (and including) the final instance of
+ * '.' if one exists, otherwise return the full path. */
+ARBITER_DLL std::string stripExtension(std::string path);
+
 } // namespace arbiter
 
 #ifdef ARBITER_CUSTOM_NAMESPACE
@@ -4292,10 +4308,9 @@ ARBITER_DLL std::vector<std::string> glob(std::string path);
  */
 class ARBITER_DLL LocalHandle
 {
-    friend class arbiter::Arbiter;
-    friend class arbiter::Endpoint;
-
 public:
+    LocalHandle(std::string localPath, bool isRemote);
+
     /** @brief Deletes the local path if the data was copied from a remote
      * source.
      *
@@ -4323,8 +4338,6 @@ public:
     }
 
 private:
-    LocalHandle(std::string localPath, bool isRemote);
-
     const std::string m_localPath;
     bool m_erase;
 };
@@ -5158,7 +5171,7 @@ public:
     bool isHttpDerived() const;
 
     /** See Arbiter::getLocalHandle. */
-    std::unique_ptr<LocalHandle> getLocalHandle(
+    LocalHandle getLocalHandle(
             std::string subpath,
             http::Headers headers = http::Headers(),
             http::Query query = http::Query()) const;
@@ -5287,7 +5300,7 @@ private:
     const drivers::Http* tryGetHttpDriver() const;
     const drivers::Http& getHttpDriver() const;
 
-    const Driver& m_driver;
+    const Driver* m_driver;
     std::string m_root;
 };
 
@@ -5566,7 +5579,7 @@ public:
      *
      * @return A LocalHandle for local access to the resulting file.
      */
-    std::unique_ptr<LocalHandle> getLocalHandle(
+    LocalHandle getLocalHandle(
             std::string path,
             const Endpoint& tempEndpoint) const;
 
@@ -5575,25 +5588,9 @@ public:
      * If @p tempPath is not specified, the environment will be searched for a
      * temporary location.
      */
-    std::unique_ptr<LocalHandle> getLocalHandle(
+    LocalHandle getLocalHandle(
             std::string path,
             std::string tempPath = "") const;
-
-    /** If no delimiter of "://" is found, returns "file".  Otherwise, returns
-     * the substring prior to but not including this delimiter.
-     */
-    static std::string getType(std::string path);
-
-    /** Strip the type and delimiter `://`, if they exist. */
-    static std::string stripType(std::string path);
-
-    /** Get the characters following the final instance of '.', or an empty
-     * string if there are no '.' characters. */
-    static std::string getExtension(std::string path);
-
-    /** Strip the characters following (and including) the final instance of
-     * '.' if one exists, otherwise return the full path. */
-    static std::string stripExtension(std::string path);
 
     /** Fetch the common HTTP pool, which may be useful when dynamically
      * constructing adding a Driver via Arbiter::addDriver.


### PR DESCRIPTION
- Remove logging if a homedir is not found (closes #2957) 
- Make `arbiter::Endpoint` instances copyable
- Move some utils out of a nested namespace
- More accurate naming for some internal variables