### PR TITLE
Enhance eigenvalues filter with radius and stride options for defining neighborhood

### DIFF
--- a/filters/EigenvaluesFilter.cpp
+++ b/filters/EigenvaluesFilter.cpp
@@ -55,27 +55,59 @@ static StaticPluginInfo const s_info
 
 CREATE_STATIC_STAGE(EigenvaluesFilter, s_info)
 
+struct EigenvalueArgs
+{
+    int m_knn;
+    bool m_normalize;
+    size_t m_stride;
+    double m_radius;
+    Arg* m_radiusArg;
+    int m_minK;
+};
+
+EigenvaluesFilter::EigenvaluesFilter() : m_args(new EigenvalueArgs) {}
+
 std::string EigenvaluesFilter::getName() const
 {
     return s_info.name;
 }
 
-
 void EigenvaluesFilter::addArgs(ProgramArgs& args)
 {
-    args.add("knn", "k-Nearest neighbors", m_knn, 8);
-    args.add("normalize", "Normalize eigenvalues?", m_normalize, false);
-    args.add("stride", "Compute features on strided neighbors", m_stride, size_t(1));
-    args.add("radius", "Radius for nearest neighbor search", m_radius, 0.0);
-    args.add("min_k", "Minimum number of neighbors in radius", m_minK, 3);
+    args.add("knn", "k-Nearest neighbors", m_args->m_knn, 8);
+    args.add("normalize", "Normalize eigenvalues?", m_args->m_normalize, false);
+    args.add("stride", "Compute features on strided neighbors",
+             m_args->m_stride, size_t(1));
+    m_args->m_radiusArg = &args.add(
+        "radius", "Radius for nearest neighbor search", m_args->m_radius);
+    args.add("min_k", "Minimum number of neighbors in radius", m_args->m_minK,
+             3);
 }
-
 
 void EigenvaluesFilter::addDimensions(PointLayoutPtr layout)
 {
     m_e0 = layout->registerOrAssignDim("Eigenvalue0", Dimension::Type::Double);
     m_e1 = layout->registerOrAssignDim("Eigenvalue1", Dimension::Type::Double);
     m_e2 = layout->registerOrAssignDim("Eigenvalue2", Dimension::Type::Double);
+}
+
+void EigenvaluesFilter::prepared(PointTableRef table)
+{
+    if (m_args->m_radiusArg->set())
+    {
+        log()->get(LogLevel::Warning)
+            << "Radius has been set. Ignoring knn and stride values."
+            << std::endl;
+        if (m_args->m_radius <= 0.0)
+            log()->get(LogLevel::Error)
+                << "Radius must be greater than 0." << std::endl;
+    }
+    else
+    {
+        log()->get(LogLevel::Warning) << "No radius specified. Proceeding with "
+                                         "knn and stride, but ignoring min_k."
+                                      << std::endl;
+    }
 }
 
 void EigenvaluesFilter::filter(PointView& view)
@@ -88,16 +120,20 @@ void EigenvaluesFilter::filter(PointView& view)
     {
         // find neighbors, either by radius or k nearest neighbors
         PointIdList ids;
-        if (m_radius > 0.0)
-            ids = kdi.radius(i, m_radius);
-        else
-            ids = kdi.neighbors(i, m_knn + 1, m_stride);
+        if (m_args->m_radiusArg->set())
+        {
+            ids = kdi.radius(i, m_args->m_radius);
 
-        // if insufficient number of neighbors, eigen solver will fail anyway, it
-        // may be okay to silently return without setting any of the computed
-        // features?
-        if (ids.size() < (size_t)m_minK)
-            return;
+            // if insufficient number of neighbors, eigen solver will fail
+            // anyway, it may be okay to silently return without setting any of
+            // the computed features?
+            if (ids.size() < (size_t)m_args->m_minK)
+                return;
+        }
+        else
+        {
+            ids = kdi.neighbors(i, m_args->m_knn + 1, m_args->m_stride);
+        }
 
         // compute covariance of the neighborhood
         auto B = computeCovariance(view, ids);
@@ -108,7 +144,7 @@ void EigenvaluesFilter::filter(PointView& view)
             throwError("Cannot perform eigen decomposition.");
         auto ev = solver.eigenvalues();
 
-        if (m_normalize)
+        if (m_args->m_normalize)
         {
             double sum = ev[0] + ev[1] + ev[2];
             ev /= sum;

--- a/filters/EigenvaluesFilter.hpp
+++ b/filters/EigenvaluesFilter.hpp
@@ -46,27 +46,24 @@ namespace pdal
 class Options;
 class PointLayout;
 class PointView;
+struct EigenvalueArgs;
 
 class PDAL_DLL EigenvaluesFilter : public Filter
 {
 public:
-    EigenvaluesFilter() : Filter()
-    {}
+    EigenvaluesFilter();
     EigenvaluesFilter& operator=(const EigenvaluesFilter&) = delete;
     EigenvaluesFilter(const EigenvaluesFilter&) = delete;
 
     std::string getName() const;
 
 private:
-    int m_knn;
+    std::unique_ptr<EigenvalueArgs> m_args;
     Dimension::Id m_e0, m_e1, m_e2;
-    bool m_normalize;
-    size_t m_stride;
-    double m_radius;
-    int m_minK;
 
     virtual void addDimensions(PointLayoutPtr layout);
     virtual void addArgs(ProgramArgs& args);
+    virtual void prepared(PointTableRef table);
     virtual void filter(PointView& view);
 };
 

--- a/filters/EigenvaluesFilter.hpp
+++ b/filters/EigenvaluesFilter.hpp
@@ -61,6 +61,9 @@ private:
     int m_knn;
     Dimension::Id m_e0, m_e1, m_e2;
     bool m_normalize;
+    size_t m_stride;
+    double m_radius;
+    int m_minK;
 
     virtual void addDimensions(PointLayoutPtr layout);
     virtual void addArgs(ProgramArgs& args);


### PR DESCRIPTION
Default behavior does not change at all, but adds radius and strided neighborhood options which can be better in irregularly sampled data.