### PR TITLE
Allow zero results from TileDB query

### DIFF
--- a/pdal/PointTable.hpp
+++ b/pdal/PointTable.hpp
@@ -199,6 +199,7 @@ protected:
     StreamPointTable(PointLayout& layout, point_count_t capacity)
         : SimplePointTable(layout)
         , m_capacity(capacity)
+        , m_numPoints(0)
         , m_skips(m_capacity, false)
     {}
 

--- a/plugins/tiledb/io/TileDBReader.cpp
+++ b/plugins/tiledb/io/TileDBReader.cpp
@@ -442,12 +442,19 @@ bool TileDBReader::processPoint(PointRef& point)
         }     
     }
 
-    for (DimInfo& dim : m_dims)
-        if (!setField(point, dim, m_offset))
-            throwError("Invalid dimension type when setting data.");
+    if (m_resultSize > 0)
+    {
+        for (DimInfo& dim : m_dims)
+            if (!setField(point, dim, m_offset))
+                throwError("Invalid dimension type when setting data.");
 
-    ++m_offset;
-    return true;
+        ++m_offset;
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 point_count_t TileDBReader::read(PointViewPtr view, point_count_t count)

--- a/plugins/tiledb/test/TileDBReaderTest.cpp
+++ b/plugins/tiledb/test/TileDBReaderTest.cpp
@@ -92,6 +92,24 @@ class TileDBReaderTest : public ::testing::Test
         EXPECT_EQ(table.numPoints(), 50);
     }
 
+    TEST_F(TileDBReaderTest, read_zero_bbox)
+    {
+        tiledb::Context ctx;
+        tiledb::VFS vfs(ctx);
+        std::string pth(Support::datapath("tiledb/array"));
+        Options options;
+        options.add("array_name", pth);
+        options.add("bbox3d", "([1.1, 1.2], [1.1, 1.2], [1.1, 1.2])");
+
+        TileDBReader reader;
+        reader.setOptions(options);
+
+        FixedPointTable table(100);
+        reader.prepare(table);
+        reader.execute(table);
+        EXPECT_EQ(table.numPoints(), 0);
+    }
+
     TEST_F(TileDBReaderTest, read)
     {
         class Checker : public Filter, public Streamable


### PR DESCRIPTION
If making a bounding box query to TileDB within a pipeline it is possible to get an result of zero length if the bounding box specified doesn't contain any points. This PR adds a test for this and initializes the point table result size to zero.