### PR TITLE
Add OptimalNeighborhoodFilter and refactor CovarianceFeaturesFilter

### DIFF
--- a/doc/stages/filters.covariancefeatures.rst
+++ b/doc/stages/filters.covariancefeatures.rst
@@ -112,8 +112,10 @@ mode
 
 optimized
   ``optimized`` can be set to ``true`` to enable computation of features using
-  precomputed optimal neighborhoods (see :ref:`filters.optimalneighborhood`).
-  Enables computation of ``Density`` feature. [Default: false]
+  precomputed optimal neighborhoods. Requires
+  :ref:`filters.optimalneighborhood` be run prior to this stage. Enables
+  computation of ``Density`` feature and use of ``OptimalKNN`` to define local
+  neighborhood size. [Default: false]
 
 .. _dimensionality:
 

--- a/doc/stages/filters.covariancefeatures.rst
+++ b/doc/stages/filters.covariancefeatures.rst
@@ -9,24 +9,24 @@ covariance matrix of a point's neighborhood.
 
 The user can pick a set of feature descriptors by setting the ``feature_set``
 option. Currently, the only supported feature is the dimensionality_ set of
-feature descriptors introduced below. Specifying any unrecognized
-``feature_set`` will trigger computation of all available covariance features.
+feature descriptors introduced below.
 
 Alternately, the user can provide a comma-separated list of ``features`` to
 explicitly itemize those covariance features they wish to be computed.
 
 Supported features include:
 
+* Anisotropy
+* DemantkeVerticality
+* Density
+* Eigenentropy
 * Linearity
+* Omnivariance
 * Planarity
 * Scattering
-* Verticality
-* DemantkeVerticality
-* Omnivariance
-* Anisotropy
 * Sum
-* Eigenentropy
 * SurfaceVariation
+* Verticality
 
 Example #1
 -------------------------------------------------------------------------------
@@ -86,7 +86,6 @@ threads
 
 feature_set
   The features to be computed. Currently only supports ``Dimensionality``.
-  [Default: "Dimensionality"]
 
 stride
   When finding k nearest neighbors, stride determines the sampling rate. A
@@ -97,23 +96,24 @@ min_k
   Minimum number of neighbors in radius (radius search only). [Default: 3]
 
 radius
-  If radius specified greater than zero, neighbors will be obtained by radius
-  search rather than k nearest neighbors, subject to meeting the minimum number
-  of neighbors (``min_k``). [Default: 0.0]
+  If radius is specified, neighbors will be obtained by radius search rather
+  than k nearest neighbors, subject to meeting the minimum number of neighbors
+  (``min_k``).
 
 features
-  A comma-separated list of individual features to be computed.
+  A comma-separated list of individual features to be computed. [Default: "all"]
 
 mode
-  By default, filter will compute features using raw eigenvalues. ``mode`` can
-  be set to "SQRT" to take the square root of each eigenvalue, thus computing
-  features on the standard deviation along each eigenvector. ``mode`` also
-  accepts "NORM" which normalizes eigenvalue such that they sum to one.
+  By default, features are computed using the standard deviation along each
+  eigenvector, i.e., using the square root of the computed eigenvalues
+  (``mode="SQRT"``). ``mode`` also accepts "Normalized" which normalizes
+  eigenvalue such that they sum to one, or "Raw" such that the eigenvalues are
+  used directly. [Default: "SQRT"]
 
 optimized
   ``optimized`` can be set to ``true`` to enable computation of features using
   precomputed optimal neighborhoods (see :ref:`filters.optimalneighborhood`).
-  Enables computation of ``Density`` feature as well. [Default: false]
+  Enables computation of ``Density`` feature. [Default: false]
 
 .. _dimensionality:
 

--- a/doc/stages/filters.covariancefeatures.rst
+++ b/doc/stages/filters.covariancefeatures.rst
@@ -4,12 +4,31 @@
 filters.covariancefeatures
 ===============================================================================
 
-This filter implements various local feature descriptors introduced that are based on the covariance matrix of a
-point's neighborhood. The user can pick a set of feature descriptors by
-setting the ``feature_set`` option. Currently, the only supported feature is the dimensionality_
-set of feature descriptors introduced below.
+This filter implements various local feature descriptors that are based on the
+covariance matrix of a point's neighborhood.
 
-Example
+The user can pick a set of feature descriptors by setting the ``feature_set``
+option. Currently, the only supported feature is the dimensionality_ set of
+feature descriptors introduced below. Specifying any unrecognized
+``feature_set`` will trigger computation of all available covariance features.
+
+Alternately, the user can provide a comma-separated list of ``features`` to
+explicitly itemize those covariance features they wish to be computed.
+
+Supported features include:
+
+* Linearity
+* Planarity
+* Scattering
+* Verticality
+* DemantkeVerticality
+* Omnivariance
+* Anisotropy
+* Sum
+* Eigenentropy
+* SurfaceVariation
+
+Example #1
 -------------------------------------------------------------------------------
 
 .. code-block:: json
@@ -24,8 +43,34 @@ Example
       },
       {
           "type":"writers.bpf",
-          "filename":"output.las",
+          "filename":"output.bpf",
           "output_dims":"X,Y,Z,Linearity,Planarity,Scattering,Verticality"
+      }
+  ]
+
+Example #2
+-------------------------------------------------------------------------------
+
+.. code-block:: json
+
+  [
+      "input.las",
+      {
+          "type":"filters.optimalneighborhood"
+      },
+      {
+          "type":"filters.covariancefeatures",
+          "knn":8,
+          "threads": 2,
+          "optimized":true,
+          "features": "Linearity,Omnivariance,Density"
+      },
+      {
+          "type":"writers.las",
+          "minor_version":4,
+          "extra_dims":"all",
+          "forward":"all",
+          "filename":"output.las"
       }
   ]
 
@@ -33,13 +78,15 @@ Options
 -------------------------------------------------------------------------------
 
 knn
-  The number of k nearest neighbors used for calculating the covariance matrix. [Default: 10]
+  The number of k nearest neighbors used for calculating the covariance matrix.
+  [Default: 10]
 
 threads
   The number of threads used for computing the feature descriptors. [Default: 1]
 
 feature_set
-  The features to be computed. Currently only supports ``Dimensionality``. [Default: "Dimensionality"]
+  The features to be computed. Currently only supports ``Dimensionality``.
+  [Default: "Dimensionality"]
 
 stride
   When finding k nearest neighbors, stride determines the sampling rate. A
@@ -54,25 +101,38 @@ radius
   search rather than k nearest neighbors, subject to meeting the minimum number
   of neighbors (``min_k``). [Default: 0.0]
 
+features
+  A comma-separated list of individual features to be computed.
+
+mode
+  By default, filter will compute features using raw eigenvalues. ``mode`` can
+  be set to "SQRT" to take the square root of each eigenvalue, thus computing
+  features on the standard deviation along each eigenvector. ``mode`` also
+  accepts "NORM" which normalizes eigenvalue such that they sum to one.
+
+optimized
+  ``optimized`` can be set to ``true`` to enable computation of features using
+  precomputed optimal neighborhoods (see :ref:`filters.optimalneighborhood`).
+  Enables computation of ``Density`` feature as well. [Default: false]
+
 .. _dimensionality:
 
 Dimensionality feature set
 ................................................................................
-The features introduced in [Demantke2011]_ describe the shape
-of the neighborhood, indicating whether
-the local geometry is more linear (1D), planar (2D) or volumetric (3D) while the one introduced in
-[Guinard2017]_ adds the idea of a structure being vertical.
+The features introduced in [Demantke2011]_ describe the shape of the
+neighborhood, indicating whether the local geometry is more linear (1D), planar
+(2D) or volumetric (3D) while the one introduced in [Guinard2017]_ adds the
+idea of a structure being vertical.
 
-
-The dimensionality filter introduces the following four descriptors that are computed from the covariance matrix of the ``knn`` neighbors:
+The dimensionality filter introduces the following four descriptors that are
+computed from the covariance matrix of a point's neighbors (as defined by
+``knn`` or ``radius``):
 
 * linearity - higher for long thin strips
 * planarity - higher for planar surfaces
 * scattering - higher for complex 3d neighbourhoods
 * verticality - higher for vertical structures, highest for thin vertical strips
 
-It introduces four new dimensions that hold each one of these values: ``Linearity``  ``Planarity``  ``Scattering``
-and  ``Verticality``.
-
-
+It introduces four new dimensions that hold each one of these values:
+``Linearity``, ``Planarity``, ``Scattering`` and ``Verticality``.
 

--- a/doc/stages/filters.covariancefeatures.rst
+++ b/doc/stages/filters.covariancefeatures.rst
@@ -8,11 +8,11 @@ This filter implements various local feature descriptors that are based on the
 covariance matrix of a point's neighborhood.
 
 The user can pick a set of feature descriptors by setting the ``feature_set``
-option. Currently, the only supported feature is the dimensionality_ set of
-feature descriptors introduced below.
-
-Alternately, the user can provide a comma-separated list of ``features`` to
-explicitly itemize those covariance features they wish to be computed.
+option. The dimensionality_ set of feature descriptors introduced below is the
+default. The user can also provide a comma-separated list of features to
+explicitly itemize those covariance features they wish to be computed. This can
+be combined with any suppported presets like "Dimensionality".  Specifying "all"
+will compute all available features.
 
 Supported features include:
 
@@ -27,6 +27,12 @@ Supported features include:
 * EigenvalueSum
 * SurfaceVariation
 * Verticality
+
+.. note::
+
+    Density requires both ``OptimalKNN`` and ``OptimalRadius`` which can be
+    computed by running :ref:`filters.optimalneighborhood` prior to
+    ``filters.covariancefeatures``.
 
 Example #1
 -------------------------------------------------------------------------------
@@ -63,7 +69,7 @@ Example #2
           "knn":8,
           "threads": 2,
           "optimized":true,
-          "features": "Linearity,Omnivariance,Density"
+          "feature_set": "Linearity,Omnivariance,Density"
       },
       {
           "type":"writers.las",
@@ -85,7 +91,9 @@ threads
   The number of threads used for computing the feature descriptors. [Default: 1]
 
 feature_set
-  The features to be computed. Currently only supports ``Dimensionality``.
+  A comma-separated list of individual features or feature presets (e.g.,
+  "Dimensionality") to be computed. To compute all available features, specify
+  "all". [Default: "Dimensionality"]
 
 stride
   When finding k nearest neighbors, stride determines the sampling rate. A
@@ -100,9 +108,6 @@ radius
   than k nearest neighbors, subject to meeting the minimum number of neighbors
   (``min_k``).
 
-features
-  A comma-separated list of individual features to be computed. [Default: "all"]
-
 mode
   By default, features are computed using the standard deviation along each
   eigenvector, i.e., using the square root of the computed eigenvalues
@@ -112,15 +117,15 @@ mode
 
 optimized
   ``optimized`` can be set to ``true`` to enable computation of features using
-  precomputed optimal neighborhoods. Requires
-  :ref:`filters.optimalneighborhood` be run prior to this stage. Enables
-  computation of ``Density`` feature and use of ``OptimalKNN`` to define local
-  neighborhood size. [Default: false]
+  precomputed optimal neighborhoods (found in the ``OptimalKNN`` dimension).
+  Requires :ref:`filters.optimalneighborhood` be run prior to this stage.
+  [Default: false]
 
 .. _dimensionality:
 
 Dimensionality feature set
 ................................................................................
+
 The features introduced in [Demantke2011]_ describe the shape of the
 neighborhood, indicating whether the local geometry is more linear (1D), planar
 (2D) or volumetric (3D) while the one introduced in [Guinard2017]_ adds the

--- a/doc/stages/filters.covariancefeatures.rst
+++ b/doc/stages/filters.covariancefeatures.rst
@@ -24,7 +24,7 @@ Supported features include:
 * Omnivariance
 * Planarity
 * Scattering
-* Sum
+* EigenvalueSum
 * SurfaceVariation
 * Verticality
 

--- a/doc/stages/filters.optimalneighborhood.rst
+++ b/doc/stages/filters.optimalneighborhood.rst
@@ -1,0 +1,47 @@
+.. _filters.optimalneighborhood:
+
+===============================================================================
+filters.optimalneighborhood
+===============================================================================
+
+The **Optimal Neighborhood filter** computes the eigenentropy (defined as the
+Shannon entropy of the normalized eigenvalues) for a neighborhood of points in
+the range ``min_k`` to ``max_k``. The neighborhood size that minimizes the
+eigenentropy is saved to a new dimension ``OptimalKNN``. The corresponding
+radius of the neighborhood is saved to ``OptimalRadius``. These dimensions can
+be written to an output file or utilized directly by
+:ref:`filters.covariancefeatures`.
+
+.. embed::
+
+Example
+-------------------------------------------------------------------------------
+
+.. code-block:: json
+
+  [
+      "input.las",
+      {
+          "type":"filters.optimalneighborhood",
+          "min_k":8,
+          "max_k": 50
+      },
+      {
+          "type":"writers.las",
+          "minor_version":4,
+          "extra_dims":"all",
+          "forward":"all",
+          "filename":"output.las"
+      }
+  ]
+
+Options
+-------------------------------------------------------------------------------
+
+min_k
+  The minimum number of k nearest neighbors to consider for optimal
+  neighborhood selection. [Default: 10]
+
+max_k
+  The maximum number of k nearest neighbors to consider for optimal
+  neighborhood selection. [Default: 100]

--- a/doc/stages/filters.rst
+++ b/doc/stages/filters.rst
@@ -186,6 +186,7 @@ Pointwise Features
    filters.miniball
    filters.nndistance
    filters.normal
+   filters.optimalneighborhood
    filters.planefit
    filters.radialdensity
    filters.reciprocity
@@ -217,6 +218,11 @@ Pointwise Features
 
 :ref:`filters.normal`
     Compute pointwise normal and curvature, based on k-nearest neighbors.
+
+:ref:`filters.optimalneighborhood`
+    Compute optimal k nearest neighbors and corresponding radius by minimizing
+    pointwise eigenentropy. Creates two new dimensions ``OptimalKNN`` and
+    ``OptimalRadius``.
 
 :ref:`filters.planefit`
     Compute a deviation of a point from a manifold approximating its neighbors.

--- a/filters/CovarianceFeaturesFilter.cpp
+++ b/filters/CovarianceFeaturesFilter.cpp
@@ -150,27 +150,38 @@ void CovarianceFeaturesFilter::addDimensions(PointLayoutPtr layout)
             << "Feature list provided. Ignoring feature_set " << m_featureSet
             << ".\n";
         if (m_featureTypes & FeatureType::Linearity)
-            m_extraDims["Linearity"] = layout->registerOrAssignDim("Linearity", Dimension::Type::Double);
+            m_extraDims["Linearity"] = layout->registerOrAssignDim(
+                "Linearity", Dimension::Type::Double);
         if (m_featureTypes & FeatureType::Planarity)
-            m_extraDims["Planarity"] = layout->registerOrAssignDim("Planarity", Dimension::Type::Double);
+            m_extraDims["Planarity"] = layout->registerOrAssignDim(
+                "Planarity", Dimension::Type::Double);
         if (m_featureTypes & FeatureType::Scattering)
-            m_extraDims["Scattering"] = layout->registerOrAssignDim("Scattering", Dimension::Type::Double);
+            m_extraDims["Scattering"] = layout->registerOrAssignDim(
+                "Scattering", Dimension::Type::Double);
         if (m_featureTypes & FeatureType::Verticality)
-            m_extraDims["Verticality"] = layout->registerOrAssignDim("Verticality", Dimension::Type::Double);
+            m_extraDims["Verticality"] = layout->registerOrAssignDim(
+                "Verticality", Dimension::Type::Double);
         if (m_featureTypes & FeatureType::Omnivariance)
-            m_extraDims["Omnivariance"] = layout->registerOrAssignDim("Omnivariance", Dimension::Type::Double);
+            m_extraDims["Omnivariance"] = layout->registerOrAssignDim(
+                "Omnivariance", Dimension::Type::Double);
         if (m_featureTypes & FeatureType::Anisotropy)
-            m_extraDims["Anisotropy"] = layout->registerOrAssignDim("Anisotropy", Dimension::Type::Double);
+            m_extraDims["Anisotropy"] = layout->registerOrAssignDim(
+                "Anisotropy", Dimension::Type::Double);
         if (m_featureTypes & FeatureType::Eigenentropy)
-            m_extraDims["Eigenentropy"] = layout->registerOrAssignDim("Eigenentropy", Dimension::Type::Double);
+            m_extraDims["Eigenentropy"] = layout->registerOrAssignDim(
+                "Eigenentropy", Dimension::Type::Double);
         if (m_featureTypes & FeatureType::Sum)
-            m_extraDims["Sum"] = layout->registerOrAssignDim("Sum", Dimension::Type::Double);
+            m_extraDims["Sum"] =
+                layout->registerOrAssignDim("Sum", Dimension::Type::Double);
         if (m_featureTypes & FeatureType::SurfaceVariation)
-            m_extraDims["SurfaceVariation"] = layout->registerOrAssignDim("SurfaceVariation", Dimension::Type::Double);
+            m_extraDims["SurfaceVariation"] = layout->registerOrAssignDim(
+                "SurfaceVariation", Dimension::Type::Double);
         if (m_featureTypes & FeatureType::DemantkeVerticality)
-            m_extraDims["DemantkeVerticality"] = layout->registerOrAssignDim("DemantkeVerticality", Dimension::Type::Double);
+            m_extraDims["DemantkeVerticality"] = layout->registerOrAssignDim(
+                "DemantkeVerticality", Dimension::Type::Double);
         if (m_featureTypes & FeatureType::Density)
-            m_extraDims["Density"] = layout->registerOrAssignDim("Density", Dimension::Type::Double);
+            m_extraDims["Density"] =
+                layout->registerOrAssignDim("Density", Dimension::Type::Double);
     }
 }
 
@@ -221,16 +232,16 @@ void CovarianceFeaturesFilter::prepared(PointTableRef table)
     {
         m_kopt = layout->findDim("OptimalKNN");
         if (m_kopt == Dimension::Id::Unknown)
-            throwError("No dimension \"OptimalKNN\".");
+            throwError("No dimension 'OptimalKNN'.");
         m_ropt = layout->findDim("OptimalRadius");
         if (m_ropt == Dimension::Id::Unknown)
-            throwError("No dimension \"OptimalRadius\".");
+            throwError("No dimension 'OptimalRadius'.");
     }
 }
 
 void CovarianceFeaturesFilter::filter(PointView& view)
 {
-    KD3Index& kdin = view.build3dIndex();
+    KD3Index& kdi = view.build3dIndex();
 
     point_count_t nloops = view.size();
     std::vector<std::thread> threadList(m_threads);
@@ -240,7 +251,7 @@ void CovarianceFeaturesFilter::filter(PointView& view)
                 [&](const PointId start, const PointId end)
                 {
                     for(PointId i = start;i<end;i++)
-                        setDimensionality(view, i, kdin);
+                        setDimensionality(view, i, kdi);
                 },
                 t*nloops/m_threads,(t+1)==m_threads?nloops:(t+1)*nloops/m_threads));
     }

--- a/filters/CovarianceFeaturesFilter.cpp
+++ b/filters/CovarianceFeaturesFilter.cpp
@@ -44,7 +44,6 @@
 
 #include <Eigen/Dense>
 
-#define _USE_MATH_DEFINES  // for M_PI
 #include <cmath>
 #include <numeric>
 #include <string>
@@ -335,8 +334,9 @@ void CovarianceFeaturesFilter::setDimensionality(PointView &view, const PointId 
         {
             double kopt = p.getFieldAs<uint64_t>(Id::OptimalKNN);
             double ropt = p.getFieldAs<double>(Id::OptimalRadius);
+	    double pi = 3.14159265;
             p.setField(Id::Density,
-                       (kopt + 1) / ((4 / 3) * M_PI * std::pow(ropt, 3)));
+                       (kopt + 1) / ((4 / 3) * pi * std::pow(ropt, 3)));
         }
     }
 }

--- a/filters/CovarianceFeaturesFilter.cpp
+++ b/filters/CovarianceFeaturesFilter.cpp
@@ -191,7 +191,6 @@ void CovarianceFeaturesFilter::initialize()
     {
         std::string f = Utils::tolower(feat);
         Utils::trim(f);
-        std::cerr << f << std::endl;
         if (f == "all")
         {
             m_featureTypes = ~0;
@@ -221,7 +220,6 @@ void CovarianceFeaturesFilter::initialize()
             m_featureTypes |= FeatureType::Density;
         else
             throwError("Invalid feature type: '" + f + "'.");
-        std::cerr << m_featureTypes << std::endl;
     }
 }
 

--- a/filters/CovarianceFeaturesFilter.hpp
+++ b/filters/CovarianceFeaturesFilter.hpp
@@ -50,7 +50,7 @@ public:
     static const int Omnivariance = 16;
     static const int Anisotropy = 32;
     static const int Eigenentropy = 64;
-    static const int Sum = 128;
+    static const int EigenvalueSum = 128;
     static const int SurfaceVariation = 256;
     static const int DemantkeVerticality = 512;
     static const int Density = 1024;

--- a/filters/CovarianceFeaturesFilter.hpp
+++ b/filters/CovarianceFeaturesFilter.hpp
@@ -50,6 +50,12 @@ public:
     std::string getName() const;
 
 private:
+    enum class Mode
+    {
+        Raw,
+        SQRT,
+        Normalized
+    };
 
     int m_knn;
     int m_threads;
@@ -60,7 +66,7 @@ private:
     int m_minK;
     Arg* m_featuresArg;
     StringList m_features;
-    std::string m_mode;
+    Mode m_mode;
     Dimension::Id m_kopt, m_ropt;
     Arg* m_radiusArg;
     bool m_optimal;
@@ -71,6 +77,11 @@ private:
     virtual void prepared(PointTableRef table);
 
     void setDimensionality(PointView &view, const PointId &id, const KD3Index &kid);
+
+    friend std::istream& operator>>(std::istream& in,
+        CovarianceFeaturesFilter::Mode& mode);
+    friend std::ostream& operator<<(std::ostream& in,
+        const CovarianceFeaturesFilter::Mode& mode);
 };
 }
 

--- a/filters/CovarianceFeaturesFilter.hpp
+++ b/filters/CovarianceFeaturesFilter.hpp
@@ -40,10 +40,26 @@
 
 namespace pdal {
 
+class FeatureType
+{
+public:
+    static const int Linearity = 1;
+    static const int Planarity = 2;
+    static const int Scattering = 4;
+    static const int Verticality = 8;
+    static const int Omnivariance = 16;
+    static const int Anisotropy = 32;
+    static const int Eigenentropy = 64;
+    static const int Sum = 128;
+    static const int SurfaceVariation = 256;
+    static const int DemantkeVerticality = 512;
+    static const int Density = 1024;
+};
+
 class PDAL_DLL CovarianceFeaturesFilter: public Filter
 {
 public:
-    CovarianceFeaturesFilter() : Filter() {}
+    CovarianceFeaturesFilter() : m_featureTypes(0) {}
     CovarianceFeaturesFilter &operator=(const CovarianceFeaturesFilter &) = delete;
     CovarianceFeaturesFilter(const CovarianceFeaturesFilter &) = delete;
 
@@ -57,15 +73,21 @@ private:
         Normalized
     };
 
+    enum class FeatureSet
+    {
+        Dimensionality,
+    };
+
     int m_knn;
     int m_threads;
-    std::string m_featureSet;
+    FeatureSet m_featureSet;
     std::map<std::string,Dimension::Id> m_extraDims;
     size_t m_stride;
     double m_radius;
     int m_minK;
-    Arg* m_featuresArg;
+    Arg* m_featureSetArg;
     StringList m_features;
+    int m_featureTypes;
     Mode m_mode;
     Dimension::Id m_kopt, m_ropt;
     Arg* m_radiusArg;
@@ -74,6 +96,7 @@ private:
     virtual void addDimensions(PointLayoutPtr layout);
     virtual void addArgs(ProgramArgs &args);
     virtual void filter(PointView &view);
+    virtual void initialize();
     virtual void prepared(PointTableRef table);
 
     void setDimensionality(PointView &view, const PointId &id, const KD3Index &kid);
@@ -82,6 +105,10 @@ private:
         CovarianceFeaturesFilter::Mode& mode);
     friend std::ostream& operator<<(std::ostream& in,
         const CovarianceFeaturesFilter::Mode& mode);
+    friend std::istream& operator>>(std::istream& in,
+        CovarianceFeaturesFilter::FeatureSet& featureset);
+    friend std::ostream& operator<<(std::ostream& in,
+        const CovarianceFeaturesFilter::FeatureSet& featureset);
 };
 }
 

--- a/filters/CovarianceFeaturesFilter.hpp
+++ b/filters/CovarianceFeaturesFilter.hpp
@@ -40,26 +40,10 @@
 
 namespace pdal {
 
-class FeatureType
-{
-public:
-    static const int Linearity = 1;
-    static const int Planarity = 2;
-    static const int Scattering = 4;
-    static const int Verticality = 8;
-    static const int Omnivariance = 16;
-    static const int Anisotropy = 32;
-    static const int Eigenentropy = 64;
-    static const int EigenvalueSum = 128;
-    static const int SurfaceVariation = 256;
-    static const int DemantkeVerticality = 512;
-    static const int Density = 1024;
-};
-
 class PDAL_DLL CovarianceFeaturesFilter: public Filter
 {
 public:
-    CovarianceFeaturesFilter() : m_featureTypes(0) {}
+    CovarianceFeaturesFilter() {}
     CovarianceFeaturesFilter &operator=(const CovarianceFeaturesFilter &) = delete;
     CovarianceFeaturesFilter(const CovarianceFeaturesFilter &) = delete;
 
@@ -73,20 +57,13 @@ private:
         Normalized
     };
 
-    enum class FeatureSet
-    {
-        Dimensionality,
-    };
-
     int m_knn;
     int m_threads;
-    FeatureSet m_featureSet;
+    StringList m_featureSetString;
+    std::vector<Dimension::Id> m_extraDims;
     size_t m_stride;
     double m_radius;
     int m_minK;
-    Arg* m_featureSetArg;
-    StringList m_features;
-    int m_featureTypes;
     Mode m_mode;
     Arg* m_radiusArg;
     bool m_optimal;
@@ -94,7 +71,6 @@ private:
     virtual void addDimensions(PointLayoutPtr layout);
     virtual void addArgs(ProgramArgs &args);
     virtual void filter(PointView &view);
-    virtual void initialize();
     virtual void prepared(PointTableRef table);
 
     void setDimensionality(PointView &view, const PointId &id, const KD3Index &kid);
@@ -103,10 +79,6 @@ private:
         CovarianceFeaturesFilter::Mode& mode);
     friend std::ostream& operator<<(std::ostream& in,
         const CovarianceFeaturesFilter::Mode& mode);
-    friend std::istream& operator>>(std::istream& in,
-        CovarianceFeaturesFilter::FeatureSet& featureset);
-    friend std::ostream& operator<<(std::ostream& in,
-        const CovarianceFeaturesFilter::FeatureSet& featureset);
 };
 }
 

--- a/filters/CovarianceFeaturesFilter.hpp
+++ b/filters/CovarianceFeaturesFilter.hpp
@@ -81,7 +81,6 @@ private:
     int m_knn;
     int m_threads;
     FeatureSet m_featureSet;
-    std::map<std::string,Dimension::Id> m_extraDims;
     size_t m_stride;
     double m_radius;
     int m_minK;
@@ -89,7 +88,6 @@ private:
     StringList m_features;
     int m_featureTypes;
     Mode m_mode;
-    Dimension::Id m_kopt, m_ropt;
     Arg* m_radiusArg;
     bool m_optimal;
 

--- a/filters/CovarianceFeaturesFilter.hpp
+++ b/filters/CovarianceFeaturesFilter.hpp
@@ -58,10 +58,17 @@ private:
     size_t m_stride;
     double m_radius;
     int m_minK;
+    Arg* m_featuresArg;
+    StringList m_features;
+    std::string m_mode;
+    Dimension::Id m_kopt, m_ropt;
+    Arg* m_radiusArg;
+    bool m_optimal;
 
     virtual void addDimensions(PointLayoutPtr layout);
     virtual void addArgs(ProgramArgs &args);
     virtual void filter(PointView &view);
+    virtual void prepared(PointTableRef table);
 
     void setDimensionality(PointView &view, const PointId &id, const KD3Index &kid);
 };

--- a/filters/OptimalNeighborhoodFilter.cpp
+++ b/filters/OptimalNeighborhoodFilter.cpp
@@ -82,7 +82,7 @@ void OptimalNeighborhood::filter(PointView& view)
         std::vector<double> dists(m_kMax);
         index.knnSearch(p, m_kMax, &id3, &dists);
 
-        double minentropy(std::numeric_limits<double>::max());
+        double minentropy = (std::numeric_limits<double>::max)();
         point_count_t kopt(0);
         double ropt(0.0);
         double mx(0.0);

--- a/filters/OptimalNeighborhoodFilter.cpp
+++ b/filters/OptimalNeighborhoodFilter.cpp
@@ -1,0 +1,166 @@
+/******************************************************************************
+ * Copyright (c) 2020, Bradley J Chambers (brad.chambers@gmail.com)
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of Hobu, Inc. or Flaxen Geo Consulting nor the
+ *       names of its contributors may be used to endorse or promote
+ *       products derived from this software without specific prior
+ *       written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ ****************************************************************************/
+
+#include "OptimalNeighborhoodFilter.hpp"
+
+#include <pdal/KDIndex.hpp>
+
+#include <Eigen/Dense>
+
+#include <numeric>
+
+namespace pdal
+{
+using namespace Dimension;
+using namespace Eigen;
+
+static StaticPluginInfo const s_info{
+    "filters.optimalneighborhood", "OptimalNeighborhood Filter",
+    "http://pdal.io/stages/filters.optimalneighborhood.html"};
+
+CREATE_STATIC_STAGE(OptimalNeighborhood, s_info)
+
+std::string OptimalNeighborhood::getName() const
+{
+    return s_info.name;
+}
+
+OptimalNeighborhood::OptimalNeighborhood() : Filter() {}
+
+void OptimalNeighborhood::addArgs(ProgramArgs& args)
+{
+    args.add("min_k", "Minimum k-Nearest Neighbors", m_kMin, (point_count_t)10);
+    args.add("max_k", "Maximum k-Nearest Neighbors", m_kMax, (point_count_t)14);
+}
+
+void OptimalNeighborhood::addDimensions(PointLayoutPtr layout)
+{
+    m_kOpt = layout->registerOrAssignDim("OptimalKNN", Type::Unsigned64);
+    m_rOpt = layout->registerOrAssignDim("OptimalRadius", Type::Double);
+}
+
+void OptimalNeighborhood::filter(PointView& view)
+{
+    // Build the 3D KD-tree.
+    KD3Index& index = view.build3dIndex();
+
+    for (PointRef p : view)
+    {
+        // find the max k-nearest neighbors
+        PointIdList id3(m_kMax);
+        std::vector<double> dists(m_kMax);
+        index.knnSearch(p, m_kMax, &id3, &dists);
+
+        double minentropy(std::numeric_limits<double>::max());
+        point_count_t kopt(0);
+        double ropt(0.0);
+        double mx(0.0);
+        double my(0.0);
+        double mz(0.0);
+        Matrix3d B = Matrix3d::Zero(3, 3);
+
+        // precompute covariance matrix up to k-1 neighbors
+        for (point_count_t k = 0; k < m_kMin - 1; ++k)
+        {
+            PointRef q = view.point(id3[k]);
+
+            double dx = q.getFieldAs<double>(Id::X) - mx;
+            double dy = q.getFieldAs<double>(Id::Y) - my;
+            double dz = q.getFieldAs<double>(Id::Z) - mz;
+            double n = double(k + 1);
+            mx += dx / n;
+            my += dy / n;
+            mz += dz / n;
+            double s = (n - 1) / n;
+            B(0, 0) = B(0, 0) + s * dx * dx;
+            B(1, 1) = B(1, 1) + s * dy * dy;
+            B(2, 2) = B(2, 2) + s * dz * dz;
+            B(1, 0) = B(0, 1) = B(0, 1) + s * dx * dy;
+            B(2, 0) = B(0, 2) = B(0, 2) + s * dx * dz;
+            B(1, 2) = B(2, 1) = B(2, 1) + s * dy * dz;
+        }
+
+        // update covariance for all k in the range [kMin, kMax], compute
+        // eigenentropy and update optimal values
+        for (point_count_t k = m_kMin - 1; k < m_kMax; ++k)
+        {
+            PointRef q = view.point(id3[k]);
+
+            double dx = q.getFieldAs<double>(Id::X) - mx;
+            double dy = q.getFieldAs<double>(Id::Y) - my;
+            double dz = q.getFieldAs<double>(Id::Z) - mz;
+            double n = double(k + 1);
+            mx += dx / n;
+            my += dy / n;
+            mz += dz / n;
+            double s = (n - 1) / n;
+            B(0, 0) = B(0, 0) + s * dx * dx;
+            B(1, 1) = B(1, 1) + s * dy * dy;
+            B(2, 2) = B(2, 2) + s * dz * dz;
+            B(1, 0) = B(0, 1) = B(0, 1) + s * dx * dy;
+            B(2, 0) = B(0, 2) = B(0, 2) + s * dx * dz;
+            B(1, 2) = B(2, 1) = B(2, 1) + s * dy * dz;
+
+            // perform the eigen decomposition
+            SelfAdjointEigenSolver<Matrix3d> solver(B / (n - 1));
+            if (solver.info() != Success)
+                throwError("Cannot perform eigen decomposition.");
+            auto ev = solver.eigenvalues();
+
+            std::vector<double> lambda = {((std::max)(ev[2], 0.0)),
+                                          ((std::max)(ev[1], 0.0)),
+                                          ((std::max)(ev[0], 0.0))};
+            double sum = std::accumulate(lambda.begin(), lambda.end(), 0.0);
+
+            std::transform(lambda.begin(), lambda.end(), lambda.begin(),
+                           [&sum](double v) -> double { return v / sum; });
+
+            double entropy = -(lambda[2] * std::log(lambda[2]) +
+                               lambda[1] * std::log(lambda[1]) +
+                               lambda[0] * std::log(lambda[0]));
+
+            if (entropy < minentropy)
+            {
+                minentropy = entropy;
+                kopt = k + 1;
+                ropt = dists[k];
+            }
+        }
+
+        p.setField(m_kOpt, kopt);
+        p.setField(m_rOpt, std::sqrt(ropt));
+    }
+}
+
+} // namespace pdal

--- a/filters/OptimalNeighborhoodFilter.hpp
+++ b/filters/OptimalNeighborhoodFilter.hpp
@@ -1,0 +1,61 @@
+/******************************************************************************
+ * Copyright (c) 2020, Bradley J Chambers (brad.chambers@gmail.com)
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of Hobu, Inc. or Flaxen Geo Consulting nor the
+ *       names of its contributors may be used to endorse or promote
+ *       products derived from this software without specific prior
+ *       written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ ****************************************************************************/
+
+#pragma once
+
+#include <pdal/Filter.hpp>
+
+namespace pdal
+{
+
+class PDAL_DLL OptimalNeighborhood : public Filter
+{
+public:
+    OptimalNeighborhood();
+
+    OptimalNeighborhood& operator=(const OptimalNeighborhood&) = delete;
+    OptimalNeighborhood(const OptimalNeighborhood&) = delete;
+
+    std::string getName() const;
+
+private:
+    point_count_t m_kMin, m_kMax;
+    Dimension::Id m_kOpt, m_rOpt;
+
+    virtual void addDimensions(PointLayoutPtr layout);
+    virtual void addArgs(ProgramArgs& args);
+    virtual void filter(PointView& view);
+};
+
+} // namespace pdal

--- a/pdal/Dimension.json
+++ b/pdal/Dimension.json
@@ -383,5 +383,65 @@
     "name": "NNDistance",
     "type": "double",
     "description": "Distance metric related to a point's nearest neighbors."
+    },
+    {
+    "name": "Linearity",
+    "type": "double",
+    "description": "Linearity of a point; larger values indicate more linear regions."
+    },
+    {
+    "name": "Planarity",
+    "type": "double",
+    "description": "Planarity of a point; larger values indicate more planar regions."
+    },
+    {
+    "name": "Scattering",
+    "type": "double",
+    "description": "Scattering of a point; larger values incidate complex (scattered) 3D regions."
+    },
+    {
+    "name": "Verticality",
+    "type": "double",
+    "description": "Verticality of a point; larger values indicate vertical structure."
+    },
+    {
+    "name": "Omnivariance",
+    "type": "double",
+    "description": "Omnivariance of a point; cube root of the product of all eigenvalues."
+    },
+    {
+    "name": "Anisotropy",
+    "type": "double",
+    "description": "Anisotropy of a point; larger values indicate strong variance in multiple dimensions."
+    },
+    {
+    "name": "Eigenentropy",
+    "type": "double",
+    "description": "Eigenentropy of a point; small values indicate more ordered regions, while large values indicate disorder."
+    },
+    {
+    "name": "EigenvalueSum",
+    "type": "double",
+    "description": "Sum of computed eigenvalues."
+    },
+    {
+    "name": "SurfaceVariation",
+    "type": "double",
+    "description": "Surface variation of a point; larger values indicate higher surface variation."
+    },
+    {
+    "name": "DemantkeVerticality",
+    "type": "double",
+    "description": "Verticality of a point; larger values indicate vertical structure (Demantke's variation)."
+    },
+    {
+    "name": "OptimalKNN",
+    "type": "uint64",
+    "description": "Optimal number of k nearest neighbors, such that eigenentropy is minimized."
+    },
+    {
+    "name": "OptimalRadius",
+    "type": "double",
+    "description": "Radius corresponding to optimal k nearest neighbors, such that eigenentropy is minimized."
     }
 ] }

--- a/test/unit/filters/CovarianceFeaturesTest.cpp
+++ b/test/unit/filters/CovarianceFeaturesTest.cpp
@@ -54,8 +54,6 @@ TEST(DimensionalityTest, Linearity)
     CovarianceFeaturesFilter filter;
     Options ops;
     ops.add("knn", 3);
-    ops.add("feature_set", "all");
-    ops.add("mode", "SQRT");
     filter.setInput(bufferReader);
     filter.setOptions(ops);
     filter.prepare(table);
@@ -111,8 +109,6 @@ TEST(DimensionalityTest, Planarity)
     BufferReader bufferReader;
     CovarianceFeaturesFilter filter;
     Options ops;
-    ops.add("feature_set", "all");
-    ops.add("mode", "SQRT");
     filter.setInput(bufferReader);
     filter.setOptions(ops);
     filter.prepare(table);
@@ -173,8 +169,6 @@ TEST(DimensionalityTest, Scattering)
     BufferReader bufferReader;
     CovarianceFeaturesFilter filter;
     Options ops;
-    ops.add("features", "Planarity,Linearity,Verticality,Scattering,Omnivariance,Anisotropy,Eigenentropy,Sum,SurfaceVariation,DemantkeVerticality");
-    ops.add("mode", "SQRT");
     filter.setInput(bufferReader);
     filter.setOptions(ops);
     filter.prepare(table);

--- a/test/unit/filters/CovarianceFeaturesTest.cpp
+++ b/test/unit/filters/CovarianceFeaturesTest.cpp
@@ -73,29 +73,18 @@ TEST(DimensionalityTest, Linearity)
     PointViewSet viewSet = filter.execute(table);
     PointViewPtr outView = *viewSet.begin();
 
-    Dimension::Id planarity = table.layout()->findDim("Planarity");
-    Dimension::Id verticality = table.layout()->findDim("Verticality");
-    Dimension::Id linearity = table.layout()->findDim("Linearity");
-    Dimension::Id scattering = table.layout()->findDim("Scattering");
-    Dimension::Id omnivariance = table.layout()->findDim("Omnivariance");
-    Dimension::Id anisotropy = table.layout()->findDim("Anisotropy");
-    Dimension::Id eigenentropy = table.layout()->findDim("Eigenentropy");
-    Dimension::Id sum = table.layout()->findDim("Sum");
-    Dimension::Id surfacevariation = table.layout()->findDim("SurfaceVariation");
-    Dimension::Id verticality2 = table.layout()->findDim("DemantkeVerticality");
-
     for (point_count_t i =0; i < outView->size(); i++)
     {
-        ASSERT_FLOAT_EQ(outView->getFieldAs<float>(linearity, i) ,1);
-        ASSERT_FLOAT_EQ(outView->getFieldAs<float>(verticality, i) ,1);
-        ASSERT_FLOAT_EQ(outView->getFieldAs<float>(planarity, i) ,0);
-        ASSERT_FLOAT_EQ(outView->getFieldAs<float>(scattering, i) ,0);
-        ASSERT_FLOAT_EQ(outView->getFieldAs<float>(omnivariance, i), 0);
-        ASSERT_FLOAT_EQ(outView->getFieldAs<float>(anisotropy, i), 1);
-        ASSERT_TRUE(std::isnan(outView->getFieldAs<float>(eigenentropy, i)));
-        ASSERT_FLOAT_EQ(outView->getFieldAs<float>(sum, i), 1);
-        ASSERT_FLOAT_EQ(outView->getFieldAs<float>(surfacevariation, i), 0);
-        ASSERT_FLOAT_EQ(outView->getFieldAs<float>(verticality2, i), 1);
+        ASSERT_FLOAT_EQ(outView->getFieldAs<float>(Id::Linearity, i) ,1);
+        ASSERT_FLOAT_EQ(outView->getFieldAs<float>(Id::Verticality, i) ,1);
+        ASSERT_FLOAT_EQ(outView->getFieldAs<float>(Id::Planarity, i) ,0);
+        ASSERT_FLOAT_EQ(outView->getFieldAs<float>(Id::Scattering, i) ,0);
+        ASSERT_FLOAT_EQ(outView->getFieldAs<float>(Id::Omnivariance, i), 0);
+        ASSERT_FLOAT_EQ(outView->getFieldAs<float>(Id::Anisotropy, i), 1);
+        ASSERT_TRUE(std::isnan(outView->getFieldAs<float>(Id::Eigenentropy, i)));
+        ASSERT_FLOAT_EQ(outView->getFieldAs<float>(Id::EigenvalueSum, i), 1);
+        ASSERT_FLOAT_EQ(outView->getFieldAs<float>(Id::SurfaceVariation, i), 0);
+        ASSERT_FLOAT_EQ(outView->getFieldAs<float>(Id::DemantkeVerticality, i), 1);
     }
 }
 
@@ -133,29 +122,18 @@ TEST(DimensionalityTest, Planarity)
     PointViewSet viewSet = filter.execute(table);
     PointViewPtr outView = *viewSet.begin();
 
-    Dimension::Id planarity = table.layout()->findDim("Planarity");
-    Dimension::Id verticality = table.layout()->findDim("Verticality");
-    Dimension::Id linearity = table.layout()->findDim("Linearity");
-    Dimension::Id scattering = table.layout()->findDim("Scattering");
-    Dimension::Id omnivariance = table.layout()->findDim("Omnivariance");
-    Dimension::Id anisotropy = table.layout()->findDim("Anisotropy");
-    Dimension::Id eigenentropy = table.layout()->findDim("Eigenentropy");
-    Dimension::Id sum = table.layout()->findDim("Sum");
-    Dimension::Id surfacevariation = table.layout()->findDim("SurfaceVariation");
-    Dimension::Id verticality2 = table.layout()->findDim("DemantkeVerticality");
-
     for (point_count_t i =0; i < outView->size(); i++)
     {
-        ASSERT_LE(outView->getFieldAs<float>(linearity, i) ,0.5);
-        ASSERT_FLOAT_EQ(outView->getFieldAs<float>(verticality, i) ,0);
-        ASSERT_FLOAT_EQ(outView->getFieldAs<float>(planarity, i) ,1);
-        ASSERT_FLOAT_EQ(outView->getFieldAs<float>(scattering, i) ,0);
-        ASSERT_FLOAT_EQ(outView->getFieldAs<float>(omnivariance, i), 0);
-        ASSERT_FLOAT_EQ(outView->getFieldAs<float>(anisotropy, i), 1);
-        ASSERT_TRUE(std::isnan(outView->getFieldAs<float>(eigenentropy, i)));
-        ASSERT_NEAR(outView->getFieldAs<float>(sum, i), 0.667, 0.001);
-        ASSERT_FLOAT_EQ(outView->getFieldAs<float>(surfacevariation, i), 0);
-        ASSERT_FLOAT_EQ(outView->getFieldAs<float>(verticality2, i), 0);
+        ASSERT_LE(outView->getFieldAs<float>(Id::Linearity, i) ,0.5);
+        ASSERT_FLOAT_EQ(outView->getFieldAs<float>(Id::Verticality, i) ,0);
+        ASSERT_FLOAT_EQ(outView->getFieldAs<float>(Id::Planarity, i) ,1);
+        ASSERT_FLOAT_EQ(outView->getFieldAs<float>(Id::Scattering, i) ,0);
+        ASSERT_FLOAT_EQ(outView->getFieldAs<float>(Id::Omnivariance, i), 0);
+        ASSERT_FLOAT_EQ(outView->getFieldAs<float>(Id::Anisotropy, i), 1);
+        ASSERT_TRUE(std::isnan(outView->getFieldAs<float>(Id::Eigenentropy, i)));
+        ASSERT_NEAR(outView->getFieldAs<float>(Id::EigenvalueSum, i), 0.667, 0.001);
+        ASSERT_FLOAT_EQ(outView->getFieldAs<float>(Id::SurfaceVariation, i), 0);
+        ASSERT_FLOAT_EQ(outView->getFieldAs<float>(Id::DemantkeVerticality, i), 0);
     }
 }
 
@@ -193,29 +171,18 @@ TEST(DimensionalityTest, Scattering)
     PointViewSet viewSet = filter.execute(table);
     PointViewPtr outView = *viewSet.begin();
 
-    Dimension::Id planarity = table.layout()->findDim("Planarity");
-    Dimension::Id verticality = table.layout()->findDim("Verticality");
-    Dimension::Id linearity = table.layout()->findDim("Linearity");
-    Dimension::Id scattering = table.layout()->findDim("Scattering");
-    Dimension::Id omnivariance = table.layout()->findDim("Omnivariance");
-    Dimension::Id anisotropy = table.layout()->findDim("Anisotropy");
-    Dimension::Id eigenentropy = table.layout()->findDim("Eigenentropy");
-    Dimension::Id sum = table.layout()->findDim("Sum");
-    Dimension::Id surfacevariation = table.layout()->findDim("SurfaceVariation");
-    Dimension::Id verticality2 = table.layout()->findDim("DemantkeVerticality");
-
     for (point_count_t i =0; i < outView->size(); i++)
     {
-        ASSERT_LE(outView->getFieldAs<float>(linearity, i) ,0.5);
-        ASSERT_GE(outView->getFieldAs<float>(verticality, i) ,0.5);
-        ASSERT_LE(outView->getFieldAs<float>(planarity, i) ,1);
-        ASSERT_GE(outView->getFieldAs<float>(scattering, i) ,0.1);
-        ASSERT_NEAR(outView->getFieldAs<float>(omnivariance, i), 0.458, 0.001);
-        ASSERT_NEAR(outView->getFieldAs<float>(anisotropy, i), 0.864, 0.001);
-        ASSERT_NEAR(outView->getFieldAs<float>(eigenentropy, i), 0.488, 0.001);
-        ASSERT_NEAR(outView->getFieldAs<float>(sum, i), 1.583, 0.001);
-        ASSERT_NEAR(outView->getFieldAs<float>(surfacevariation, i), 0.095, 0.001);
-        ASSERT_NEAR(outView->getFieldAs<float>(verticality2, i), 0.492, 0.001);
+        ASSERT_LE(outView->getFieldAs<float>(Id::Linearity, i) ,0.5);
+        ASSERT_GE(outView->getFieldAs<float>(Id::Verticality, i) ,0.5);
+        ASSERT_LE(outView->getFieldAs<float>(Id::Planarity, i) ,1);
+        ASSERT_GE(outView->getFieldAs<float>(Id::Scattering, i) ,0.1);
+        ASSERT_NEAR(outView->getFieldAs<float>(Id::Omnivariance, i), 0.458, 0.001);
+        ASSERT_NEAR(outView->getFieldAs<float>(Id::Anisotropy, i), 0.864, 0.001);
+        ASSERT_NEAR(outView->getFieldAs<float>(Id::Eigenentropy, i), 0.488, 0.001);
+        ASSERT_NEAR(outView->getFieldAs<float>(Id::EigenvalueSum, i), 1.583, 0.001);
+        ASSERT_NEAR(outView->getFieldAs<float>(Id::SurfaceVariation, i), 0.095, 0.001);
+        ASSERT_NEAR(outView->getFieldAs<float>(Id::DemantkeVerticality, i), 0.492, 0.001);
     }
 }
 

--- a/test/unit/filters/CovarianceFeaturesTest.cpp
+++ b/test/unit/filters/CovarianceFeaturesTest.cpp
@@ -54,6 +54,8 @@ TEST(DimensionalityTest, Linearity)
     CovarianceFeaturesFilter filter;
     Options ops;
     ops.add("knn", 3);
+    ops.add("feature_set", "all");
+    ops.add("mode", "SQRT");
     filter.setInput(bufferReader);
     filter.setOptions(ops);
     filter.prepare(table);
@@ -77,6 +79,12 @@ TEST(DimensionalityTest, Linearity)
     Dimension::Id verticality = table.layout()->findDim("Verticality");
     Dimension::Id linearity = table.layout()->findDim("Linearity");
     Dimension::Id scattering = table.layout()->findDim("Scattering");
+    Dimension::Id omnivariance = table.layout()->findDim("Omnivariance");
+    Dimension::Id anisotropy = table.layout()->findDim("Anisotropy");
+    Dimension::Id eigenentropy = table.layout()->findDim("Eigenentropy");
+    Dimension::Id sum = table.layout()->findDim("Sum");
+    Dimension::Id surfacevariation = table.layout()->findDim("SurfaceVariation");
+    Dimension::Id verticality2 = table.layout()->findDim("DemantkeVerticality");
 
     for (point_count_t i =0; i < outView->size(); i++)
     {
@@ -84,6 +92,12 @@ TEST(DimensionalityTest, Linearity)
         ASSERT_FLOAT_EQ(outView->getFieldAs<float>(verticality, i) ,1);
         ASSERT_FLOAT_EQ(outView->getFieldAs<float>(planarity, i) ,0);
         ASSERT_FLOAT_EQ(outView->getFieldAs<float>(scattering, i) ,0);
+        ASSERT_FLOAT_EQ(outView->getFieldAs<float>(omnivariance, i), 0);
+        ASSERT_FLOAT_EQ(outView->getFieldAs<float>(anisotropy, i), 1);
+        ASSERT_TRUE(std::isnan(outView->getFieldAs<float>(eigenentropy, i)));
+        ASSERT_FLOAT_EQ(outView->getFieldAs<float>(sum, i), 1);
+        ASSERT_FLOAT_EQ(outView->getFieldAs<float>(surfacevariation, i), 0);
+        ASSERT_FLOAT_EQ(outView->getFieldAs<float>(verticality2, i), 1);
     }
 }
 
@@ -97,7 +111,10 @@ TEST(DimensionalityTest, Planarity)
     BufferReader bufferReader;
     CovarianceFeaturesFilter filter;
     Options ops;
+    ops.add("feature_set", "all");
+    ops.add("mode", "SQRT");
     filter.setInput(bufferReader);
+    filter.setOptions(ops);
     filter.prepare(table);
 
     PointViewPtr view(new PointView(table));
@@ -124,6 +141,12 @@ TEST(DimensionalityTest, Planarity)
     Dimension::Id verticality = table.layout()->findDim("Verticality");
     Dimension::Id linearity = table.layout()->findDim("Linearity");
     Dimension::Id scattering = table.layout()->findDim("Scattering");
+    Dimension::Id omnivariance = table.layout()->findDim("Omnivariance");
+    Dimension::Id anisotropy = table.layout()->findDim("Anisotropy");
+    Dimension::Id eigenentropy = table.layout()->findDim("Eigenentropy");
+    Dimension::Id sum = table.layout()->findDim("Sum");
+    Dimension::Id surfacevariation = table.layout()->findDim("SurfaceVariation");
+    Dimension::Id verticality2 = table.layout()->findDim("DemantkeVerticality");
 
     for (point_count_t i =0; i < outView->size(); i++)
     {
@@ -131,6 +154,12 @@ TEST(DimensionalityTest, Planarity)
         ASSERT_FLOAT_EQ(outView->getFieldAs<float>(verticality, i) ,0);
         ASSERT_FLOAT_EQ(outView->getFieldAs<float>(planarity, i) ,1);
         ASSERT_FLOAT_EQ(outView->getFieldAs<float>(scattering, i) ,0);
+        ASSERT_FLOAT_EQ(outView->getFieldAs<float>(omnivariance, i), 0);
+        ASSERT_FLOAT_EQ(outView->getFieldAs<float>(anisotropy, i), 1);
+        ASSERT_TRUE(std::isnan(outView->getFieldAs<float>(eigenentropy, i)));
+        ASSERT_NEAR(outView->getFieldAs<float>(sum, i), 0.667, 0.001);
+        ASSERT_FLOAT_EQ(outView->getFieldAs<float>(surfacevariation, i), 0);
+        ASSERT_FLOAT_EQ(outView->getFieldAs<float>(verticality2, i), 0);
     }
 }
 
@@ -144,7 +173,10 @@ TEST(DimensionalityTest, Scattering)
     BufferReader bufferReader;
     CovarianceFeaturesFilter filter;
     Options ops;
+    ops.add("features", "Planarity,Linearity,Verticality,Scattering,Omnivariance,Anisotropy,Eigenentropy,Sum,SurfaceVariation,DemantkeVerticality");
+    ops.add("mode", "SQRT");
     filter.setInput(bufferReader);
+    filter.setOptions(ops);
     filter.prepare(table);
 
     PointViewPtr view(new PointView(table));
@@ -171,6 +203,12 @@ TEST(DimensionalityTest, Scattering)
     Dimension::Id verticality = table.layout()->findDim("Verticality");
     Dimension::Id linearity = table.layout()->findDim("Linearity");
     Dimension::Id scattering = table.layout()->findDim("Scattering");
+    Dimension::Id omnivariance = table.layout()->findDim("Omnivariance");
+    Dimension::Id anisotropy = table.layout()->findDim("Anisotropy");
+    Dimension::Id eigenentropy = table.layout()->findDim("Eigenentropy");
+    Dimension::Id sum = table.layout()->findDim("Sum");
+    Dimension::Id surfacevariation = table.layout()->findDim("SurfaceVariation");
+    Dimension::Id verticality2 = table.layout()->findDim("DemantkeVerticality");
 
     for (point_count_t i =0; i < outView->size(); i++)
     {
@@ -178,6 +216,12 @@ TEST(DimensionalityTest, Scattering)
         ASSERT_GE(outView->getFieldAs<float>(verticality, i) ,0.5);
         ASSERT_LE(outView->getFieldAs<float>(planarity, i) ,1);
         ASSERT_GE(outView->getFieldAs<float>(scattering, i) ,0.1);
+        ASSERT_NEAR(outView->getFieldAs<float>(omnivariance, i), 0.458, 0.001);
+        ASSERT_NEAR(outView->getFieldAs<float>(anisotropy, i), 0.864, 0.001);
+        ASSERT_NEAR(outView->getFieldAs<float>(eigenentropy, i), 0.488, 0.001);
+        ASSERT_NEAR(outView->getFieldAs<float>(sum, i), 1.583, 0.001);
+        ASSERT_NEAR(outView->getFieldAs<float>(surfacevariation, i), 0.095, 0.001);
+        ASSERT_NEAR(outView->getFieldAs<float>(verticality2, i), 0.492, 0.001);
     }
 }
 

--- a/test/unit/filters/CovarianceFeaturesTest.cpp
+++ b/test/unit/filters/CovarianceFeaturesTest.cpp
@@ -54,6 +54,7 @@ TEST(DimensionalityTest, Linearity)
     CovarianceFeaturesFilter filter;
     Options ops;
     ops.add("knn", 3);
+    ops.add("feature_set", "Dimensionality,Omnivariance,Anisotropy,Eigenentropy,EigenvalueSum,SurfaceVariation,DemantkeVerticality");
     filter.setInput(bufferReader);
     filter.setOptions(ops);
     filter.prepare(table);
@@ -98,6 +99,7 @@ TEST(DimensionalityTest, Planarity)
     BufferReader bufferReader;
     CovarianceFeaturesFilter filter;
     Options ops;
+    ops.add("feature_set", "Dimensionality,Omnivariance,Anisotropy,Eigenentropy,EigenvalueSum,SurfaceVariation,DemantkeVerticality");
     filter.setInput(bufferReader);
     filter.setOptions(ops);
     filter.prepare(table);
@@ -147,6 +149,7 @@ TEST(DimensionalityTest, Scattering)
     BufferReader bufferReader;
     CovarianceFeaturesFilter filter;
     Options ops;
+    ops.add("feature_set", "Dimensionality,Omnivariance,Anisotropy,Eigenentropy,EigenvalueSum,SurfaceVariation,DemantkeVerticality");
     filter.setInput(bufferReader);
     filter.setOptions(ops);
     filter.prepare(table);


### PR DESCRIPTION
OptimalNeighborhoodFilter reports the pointwise optimal number of neighbors (OptimalKNN) and corresponding radius (OptimalRadius), based on Weinmann, et al. The optimal neighborhood size is found by minimizing the Shannon entropy of normalized eigenvalues (the eigenentropy) while sweeping a range of candidate k-nearest neighbors.

> Weinmann, Martin, et al. "Semantic point cloud interpretation based  on optimal neighborhoods, relevant features and efficient  classifiers." ISPRS Journal of Photogrammetry and Remote Sensing 105 (2015): 286-304.
    
Augment the original CovarianceFeaturesFilter to add optional specifiation of additional features derived from covariance matrix.
    
- Omnivariance
- Sum
- Eigenentropy
- Anisotropy
- Surface variation
- DemantkeVerticality
- Density (requires precomputed OptimalKNN and OptimalRadius)
    
Any `feature_set` other than "Dimensionality" will result in an error. Alternately, covariance features can be passed as a comma-separated list to the `features` argument, allowing explicit definition of the desired features.
    
Add flexibility to normalize eigenvalues or to compute the standard deviation along each dimension by taking the square root of the eigenvalues.
    
Update tests to compute and check most features.
