### PR TITLE
tiledb: support duplicate coordinate values

### DIFF
--- a/plugins/tiledb/io/TileDBWriter.cpp
+++ b/plugins/tiledb/io/TileDBWriter.cpp
@@ -328,7 +328,9 @@ void TileDBWriter::initialize()
             {
                 opts = m_args->m_defaults["coords"];
             }
-
+#if TILEDB_VERSION_MAJOR > 1
+            m_schema->set_allows_dups(true);
+#endif
             m_schema->set_coords_filter_list(
                 *createFilterList(*m_ctx, opts));
         }


### PR DESCRIPTION
The latest version of TileDB supports duplicate point values, this PR enables support for duplicates at the schema level and adds a test to the TileDBWriter plugin.

Note: I am using `TILEDB_COORDS` in the writer test, I will have another PR where I refactor all of the writer tests to be consistent with the https://github.com/PDAL/PDAL/pull/3030 for split coordinates.