### PR TITLE
Add max_dist and init parameters to ICP

### DIFF
--- a/filters/IterativeClosestPoint.cpp
+++ b/filters/IterativeClosestPoint.cpp
@@ -140,7 +140,7 @@ PointViewPtr IterativeClosestPoint::icp(PointViewPtr fixed,
     // be reasonable to alternately accept an initial guess.
     Matrix4d final_transformation;
     if (m_matrixArg->set())
-        final_transformation = Map<const Matrix4d>(m_vec.data());
+        final_transformation = Eigen::Map<const Matrix4d>(m_vec.data());
     else
         final_transformation = Matrix4d::Identity();
 
@@ -200,7 +200,7 @@ PointViewPtr IterativeClosestPoint::icp(PointViewPtr fixed,
         // current translation in X and Y.
         auto A = math::pointViewToEigen(*tempFixed, fixed_idx);
         auto B = math::pointViewToEigen(*tempMovingTransformed, moving_idx);
-        auto T = umeyama(B.transpose(), A.transpose(), false);
+        auto T = Eigen::umeyama(B.transpose(), A.transpose(), false);
         log()->get(LogLevel::Debug2) << "Current dx: " << T.coeff(0, 3) << ", "
                                      << "dy: " << T.coeff(1, 3) << std::endl;
 
@@ -307,8 +307,8 @@ PointViewPtr IterativeClosestPoint::icp(PointViewPtr fixed,
 
     // Populate metadata nodes to capture the final transformation, convergence
     // status, and MSE.
-    IOFormat MetadataFmt(FullPrecision, DontAlignCols, " ", "\n", "", "", "",
-                         "");
+    Eigen::IOFormat MetadataFmt(Eigen::FullPrecision, Eigen::DontAlignCols, " ",
+                                "\n", "", "", "", "");
     MetadataNode root = getMetadata();
     std::stringstream ss;
     ss << final_transformation.format(MetadataFmt);

--- a/filters/IterativeClosestPoint.cpp
+++ b/filters/IterativeClosestPoint.cpp
@@ -35,8 +35,8 @@
 #include "IterativeClosestPoint.hpp"
 
 #include <pdal/KDIndex.hpp>
-#include <pdal/util/Utils.hpp>
 #include <pdal/private/MathUtils.hpp>
+#include <pdal/util/Utils.hpp>
 
 #include <Eigen/Dense>
 
@@ -44,6 +44,9 @@
 
 namespace pdal
 {
+
+using namespace Dimension;
+using namespace Eigen;
 
 static StaticPluginInfo const s_info
 {
@@ -70,12 +73,30 @@ void IterativeClosestPoint::addArgs(ProgramArgs& args)
     args.add("max_similar",
              "Max number of similar transforms to consider converged",
              m_max_similar, 0);
+    m_maxdistArg =
+        &args.add("max_dist", "Maximum correspondence distance", m_maxdist);
+    m_matrixArg =
+        &args.add("init", "Initial transformation matrix", m_matrixStr);
+}
+
+void IterativeClosestPoint::prepared(PointTableRef table)
+{
+    if (m_matrixArg->set())
+    {
+        std::stringstream matrix;
+        matrix.str(m_matrixStr);
+        matrix.seekg(0);
+        double val;
+        while (matrix >> val)
+            m_vec.push_back(val);
+        if (m_vec.size() != 16)
+            throwError("Expecting exactly 16 values in 'init' got " +
+                       m_vec.size());
+    }
 }
 
 PointViewSet IterativeClosestPoint::run(PointViewPtr view)
 {
-    using namespace Dimension;
-
     PointViewSet viewSet;
     if (this->m_fixed)
     {
@@ -117,7 +138,11 @@ PointViewPtr IterativeClosestPoint::icp(PointViewPtr fixed,
 
     // Initialize the final_transformation to identity. In the future, it would
     // be reasonable to alternately accept an initial guess.
-    Eigen::Matrix4d final_transformation = Eigen::Matrix4d::Identity();
+    Matrix4d final_transformation;
+    if (m_matrixArg->set())
+        final_transformation = Map<const Matrix4d>(m_vec.data());
+    else
+        final_transformation = Matrix4d::Identity();
 
     // Construct 3D KD-tree of the centered, fixed PointView to facilitate
     // nearest neighbor searches in each iteration.
@@ -140,24 +165,29 @@ PointViewPtr IterativeClosestPoint::icp(PointViewPtr fixed,
         fixed_idx.reserve(tempMovingTransformed->size());
         moving_idx.reserve(tempMovingTransformed->size());
         double mse(0.0);
+        double sqr_maxdist = m_maxdist * m_maxdist;
 
         // For every point in the centered, moving PointView, find the nearest
         // neighbor in the centered fixed PointView. Record the indices of each
         // and update the MSE.
-        for (PointId i = 0; i < tempMovingTransformed->size(); ++i)
+        for (PointRef p : *tempMovingTransformed)
         {
             // Find the index of the nearest neighbor, and the square distance
             // between each point.
-            PointRef p = tempMovingTransformed->point(i);
             PointIdList indices(1);
             std::vector<double> sqr_dists(1);
             kd_fixed.knnSearch(p, 1, &indices, &sqr_dists);
 
             // In the PCL code, there would've been a check that the square
             // distance did not exceed a threshold value.
+            if (m_maxdistArg->set())
+            {
+                if (sqr_dists[0] > sqr_maxdist)
+                    continue;
+            }
 
             // Store the indices of the correspondence and update the MSE.
-            moving_idx.push_back(i);
+            moving_idx.push_back(p.pointId());
             fixed_idx.push_back(indices[0]);
             mse += std::sqrt(sqr_dists[0]);
         }
@@ -170,7 +200,7 @@ PointViewPtr IterativeClosestPoint::icp(PointViewPtr fixed,
         // current translation in X and Y.
         auto A = math::pointViewToEigen(*tempFixed, fixed_idx);
         auto B = math::pointViewToEigen(*tempMovingTransformed, moving_idx);
-        auto T = Eigen::umeyama(B.transpose(), A.transpose(), false);
+        auto T = umeyama(B.transpose(), A.transpose(), false);
         log()->get(LogLevel::Debug2) << "Current dx: " << T.coeff(0, 3) << ", "
                                      << "dy: " << T.coeff(1, 3) << std::endl;
 
@@ -229,38 +259,31 @@ PointViewPtr IterativeClosestPoint::icp(PointViewPtr fixed,
     }
 
     // Apply the final_transformation to the moving PointView.
-    for (PointId i = 0; i < moving->size(); ++i)
+    for (PointRef p : *moving)
     {
-        double x =
-            moving->getFieldAs<double>(Dimension::Id::X, i) - centroid.x();
-        double y =
-            moving->getFieldAs<double>(Dimension::Id::Y, i) - centroid.y();
-        double z =
-            moving->getFieldAs<double>(Dimension::Id::Z, i) - centroid.z();
-        moving->setField(Dimension::Id::X, i,
-                         x * final_transformation.coeff(0, 0) +
-                             y * final_transformation.coeff(0, 1) +
-                             z * final_transformation.coeff(0, 2) +
-                             final_transformation.coeff(0, 3) + centroid.x());
-        moving->setField(Dimension::Id::Y, i,
-                         x * final_transformation.coeff(1, 0) +
-                             y * final_transformation.coeff(1, 1) +
-                             z * final_transformation.coeff(1, 2) +
-                             final_transformation.coeff(1, 3) + centroid.y());
-        moving->setField(Dimension::Id::Z, i,
-                         x * final_transformation.coeff(2, 0) +
-                             y * final_transformation.coeff(2, 1) +
-                             z * final_transformation.coeff(2, 2) +
-                             final_transformation.coeff(2, 3) + centroid.z());
+        double x = p.getFieldAs<double>(Id::X) - centroid.x();
+        double y = p.getFieldAs<double>(Id::Y) - centroid.y();
+        double z = p.getFieldAs<double>(Id::Z) - centroid.z();
+        p.setField(Id::X, x * final_transformation.coeff(0, 0) +
+                              y * final_transformation.coeff(0, 1) +
+                              z * final_transformation.coeff(0, 2) +
+                              final_transformation.coeff(0, 3) + centroid.x());
+        p.setField(Id::Y, x * final_transformation.coeff(1, 0) +
+                              y * final_transformation.coeff(1, 1) +
+                              z * final_transformation.coeff(1, 2) +
+                              final_transformation.coeff(1, 3) + centroid.y());
+        p.setField(Id::Z, x * final_transformation.coeff(2, 0) +
+                              y * final_transformation.coeff(2, 1) +
+                              z * final_transformation.coeff(2, 2) +
+                              final_transformation.coeff(2, 3) + centroid.z());
     }
 
     // Compute the MSE one last time, using the unaltered, fixed PointView and
     // the transformed, moving PointView.
     double mse(0.0);
     KD3Index& kd_fixed_orig = fixed->build3dIndex();
-    for (PointId i = 0; i < moving->size(); ++i)
+    for (PointRef p : *moving)
     {
-        PointRef p = moving->point(i);
         PointIdList indices(1);
         std::vector<double> sqr_dists(1);
         kd_fixed_orig.knnSearch(p, 1, &indices, &sqr_dists);
@@ -270,22 +293,22 @@ PointViewPtr IterativeClosestPoint::icp(PointViewPtr fixed,
     log()->get(LogLevel::Debug2) << "MSE: " << mse << std::endl;
 
     // Transformation to demean coords
-    Eigen::Matrix4d pretrans = Eigen::Matrix4d::Identity();
+    Matrix4d pretrans = Matrix4d::Identity();
     pretrans.block<3, 1>(0, 3) = -centroid;
 
     // Transformation to return to global coords
-    Eigen::Matrix4d posttrans = Eigen::Matrix4d::Identity();
+    Matrix4d posttrans = Matrix4d::Identity();
     posttrans.block<3, 1>(0, 3) = centroid;
 
     // The composed transformation is built from right to left in order of
     // operations.
-    Eigen::Matrix4d composed_transformation =
+    Matrix4d composed_transformation =
         posttrans * final_transformation * pretrans;
 
     // Populate metadata nodes to capture the final transformation, convergence
     // status, and MSE.
-    Eigen::IOFormat MetadataFmt(Eigen::FullPrecision, Eigen::DontAlignCols,
-                                " ", "\n", "", "", "", "");
+    IOFormat MetadataFmt(FullPrecision, DontAlignCols, " ", "\n", "", "", "",
+                         "");
     MetadataNode root = getMetadata();
     std::stringstream ss;
     ss << final_transformation.format(MetadataFmt);

--- a/filters/IterativeClosestPoint.hpp
+++ b/filters/IterativeClosestPoint.hpp
@@ -53,8 +53,14 @@ private:
     double m_rotation_threshold;
     double m_translation_threshold;
     double m_mse_abs;
+    Arg *m_maxdistArg;
+    double m_maxdist;
+    Arg *m_matrixArg;
+    std::string m_matrixStr;
+    std::vector<double> m_vec;
 
     virtual void addArgs(ProgramArgs& args);
+    virtual void prepared(PointTableRef table);
     virtual PointViewSet run(PointViewPtr view);
     virtual void done(PointTableRef _);
     PointViewPtr icp(PointViewPtr fixed, PointViewPtr moving) const;

--- a/test/unit/filters/IcpFilterTest.cpp
+++ b/test/unit/filters/IcpFilterTest.cpp
@@ -35,6 +35,7 @@
 #include "Support.hpp"
 #include <Eigen/Dense>
 #include <filters/TransformationFilter.hpp>
+#include <io/BufferReader.hpp>
 #include <io/LasReader.hpp>
 #include <memory>
 #include <pdal/pdal_test_main.hpp>
@@ -134,6 +135,269 @@ TEST(IcpFilterTest, RecoverTranslation)
     EXPECT_NEAR(-2.0, transform(1, 3), tolerance);
     EXPECT_NEAR(-3.0, transform(2, 3), tolerance);
     checkPointsEqualReader(pointViewSet, tolerance);
+}
+
+TEST(IcpFilterTest, RecoverTranslationWithNoise)
+{
+    // Create two views, the second being translated by (1, 2, 3), but with a
+    // large amount of noise added to the second X value. Test that max_dist
+    // argument rejects this match and we come up with the correct translation.
+    using namespace Dimension;
+
+    PointTable table;
+    table.layout()->registerDims({Id::X, Id::Y, Id::Z});
+
+    BufferReader reader1;
+    BufferReader reader2;
+
+    PointViewPtr view1(new PointView(table));
+    view1->setField(Id::X, 0, 0);
+    view1->setField(Id::X, 1, 10);
+    view1->setField(Id::X, 2, 0);
+    view1->setField(Id::Y, 0, 0);
+    view1->setField(Id::Y, 1, 0);
+    view1->setField(Id::Y, 2, 10);
+    view1->setField(Id::Z, 0, 0);
+    view1->setField(Id::Z, 1, 0);
+    view1->setField(Id::Z, 2, 0);
+    reader1.addView(view1);
+
+    PointViewPtr view2(new PointView(table));
+    view2->setField(Id::X, 0, 1);
+    view2->setField(Id::X, 1, 16);
+    view2->setField(Id::X, 2, 1);
+    view2->setField(Id::Y, 0, 2);
+    view2->setField(Id::Y, 1, 2);
+    view2->setField(Id::Y, 2, 12);
+    view2->setField(Id::Z, 0, 3);
+    view2->setField(Id::Z, 1, 3);
+    view2->setField(Id::Z, 2, 3);
+    reader2.addView(view2);
+    
+    auto filter = newFilter();
+    Options icpOptions;
+    icpOptions.add("max_dist", 5.0);
+    filter->setInput(reader1);
+    filter->setInput(reader2);
+    filter->setOptions(icpOptions);
+
+    filter->prepare(table);
+    PointViewSet pointViewSet = filter->execute(table);
+
+    MetadataNode root = filter->getMetadata();
+    Eigen::MatrixXd transform =
+        root.findChild("transform").value<Eigen::MatrixXd>();
+    double tolerance = 1.5;
+    EXPECT_NEAR(-1.0, transform(0, 3), tolerance);
+    EXPECT_NEAR(-2.0, transform(1, 3), tolerance);
+    EXPECT_NEAR(-3.0, transform(2, 3), tolerance);
+}
+
+TEST(IcpFilterTest, RecoverTranslationWithNoise2)
+{
+    // Create two views, the second being translated by (1, 2, 3), but with a
+    // large amount of noise added to the second X value. Test that without the
+    // max_dist argument the X component of the translation is incorrect.
+    using namespace Dimension;
+
+    PointTable table;
+    table.layout()->registerDims({Id::X, Id::Y, Id::Z});
+
+    BufferReader reader1;
+    BufferReader reader2;
+
+    PointViewPtr view1(new PointView(table));
+    view1->setField(Id::X, 0, 0);
+    view1->setField(Id::X, 1, 10);
+    view1->setField(Id::X, 2, 0);
+    view1->setField(Id::Y, 0, 0);
+    view1->setField(Id::Y, 1, 0);
+    view1->setField(Id::Y, 2, 10);
+    view1->setField(Id::Z, 0, 0);
+    view1->setField(Id::Z, 1, 0);
+    view1->setField(Id::Z, 2, 0);
+    reader1.addView(view1);
+
+    PointViewPtr view2(new PointView(table));
+    view2->setField(Id::X, 0, 1);
+    view2->setField(Id::X, 1, 16);
+    view2->setField(Id::X, 2, 1);
+    view2->setField(Id::Y, 0, 2);
+    view2->setField(Id::Y, 1, 2);
+    view2->setField(Id::Y, 2, 12);
+    view2->setField(Id::Z, 0, 3);
+    view2->setField(Id::Z, 1, 3);
+    view2->setField(Id::Z, 2, 3);
+    reader2.addView(view2);
+    
+    auto filter = newFilter();
+    filter->setInput(reader1);
+    filter->setInput(reader2);
+
+    filter->prepare(table);
+    PointViewSet pointViewSet = filter->execute(table);
+
+    MetadataNode root = filter->getMetadata();
+    Eigen::MatrixXd transform =
+        root.findChild("transform").value<Eigen::MatrixXd>();
+    double tolerance = 1.5;
+    EXPECT_GT(-1.0, transform(0, 3));
+    EXPECT_NEAR(-2.0, transform(1, 3), tolerance);
+    EXPECT_NEAR(-3.0, transform(2, 3), tolerance);
+}
+
+TEST(IcpFilterTest, RecoverTranslationWithGuess)
+{
+    using namespace Dimension;
+
+    PointTable table;
+    table.layout()->registerDims({Id::X, Id::Y, Id::Z});
+
+    BufferReader reader1;
+    BufferReader reader2;
+
+    PointViewPtr view1(new PointView(table));
+    view1->setField(Id::X, 0, 0);
+    view1->setField(Id::X, 1, 10);
+    view1->setField(Id::X, 2, 0);
+    view1->setField(Id::Y, 0, 0);
+    view1->setField(Id::Y, 1, 0);
+    view1->setField(Id::Y, 2, 10);
+    view1->setField(Id::Z, 0, 0);
+    view1->setField(Id::Z, 1, 0);
+    view1->setField(Id::Z, 2, 0);
+    reader1.addView(view1);
+
+    PointViewPtr view2(new PointView(table));
+    view2->setField(Id::X, 0, 1);
+    view2->setField(Id::X, 1, 11);
+    view2->setField(Id::X, 2, 1);
+    view2->setField(Id::Y, 0, 2);
+    view2->setField(Id::Y, 1, 2);
+    view2->setField(Id::Y, 2, 12);
+    view2->setField(Id::Z, 0, 3);
+    view2->setField(Id::Z, 1, 3);
+    view2->setField(Id::Z, 2, 3);
+    reader2.addView(view2);
+    
+    auto filter = newFilter();
+    Options icpOptions;
+    // Start with the actual transformation for the initial guess.
+    icpOptions.add("init", "1 0 0 -1 0 1 0 -2 0 0 1 -3 0 0 0 1");
+    filter->setInput(reader1);
+    filter->setInput(reader2);
+    filter->setOptions(icpOptions);
+
+    filter->prepare(table);
+    PointViewSet pointViewSet = filter->execute(table);
+
+    MetadataNode root = filter->getMetadata();
+    Eigen::MatrixXd transform =
+        root.findChild("transform").value<Eigen::MatrixXd>();
+    double tolerance = 1.5;
+    EXPECT_NEAR(-1.0, transform(0, 3), tolerance);
+    EXPECT_NEAR(-2.0, transform(1, 3), tolerance);
+    EXPECT_NEAR(-3.0, transform(2, 3), tolerance);
+}
+
+TEST(IcpFilterTest, RecoverTranslationWithBadGuess)
+{
+    using namespace Dimension;
+
+    PointTable table;
+    table.layout()->registerDims({Id::X, Id::Y, Id::Z});
+
+    BufferReader reader1;
+    BufferReader reader2;
+
+    PointViewPtr view1(new PointView(table));
+    view1->setField(Id::X, 0, 0);
+    view1->setField(Id::X, 1, 10);
+    view1->setField(Id::X, 2, 0);
+    view1->setField(Id::Y, 0, 0);
+    view1->setField(Id::Y, 1, 0);
+    view1->setField(Id::Y, 2, 10);
+    view1->setField(Id::Z, 0, 0);
+    view1->setField(Id::Z, 1, 0);
+    view1->setField(Id::Z, 2, 0);
+    reader1.addView(view1);
+
+    PointViewPtr view2(new PointView(table));
+    view2->setField(Id::X, 0, 1);
+    view2->setField(Id::X, 1, 11);
+    view2->setField(Id::X, 2, 1);
+    view2->setField(Id::Y, 0, 2);
+    view2->setField(Id::Y, 1, 2);
+    view2->setField(Id::Y, 2, 12);
+    view2->setField(Id::Z, 0, 3);
+    view2->setField(Id::Z, 1, 3);
+    view2->setField(Id::Z, 2, 3);
+    reader2.addView(view2);
+    
+    auto filter = newFilter();
+    Options icpOptions;
+    // Provide a bad initial guess for the tranformation.
+    icpOptions.add("init", "0.996 0 0.087 -50 0 1 0 100 0.996 0 0.087 -300 0 0 0 1");
+    filter->setInput(reader1);
+    filter->setInput(reader2);
+    filter->setOptions(icpOptions);
+
+    filter->prepare(table);
+    PointViewSet pointViewSet = filter->execute(table);
+
+    MetadataNode root = filter->getMetadata();
+    Eigen::MatrixXd transform =
+        root.findChild("transform").value<Eigen::MatrixXd>();
+    double tolerance = 1.5;
+    // No reason to check exact values, only that they are LT/GT the expected values.
+    EXPECT_GT(-1.0, transform(0, 3));
+    EXPECT_LT(-2.0, transform(1, 3));
+    EXPECT_GT(-3.0, transform(2, 3));
+}
+
+TEST(IcpFilterTest, RecoverTranslationWithMalformedGuess)
+{
+    using namespace Dimension;
+
+    PointTable table;
+    table.layout()->registerDims({Id::X, Id::Y, Id::Z});
+
+    BufferReader reader1;
+    BufferReader reader2;
+
+    PointViewPtr view1(new PointView(table));
+    view1->setField(Id::X, 0, 0);
+    view1->setField(Id::X, 1, 10);
+    view1->setField(Id::X, 2, 0);
+    view1->setField(Id::Y, 0, 0);
+    view1->setField(Id::Y, 1, 0);
+    view1->setField(Id::Y, 2, 10);
+    view1->setField(Id::Z, 0, 0);
+    view1->setField(Id::Z, 1, 0);
+    view1->setField(Id::Z, 2, 0);
+    reader1.addView(view1);
+
+    PointViewPtr view2(new PointView(table));
+    view2->setField(Id::X, 0, 1);
+    view2->setField(Id::X, 1, 11);
+    view2->setField(Id::X, 2, 1);
+    view2->setField(Id::Y, 0, 2);
+    view2->setField(Id::Y, 1, 2);
+    view2->setField(Id::Y, 2, 12);
+    view2->setField(Id::Z, 0, 3);
+    view2->setField(Id::Z, 1, 3);
+    view2->setField(Id::Z, 2, 3);
+    reader2.addView(view2);
+    
+    auto filter = newFilter();
+    Options icpOptions;
+    // Provide a malformed initial guess (too many entries).
+    icpOptions.add("init", "7 1 0 0 -1 0 1 0 -2 0 0 1 -3 0 0 0 1");
+    filter->setInput(reader1);
+    filter->setInput(reader2);
+    filter->setOptions(icpOptions);
+
+    EXPECT_THROW(filter->prepare(table), pdal_error);
 }
 
 TEST(IcpFilterTest, RecoverRotation)


### PR DESCRIPTION
`max_dist` will reject correspondences that exceed the provided maximum distance.

`init` is a user-provided initial guess at the transformation matrix.

Closes #3213 and closes #3214 