### PR TITLE
default to unordered reads with TileDB

### DIFF
--- a/plugins/tiledb/io/TileDBReader.cpp
+++ b/plugins/tiledb/io/TileDBReader.cpp
@@ -253,6 +253,8 @@ void TileDBReader::localReady()
 
     m_query.reset(new tiledb::Query(*m_ctx, *m_array));
 
+    m_query->set_layout( TILEDB_UNORDERED );
+
     // Build the buffer for the dimensions.
     auto it = std::find_if(m_dims.begin(), m_dims.end(),
         [](DimInfo& di){ return di.m_dimCategory == DimCategory::Dimension; });


### PR DESCRIPTION
Default to not ordering the result data on read with TileDB to avoid unnecessary overhead, ordering should be done with a subsequent pipeline stage.