### PR TITLE
Replace non-standard endian functions with alternative implementations

### DIFF
--- a/pdal/util/portable_endian.hpp
+++ b/pdal/util/portable_endian.hpp
@@ -65,9 +65,9 @@
 #       define be32toh ntohl
 #       define le32toh(x) (x)
                         
-#       define htobe64 htonll
+#       define htobe64(x) ((((uint64_t)htonl(x&0xFFFFFFFF)) << 32) + htonl(x >> 32))
 #       define htole64(x) (x)
-#       define be64toh ntohll
+#       define be64toh(x) ((((uint64_t)ntohl(x&0xFFFFFFFF)) << 32) + ntohl(x >> 32))
 #       define le64toh(x) (x)
                          
 #   elif BYTE_ORDER == BIG_ENDIAN


### PR DESCRIPTION
`htonll` and `ntohll` aren't part of any standard and aren't provided by MinGW,
which prevents cross-compiling the library for Windows using this runtime.  For
the alternative implementations, see
https://stackoverflow.com/a/49167531/2442087.