### PR TITLE
Use consistent lowercase for Windows header files

### DIFF
--- a/pdal/DynamicLibrary.cpp
+++ b/pdal/DynamicLibrary.cpp
@@ -38,7 +38,7 @@
 // The original work was released under the Apache License v2.
 
 #ifdef _WIN32
-  #include <Windows.h>
+  #include <windows.h>
 #else
   #include <dlfcn.h>
 #endif

--- a/pdal/util/FileUtils.hpp
+++ b/pdal/util/FileUtils.hpp
@@ -44,7 +44,7 @@
 #include <vector>
 
 #ifdef _WIN32
-#include <Windows.h>
+#include <windows.h>
 #endif
 
 #include "pdal_util_export.hpp"

--- a/vendor/arbiter/arbiter.cpp
+++ b/vendor/arbiter/arbiter.cpp
@@ -893,7 +893,7 @@ const drivers::Http& Endpoint::getHttpDriver() const
 #include <sys/stat.h>
 #else
 #define UNICODE
-#include <Shlwapi.h>
+#include <shlwapi.h>
 #include <iterator>
 #include <locale>
 #include <codecvt>

--- a/vendor/kazhdan/MemoryUsage.h
+++ b/vendor/kazhdan/MemoryUsage.h
@@ -31,8 +31,8 @@ DAMAGE.
 
 #if defined( _WIN32 ) || defined( _WIN64 )
 
-#include <Windows.h>
-#include <Psapi.h>
+#include <windows.h>
+#include <psapi.h>
 struct MemoryInfo
 {
 	static size_t Usage( void )

--- a/vendor/kazhdan/PoissonRecon.h
+++ b/vendor/kazhdan/PoissonRecon.h
@@ -34,8 +34,8 @@ DAMAGE.
 //ABELL - Necessary?
 /**
 #if defined( _WIN32 ) || defined( _WIN64 )
-#include <Windows.h>
-#include <Psapi.h>
+#include <windows.h>
+#include <psapi.h>
 #endif // _WIN32 || _WIN64
 **/
 


### PR DESCRIPTION
Windows header files are used with inconsistent cases in the codebase.  When
building on a case-insensitive file system (common when doing native compilation
on Windows) this doesn't matter, but when using case-sensitive file
system (e.g., when cross-compiling on Linux) this leads to errors.