### PR TITLE
Docker images missing certificates

### DIFF
--- a/scripts/docker/alpine/Dockerfile.2.0
+++ b/scripts/docker/alpine/Dockerfile.2.0
@@ -39,6 +39,7 @@ RUN    \
     rm /usr/bin/h5*;
 
 FROM alpine:3.11
+RUN apk add --no-cache ca-certificates
 
 COPY --from=builder /usr/ /usr/
 COPY --from=builder /lib/ /lib/

--- a/scripts/docker/ubuntu/Dockerfile
+++ b/scripts/docker/ubuntu/Dockerfile
@@ -68,7 +68,7 @@ ARG PDAL_CONDA=/opt/conda/envs/pdal
 
 RUN apt-get update --fix-missing && \
     apt-get install -y \
-        sudo && \
+        sudo ca-certificates && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Ubuntu and alpine docker images are missing the ca-certificates files preventing arbiter access