### PR TITLE
Fix type of arguments of `ifstream`/`ofstream`

### DIFF
--- a/pdal/util/FileUtils.cpp
+++ b/pdal/util/FileUtils.cpp
@@ -119,7 +119,7 @@ std::istream *openFile(std::string const& filename, bool asBinary)
     if (asBinary)
         mode |= std::ios::binary;
 
-    ifs = new std::ifstream(toNative(name), mode);
+    ifs = new std::ifstream(name, mode);
     if (!ifs->good())
     {
         delete ifs;
@@ -138,7 +138,7 @@ std::ostream *createFile(std::string const& name, bool asBinary)
     if (asBinary)
         mode |= std::ios::binary;
 
-    std::ostream *ofs = new std::ofstream(toNative(name), mode);
+    std::ostream *ofs = new std::ofstream(name, mode);
     if (!ofs->good())
     {
         delete ofs;


### PR DESCRIPTION
The first argument of `ifstream`/`ofstream` must be `string`, not `wstring`:
https://en.cppreference.com/w/cpp/io/basic_ifstream.