### PR TITLE
filters.colorization keep points outside raster when streaming (#3391)

### DIFF
--- a/filters/ColorizationFilter.cpp
+++ b/filters/ColorizationFilter.cpp
@@ -215,9 +215,11 @@ bool ColorizationFilter::processOne(PointRef& point)
             point.setField(b.m_dim, data[i] * b.m_scale);
             ++i;
         }
-        return true;
     }
-    return false;
+
+    // always return true to retain all points inside OR outside the raster. the output bands of
+    // any points outside the raster are ignored.
+    return true;
 }
 
 


### PR DESCRIPTION
always return true from ColorizationFilter::processOne regardless of if
the raster read for the x, y position of the point did not succeed. the
output band(s) of points outside the raster are ignored.

the normal mode output and stream mode output should now be equal for
filters.colorization.

added a quick unit test to check this scenario.