### PR TITLE
set default ZSTD level

### DIFF
--- a/plugins/tiledb/io/TileDBWriter.cpp
+++ b/plugins/tiledb/io/TileDBWriter.cpp
@@ -83,8 +83,8 @@ std::string attributeDefaults(R"(
         {"compression": "gzip", "compression_level": 9}
     ],
     "Intensity":{"compression": "bzip2", "compression_level": 5},
-    "ReturnNumber": {"compression": "zstd", "compression_level": 75},
-    "NumberOfReturns": {"compression": "zstd", "compression_level": 75},
+    "ReturnNumber": {"compression": "zstd", "compression_level": 7},
+    "NumberOfReturns": {"compression": "zstd", "compression_level": 7},
     "ScanDirectionFlag": {"compression": "bzip2", "compression_level": 5},
     "EdgeOfFlightLine": {"compression": "bzip2", "compression_level": 5},
     "Classification": {"compression": "gzip", "compression_level": 9},
@@ -96,7 +96,7 @@ std::string attributeDefaults(R"(
     "Blue": {"compression": "rle"},
     "GpsTime": [
         {"compression": "bit-shuffle"},
-        {"compression": "zstd", "compression_level": 75}
+        {"compression": "zstd", "compression_level": 7}
     ]
 })");
 

--- a/plugins/tiledb/test/TileDBWriterTest.cpp
+++ b/plugins/tiledb/test/TileDBWriterTest.cpp
@@ -222,7 +222,7 @@ namespace pdal
         Options options;
         options.add("array_name", pth);
         options.add("compression", "zstd");
-        options.add("compression_level", 50);
+        options.add("compression_level", 7);
 
         if (vfs.is_dir(pth))
         {
@@ -246,7 +246,7 @@ namespace pdal
         EXPECT_EQ(f.filter_type(), TILEDB_FILTER_ZSTD);
         int32_t compressionLevel;
         f.get_option(TILEDB_COMPRESSION_LEVEL, &compressionLevel);
-        EXPECT_EQ(compressionLevel, 50);
+        EXPECT_EQ(compressionLevel, 7);
     }
 
     TEST_F(TileDBWriterTest, write_options)
@@ -261,7 +261,7 @@ namespace pdal
         // add an array filter
         jsonOptions["coords"] = {
             {{"compression", "bit-shuffle"}},
-            {{"compression", "zstd"}, {"compression_level", 50}}
+            {{"compression", "zstd"}, {"compression_level", 7}}
         };
         jsonOptions["OffsetTime"]["compression"] = "rle";
 
@@ -292,7 +292,7 @@ namespace pdal
         EXPECT_EQ(f2.filter_type(), TILEDB_FILTER_ZSTD);
         int32_t compressionLevel;
         f2.get_option(TILEDB_COMPRESSION_LEVEL, &compressionLevel);
-        EXPECT_EQ(compressionLevel, 50);
+        EXPECT_EQ(compressionLevel, 7);
 
         tiledb::Attribute att = array.schema().attributes().begin()->second;
         tiledb::FilterList flAtts = att.filter_list();
@@ -318,7 +318,7 @@ namespace pdal
 
         options.add("array_name", pth);
         options.add("compression", "zstd");
-        options.add("compression_level", 50);
+        options.add("compression_level", 7);
         options.add("filters", jsonOptions);
 
         if (vfs.is_dir(pth))


### PR DESCRIPTION
In 2.1 the TIleDB driver defaulted to compression level 75 (as a percent) for zstd which is incorrect and resulted in a zstd compression level of 19 as the maximum level of zstd is 22. This doesn't cause any data loss (as zstd is lossless) but will result in slower compression/decompression times.

This PR sets the defaults for ZSTD appropriately to 7.