### PR TITLE
Add vertical ellipsoid height wkt1

### DIFF
--- a/pdal/SpatialReference.cpp
+++ b/pdal/SpatialReference.cpp
@@ -485,7 +485,7 @@ std::string SpatialReference::getWKT1() const
     if (srs)
     {
         char *buf = nullptr;
-        const char* apszOptions[] = { "FORMAT=WKT1_GDAL", nullptr };
+        const char* apszOptions[] = { ["FORMAT=WKT1_GDAL", "ALLOW_ELLIPSOIDAL_HEIGHT_AS_VERTICAL_CRS=YES"], nullptr };
 
         srs->exportToWkt(&buf, apszOptions);
         if (buf)

--- a/pdal/SpatialReference.cpp
+++ b/pdal/SpatialReference.cpp
@@ -485,7 +485,7 @@ std::string SpatialReference::getWKT1() const
     if (srs)
     {
         char *buf = nullptr;
-        const char* apszOptions[] = { ["FORMAT=WKT1_GDAL", "ALLOW_ELLIPSOIDAL_HEIGHT_AS_VERTICAL_CRS=YES"], nullptr };
+        const char* apszOptions[] = { "FORMAT=WKT1_GDAL", "ALLOW_ELLIPSOIDAL_HEIGHT_AS_VERTICAL_CRS=YES", nullptr };
 
         srs->exportToWkt(&buf, apszOptions);
         if (buf)


### PR DESCRIPTION
Source problem for LAS 1.4
```
(pdal pipeline writers.las Error) GDAL failure (1) PROJ: proj_as_wkt: Projected 3D CRS can only be exported since WKT2:2019
PDAL: Couldn't convert spatial reference to WKT version 1.
```

requires:
- PROJ 7.2.1
- GDAL 3.3.0