### PR TITLE
TileDB SFC

### DIFF
--- a/plugins/tiledb/io/TileDBWriter.cpp
+++ b/plugins/tiledb/io/TileDBWriter.cpp
@@ -359,13 +359,26 @@ void TileDBWriter::ready(pdal::BasePointTable &table)
         double dimMin = std::numeric_limits<double>::lowest();
         double dimMax = std::numeric_limits<double>::max();
 
-        domain.add_dimension(tiledb::Dimension::create<double>(*m_ctx, "X",
-            {{dimMin, dimMax}}, m_args->m_x_tile_size))
-            .add_dimension(tiledb::Dimension::create<double>(*m_ctx, "Y",
-            {{dimMin, dimMax}}, m_args->m_y_tile_size))
-            .add_dimension(tiledb::Dimension::create<double>(*m_ctx, "Z",
-            {{dimMin, dimMax}}, m_args->m_z_tile_size));
-
+        if ( (m_args->m_x_tile_size > 0) &&
+             (m_args->m_y_tile_size > 0) &&
+             (m_args->m_z_tile_size > 0) )
+            domain.add_dimension(tiledb::Dimension::create<double>(*m_ctx, "X",
+                {{dimMin, dimMax}}, m_args->m_x_tile_size))
+                .add_dimension(tiledb::Dimension::create<double>(*m_ctx, "Y",
+                {{dimMin, dimMax}}, m_args->m_y_tile_size))
+                .add_dimension(tiledb::Dimension::create<double>(*m_ctx, "Z",
+                {{dimMin, dimMax}}, m_args->m_z_tile_size));
+#if TILEDB_VERSION_MAJOR >= 2
+    #if ((TILEDB_VERSION_MINOR > 1) || (TILEDB_VERSION_MAJOR > 2))
+        else
+            domain.add_dimension(tiledb::Dimension::create<double>(*m_ctx, "X",
+                {{dimMin, dimMax}}))
+                .add_dimension(tiledb::Dimension::create<double>(*m_ctx, "Y",
+                {{dimMin, dimMax}}))
+                .add_dimension(tiledb::Dimension::create<double>(*m_ctx, "Z",
+                {{dimMin, dimMax}}));
+    #endif
+#endif
         m_schema->set_domain(domain).set_order(
             {{TILEDB_ROW_MAJOR, TILEDB_ROW_MAJOR}});
         m_schema->set_capacity(m_args->m_tile_capacity);

--- a/plugins/tiledb/io/TileDBWriter.cpp
+++ b/plugins/tiledb/io/TileDBWriter.cpp
@@ -309,10 +309,6 @@ void TileDBWriter::initialize()
         {
             NL::json opts;
 
-            if (tiledb::Object::object(*m_ctx, m_args->m_arrayName).type() ==
-                    tiledb::Object::Type::Array)
-                throwError("Array already exists.");
-
             m_schema.reset(new tiledb::ArraySchema(*m_ctx, TILEDB_SPARSE));
 
             if (m_args->m_filters.count("coords") > 0)

--- a/plugins/tiledb/test/TileDBWriterTest.cpp
+++ b/plugins/tiledb/test/TileDBWriterTest.cpp
@@ -442,4 +442,45 @@ namespace pdal
             EXPECT_EQ(v, 1.0);
     }
 #endif
+
+#if TILEDB_VERSION_MAJOR >= 2
+    #if ((TILEDB_VERSION_MINOR > 1) || (TILEDB_VERSION_MAJOR > 2))
+    TEST_F(TileDBWriterTest, sf_curve)
+    {
+        Options reader_options;
+        FauxReader reader;
+        BOX3D bounds(1.0, 1.0, 1.0, 2.0, 2.0, 2.0);
+        reader_options.add("bounds", bounds);
+        reader_options.add("mode", "constant");
+        reader_options.add("count", count);
+        reader.setOptions(reader_options);
+
+        tiledb::Context ctx;
+        tiledb::VFS vfs(ctx);
+        std::string pth = Support::temppath("tiledb_test_sf_curve");
+
+        Options writer_options;
+        writer_options.add("array_name", pth);
+        writer_options.add("x_tile_size", 0);
+        writer_options.add("y_tile_size", 0);
+        writer_options.add("z_tile_size", 0);
+
+        if (vfs.is_dir(pth))
+        {
+            vfs.remove_dir(pth);
+        }
+
+        TileDBWriter writer;
+        writer.setOptions(writer_options);
+        writer.setInput(reader);
+
+        FixedPointTable table(count);
+        writer.prepare(table);
+        writer.execute(table);
+
+        EXPECT_EQ(true,
+            tiledb::Object::object(ctx, pth).type() == tiledb::Object::Type::Array);
+    }
+    #endif
+#endif
 }


### PR DESCRIPTION
This PR adds support for Hilbert ordering of the points in a TileDB sparse array, this feature is enabled by allowing the input tile sizes to be set to zero. This feature is in TileDB 2.2.0 and greater.

I added a separate commit to remove a redundant check on object type as this is handled internally by the TileDB library.

