### PR TITLE
Return correct ICP transformation

### DIFF
--- a/filters/IterativeClosestPoint.cpp
+++ b/filters/IterativeClosestPoint.cpp
@@ -109,8 +109,8 @@ PointViewPtr IterativeClosestPoint::icp(PointViewPtr fixed,
     // be reasonable to alternately accept an initial guess.
     Eigen::Matrix4d final_transformation = Eigen::Matrix4d::Identity();
 
-    // Construct 3D KD-tree of the centered, fixed PointView to facilitate
-    // nearest neighbor searches in each iteration.
+    // Construct 3D KD-tree of the fixed PointView to facilitate nearest
+    // neighbor searches in each iteration.
     KD3Index& kd_fixed = fixed->build3dIndex();
 
     // Iterate to the max number of iterations or until converged.
@@ -119,8 +119,8 @@ PointViewPtr IterativeClosestPoint::icp(PointViewPtr fixed,
     int num_similar(0);
     for (int iter = 0; iter < m_max_iters; ++iter)
     {
-        // At the beginning of each iteration, transform our centered, moving
-        // PointView by the current final_transformation.
+	// At the beginning of each iteration, transform our moving PointView
+	// by the current final_transformation.
         PointViewPtr tempMovingTransformed =
             transform(*moving, final_transformation.data());
 
@@ -131,9 +131,9 @@ PointViewPtr IterativeClosestPoint::icp(PointViewPtr fixed,
         moving_idx.reserve(tempMovingTransformed->size());
         double mse(0.0);
 
-        // For every point in the centered, moving PointView, find the nearest
-        // neighbor in the centered fixed PointView. Record the indices of each
-        // and update the MSE.
+	// For every point in the moving PointView, find the nearest neighbor
+	// in the fixed PointView. Record the indices of each and update the
+	// MSE.
         for (PointRef&& point : *tempMovingTransformed)
         {
             // Find the index of the nearest neighbor, and the square distance

--- a/test/unit/filters/IcpFilterTest.cpp
+++ b/test/unit/filters/IcpFilterTest.cpp
@@ -136,6 +136,36 @@ TEST(IcpFilterTest, RecoverTranslation)
     checkPointsEqualReader(pointViewSet, tolerance);
 }
 
+TEST(IcpFilterTest, RecoverRotation)
+{
+    auto reader1 = newReader();
+    auto reader2 = newReader();
+    TransformationFilter transformationFilter;
+    Options transformationOptions;
+    transformationOptions.add("matrix", "0.996 0 0.087 0\n0 1 0 0\n-0.087 0 0.996 0\n0 0 0 1");
+    transformationFilter.setOptions(transformationOptions);
+    transformationFilter.setInput(*reader2);
+
+    auto filter = newFilter();
+    filter->setInput(*reader1);
+    filter->setInput(transformationFilter);
+
+    PointTable table;
+    filter->prepare(table);
+    PointViewSet pointViewSet = filter->execute(table);
+
+    MetadataNode root = filter->getMetadata();
+    Eigen::MatrixXd transform =
+        root.findChild("transform").value<Eigen::MatrixXd>();
+    double tolerance = 0.001;
+    EXPECT_NEAR(0.996, transform(0, 0), tolerance);
+    EXPECT_NEAR(-0.087, transform(0, 2), tolerance);
+    EXPECT_NEAR(0.087, transform(2, 0), tolerance);
+    EXPECT_NEAR(0.996, transform(2, 2), tolerance);
+    double tolerance2 = 0.5;
+    checkPointsEqualReader(pointViewSet, tolerance2);
+}
+
 TEST(IcpFilterTest, TooFewInputs)
 {
     auto reader = newReader();


### PR DESCRIPTION
* Remove the centering step, which is unnecessary and can cause problems when applying the same transformation after the fact
* Add test to recover rotation (5 degrees about Y axis)

Supersedes #2962 

Fixes #2939 