### PR TITLE
Fix #3258 - use 'density' rather than deprecated 'normed' kwarg 

### DIFF
--- a/doc/workshop/exercises/python/histogram.py
+++ b/doc/workshop/exercises/python/histogram.py
@@ -32,7 +32,7 @@ def make_plot(ins, outs):
 
         # histogram the current dimension with 30 bins
         n, bins, patches = ax.hist( dimension, 30,
-                                    normed=0,
+                                    density=0,
                                     facecolor='grey',
                                     alpha=0.75,
                                     align='mid',


### PR DESCRIPTION
Update the workshop example as suggested in #3258 