### PR TITLE
Output fully composed transformation from ICP

### DIFF
--- a/doc/stages/filters.icp.rst
+++ b/doc/stages/filters.icp.rst
@@ -46,7 +46,7 @@ Examples
       "output.las"
   ]
 
-To get the transform matrix, you'll need to use the ``--metadata`` option
+To get the ``transform`` matrix, you'll need to use the ``--metadata`` option
 from the pipeline command:
 
 ::
@@ -63,14 +63,15 @@ The metadata output might start something like:
             "filters.icp":
             {
                 "centroid": "    583394  5.2831e+06   498.152",
+                "composed": "           1  2.60209e-18 -1.97906e-09       -0.374999  8.9407e-08            1  5.58794e-09      -0.614662 6.98492e -10 -5.58794e-09            1   0.033234           0            0            0            1",
                 "converged": true,
                 "fitness": 0.01953125097,
                 "transform": "           1  2.60209e-18 -1.97906e-09       -0.375  8.9407e-08            1  5.58794e-09      -0.5625 6.98492e -10 -5.58794e-09            1   0.00411987           0            0            0            1"
             }
 
 
-To apply this transformation to other points, the centroid and transform
-metadata items can by used with filters.transform in another pipeline.  First,
+To apply this transformation to other points, the ``centroid`` and ``transform``
+metadata items can by used with ``filters.transformation`` in another pipeline.  First,
 move the centroid of the points to (0,0,0), then apply the transform, then move
 the points back to the original location.  For the above metadata, the pipeline
 would be similar to:
@@ -99,6 +100,10 @@ would be similar to:
             "filename": "out.las"
         }
     ]
+
+.. note::
+
+    The ``composed`` metadata matrix is a composition of the three transformation steps outlined above, and can be used in a single call to ``filters.transformation`` as opposed to the three separate calls.
 
 .. seealso::
 

--- a/test/unit/filters/IcpFilterTest.cpp
+++ b/test/unit/filters/IcpFilterTest.cpp
@@ -136,6 +136,36 @@ TEST(IcpFilterTest, RecoverTranslation)
     checkPointsEqualReader(pointViewSet, tolerance);
 }
 
+TEST(IcpFilterTest, RecoverRotation)
+{
+    auto reader1 = newReader();
+    auto reader2 = newReader();
+    TransformationFilter transformationFilter;
+    Options transformationOptions;
+    transformationOptions.add("matrix", "0.996 0 0.087 0\n0 1 0 0\n-0.087 0 0.996 0\n0 0 0 1");
+    transformationFilter.setOptions(transformationOptions);
+    transformationFilter.setInput(*reader2);
+
+    auto filter = newFilter();
+    filter->setInput(*reader1);
+    filter->setInput(transformationFilter);
+
+    PointTable table;
+    filter->prepare(table);
+    PointViewSet pointViewSet = filter->execute(table);
+
+    MetadataNode root = filter->getMetadata();
+    Eigen::MatrixXd transform =
+        root.findChild("transform").value<Eigen::MatrixXd>();
+    double tolerance = 0.001;
+    EXPECT_NEAR(0.996, transform(0, 0), tolerance);
+    EXPECT_NEAR(-0.087, transform(0, 2), tolerance);
+    EXPECT_NEAR(0.087, transform(2, 0), tolerance);
+    EXPECT_NEAR(0.996, transform(2, 2), tolerance);
+    double tolerance2 = 0.5;
+    checkPointsEqualReader(pointViewSet, tolerance2);
+}
+
 TEST(IcpFilterTest, TooFewInputs)
 {
     auto reader = newReader();


### PR DESCRIPTION
In conjunction with #2962, which outputs the centroid used internal to ICP, and as an alternative to #2963, which looked at computing ICP without first centering the data, this pull request keeps the centering step (and subsequent translation back to global coordinates), but adds another item to the output metadata: the fully composed transformation formed by concatenating the internal transformation steps. With this, a downstream user wishing to apply the same transformation can simply use the matrix specified in "composed" and pass it directly to `filters.transformation`.

Fixes #2939 