### PR TITLE
CI: update to conda-incubator/setup-miniconda@v2 due to GHA security fix

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - uses: goanpeca/setup-miniconda@v1
+    - uses: conda-incubator/setup-miniconda@v2
       with:
         channels: conda-forge
         auto-update-conda: true

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: goanpeca/setup-miniconda@v1
+    - uses: conda-incubator/setup-miniconda@v2
       with:
         channels: conda-forge
         auto-update-conda: true

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: goanpeca/setup-miniconda@v1
+    - uses: conda-incubator/setup-miniconda@v2
       with:
         channels: conda-forge
         auto-update-conda: true

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: ilammy/msvc-dev-cmd@v1
-    - uses: goanpeca/setup-miniconda@v1
+    - uses: conda-incubator/setup-miniconda@v2
       with:
         channels: conda-forge
         auto-update-conda: true


### PR DESCRIPTION
Due to
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
and the old action still using the deprecated syntax