### PR TITLE
Clamp values to min/max range

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -6,6 +6,9 @@ FAQ
 
 .. index:: pronounce
 
+.. |nbsp| unicode:: 0xA0
+   :trim:
+
 * How do you pronounce PDAL?
 
   The proper spelling of the project name is PDAL, in uppercase. It is
@@ -13,7 +16,7 @@ FAQ
 
   .. it is properly pronounced like the dog though :) -- hobu
 
-|
+  |nbsp|
 
 * Why do I get the error "Couldn't create ... stage of type ..."?
 
@@ -23,7 +26,8 @@ FAQ
   be found by running ``pdal --drivers``
 
   If you've built pdal yourself, make sure you've requested to build the
-  plugin in question (set BUILD_PLUGIN_TILEDB=ON, for example, in CMakeCache.txt).
+  plugin in question (set BUILD_PLUGIN_TILEDB=ON, for example,
+  in CMakeCache.txt).
 
   If you've successfully built the plugin, a
   shared object called
@@ -41,6 +45,31 @@ FAQ
   variable ``PDAL_DRIVER_PATH`` to a list of directories that pdal should search
   for plugins.
 
+  |nbsp|
+
+* Why do I get the error ``Unable to convert scaled value ... "
+
+  This error usually occurs when writing LAS files, but can occur with other
+  formats.
+
+  Simply, the output format you've chosen doesn't support values as large
+  (or small) as those that you're trying to write.  For example. if the
+  output format specifies 32-bit signed integers, attempting to write a
+  value larger than 2,147,483,647 will cause this error, as 2,147,483,647
+  is the largest 32-bit signed integer.
+
+  The LAS format always stores X, Y and Z values as 32-bit integers.
+  You can specify a scale factor to be applied to those values in order
+  to change their magnitude, but their precision is limited to 32 bits.
+  If the value
+  you're attempting to write, when divided by the scale factor you've
+  specified, is larger than 2,147,483,647, you will get this error.
+  For example, if you attempt to write the value 6 with a scale factor
+  of .000000001, you'll get this error, as 6 / .000000001 is 6,000,000,000,
+  which is larger than the maximum integer value.
+
+  |nbsp|
+
 * Why am I using 100GB of memory when trying to process a 10GB LAZ file?
 
   If you're performing an operation that is using
@@ -53,7 +82,7 @@ FAQ
   :ref:`stream mode <processing_modes>` to
   limit memory consumption when possible.
 
-|
+  |nbsp|
 
 * What is PDAL's relationship to PCL?
 
@@ -66,6 +95,8 @@ FAQ
 
         :ref:`about_pcl` describes PDAL and PCL's relationship.
 
+  |nbsp|
+
 * What is PDAL's relationship to libLAS?
 
   The idea behind libLAS was limited to LIDAR data and basic
@@ -76,9 +107,7 @@ FAQ
   talked more about this history in a `GeoHipster interview`_ in
   2018.
 
-.. _`GeoHipster interview`: http://geohipster.com/2018/03/05/howard-butler-like-good-song-open-source-software-chance-immortal/
-
-|
+  |nbsp|
 
 * Are there any command line tools in PDAL similar to LAStools?
 
@@ -92,6 +121,8 @@ FAQ
         :ref:`apps` describes application operations you can
         achieve with PDAL.
 
+  |nbsp|
+
 * Is there any compatibility with libLAS's LAS Utility Applications or LAStools?
 
   No. The the command line interface was developed from scratch with
@@ -99,13 +130,16 @@ FAQ
   command has several well-organized subcommands such as ``info``
   or ``translate`` (see :ref:`apps`).
 
+  |nbsp|
+
 * I get GeoTIFF errors. What can I do about them?
 
   ::
 
-    (readers.las Error) Geotiff directory contains key 0 with short entry and more than one value.
+    (readers.las Error) Geotiff directory contains key 0 with short entry
+    and more than one value.
 
-  If :ref:`readers.las` is outputting error messages about GeoTIFF, this means
+  If :ref:`readers.las` is emitting error messages about GeoTIFF, this means
   the keys that were written into your file were incorrect or at least not
   readable by `libgeotiff`_. Rewrite the file using PDAL to fix the issue:
 
@@ -114,3 +148,5 @@ FAQ
     pdal translate badfile.las goodfile.las --writers.las.forward=all
 
 .. _`libgeotiff`: https://trac.osgeo.org/geotif
+.. _`GeoHipster interview`: http://geohipster.com/2018/03/05/howard-butler-like-good-song-open-source-software-chance-immortal/
+

--- a/doc/stages/readers.ept.rst
+++ b/doc/stages/readers.ept.rst
@@ -110,7 +110,7 @@ threads
 .. _Plasio: http://speck.ly/?s=http%3A%2F%2Fc%5B0-7%5D.greyhound.io&r=ept%3A%2F%2Fna.entwine.io%2Fnyc&ca=-0&ce=49.06&ct=-8239196%2C4958509.308%2C337&cd=42640.943&cmd=125978.13&ps=2&pa=0.1&ze=1&c0s=remote%3A%2F%2Fimagery%3Furl%3Dhttp%3A%2F%2Fserver.arcgisonline.com%2FArcGIS%2Frest%2Fservices%2FWorld_Imagery%2FMapServer%2Ftile%2F%7B%7Bz%7D%7D%2F%7B%7By%7D%7D%2F%7B%7Bx%7D%7D.jpg
 .. _Schema: https://entwine.io/entwine-point-tile.html#schema
 
-headers
+header
     HTTP headers to forward for remote EPT endpoints, structured as a JSON
     object of key/value string pairs.
 

--- a/filters/ColorinterpFilter.cpp
+++ b/filters/ColorinterpFilter.cpp
@@ -138,14 +138,10 @@ void ColorinterpFilter::prepared(PointTableRef table)
     PointLayoutPtr layout(table.layout());
     m_interpDim = layout->findDim(m_interpDimString);
     if (m_interpDim == Dimension::Id::Unknown)
-    {
         throwError("Dimension '" + m_interpDimString + "' does not exist.");
-    }
     if (!std::isnan(m_min) && !std::isnan(m_max) && m_max <= m_min)
-    {
         throwError("Specified 'minimum' value must be less than "
             "'maximum' value.");
-    }
 }
 
 
@@ -161,9 +157,7 @@ void ColorinterpFilter::ready(PointTableRef table)
     m_raster = openRamp(m_colorramp);
     gdal::GDALError err = m_raster->open();
     if (err != gdal::GDALError::None && err != gdal::GDALError::NoTransform)
-    {
         throwError(m_raster->errorMsg());
-    }
 
     log()->get(LogLevel::Debug) << getName() << " raster connection: " <<
         m_raster->filename() << std::endl;
@@ -253,13 +247,9 @@ void ColorinterpFilter::filter(PointView& view)
         }
 
         if (std::isnan(m_min))
-        {
             m_min = summary.minimum();
-        }
         if (std::isnan(m_max))
-        {
             m_max = summary.maximum();
-        }
     }
 
     PointRef point(view, 0);
@@ -306,12 +296,10 @@ bool ColorinterpFilter::processOne(PointRef& point)
 
     // Handle the case that v == m_max (position == img_width) by clamping
     // position to img_width - 1
-    position = std::min(position, img_width - 1);
+    position = (std::min)(position, img_width - 1);
 
     if (m_invertRamp)
-    {
         position = (img_width - 1) - position;
-    }
 
     point.setField(Dimension::Id::Red, m_redBand[position]);
     point.setField(Dimension::Id::Blue, m_blueBand[position]);

--- a/filters/ColorinterpFilter.cpp
+++ b/filters/ColorinterpFilter.cpp
@@ -264,9 +264,7 @@ void ColorinterpFilter::filter(PointView& view)
 bool ColorinterpFilter::pipelineStreamable() const
 {
     if (std::isnan(m_min) || std::isnan(m_max))
-    {
         return false;
-    }
     return Streamable::pipelineStreamable();
 }
 


### PR DESCRIPTION
From @MattCsencsits

Previously values outside a determined range would be left with
default values, potentially providing unexpected results. This
commit adds a clamp parameter to a user can explicitly control
whether values outside the given range will be colored.

There apparently was an explicit design decision to not include
values equal to the maximum in the coloring. When clamping, this
design then resulted in values that were greater than the max to
still be left uncolored. Since nothing in the available user
documentation explicitly states that the valid range is exclusive
of the maximum value it has been changed to be inclusive.

This required modifying two unit tests which were testing for
maximum values to be excluded from the coloring.

Another approach could have been to clamp to a value slightly
less than m_max (e.g. m_max - DBL_EPSILON). But this would still
leave a discrepancy between the documentation and the implementation.