### PR TITLE
Minor updates to several filters

### DIFF
--- a/doc/stages/filters.litree.rst
+++ b/doc/stages/filters.litree.rst
@@ -17,8 +17,8 @@ given a ``ClusterID`` of 0.
 
 .. note::
 
-  In earlier PDAL releases, ``ClusterID`` was stored in the ``TreeID``
-  Dimemsion.
+  In earlier PDAL releases (up to v2.2.0), ``ClusterID`` was stored in the
+  ``TreeID`` Dimemsion.
 
 .. embed::
 

--- a/doc/stages/filters.litree.rst
+++ b/doc/stages/filters.litree.rst
@@ -6,14 +6,19 @@ filters.litree
 
 The purpose of the Li tree filter is to segment individual trees from an input
 ``PointView``. In the output ``PointView`` points that are deemed to be part of
-a tree are labeled with a ``TreeID``. Tree IDs start at 1, with non-tree points
-given a ``TreeID`` of 0.
+a tree are labeled with a ``ClusterID``. Tree IDs start at 1, with non-tree points
+given a ``ClusterID`` of 0.
 
 .. note::
 
   The filter differs only slightly from the paper in the addition of a few
   conditions on size of tree, minimum height above ground for tree seeding, and
   flexible radius for non-tree seed insertion.
+
+.. note::
+
+  In earlier PDAL releases, ``ClusterID`` was stored in the ``TreeID``
+  Dimemsion.
 
 .. embed::
 

--- a/doc/stages/filters.lof.rst
+++ b/doc/stages/filters.lof.rst
@@ -8,15 +8,15 @@ of determining the degree to which an object is an outlier. This filter
 is an implementation of the method
 described in [Breunig2000]_.
 
-The filter creates three new dimensions, ``KDistance``,
+The filter creates three new dimensions, ``NNDistance``,
 ``LocalReachabilityDistance`` and ``LocalOutlierFactor``, all of which are
-double-precision floating values. The ``KDistance`` dimension records the
+double-precision floating values. The ``NNDistance`` dimension records the
 Euclidean distance between a point and it's k-th nearest neighbor (the number
 of k neighbors is set with the minpts_ option). The
 ``LocalReachabilityDistance`` is the inverse of the mean
 of all reachability distances for a neighborhood of points. This reachability
 distance is defined as the max of the Euclidean distance to a neighboring point
-and that neighbor's own previously computed ``KDistance``. Finally, each point
+and that neighbor's own previously computed ``NNDistance``. Finally, each point
 has a ``LocalOutlierFactor`` which is the mean of all
 ``LocalReachabilityDistance`` values for the neighborhood. In each case, the
 neighborhood is the set of k nearest neighbors.
@@ -31,6 +31,11 @@ users of this filter should find instructive.
 
   To inspect the newly created, non-standard dimensions, be sure to write to an
   output format that can support arbitrary dimensions, such as BPF.
+
+.. note::
+
+  In earlier PDAL releases, ``NNDistance`` was stored in the ``KDistance``
+  Dimemsion.
 
 .. embed::
 

--- a/doc/stages/filters.lof.rst
+++ b/doc/stages/filters.lof.rst
@@ -34,8 +34,8 @@ users of this filter should find instructive.
 
 .. note::
 
-  In earlier PDAL releases, ``NNDistance`` was stored in the ``KDistance``
-  Dimemsion.
+  In earlier PDAL releases (up to v2.2.0), ``NNDistance`` was stored in the
+  ``KDistance`` Dimemsion.
 
 .. embed::
 

--- a/filters/ApproximateCoplanarFilter.cpp
+++ b/filters/ApproximateCoplanarFilter.cpp
@@ -41,10 +41,12 @@
 #include <Eigen/Dense>
 
 #include <string>
-#include <vector>
 
 namespace pdal
 {
+
+using namespace Dimension;
+using namespace Eigen;
 
 static StaticPluginInfo const s_info
 {
@@ -71,35 +73,33 @@ void ApproximateCoplanarFilter::addArgs(ProgramArgs& args)
 
 void ApproximateCoplanarFilter::addDimensions(PointLayoutPtr layout)
 {
-    m_coplanar = layout->registerOrAssignDim("Coplanar",
-        Dimension::Type::Unsigned8);
+    layout->registerDim(Id::Coplanar);
 }
+
 
 void ApproximateCoplanarFilter::filter(PointView& view)
 {
-    using namespace Eigen;
+    const KD3Index& kdi = view.build3dIndex();
 
-    KD3Index& kdi = view.build3dIndex();
-
-    for (PointId i = 0; i < view.size(); ++i)
+    for (PointRef p : view)
     {
         // find the k-nearest neighbors
-        auto ids = kdi.neighbors(i, m_knn);
+        PointIdList ids = kdi.neighbors(p, m_knn);
 
         // compute covariance of the neighborhood
-        auto B = math::computeCovariance(view, ids);
+        Matrix3d B = math::computeCovariance(view, ids);
 
         // perform the eigen decomposition
-        SelfAdjointEigenSolver<Matrix3d> solver(B);
-        if (solver.info() != Success)
+        Eigen::SelfAdjointEigenSolver<Matrix3d> solver(B);
+        if (solver.info() != Eigen::Success)
             throwError("Cannot perform eigen decomposition.");
-        auto ev = solver.eigenvalues();
+        Vector3d ev = solver.eigenvalues();
 
         // test eigenvalues to label points that are approximately coplanar
         if ((ev[1] > m_thresh1 * ev[0]) && (m_thresh2 * ev[1] > ev[2]))
-            view.setField(m_coplanar, i, 1u);
+            p.setField(Id::Coplanar, 1u);
         else
-            view.setField(m_coplanar, i, 0u);
+            p.setField(Id::Coplanar, 0u);
     }
 }
 

--- a/filters/ApproximateCoplanarFilter.hpp
+++ b/filters/ApproximateCoplanarFilter.hpp
@@ -36,14 +36,11 @@
 
 #include <pdal/Filter.hpp>
 
-#include <cstdint>
-#include <memory>
 #include <string>
 
 namespace pdal
 {
 
-class Options;
 class PointLayout;
 class PointView;
 
@@ -62,7 +59,6 @@ private:
     int m_knn;
     double m_thresh1;
     double m_thresh2;
-    Dimension::Id m_coplanar;
 
     virtual void addDimensions(PointLayoutPtr layout);
     virtual void addArgs(ProgramArgs& args);

--- a/filters/EigenvaluesFilter.cpp
+++ b/filters/EigenvaluesFilter.cpp
@@ -41,10 +41,12 @@
 #include <Eigen/Dense>
 
 #include <string>
-#include <vector>
 
 namespace pdal
 {
+
+using namespace Dimension;
+using namespace Eigen;
 
 static StaticPluginInfo const s_info
 {
@@ -86,9 +88,9 @@ void EigenvaluesFilter::addArgs(ProgramArgs& args)
 
 void EigenvaluesFilter::addDimensions(PointLayoutPtr layout)
 {
-    m_e0 = layout->registerOrAssignDim("Eigenvalue0", Dimension::Type::Double);
-    m_e1 = layout->registerOrAssignDim("Eigenvalue1", Dimension::Type::Double);
-    m_e2 = layout->registerOrAssignDim("Eigenvalue2", Dimension::Type::Double);
+    layout->registerDim(Id::Eigenvalue0);
+    layout->registerDim(Id::Eigenvalue1);
+    layout->registerDim(Id::Eigenvalue2);
 }
 
 void EigenvaluesFilter::prepared(PointTableRef table)
@@ -112,17 +114,15 @@ void EigenvaluesFilter::prepared(PointTableRef table)
 
 void EigenvaluesFilter::filter(PointView& view)
 {
-    using namespace Eigen;
+    const KD3Index& kdi = view.build3dIndex();
 
-    KD3Index& kdi = view.build3dIndex();
-
-    for (PointId i = 0; i < view.size(); ++i)
+    for (PointRef p : view)
     {
         // find neighbors, either by radius or k nearest neighbors
         PointIdList ids;
         if (m_args->m_radiusArg->set())
         {
-            ids = kdi.radius(i, m_args->m_radius);
+            ids = kdi.radius(p, m_args->m_radius);
 
             // if insufficient number of neighbors, eigen solver will fail
             // anyway, it may be okay to silently return without setting any of
@@ -132,17 +132,17 @@ void EigenvaluesFilter::filter(PointView& view)
         }
         else
         {
-            ids = kdi.neighbors(i, m_args->m_knn + 1, m_args->m_stride);
+            ids = kdi.neighbors(p, m_args->m_knn + 1, m_args->m_stride);
         }
 
         // compute covariance of the neighborhood
-        auto B = math::computeCovariance(view, ids);
+        Matrix3d B = math::computeCovariance(view, ids);
 
         // perform the eigen decomposition
-        SelfAdjointEigenSolver<Matrix3d> solver(B);
-        if (solver.info() != Success)
+        Eigen::SelfAdjointEigenSolver<Matrix3d> solver(B);
+        if (solver.info() != Eigen::Success)
             throwError("Cannot perform eigen decomposition.");
-        auto ev = solver.eigenvalues();
+        Vector3d ev = solver.eigenvalues();
 
         if (m_args->m_normalize)
         {
@@ -150,9 +150,9 @@ void EigenvaluesFilter::filter(PointView& view)
             ev /= sum;
         }
 
-        view.setField(m_e0, i, ev[0]);
-        view.setField(m_e1, i, ev[1]);
-        view.setField(m_e2, i, ev[2]);
+        p.setField(Id::Eigenvalue0, ev[0]);
+        p.setField(Id::Eigenvalue1, ev[1]);
+        p.setField(Id::Eigenvalue2, ev[2]);
     }
 }
 

--- a/filters/EigenvaluesFilter.hpp
+++ b/filters/EigenvaluesFilter.hpp
@@ -36,14 +36,11 @@
 
 #include <pdal/Filter.hpp>
 
-#include <cstdint>
-#include <memory>
 #include <string>
 
 namespace pdal
 {
 
-class Options;
 class PointLayout;
 class PointView;
 struct EigenvalueArgs;
@@ -59,7 +56,6 @@ public:
 
 private:
     std::unique_ptr<EigenvalueArgs> m_args;
-    Dimension::Id m_e0, m_e1, m_e2;
 
     virtual void addDimensions(PointLayoutPtr layout);
     virtual void addArgs(ProgramArgs& args);

--- a/filters/EstimateRankFilter.cpp
+++ b/filters/EstimateRankFilter.cpp
@@ -35,7 +35,6 @@
 #include "EstimateRankFilter.hpp"
 
 #include <string>
-#include <vector>
 
 #include <pdal/KDIndex.hpp>
 #include <pdal/util/ProgramArgs.hpp>
@@ -43,6 +42,8 @@
 
 namespace pdal
 {
+
+using namespace Dimension;
 
 static StaticPluginInfo const s_info
 {
@@ -68,19 +69,17 @@ void EstimateRankFilter::addArgs(ProgramArgs& args)
 
 void EstimateRankFilter::addDimensions(PointLayoutPtr layout)
 {
-    m_rank = layout->registerOrAssignDim("Rank", Dimension::Type::Unsigned8);
+    layout->registerDim(Id::Rank);
 }
 
 void EstimateRankFilter::filter(PointView& view)
 {
-    KD3Index& kdi = view.build3dIndex();
+    const KD3Index& kdi = view.build3dIndex();
 
-    for (PointId i = 0; i < view.size(); ++i)
+    for (PointRef p : view)
     {
-        // find the k-nearest neighbors
-        auto ids = kdi.neighbors(i, m_knn);
-
-        view.setField(m_rank, i, math::computeRank(view, ids, m_thresh));
+        PointIdList ids = kdi.neighbors(p, m_knn);
+        p.setField(Id::Rank, math::computeRank(view, ids, m_thresh));
     }
 }
 

--- a/filters/EstimateRankFilter.hpp
+++ b/filters/EstimateRankFilter.hpp
@@ -36,14 +36,11 @@
 
 #include <pdal/Filter.hpp>
 
-#include <cstdint>
-#include <memory>
 #include <string>
 
 namespace pdal
 {
 
-class Options;
 class PointLayout;
 class PointView;
 
@@ -60,7 +57,6 @@ public:
 private:
     int m_knn;
     double m_thresh;
-    Dimension::Id m_rank;
 
     virtual void addDimensions(PointLayoutPtr layout);
     virtual void addArgs(ProgramArgs& args);

--- a/filters/LOFFilter.hpp
+++ b/filters/LOFFilter.hpp
@@ -36,8 +36,6 @@
 
 #include <pdal/Filter.hpp>
 
-#include <memory>
-
 namespace pdal
 {
 
@@ -50,19 +48,17 @@ class PDAL_DLL LOFFilter : public Filter
 public:
     LOFFilter() : Filter()
     {}
+    LOFFilter& operator=(const LOFFilter&) = delete;
+    LOFFilter(const LOFFilter&) = delete;
 
     std::string getName() const;
 
 private:
-    Dimension::Id m_kdist, m_lrd, m_lof;
     size_t m_minpts;
 
     virtual void addArgs(ProgramArgs& args);
     virtual void addDimensions(PointLayoutPtr layout);
     virtual void filter(PointView& view);
-
-    LOFFilter& operator=(const LOFFilter&); // not implemented
-    LOFFilter(const LOFFilter&); // not implemented
 };
 
 } // namespace pdal

--- a/filters/LiTreeFilter.hpp
+++ b/filters/LiTreeFilter.hpp
@@ -35,7 +35,6 @@
 #pragma once
 
 #include <pdal/Filter.hpp>
-#include <pdal/KDIndex.hpp>
 
 namespace pdal
 {
@@ -50,7 +49,6 @@ public:
     std::string getName() const;
 
 private:
-    Dimension::Id m_id;
     std::vector<int> m_localMax;
     point_count_t m_minSize;
     double m_minHag;
@@ -64,11 +62,10 @@ private:
     PointId locateHighestPoint(PointView& view, PointIdList const& Ui);
     PointId locateDummyPoint(PointView& view, PointIdList const& Ui,
                              PointId t0);
-    void segmentTree(KD2Index& kdi, PointView& view, PointIdList& Ui,
-                     int64_t& tree_id);
+    void segmentTree(PointView& view, PointIdList& Ui, int64_t& tree_id);
     void classifyPoint(PointId ui, PointView& view, PointIdList& Ni,
                        PointIdList& Pi);
-    void computeLocalMax(KD2Index& kdi, PointView& view);
+    void computeLocalMax(PointView& view);
 };
 
 } // namespace pdal

--- a/filters/MiniballFilter.hpp
+++ b/filters/MiniballFilter.hpp
@@ -36,7 +36,6 @@
 
 #include <pdal/Filter.hpp>
 
-#include <memory>
 #include <string>
 
 namespace pdal
@@ -55,13 +54,12 @@ public:
 private:
     int m_knn;
     int m_threads;
-    Dimension::Id m_miniball;
 
     virtual void addArgs(ProgramArgs& args);
     virtual void addDimensions(PointLayoutPtr layout);
     virtual void filter(PointView& view);
 
-    void setMiniball(PointView& view, const PointId& i, const KD3Index& kdi);
+    void setMiniball(PointView& view, const PointId& i);
 };
 
 } // namespace pdal

--- a/filters/OptimalNeighborhoodFilter.cpp
+++ b/filters/OptimalNeighborhoodFilter.cpp
@@ -66,14 +66,14 @@ void OptimalNeighborhood::addArgs(ProgramArgs& args)
 
 void OptimalNeighborhood::addDimensions(PointLayoutPtr layout)
 {
-    m_kOpt = layout->registerOrAssignDim("OptimalKNN", Type::Unsigned64);
-    m_rOpt = layout->registerOrAssignDim("OptimalRadius", Type::Double);
+    layout->registerDim(Id::OptimalKNN);
+    layout->registerDim(Id::OptimalRadius);
 }
 
 void OptimalNeighborhood::filter(PointView& view)
 {
     // Build the 3D KD-tree.
-    KD3Index& index = view.build3dIndex();
+    const KD3Index& index = view.build3dIndex();
 
     for (PointRef p : view)
     {
@@ -133,10 +133,10 @@ void OptimalNeighborhood::filter(PointView& view)
             B(1, 2) = B(2, 1) = B(2, 1) + s * dy * dz;
 
             // perform the eigen decomposition
-            SelfAdjointEigenSolver<Matrix3d> solver(B / (n - 1));
-            if (solver.info() != Success)
+	    Eigen::SelfAdjointEigenSolver<Matrix3d> solver(B / (n - 1));
+            if (solver.info() != Eigen::Success)
                 throwError("Cannot perform eigen decomposition.");
-            auto ev = solver.eigenvalues();
+            Vector3d ev = solver.eigenvalues();
 
             std::vector<double> lambda = {((std::max)(ev[2], 0.0)),
                                           ((std::max)(ev[1], 0.0)),
@@ -158,8 +158,8 @@ void OptimalNeighborhood::filter(PointView& view)
             }
         }
 
-        p.setField(m_kOpt, kopt);
-        p.setField(m_rOpt, std::sqrt(ropt));
+        p.setField(Id::OptimalKNN, kopt);
+        p.setField(Id::OptimalRadius, std::sqrt(ropt));
     }
 }
 

--- a/filters/OptimalNeighborhoodFilter.hpp
+++ b/filters/OptimalNeighborhoodFilter.hpp
@@ -51,7 +51,6 @@ public:
 
 private:
     point_count_t m_kMin, m_kMax;
-    Dimension::Id m_kOpt, m_rOpt;
 
     virtual void addDimensions(PointLayoutPtr layout);
     virtual void addArgs(ProgramArgs& args);

--- a/filters/PlaneFitFilter.cpp
+++ b/filters/PlaneFitFilter.cpp
@@ -53,6 +53,7 @@ namespace pdal
 {
 
 using namespace Dimension;
+using namespace Eigen;
 
 static StaticPluginInfo const s_info
 {
@@ -77,14 +78,11 @@ void PlaneFitFilter::addArgs(ProgramArgs& args)
 
 void PlaneFitFilter::addDimensions(PointLayoutPtr layout)
 {
-    m_planefit =
-        layout->registerOrAssignDim("PlaneFit", Dimension::Type::Double);
+    layout->registerDim(Id::PlaneFit);
 }
 
 void PlaneFitFilter::filter(PointView& view)
 {
-    KD3Index& kdi = view.build3dIndex();
-
     point_count_t nloops = view.size();
     std::vector<std::thread> threadList(m_threads);
     for (int t = 0; t < m_threads; t++)
@@ -92,7 +90,7 @@ void PlaneFitFilter::filter(PointView& view)
         threadList[t] = std::thread(std::bind(
             [&](const PointId start, const PointId end) {
                 for (PointId i = start; i < end; i++)
-                    setPlaneFit(view, i, kdi);
+                    setPlaneFit(view, i);
             },
             t * nloops / m_threads,
             (t + 1) == m_threads ? nloops : (t + 1) * nloops / m_threads));
@@ -102,22 +100,22 @@ void PlaneFitFilter::filter(PointView& view)
 }
 
 double PlaneFitFilter::absDistance(PointView& view, const PointId& i,
-                                   Eigen::Vector3d& centroid,
-                                   Eigen::Vector3d& normal)
+                                   Vector3d& centroid,
+                                   Vector3d& normal)
 {
-    double x = view.getFieldAs<double>(Dimension::Id::X, i);
-    double y = view.getFieldAs<double>(Dimension::Id::Y, i);
-    double z = view.getFieldAs<double>(Dimension::Id::Z, i);
-    Eigen::Vector3d p;
+    double x = view.getFieldAs<double>(Id::X, i);
+    double y = view.getFieldAs<double>(Id::Y, i);
+    double z = view.getFieldAs<double>(Id::Z, i);
+    Vector3d p;
     p << x - centroid[0], y - centroid[1], z - centroid[2];
     double d = normal.dot(p);
     return std::fabs(d);
 }
 
-void PlaneFitFilter::setPlaneFit(PointView& view, const PointId& i,
-                                 const KD3Index& kdi)
+void PlaneFitFilter::setPlaneFit(PointView& view, const PointId& i)
 {
     // Find k-nearest neighbors of i.
+    const KD3Index& kdi = view.build3dIndex();
     PointIdList ni = kdi.neighbors(i, m_knn + 1);
 
     // Normal based only on neighbors, so exclude first point.
@@ -126,31 +124,31 @@ void PlaneFitFilter::setPlaneFit(PointView& view, const PointId& i,
     // Covariance and normal are based off demeaned coordinates, so we record
     // the centroid to properly offset the coordinates when computing point to
     // plance distance.
-    auto centroid = math::computeCentroid(view, neighbors);
+    Vector3d centroid = math::computeCentroid(view, neighbors);
 
     // Compute covariance of the neighbors.
-    auto B = math::computeCovariance(view, neighbors);
+    Matrix3d B = math::computeCovariance(view, neighbors);
 
     // Perform the eigen decomposition, using the eigenvector of the smallest
     // eigenvalue as the normal.
-    Eigen::SelfAdjointEigenSolver<Eigen::Matrix3d> solver(B);
+    Eigen::SelfAdjointEigenSolver<Matrix3d> solver(B);
     if (solver.info() != Eigen::Success)
         throwError("Cannot perform eigen decomposition.");
-    Eigen::Vector3d normal = solver.eigenvectors().col(0);
+    Vector3d normal = solver.eigenvectors().col(0);
 
     // Compute point to plane distance of the query point.
     double d = absDistance(view, i, centroid, normal);
 
     // Compute mean point to plane distance of neighbors.
     double d_sum(0.0);
-    for (auto const& j : neighbors)
+    for (PointId const& j : neighbors)
     {
         d_sum += absDistance(view, j, centroid, normal);
     }
     double d_bar(d_sum / m_knn);
 
     // Compute and set the plane fit criterion.
-    view.setField(m_planefit, i, d / (d + d_bar));
+    view.setField(Id::PlaneFit, i, d / (d + d_bar));
 }
 
 } // namespace pdal

--- a/filters/PlaneFitFilter.hpp
+++ b/filters/PlaneFitFilter.hpp
@@ -38,18 +38,18 @@
 
 #include <Eigen/Dense>
 
-#include <memory>
 #include <string>
 
 namespace pdal
 {
 
+using namespace Eigen;
+
 class PDAL_DLL PlaneFitFilter : public Filter
 {
 public:
-    PlaneFitFilter()
-    {
-    }
+    PlaneFitFilter() : Filter()
+    {}
     PlaneFitFilter& operator=(const PlaneFitFilter&) = delete;
     PlaneFitFilter(const PlaneFitFilter&) = delete;
 
@@ -58,15 +58,14 @@ public:
 private:
     int m_knn;
     int m_threads;
-    Dimension::Id m_planefit;
 
     virtual void addArgs(ProgramArgs& args);
     virtual void addDimensions(PointLayoutPtr layout);
     virtual void filter(PointView& view);
 
-    void setPlaneFit(PointView& view, const PointId& i, const KD3Index& kdi);
+    void setPlaneFit(PointView& view, const PointId& i);
     double absDistance(PointView& view, const PointId& i,
-                       Eigen::Vector3d& centroid, Eigen::Vector3d& normal);
+                       Vector3d& centroid, Vector3d& normal);
 };
 
 } // namespace pdal

--- a/filters/RadialDensityFilter.hpp
+++ b/filters/RadialDensityFilter.hpp
@@ -36,8 +36,6 @@
 
 #include <pdal/Filter.hpp>
 
-#include <memory>
-
 namespace pdal
 {
 
@@ -50,19 +48,17 @@ class PDAL_DLL RadialDensityFilter : public Filter
 public:
     RadialDensityFilter() : Filter()
     {}
+    RadialDensityFilter& operator=(const RadialDensityFilter&) = delete;
+    RadialDensityFilter(const RadialDensityFilter&) = delete;
 
     std::string getName() const;
 
 private:
-    Dimension::Id m_rdens;
     double m_rad;
 
     virtual void addArgs(ProgramArgs& args);
     virtual void addDimensions(PointLayoutPtr layout);
     virtual void filter(PointView& view);
-
-    RadialDensityFilter& operator=(const RadialDensityFilter&); // not implemented
-    RadialDensityFilter(const RadialDensityFilter&); // not implemented
 };
 
 } // namespace pdal

--- a/filters/ReciprocityFilter.hpp
+++ b/filters/ReciprocityFilter.hpp
@@ -36,14 +36,11 @@
 
 #include <pdal/Filter.hpp>
 
-#include <cstdint>
-#include <memory>
 #include <string>
 
 namespace pdal
 {
 
-class Options;
 class PointLayout;
 class PointView;
 
@@ -60,14 +57,12 @@ public:
 private:
     int m_knn;
     int m_threads;
-    Dimension::Id m_reciprocity;
 
     virtual void addDimensions(PointLayoutPtr layout);
     virtual void addArgs(ProgramArgs& args);
     virtual void filter(PointView& view);
 
-    void setReciprocity(PointView& view, const PointId& i,
-                        const KD3Index& kdi);
+    void setReciprocity(PointView& view, const PointId& i);
 };
 
 } // namespace pdal

--- a/pdal/Dimension.json
+++ b/pdal/Dimension.json
@@ -466,5 +466,60 @@
     "name": "OptimalRadius",
     "type": "double",
     "description": "Radius corresponding to optimal k nearest neighbors, such that eigenentropy is minimized."
+    },
+    {
+    "name": "Coplanar",
+    "type": "uint8",
+    "description": "Indicator of whether or not a point is part of a coplanar neighborhood."
+    },
+    {
+    "name": "LocalReachabilityDistance",
+    "type": "double",
+    "description": "Reachability metric based on the NNDistance of a point's nearest neighbors."
+    },
+    {
+    "name": "LocalOutlierFactor",
+    "type": "double",
+    "description": "Outlier factor based on the LocalReachabilityDistance of a point's nearest neighbors."
+    },
+    {
+    "name": "Miniball",
+    "type": "double",
+    "description": "Metric capturing distance from a point to the center of the smallest enclosing ball encapsulating k-nearest neighbors, scaled by radius of the ball."
+    },
+    {
+    "name": "Reciprocity",
+    "type": "double",
+    "description": "Metric capturing percentage of k-nearest neighbors that also contain the current point in their k-neighborhood."
+    },
+    {
+    "name": "Rank",
+    "type": "uint8",
+    "description": "Estimated rank of neighborhood of points."
+    },
+    {
+    "name": "Eigenvalue0",
+    "type": "double",
+    "description": "Smallest eigenvalue obtained form covariance of XYZ coordinates in k-neighborhood."
+    },
+    {
+    "name": "Eigenvalue1",
+    "type": "double",
+    "description": "Middle eigenvalue obtained form covariance of XYZ coordinates in k-neighborhood."
+    },
+    {
+    "name": "Eigenvalue2",
+    "type": "double",
+    "description": "Largest eigenvalue obtained form covariance of XYZ coordinates in k-neighborhood."
+    },
+    {
+    "name": "PlaneFit",
+    "type": "double",
+    "description": "Metric capturing current point's point to plane distance compared to those in the same k-neighborhood used to estimate the plane."
+    },
+    {
+    "name": "RadialDensity",
+    "type": "double",
+    "description": "Estimate of radial point density"
     }
 ] }


### PR DESCRIPTION
Initial focus is on updating static filters to always register official Dimensions.

* LiTreeFilter now registers existing ClusterID instead of custom TreeID.

* LOFFilter now registers existing NNDistance instead of custom KDistance.

* OptimalNeighborhoodFilter now registers existing OptimalRadius and OptimalKNN.

* Register the following as "official" Dimensions: Coplanar, Eigenvalue0, Eigenvalue1, Eigenvalue2, LocalOutlierFactor, LocalReachabilityDistance, Miniball, PlaneFit, RadialDensity, Rank, Reciprocity

While updating Dimensions, also took the opportunity to:

* Be more explicit about datatypes, instead of relying on auto, to improve readability.

* Use PointView range-based for loops where it make sense. Generally makes code a little more succinct.

* Do not pass KDIndex as frequently, when it can typically be grabbed off the view at no cost.