### PR TITLE
Use signed int for clustering/grouping

### DIFF
--- a/filters/DBSCANFilter.hpp
+++ b/filters/DBSCANFilter.hpp
@@ -56,7 +56,6 @@ public:
 private:
     uint64_t m_minPoints;
     double m_eps;
-    Dimension::Id m_cluster;
     StringList m_dimStringList;
     Dimension::IdList m_dimIdList;
 

--- a/filters/GroupByFilter.cpp
+++ b/filters/GroupByFilter.cpp
@@ -77,7 +77,7 @@ PointViewSet GroupByFilter::run(PointViewPtr inView)
 
     for (PointId idx = 0; idx < inView->size(); idx++)
     {
-        uint64_t val = inView->getFieldAs<uint64_t>(m_dimId, idx);
+        int64_t val = inView->getFieldAs<int64_t>(m_dimId, idx);
         PointViewPtr& outView = m_viewMap[val];
         if (!outView)
             outView = inView->makeNew();

--- a/pdal/Dimension.json
+++ b/pdal/Dimension.json
@@ -376,7 +376,7 @@
     },
     {
     "name": "ClusterID",
-    "type": "uint64_t",
+    "type": "int64_t",
     "description": "ID assigned to a point by a point-clustering algorithm."
     },
     {


### PR DESCRIPTION
Modify DBSCAN to use the standard ClusterID dimension, which is now
defined as int64. The Groupby filter is similarly instructed to evaluate
int64. This allows clustering algorithms like DBSCAN to use -1 to
indicate noise.

Close #3079 