### PR TITLE
Write more glTF attributes, including color and normals

### DIFF
--- a/io/GltfWriter.cpp
+++ b/io/GltfWriter.cpp
@@ -60,6 +60,12 @@ static StaticPluginInfo const s_info
 
 CREATE_STATIC_STAGE(GltfWriter, s_info)
 
+GltfWriter::GltfWriter()
+{}
+
+GltfWriter::~GltfWriter()
+{}
+
 std::string GltfWriter::getName() const {
     return s_info.name;
 }

--- a/io/GltfWriter.cpp
+++ b/io/GltfWriter.cpp
@@ -246,35 +246,35 @@ void GltfWriter::writeJsonChunk()
         // Vertex indices (faces)
         const uint16_t faceBufferViewIndex = 0;
         j["bufferViews"].push_back(
-        {
-            { "buffer", 0 },
-            { "byteOffset", vd.m_indexOffset },
-            { "byteLength", vd.m_indexByteLength },
-            { "target", 34963 }      // Vertex indices code
-        }
+            {
+                { "buffer", 0 },
+                { "byteOffset", vd.m_indexOffset },
+                { "byteLength", vd.m_indexByteLength },
+                { "target", 34963 }      // Vertex indices code
+            }
         );
         // Vertex attributes (positions, normals, and colors)
         const uint16_t vertexAttributeBufferViewIndex = 1;
         j["bufferViews"].push_back(
-        {
-            { "buffer", 0 },
-            { "byteOffset", vd.m_vertexOffset },
-            { "byteLength", vd.m_vertexByteLength },
-            { "target", 34962 },      // Vertices code
-            { "byteStride", elementSize },
-        }
+            {
+                { "buffer", 0 },
+                { "byteOffset", vd.m_vertexOffset },
+                { "byteLength", vd.m_vertexByteLength },
+                { "target", 34962 },      // Vertices code
+                { "byteStride", elementSize },
+            }
         );
 
         // Accessors
         // Face index accessor
         faceAccessorIndex = nextAccessorIndex++;
         j["accessors"].push_back(
-        {
-            { "bufferView", faceBufferViewIndex },
-            { "componentType", 5125 },      // unsigned int code
-            { "type", "SCALAR" },
-            { "count", vd.m_indexCount }
-        }
+            {
+                { "bufferView", faceBufferViewIndex },
+                { "componentType", 5125 },      // unsigned int code
+                { "type", "SCALAR" },
+                { "count", vd.m_indexCount }
+            }
         );
         const BOX3D& b = vd.m_bounds;
         uint16_t byteOffset = 0;
@@ -282,15 +282,15 @@ void GltfWriter::writeJsonChunk()
         // Vertex position accessor
         positionAccessorIndex = nextAccessorIndex++;
         j["accessors"].push_back(
-        {
-            { "bufferView", vertexAttributeBufferViewIndex },
-            { "componentType", 5126 },      // float code
-            { "type", "VEC3" },
-            { "count", vd.m_vertexCount },
-            { "byteOffset", byteOffset },
-            { "min", { b.minx, b.miny, b.minz } },
-            { "max", { b.maxx, b.maxy, b.maxz } }
-        }
+            {
+                { "bufferView", vertexAttributeBufferViewIndex },
+                { "componentType", 5126 },      // float code
+                { "type", "VEC3" },
+                { "count", vd.m_vertexCount },
+                { "byteOffset", byteOffset },
+                { "min", { b.minx, b.miny, b.minz } },
+                { "max", { b.maxx, b.maxy, b.maxz } }
+            }
         );
 
         if (m_writeNormals) {
@@ -298,13 +298,13 @@ void GltfWriter::writeJsonChunk()
             // Vertex normal accessor
             normalAccessorIndex = nextAccessorIndex++;
             j["accessors"].push_back(
-            {
-                { "bufferView", vertexAttributeBufferViewIndex },
-                { "componentType", 5126 },      // float code
-                { "type", "VEC3" },
-                { "byteOffset", byteOffset },
-                { "count", vd.m_vertexCount },
-            }
+                {
+                    { "bufferView", vertexAttributeBufferViewIndex },
+                    { "componentType", 5126 },      // float code
+                    { "type", "VEC3" },
+                    { "byteOffset", byteOffset },
+                    { "count", vd.m_vertexCount },
+                }
             );
         }
 
@@ -313,13 +313,13 @@ void GltfWriter::writeJsonChunk()
             // Vertex color accessor
             colorAccessorIndex = nextAccessorIndex++;
             j["accessors"].push_back(
-            {
-                { "bufferView", vertexAttributeBufferViewIndex },
-                { "componentType", 5126 },      // float code
-                { "type", "VEC3" },
-                { "byteOffset", byteOffset },
-                { "count", vd.m_vertexCount },
-            }
+                {
+                    { "bufferView", vertexAttributeBufferViewIndex },
+                    { "componentType", 5126 },      // float code
+                    { "type", "VEC3" },
+                    { "byteOffset", byteOffset },
+                    { "count", vd.m_vertexCount },
+                }
             );
         }
     }
@@ -335,44 +335,44 @@ void GltfWriter::writeJsonChunk()
 
     NL::json mesh;
     mesh["primitives"].push_back(
-    {
-        { "attributes", meshAttributes },
-        { "indices", 0 },
-        { "material", 0 }
-    }
+        {
+            { "attributes", meshAttributes },
+            { "indices", 0 },
+            { "material", 0 }
+        }
     );
 
     j["meshes"].push_back(mesh);
     j["scene"] = 0;
 
     j["nodes"].push_back(
-    {
-        { "mesh", 0 },
-        { "matrix", { 1, 0, 0, 0, 0, 0, -1, 0, 0, 1, 0, 0, 0, 0, 0, 1 } }
-    }
+        {
+            { "mesh", 0 },
+            { "matrix", { 1, 0, 0, 0, 0, 0, -1, 0, 0, 1, 0, 0, 0, 0, 0, 1 } }
+        }
     );
 
     j["scenes"].push_back(
-    {
-        { "nodes", { 0 } }
-    }
+        {
+            { "nodes", { 0 } }
+        }
     );
 
     // This seems very crude.  But I'm not sure we can do much else at this
     // point.
     j["materials"].push_back(
-    {
         {
-            "pbrMetallicRoughness",
             {
-                { "metallicFactor", m_metallic },
-                { "roughnessFactor", m_roughness },
-                { "baseColorFactor", { m_red, m_blue, m_green, m_alpha } }
-            }
-        },
-        { "name", "Color" },
-        { "doubleSided", m_doubleSided }
-    }
+                "pbrMetallicRoughness",
+                {
+                    { "metallicFactor", m_metallic },
+                    { "roughnessFactor", m_roughness },
+                    { "baseColorFactor", { m_red, m_blue, m_green, m_alpha } }
+                }
+            },
+            { "name", "Color" },
+            { "doubleSided", m_doubleSided }
+        }
     );
 
     std::string js(j.dump());

--- a/io/GltfWriter.cpp
+++ b/io/GltfWriter.cpp
@@ -78,7 +78,7 @@ void GltfWriter::addArgs(ProgramArgs& args)
     args.add("color_vertices", "If color data is present for each point, write "
              "it to the output vertices. Note that most renderers will "
              "interpolate the color of each vertex across a face, so this may "
-             "look odd.", m_colorVertices, true);
+             "look odd.", m_colorVertices, false);
 }
 
 

--- a/io/GltfWriter.hpp
+++ b/io/GltfWriter.hpp
@@ -71,6 +71,7 @@ private:
     std::vector<ViewData> m_viewData;
     size_t m_totalSize;
     size_t m_binSize;
+    bool m_writeNormals;
 
     double m_metallic;
     double m_roughness;
@@ -79,6 +80,17 @@ private:
     double m_blue;
     double m_alpha;
     bool m_doubleSided;
+};
+
+struct GltfWriter::ViewData
+{
+    BOX3D m_bounds;
+    size_t m_indexOffset;
+    size_t m_indexByteLength;
+    size_t m_indexCount;
+    size_t m_vertexOffset;
+    size_t m_vertexByteLength;
+    size_t m_vertexCount;
 };
 
 } // namespace pdal

--- a/io/GltfWriter.hpp
+++ b/io/GltfWriter.hpp
@@ -80,7 +80,9 @@ private:
     double m_blue;
     double m_alpha;
     bool m_doubleSided;
+    bool m_colorVertices;
 };
+
 
 struct GltfWriter::ViewData
 {
@@ -92,5 +94,6 @@ struct GltfWriter::ViewData
     size_t m_vertexByteLength;
     size_t m_vertexCount;
 };
+
 
 } // namespace pdal

--- a/io/GltfWriter.hpp
+++ b/io/GltfWriter.hpp
@@ -59,6 +59,7 @@ private:
     virtual void ready(PointTableRef table);
     virtual void write(const PointViewPtr v);
     virtual void done(PointTableRef table);
+    virtual void prepared(PointTableRef table);
 
     void writeGltfHeader();
     void writeJsonChunk();

--- a/scripts/docker/ubuntu/Dockerfile
+++ b/scripts/docker/ubuntu/Dockerfile
@@ -14,7 +14,7 @@ RUN . /opt/conda/etc/profile.d/conda.sh && \
     mkdir -p pdal/build && \
     cd pdal/build  && \
     cmake -G Ninja  \
-        -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} \
+        -DCMAKE_INSTALL_PREFIX=/usr \
         -DBUILD_PLUGIN_CPD=ON \
         -DBUILD_PLUGIN_PGPOINTCLOUD=ON \
         -DBUILD_PLUGIN_NITF=ON \
@@ -59,12 +59,12 @@ RUN rm /opt/conda/envs/pdal/lib/*.a && \
     rm -rf /opt/conda/envs/pdal/include/freetype2 && \
     rm -rf /opt/conda/envs/pdal/include/informix && \
     rm -rf /opt/conda/envs/pdal/include/fontconfig && \
-    rm -rf /opt/conda/envs/pdal/include/X11
+    rm -rf /opt/conda/envs/pdal/include/X11 && \
+    rm -rf /opt/conda/envs/pdal/lib/cmake
 
 FROM ubuntu:bionic
 
 ARG PDAL_CONDA=/opt/conda/envs/pdal
-
 
 RUN apt-get update --fix-missing && \
     apt-get install -y \
@@ -77,7 +77,6 @@ COPY --from=builder /lib/ /lib/
 COPY --from=builder /${PDAL_CONDA}/lib/ /usr/lib/
 COPY --from=builder /${PDAL_CONDA}/include/ /usr/include/
 COPY --from=builder /${PDAL_CONDA}/share/ /usr/share/
-COPY --from=builder /${PDAL_CONDA}/bin/pdal /usr/bin/pdal
 
 ENV GDAL_DATA=/usr/share/gdal
 ENV PDAL_DRIVER_PATH=/usr/lib

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -162,10 +162,6 @@ PDAL_ADD_TEST(pdal_io_gdal_writer_test
     INCLUDES
         ${GDAL_INCLUDE_DIR}
 )
-PDAL_ADD_TEST(pdal_io_gltf_writer_test
-    FILES
-        io/GltfWriterTest.cpp
-)
 PDAL_ADD_TEST(pdal_io_las_reader_test
     FILES
         io/LasReaderTest.cpp

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -209,6 +209,7 @@ PDAL_ADD_TEST(pdal_io_text_reader_test
     INCLUDES
         ${NLOHMANN_INCLUDE_DIR}
 )
+PDAL_ADD_TEST(pdal_io_gltf_writer_test FILES io/GltfWriterTest.cpp)
 
 #
 # sources for the native filters

--- a/test/unit/io/GltfWriterTest.cpp
+++ b/test/unit/io/GltfWriterTest.cpp
@@ -98,8 +98,8 @@ void testWrite(bool writeNormals, bool writeColors, std::string path)
         v->setField(Dimension::Id::NormalY, 2, 1);
         v->setField(Dimension::Id::NormalZ, 2, 0);
 
-        v->setField(Dimension::Id::NormalX, 3, 0);
-        v->setField(Dimension::Id::NormalY, 3, 1);
+        v->setField(Dimension::Id::NormalX, 3, 1);
+        v->setField(Dimension::Id::NormalY, 3, 0);
         v->setField(Dimension::Id::NormalZ, 3, 0);
     }
 
@@ -124,7 +124,7 @@ void testWrite(bool writeNormals, bool writeColors, std::string path)
 
     TriangularMesh* mesh = v->createMesh("foo");
     mesh->add(0, 1, 2);
-    mesh->add(1, 2, 3);
+    mesh->add(3, 2, 1);
 
     BufferReader r;
     r.addView(v);
@@ -134,6 +134,9 @@ void testWrite(bool writeNormals, bool writeColors, std::string path)
 
     Options writerOptions;
     writerOptions.add("filename", path);
+    if (writeColors) {
+        writerOptions.add("color_vertices", true);
+    }
     writer->setOptions(writerOptions);
     writer->setInput(r);
     writer->prepare(t);

--- a/test/unit/io/GltfWriterTest.cpp
+++ b/test/unit/io/GltfWriterTest.cpp
@@ -1,0 +1,132 @@
+/******************************************************************************
+ * Copyright (c) 2020, Emma Krantz <krantzemmaj@gmail.com>
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of Hobu, Inc. or Flaxen Geo Consulting nor the
+ *       names of its contributors may be used to endorse or promote
+ *       products derived from this software without specific prior
+ *       written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ ****************************************************************************/
+
+#include <pdal/pdal_test_main.hpp>
+
+#include <io/BufferReader.hpp>
+#include <io/GltfWriter.hpp>
+#include <pdal/util/FileUtils.hpp>
+#include <pdal/util/OStream.hpp>
+#include <pdal/StageFactory.hpp>
+
+#include "Support.hpp"
+
+namespace pdal
+{
+
+
+void testWrite(bool writeNormals, std::string path)
+{
+    PointTable t;
+
+    t.layout()->registerDim(Dimension::Id::X);
+    t.layout()->registerDim(Dimension::Id::Y);
+    t.layout()->registerDim(Dimension::Id::Z);
+
+    PointViewPtr v(new PointView(t));
+    v->setField(Dimension::Id::X, 0, 1);
+    v->setField(Dimension::Id::Y, 0, 1);
+    v->setField(Dimension::Id::Z, 0, 0);
+
+    v->setField(Dimension::Id::X, 1, 2);
+    v->setField(Dimension::Id::Y, 1, 1);
+    v->setField(Dimension::Id::Z, 1, 0);
+
+    v->setField(Dimension::Id::X, 2, 1);
+    v->setField(Dimension::Id::Y, 2, 2);
+    v->setField(Dimension::Id::Z, 2, 0);
+
+    v->setField(Dimension::Id::X, 3, 2);
+    v->setField(Dimension::Id::Y, 3, 2);
+    v->setField(Dimension::Id::Z, 3, 2);
+
+    if (writeNormals)
+    {
+        t.layout()->registerDim(Dimension::Id::NormalX);
+        t.layout()->registerDim(Dimension::Id::NormalY);
+        t.layout()->registerDim(Dimension::Id::NormalZ);
+
+        v->setField(Dimension::Id::NormalX, 0, 0);
+        v->setField(Dimension::Id::NormalY, 0, 1);
+        v->setField(Dimension::Id::NormalZ, 0, 0);
+
+        v->setField(Dimension::Id::NormalX, 1, 0);
+        v->setField(Dimension::Id::NormalY, 1, 1);
+        v->setField(Dimension::Id::NormalZ, 1, 0);
+
+        v->setField(Dimension::Id::NormalX, 2, 0);
+        v->setField(Dimension::Id::NormalY, 2, 1);
+        v->setField(Dimension::Id::NormalZ, 2, 0);
+
+        v->setField(Dimension::Id::NormalX, 3, 0);
+        v->setField(Dimension::Id::NormalY, 3, 1);
+        v->setField(Dimension::Id::NormalZ, 3, 0);
+    }
+
+    TriangularMesh* mesh = v->createMesh("foo");
+    mesh->add(0, 1, 2);
+    mesh->add(1, 2, 3);
+
+    BufferReader r;
+    r.addView(v);
+
+    StageFactory factory;
+    Stage *writer = factory.createStage("writers.gltf");
+
+    Options writerOptions;
+    writerOptions.add("filename", path);
+    writer->setOptions(writerOptions);
+    writer->setInput(r);
+    writer->prepare(t);
+    writer->execute(t);
+}
+
+
+TEST(GltfWriter, Write)
+{
+    std::string path = Support::temppath("out.glb");
+    testWrite(false, path);
+    ASSERT_EQ(FileUtils::fileSize(path), 5100);
+}
+
+
+TEST(GltfWriter, WriteWithNormals)
+{
+    std::string path = Support::temppath("out_normals.glb");
+    testWrite(true, path);
+    ASSERT_EQ(FileUtils::fileSize(path), 5148);
+}
+
+
+} // namespace pdal

--- a/test/unit/io/GltfWriterTest.cpp
+++ b/test/unit/io/GltfWriterTest.cpp
@@ -46,13 +46,25 @@ namespace pdal
 {
 
 
-void testWrite(bool writeNormals, std::string path)
+void testWrite(bool writeNormals, bool writeColors, std::string path)
 {
     PointTable t;
 
     t.layout()->registerDim(Dimension::Id::X);
     t.layout()->registerDim(Dimension::Id::Y);
     t.layout()->registerDim(Dimension::Id::Z);
+
+    if (writeNormals) {
+        t.layout()->registerDim(Dimension::Id::NormalX);
+        t.layout()->registerDim(Dimension::Id::NormalY);
+        t.layout()->registerDim(Dimension::Id::NormalZ);
+    }
+
+    if (writeColors) {
+        t.layout()->registerDim(Dimension::Id::Red);
+        t.layout()->registerDim(Dimension::Id::Blue);
+        t.layout()->registerDim(Dimension::Id::Green);
+    }
 
     PointViewPtr v(new PointView(t));
     v->setField(Dimension::Id::X, 0, 1);
@@ -71,12 +83,9 @@ void testWrite(bool writeNormals, std::string path)
     v->setField(Dimension::Id::Y, 3, 2);
     v->setField(Dimension::Id::Z, 3, 2);
 
+
     if (writeNormals)
     {
-        t.layout()->registerDim(Dimension::Id::NormalX);
-        t.layout()->registerDim(Dimension::Id::NormalY);
-        t.layout()->registerDim(Dimension::Id::NormalZ);
-
         v->setField(Dimension::Id::NormalX, 0, 0);
         v->setField(Dimension::Id::NormalY, 0, 1);
         v->setField(Dimension::Id::NormalZ, 0, 0);
@@ -92,6 +101,25 @@ void testWrite(bool writeNormals, std::string path)
         v->setField(Dimension::Id::NormalX, 3, 0);
         v->setField(Dimension::Id::NormalY, 3, 1);
         v->setField(Dimension::Id::NormalZ, 3, 0);
+    }
+
+    if (writeColors)
+    {
+        v->setField(Dimension::Id::Red, 0, 255);
+        v->setField(Dimension::Id::Blue, 0, 0);
+        v->setField(Dimension::Id::Green, 0, 0);
+
+        v->setField(Dimension::Id::Red, 1, 0);
+        v->setField(Dimension::Id::Blue, 1, 255);
+        v->setField(Dimension::Id::Green, 1, 0);
+
+        v->setField(Dimension::Id::Red, 2, 0);
+        v->setField(Dimension::Id::Blue, 2, 0);
+        v->setField(Dimension::Id::Green, 2, 255);
+
+        v->setField(Dimension::Id::Red, 3, 255);
+        v->setField(Dimension::Id::Blue, 3, 0);
+        v->setField(Dimension::Id::Green, 3, 0);
     }
 
     TriangularMesh* mesh = v->createMesh("foo");
@@ -116,7 +144,7 @@ void testWrite(bool writeNormals, std::string path)
 TEST(GltfWriter, Write)
 {
     std::string path = Support::temppath("out.glb");
-    testWrite(false, path);
+    testWrite(false, false, path);
     ASSERT_EQ(FileUtils::fileSize(path), 5100);
 }
 
@@ -124,8 +152,24 @@ TEST(GltfWriter, Write)
 TEST(GltfWriter, WriteWithNormals)
 {
     std::string path = Support::temppath("out_normals.glb");
-    testWrite(true, path);
+    testWrite(true, false, path);
     ASSERT_EQ(FileUtils::fileSize(path), 5148);
+}
+
+
+TEST(GltfWriter, WriteWithColors)
+{
+    std::string path = Support::temppath("out_colors.glb");
+    testWrite(false, true, path);
+    ASSERT_EQ(FileUtils::fileSize(path), 5148);
+}
+
+
+TEST(GltfWriter, WriteWithNormalsAndColors)
+{
+    std::string path = Support::temppath("out_normals_colors.glb");
+    testWrite(true, true, path);
+    ASSERT_EQ(FileUtils::fileSize(path), 5196);
 }
 
 


### PR DESCRIPTION
**Summary:**
- Adds a `color_vertices` flag, which defaults to false, which tells the writer to include color information for each vertex in the output glTF. 
- Writes out normals for each vertex if they are present.
- New unit test file for GltfWriter, with some very basic tests.

**Background:**
I was using `filters.poisson` on a point cloud to generate a glTF mesh, and noticed that the normals were missing in the resulting .glb file. @nf-s asked me to add the color attribute while I was at it, since he was doing something similar for a colored point cloud.

If anyone is ever attempting something similar, you have to run `filters.normal` on the output of `filters.poisson` for the resulting mesh to have normal information.