### PR TITLE
Prevent macro expansion of isspecial() on FreeBSD. Fixes: #3190

### DIFF
--- a/io/TextReader.cpp
+++ b/io/TextReader.cpp
@@ -157,7 +157,8 @@ void TextReader::parseUnquotedHeader(const std::string& header)
     {
         // Scan string for some character not a number or letter.
         for (size_t i = 0; i < header.size(); ++i)
-            if (isspecial(header[i]))
+            // Parenthesis around special to prevent macro expansion, see #3190
+            if ((isspecial)(header[i]))
             {
                 m_separator = header[i];
                 break;


### PR DESCRIPTION
Fix for readers.Text on FreeBSD.
FreeBSD has a macro, isspecial(char) in ctype.h. This patch adds parenthesis around the isspecial() function call to prevent macro expansion.

I understand this clutters the code a little bit but it would be very friendly to us FreeBSD-users if it gets accepted.