### PR TITLE
Fix spelling errors.

### DIFF
--- a/filters/private/expr/ConditionalExpression.cpp
+++ b/filters/private/expr/ConditionalExpression.cpp
@@ -15,7 +15,7 @@ Utils::StatusWithReason ConditionalExpression::prepare(PointLayoutPtr layout)
         {
             if (top->isValue())
                 status =
-                    { -1, "Expression evalutes to a value, not a boolean." };
+                    { -1, "Expression evaluates to a value, not a boolean." };
             else
             {
                 ConstLogicalNode *n = dynamic_cast<ConstLogicalNode *>(top);

--- a/filters/private/expr/Expression.cpp
+++ b/filters/private/expr/Expression.cpp
@@ -326,7 +326,7 @@ Utils::StatusWithReason VarNode::prepare(PointLayoutPtr l)
 {
     m_id = l->findDim(m_name);
     if (m_id == Dimension::Id::Unknown)
-        return { -1, "Unknown dimension '" + m_name + "' in assigment." };
+        return { -1, "Unknown dimension '" + m_name + "' in assignment." };
     return true;
 }
 

--- a/filters/private/miniball/Seb_debug.h
+++ b/filters/private/miniball/Seb_debug.h
@@ -57,7 +57,7 @@ namespace SEB_NAMESPACE {
   //   created and started.  Otherwise, the timer with name name is
   //   restarted.
   //
-  // - lapse(name): Retuns the number of seconds which have elapsed
+  // - lapse(name): Returns the number of seconds which have elapsed
   //   since start(name) was called last.
   //   Precondition: start(name) has been called once.
   {

--- a/io/private/ept/Addon.cpp
+++ b/io/private/ept/Addon.cpp
@@ -75,7 +75,7 @@ AddonList Addon::store(const Connector& connector, const NL::json& spec,
             Dimension::Id id = layout.findDim(dimName);
             if (id == Dimension::Id::Unknown)
                 throw pdal_error("Invalid dimension '" + dimName + "' in "
-                    "addon specificiation. Does not exist in source data.");
+                    "addon specification. Does not exist in source data.");
             Dimension::Type type = layout.dimType(id);
             std::string typestring = Dimension::toName(Dimension::base(type));
             size_t size = Dimension::size(type);

--- a/pdal/Dimension.json
+++ b/pdal/Dimension.json
@@ -147,7 +147,7 @@
     {
     "name": "Deviation",
     "type": "float",
-    "description": "Difference between the shape of the reference pulse and the retun pulse. A larger value for deviation indicates larger distortion."
+    "description": "Difference between the shape of the reference pulse and the return pulse. A larger value for deviation indicates larger distortion."
     },
     {
     "name": "PassiveSignal",

--- a/vendor/gtest/src/gtest-death-test.cc
+++ b/vendor/gtest/src/gtest-death-test.cc
@@ -795,8 +795,8 @@ DeathTest::TestRole WindowsDeathTest::AssumeRole() {
   GTEST_DEATH_TEST_CHECK_(
       ::CreateProcessA(
           executable_path, const_cast<char*>(command_line.c_str()),
-          nullptr,  // Retuned process handle is not inheritable.
-          nullptr,  // Retuned thread handle is not inheritable.
+          nullptr,  // Returned process handle is not inheritable.
+          nullptr,  // Returned thread handle is not inheritable.
           TRUE,  // Child inherits all inheritable handles (for write_handle_).
           0x0,   // Default creation flags.
           nullptr,  // Inherit the parent's environment.

--- a/vendor/pdalboost/boost/date_time/dst_rules.hpp
+++ b/vendor/pdalboost/boost/date_time/dst_rules.hpp
@@ -94,7 +94,7 @@ namespace pdalboost {
        *  @param dst_start_offset Time offset within day for dst boundary
        *  @param dst_end_day    Ending day of dst for the given locality
        *  @param dst_end_offset Time offset within day given in dst for dst boundary
-       *  @param dst_length lenght of dst adjusment
+       *  @param dst_length length of dst adjusment
        *  @retval The time is either ambiguous, invalid, in dst, or not in dst
        */
       static time_is_dst_result 

--- a/vendor/pdalboost/boost/detail/utf8_codecvt_facet.hpp
+++ b/vendor/pdalboost/boost/detail/utf8_codecvt_facet.hpp
@@ -93,7 +93,7 @@ namespace std {
 }
 #endif
 
-// maximum lenght of a multibyte string
+// maximum length of a multibyte string
 #define MB_LENGTH_MAX 8
 
 BOOST_UTF8_BEGIN_NAMESPACE

--- a/vendor/pdalboost/boost/iostreams/detail/optional.hpp
+++ b/vendor/pdalboost/boost/iostreams/detail/optional.hpp
@@ -5,7 +5,7 @@
 
 // See http://www.boost.org/libs/iostreams for documentation.
 
-// Recent changes to Boost.Optional involving assigment broke Boost.Iostreams,
+// Recent changes to Boost.Optional involving assignment broke Boost.Iostreams,
 // in a way which could be remedied only by relying on the deprecated reset
 // functions; with VC6, even reset didn't work. Until this problem is 
 // understood, Iostreams will use a private version of optional with a smart 

--- a/vendor/pdalboost/boost/type_index.hpp
+++ b/vendor/pdalboost/boost/type_index.hpp
@@ -234,7 +234,7 @@ inline type_index type_id_with_cvr() BOOST_NOEXCEPT {
 
 /// Function that works exactly like C++ typeid(rtti_val) call, but returns pdalboost::type_index.
 ///
-/// Retunrs runtime information about specified type.
+/// Returns runtime information about specified type.
 ///
 /// \b Requirements: RTTI available or Base and Derived classes must be marked with BOOST_TYPE_INDEX_REGISTER_CLASS.
 ///


### PR DESCRIPTION
The lintian QA tool reported a couple of spelling errors for the Debian package build:

 * assigment      -> assignment
 * evalutes       -> evaluates
 * lenght         -> length
 * retun          -> return
 * specificiation -> specification