### PR TITLE
Quick grammatical update

### DIFF
--- a/doc/tutorial/iowa-entwine.rst
+++ b/doc/tutorial/iowa-entwine.rst
@@ -48,7 +48,7 @@ following commands:
 
       conda install -c conda-forge pdal -y
 
-4. Insure PDAL works by listing the available drivers
+4. Ensure PDAL works by listing the available drivers
 
 
    ::


### PR DESCRIPTION
Unless there's an insurance policy that I don't know about, ensure is correct usage here. 