### PR TITLE
Update readers.ept.rst (headers -> header)

### DIFF
--- a/doc/stages/readers.ept.rst
+++ b/doc/stages/readers.ept.rst
@@ -110,7 +110,7 @@ threads
 .. _Plasio: http://speck.ly/?s=http%3A%2F%2Fc%5B0-7%5D.greyhound.io&r=ept%3A%2F%2Fna.entwine.io%2Fnyc&ca=-0&ce=49.06&ct=-8239196%2C4958509.308%2C337&cd=42640.943&cmd=125978.13&ps=2&pa=0.1&ze=1&c0s=remote%3A%2F%2Fimagery%3Furl%3Dhttp%3A%2F%2Fserver.arcgisonline.com%2FArcGIS%2Frest%2Fservices%2FWorld_Imagery%2FMapServer%2Ftile%2F%7B%7Bz%7D%7D%2F%7B%7By%7D%7D%2F%7B%7Bx%7D%7D.jpg
 .. _Schema: https://entwine.io/entwine-point-tile.html#schema
 
-headers
+header
     HTTP headers to forward for remote EPT endpoints, structured as a JSON
     object of key/value string pairs.
 


### PR DESCRIPTION
I noticed that the code for this (which is a very very helpful feature) has `header` and not `headers`. Tripped me up today so i thought that maybe the docs could be updated.