### PR TITLE
ObjReader: Adds a virtual desctructor that closes m_istream if it is still open

### DIFF
--- a/io/ObjReader.cpp
+++ b/io/ObjReader.cpp
@@ -47,6 +47,12 @@ static StaticPluginInfo const s_info
 
 CREATE_STATIC_STAGE(ObjReader, s_info)
 
+ObjReader::~ObjReader()
+{
+    if (m_istream != nullptr)
+        Utils::closeFile(m_istream);
+}
+
 std::string ObjReader::getName() const { return s_info.name; }
 
 void ObjReader::addDimensions(PointLayoutPtr layout)
@@ -76,6 +82,7 @@ void ObjReader::ready(PointTableRef)
 void ObjReader::done(PointTableRef)
 {
     Utils::closeFile(m_istream);
+    m_istream = nullptr;
 }
 
 point_count_t ObjReader::read(PointViewPtr view, point_count_t cnt)

--- a/io/ObjReader.hpp
+++ b/io/ObjReader.hpp
@@ -47,6 +47,7 @@ namespace pdal
 class PDAL_DLL ObjReader : public Reader
 {
 public:
+    virtual ~ObjReader();
     std::string getName() const;
 
 private:
@@ -72,11 +73,11 @@ private:
     std::vector<XYZW> m_vertices;
     std::vector<XYZW> m_textureVertices;
     std::vector<XYZW> m_normalVertices;
-    TriangularMesh *m_mesh;
+    TriangularMesh *m_mesh = nullptr;
     using VTN = std::tuple<int64_t, int64_t, int64_t>;
     std::map<VTN, PointId> m_points;
-    std::istream *m_istream;
-    point_count_t m_index;
+    std::istream *m_istream = nullptr;
+    point_count_t m_index = 0;
 
     using TRI = std::array<VTN, 3>;
     using FACE = std::vector<VTN>;


### PR DESCRIPTION
Initialize pointers and m_index plus be sure that closing m_istream is safe in the destructor.

I didn't add any sort of warning to the case where the desctructor has to do the close.  I am assuming this case might come up if there is an error after `ready()` is called, but `done()` has not yet been called.

The initial fix was written by another Google employee based on PDAL 2.2.0.  However, that code didn't have `done()` 

A `done()` call without a preceding `ready()` (or two done's in a row) will pass a nullptr to `closeFile`, but that checks for a nullptr.  That means that I probably could have left out the `if` in the destructor.