### PR TITLE
Set the log on the normal filter when running from poisson.

### DIFF
--- a/filters/PoissonFilter.cpp
+++ b/filters/PoissonFilter.cpp
@@ -271,7 +271,11 @@ void PoissonFilter::addArgs(ProgramArgs& args)
 PointViewSet PoissonFilter::run(PointViewPtr view)
 {
     if (!m_normalsProvided)
-        NormalFilter().doFilter(*view);
+    {
+        NormalFilter f;
+        f.setLog(log());
+        f.doFilter(*view);
+    }
 
     std::unique_ptr<PointSource> source;
     if (m_doColor)

--- a/pdal/Stage.hpp
+++ b/pdal/Stage.hpp
@@ -224,7 +224,7 @@ public:
 
       \param log  Log pointer.
     */
-    void setLog(LogPtr& log)
+    void setLog(const LogPtr& log)
         { m_log = log; }
 
     /**


### PR DESCRIPTION
Make setLog() take a const ref instead of ref.
Close #2990 