### PR TITLE
XMLSchema.cpp: Fix memory leak in loadMetadata

### DIFF
--- a/pdal/XMLSchema.cpp
+++ b/pdal/XMLSchema.cpp
@@ -305,8 +305,6 @@ bool XMLSchema::loadMetadata(xmlNode *startNode, MetadataNode& input)
         {
             char *fieldname =
                 (char*)xmlGetProp(node, (const xmlChar*)"name");
-            char *etype =
-                (char*)xmlGetProp(node, (const xmlChar*)"type");
             char *description =
                 (char*)xmlGetProp(node, (const xmlChar*) "description");
             char *text = (char*)xmlNodeGetContent(node);
@@ -323,7 +321,6 @@ bool XMLSchema::loadMetadata(xmlNode *startNode, MetadataNode& input)
                     description ? description : "");
             }
             xmlFree(fieldname);
-            xmlFree(etype);
             xmlFree(description);
             xmlFree(text);
         }

--- a/pdal/XMLSchema.cpp
+++ b/pdal/XMLSchema.cpp
@@ -303,13 +303,13 @@ bool XMLSchema::loadMetadata(xmlNode *startNode, MetadataNode& input)
             continue;
         if (std::string((const char*)node->name) == "Metadata")
         {
-            const char *fieldname =
-                (const char*)xmlGetProp(node, (const xmlChar*)"name");
-            const char *etype =
-                (const char*)xmlGetProp(node, (const xmlChar*)"type");
-            const char *description =
-                (const char*)xmlGetProp(node, (const xmlChar*) "description");
-            const char *text = (const char*)xmlNodeGetContent(node);
+            char *fieldname =
+                (char*)xmlGetProp(node, (const xmlChar*)"name");
+            char *etype =
+                (char*)xmlGetProp(node, (const xmlChar*)"type");
+            char *description =
+                (char*)xmlGetProp(node, (const xmlChar*) "description");
+            char *text = (char*)xmlNodeGetContent(node);
 
             if (!Utils::iequals(fieldname, "root"))
             {
@@ -322,6 +322,10 @@ bool XMLSchema::loadMetadata(xmlNode *startNode, MetadataNode& input)
                 input.add(fieldname, text ? text : "",
                     description ? description : "");
             }
+            xmlFree(fieldname);
+            xmlFree(etype);
+            xmlFree(description);
+            xmlFree(text);
         }
         loadMetadata(node->children, input);
     }


### PR DESCRIPTION
The strings returned from `xmlGetProp` and `xmlNodeGetContent` need to be freed and thus should also not be `const`