### PR TITLE
Changes to support TileDB 2.0 (in `dev`) in PDAL 2.1

### DIFF
--- a/plugins/tiledb/io/TileDBReader.cpp
+++ b/plugins/tiledb/io/TileDBReader.cpp
@@ -295,7 +295,7 @@ void TileDBReader::localReady()
     // read spatial reference
     NL::json meta = nullptr;
 
-#if TILEDB_VERSION_MAJOR >= 1 && TILEDB_VERSION_MINOR >= 7
+#if TILEDB_VERSION_MAJOR > 1 || TILEDB_VERSION_MINOR >= 7
     tiledb_datatype_t v_type = TILEDB_UINT8;
     const void* v_r;
     uint32_t v_num;
@@ -310,7 +310,7 @@ void TileDBReader::localReady()
         tiledb::VFS::filebuf fbuf(vfs);
         std::string metaFName = m_filename + pathSeparator + "pdal.json";
 
-        if (vfs.is_dir(m_filename))
+        if (vfs.is_file(metaFName))
         {
             auto nBytes = vfs.file_size(metaFName);
             tiledb::VFS::filebuf fbuf(vfs);

--- a/plugins/tiledb/io/TileDBWriter.hpp
+++ b/plugins/tiledb/io/TileDBWriter.hpp
@@ -80,9 +80,10 @@ private:
     std::unique_ptr<tiledb::Context> m_ctx;
     std::unique_ptr<tiledb::ArraySchema> m_schema;
     std::unique_ptr<tiledb::Array> m_array;
-    std::unique_ptr<tiledb::Query> m_query;
     std::vector<DimBuffer> m_attrs;
-    std::vector<double> m_coords;
+    std::vector<double> m_xs;
+    std::vector<double> m_ys;
+    std::vector<double> m_zs;
 
     TileDBWriter(const TileDBWriter&) = delete;
     TileDBWriter& operator=(const TileDBWriter&) = delete;

--- a/plugins/tiledb/test/TileDBReaderTest.cpp
+++ b/plugins/tiledb/test/TileDBReaderTest.cpp
@@ -193,11 +193,9 @@ class TileDBReaderTest : public ::testing::Test
         c.setInput(reader);
         c.prepare(table);
         c.execute(table);
-        // test using a sidecar file
-        EXPECT_EQ(reader.getSpatialReference(), utm16);
+        EXPECT_TRUE(reader.getSpatialReference().equals(utm16));
     }
 
-#if TILEDB_VERSION_MAJOR >= 1 && TILEDB_VERSION_MINOR >= 7
     TEST_F(TileDBReaderTest, spatial_reference)
     {
         tiledb::Context ctx;
@@ -233,8 +231,7 @@ class TileDBReaderTest : public ::testing::Test
         FixedPointTable table2(100);
         rdr.prepare(table2);
         rdr.execute(table2);
-        EXPECT_EQ(rdr.getSpatialReference(), utm16);
+        EXPECT_TRUE(rdr.getSpatialReference().equals(utm16));
     }
-#endif
 }
 


### PR DESCRIPTION
This is a minor refactor that is backwards compatible with the PDAL driver and TileDB 1.4+. In TileDB 2.0 it is recommended to set the coordinate buffers directly. We can also no longer reuse the query object in the PDAL TileDB driver so this is now created and used in `FlushCache`.

I changed the `utm16` reader test to be more tolerant of different proj versions.