### PR TITLE
Use neighbors() instead of knnSearch() to get only valid neighbors.

### DIFF
--- a/filters/SMRFilter.cpp
+++ b/filters/SMRFilter.cpp
@@ -623,7 +623,7 @@ void SMRFilter::knnfill(PointViewPtr view, std::vector<double>& cz)
 
     // https://github.com/PDAL/PDAL/issues/2794#issuecomment-625297062
     if (!temp->size())
-        return cz;
+        return;
 
     KD2Index& kdi = temp->build2dIndex();
 

--- a/filters/SMRFilter.hpp
+++ b/filters/SMRFilter.hpp
@@ -49,6 +49,8 @@ class PDAL_DLL SMRFilter : public Filter
 public:
     SMRFilter();
     ~SMRFilter();
+    SMRFilter& operator=(const SMRFilter&) = delete;
+    SMRFilter(const SMRFilter&) = delete;
 
     std::string getName() const;
 
@@ -76,12 +78,9 @@ private:
                                     std::vector<int> const&,
                                     std::vector<int> const&,
                                     std::vector<int> const&);
-    std::vector<double> knnfill(PointViewPtr, std::vector<double> const&);
+    void knnfill(PointViewPtr, std::vector<double>&);
     std::vector<int> progressiveFilter(std::vector<double> const&, double,
                                        double);
-
-    SMRFilter& operator=(const SMRFilter&); // not implemented
-    SMRFilter(const SMRFilter&);            // not implemented
 };
 
 } // namespace pdal


### PR DESCRIPTION
Compute filled vector in place.
Close #3071