### PR TITLE
Default to unordered reads with TileDB plugin

### DIFF
--- a/plugins/tiledb/io/TileDBReader.cpp
+++ b/plugins/tiledb/io/TileDBReader.cpp
@@ -252,6 +252,7 @@ void TileDBReader::localReady()
     int numDims = m_array->schema().domain().dimensions().size();
 
     m_query.reset(new tiledb::Query(*m_ctx, *m_array));
+    m_query->set_layout( TILEDB_UNORDERED );
 
     // Build the buffer for the dimensions.
     auto it = std::find_if(m_dims.begin(), m_dims.end(),


### PR DESCRIPTION
@abellgithub opened this against master as asked.

Default to not ordering the result data on read with TileDB to avoid unnecessary overhead, ordering should be done with a subsequent pipeline stage.