### PR TITLE
Test support update

### DIFF
--- a/pdal/util/Random.hpp
+++ b/pdal/util/Random.hpp
@@ -39,6 +39,8 @@
 #include <string>
 #include <vector>
 
+#include "pdal_util_export.hpp"
+
 namespace pdal
 {
 namespace Utils
@@ -47,14 +49,14 @@ namespace Utils
 class Random
 {
 public:
-    Random();
-    Random(int32_t seed);
-    Random(const std::vector<int32_t> seed);
-    Random(const std::string& seed);
+    PDAL_DLL Random();
+    PDAL_DLL Random(int32_t seed);
+    PDAL_DLL Random(const std::vector<int32_t> seed);
+    PDAL_DLL Random(const std::string& seed);
 
-    std::mt19937& generator();
+    PDAL_DLL std::mt19937& generator();
 
-    static unsigned int quick();
+    PDAL_DLL static unsigned int quick();
 
 private:
     std::mt19937 m_generator;

--- a/test/unit/SpatialReferenceTest.cpp
+++ b/test/unit/SpatialReferenceTest.cpp
@@ -248,8 +248,7 @@ TEST(SpatialReferenceTest, test_writing_vlr)
         LasReader readerx;
         Options readerOpts;
 
-        readerOpts.add("filename",
-            ::Support::datapath("las/1.2-with-color.las"));
+        readerOpts.add("filename", Support::datapath("las/1.2-with-color.las"));
         readerx.setOptions(readerOpts);
 
         Options writerOpts;

--- a/test/unit/Support.cpp
+++ b/test/unit/Support.cpp
@@ -45,42 +45,46 @@
 #include <pdal/PDALUtils.hpp>
 #include <pdal/Stage.hpp>
 #include <pdal/StageFactory.hpp>
+#include <pdal/util/FileUtils.hpp>
+#include <pdal/util/Random.hpp>
 #include "TestConfig.hpp"
 
-using namespace pdal;
-using namespace std;
+namespace pdal
+{
+namespace Support
+{
 
-string Support::datapath()
+std::string datapath()
 {
     return TestConfig::dataPath();
 }
 
-std::string Support::datapath(const std::string& file)
+std::string datapath(const std::string& file)
 {
     return datapath() + file;
 }
 
-string Support::configuredpath()
+std::string configuredpath()
 {
     return TestConfig::configuredPath();
 }
 
-std::string Support::configuredpath(const std::string& file)
+std::string configuredpath(const std::string& file)
 {
     return configuredpath() + file;
 }
 
-std::string Support::temppath()
+std::string temppath()
 {
     return TestConfig::dataPath() + "../temp/";
 }
 
-std::string Support::temppath(const std::string& file)
+std::string temppath(const std::string& file)
 {
     return temppath() + file;
 }
 
-std::string Support::binpath()
+std::string binpath()
 {
     std::string binpath = TestConfig::binaryPath();
 
@@ -91,12 +95,12 @@ std::string Support::binpath()
 #endif
 }
 
-std::string Support::binpath(const std::string& file)
+std::string binpath(const std::string& file)
 {
     return binpath() + file;
 }
 
-std::string Support::exename(const std::string& name)
+std::string exename(const std::string& name)
 {
 #ifdef _WIN32
     return name + ".exe";
@@ -107,24 +111,22 @@ std::string Support::exename(const std::string& name)
 
 
 // do a comparison by line of two (text) files, ignoring CRLF differences
-uint32_t Support::diff_text_files(const std::string& file1,
-    const std::string& file2, int32_t ignoreLine1)
+uint32_t diff_text_files(const std::string& file1, const std::string& file2, int32_t ignoreLine1)
 {
-    if (!pdal::Utils::fileExists(file1) || !pdal::Utils::fileExists(file2))
+    if (!Utils::fileExists(file1) || !Utils::fileExists(file2))
         return (std::numeric_limits<uint32_t>::max)();
 
-    std::istream* str1 = pdal::Utils::openFile(file1, false);
-    std::istream* str2 = pdal::Utils::openFile(file2, false);
+    std::istream* str1 = Utils::openFile(file1, false);
+    std::istream* str2 = Utils::openFile(file2, false);
 
     int32_t diffs = diff_text_files(*str1, *str2, ignoreLine1);
 
-    pdal::Utils::closeFile(str1);
-    pdal::Utils::closeFile(str2);
+    Utils::closeFile(str1);
+    Utils::closeFile(str2);
     return diffs;
 }
 
-uint32_t Support::diff_text_files(std::istream& str1, std::istream& str2,
-    int32_t ignoreLine1)
+uint32_t diff_text_files(std::istream& str1, std::istream& str2, int32_t ignoreLine1)
 {
     uint32_t numdiffs = 0;
     int32_t currLine = 1;
@@ -181,8 +183,7 @@ uint32_t Support::diff_text_files(std::istream& str1, std::istream& str2,
 }
 
 
-uint32_t Support::diff_files(const std::string& file1,
-    const std::string& file2, uint32_t ignorable_start,
+uint32_t diff_files(const std::string& file1, const std::string& file2, uint32_t ignorable_start,
     uint32_t ignorable_length)
 {
     uint32_t start[] = { ignorable_start };
@@ -192,28 +193,25 @@ uint32_t Support::diff_files(const std::string& file1,
 
 
 // do a byte-wise comparison of two (binary) files
-uint32_t Support::diff_files(const std::string& file1,
-    const std::string& file2, uint32_t* ignorable_start,
+uint32_t diff_files(const std::string& file1, const std::string& file2, uint32_t* ignorable_start,
     uint32_t* ignorable_length, uint32_t num_ignorables)
 {
-    if (!pdal::Utils::fileExists(file1) || !pdal::Utils::fileExists(file2))
+    if (!Utils::fileExists(file1) || !Utils::fileExists(file2))
         return (std::numeric_limits<uint32_t>::max)();
 
-    std::istream* str1 = pdal::Utils::openFile(file1);
-    std::istream* str2 = pdal::Utils::openFile(file2);
+    std::istream* str1 = Utils::openFile(file1);
+    std::istream* str2 = Utils::openFile(file2);
 
-    uint32_t ret = diff_files(*str1, *str2, ignorable_start, ignorable_length,
-        num_ignorables);
+    uint32_t ret = diff_files(*str1, *str2, ignorable_start, ignorable_length, num_ignorables);
 
-    pdal::Utils::closeFile(str1);
-    pdal::Utils::closeFile(str2);
+    Utils::closeFile(str1);
+    Utils::closeFile(str2);
     return ret;
 }
 
 
-uint32_t Support::diff_files(std::istream& str1, std::istream& str2,
-    uint32_t* ignorable_start, uint32_t* ignorable_length,
-    uint32_t num_ignorables)
+uint32_t diff_files(std::istream& str1, std::istream& str2, uint32_t* ignorable_start,
+    uint32_t* ignorable_length, uint32_t num_ignorables)
 {
     uint32_t numdiffs = 0;
     char p, q;
@@ -257,35 +255,32 @@ uint32_t Support::diff_files(std::istream& str1, std::istream& str2,
 }
 
 
-uint32_t Support::diff_files(const std::string& file1,
-    const std::string& file2)
+uint32_t diff_files(const std::string& file1, const std::string& file2)
 {
     return diff_files(file1, file2, NULL, NULL, 0);
 }
 
-uint32_t Support::diff_files(std::istream& str1, std::istream& str2)
+uint32_t diff_files(std::istream& str1, std::istream& str2)
 {
     return diff_files(str1, str2, NULL, NULL, 0);
 }
 
-bool Support::compare_files(const std::string& file1, const std::string& file2)
+bool compare_files(const std::string& file1, const std::string& file2)
 {
     return diff_files(file1, file2) == 0;
 }
 
-bool Support::compare_text_files(const std::string& file1,
-    const std::string& file2)
+bool compare_text_files(const std::string& file1, const std::string& file2)
 {
     return diff_text_files(file1, file2) == 0;
 }
 
-bool Support::compare_text_files(std::istream& str1, std::istream& str2)
+bool compare_text_files(std::istream& str1, std::istream& str2)
 {
     return diff_text_files(str1, str2) == 0;
 }
 
-
-void Support::checkXYZ(const std::string& file1, const std::string& file2)
+void checkXYZ(const std::string& file1, const std::string& file2)
 {
     StageFactory f;
 
@@ -334,8 +329,7 @@ void Support::checkXYZ(const std::string& file1, const std::string& file2)
 }
 
 
-void Support::check_pN(const pdal::PointView& data, PointId index,
-    double xref, double yref, double zref)
+void check_pN(const PointView& data, PointId index, double xref, double yref, double zref)
 {
     float x0 = data.getFieldAs<float>(Dimension::Id::X, index);
     float y0 = data.getFieldAs<float>(Dimension::Id::Y, index);
@@ -347,9 +341,8 @@ void Support::check_pN(const pdal::PointView& data, PointId index,
 }
 
 
-void Support::check_pN(const PointView& data, PointId index,
-    double xref, double yref, double zref, double tref,
-    uint16_t rref, uint16_t gref, uint16_t bref)
+void check_pN(const PointView& data, PointId index, double xref, double yref, double zref,
+    double tref, uint16_t rref, uint16_t gref, uint16_t bref)
 {
     check_pN(data, index, xref, yref, zref);
 
@@ -371,39 +364,22 @@ void Support::check_pN(const PointView& data, PointId index,
 }
 
 
-void Support::check_p0_p1_p2(const pdal::PointView& data)
+void check_p0_p1_p2(const PointView& data)
 {
-    Support::check_pN(data, 0, 637012.240000, 849028.310000, 431.660000);
-    Support::check_pN(data, 1, 636896.330000, 849087.700000, 446.390000);
-    Support::check_pN(data, 2, 636784.740000, 849106.660000, 426.710000);
+    check_pN(data, 0, 637012.240000, 849028.310000, 431.660000);
+    check_pN(data, 1, 636896.330000, 849087.700000, 446.390000);
+    check_pN(data, 2, 636784.740000, 849106.660000, 426.710000);
 }
 
 
-void Support::check_p100_p101_p102(const pdal::PointView& data)
+void check_p100_p101_p102(const PointView& data)
 {
-    Support::check_pN(data, 0, 636661.060000, 849854.130000, 424.900000);
-    Support::check_pN(data, 1, 636568.180000, 850179.490000, 441.800000);
-    Support::check_pN(data, 2, 636554.630000, 850040.030000, 499.110000);
+    check_pN(data, 0, 636661.060000, 849854.130000, 424.900000);
+    check_pN(data, 1, 636568.180000, 850179.490000, 441.800000);
+    check_pN(data, 2, 636554.630000, 850040.030000, 499.110000);
 }
 
-
-void Support::check_p355_p356_p357(const pdal::PointView& data)
-{
-    Support::check_pN(data, 0, 636462.600000, 850566.110000, 432.610000);
-    Support::check_pN(data, 1, 636356.140000, 850530.480000, 432.680000);
-    Support::check_pN(data, 2, 636227.530000, 850592.060000, 428.670000);
-}
-
-
-void Support::check_p710_p711_p712(const pdal::PointView& data)
-{
-    Support::check_pN(data, 0, 638720.670000, 850926.640000, 417.320000);
-    Support::check_pN(data, 1, 638672.380000, 851081.660000, 420.670000);
-    Support::check_pN(data, 2, 638598.880000, 851445.370000, 422.150000);
-}
-
-
-void Support::compareBounds(const BOX3D& p, const BOX3D& q)
+void compareBounds(const BOX3D& p, const BOX3D& q)
 {
     EXPECT_DOUBLE_EQ(p.minx, q.minx);
     EXPECT_DOUBLE_EQ(p.miny, q.miny);
@@ -413,3 +389,32 @@ void Support::compareBounds(const BOX3D& p, const BOX3D& q)
     EXPECT_DOUBLE_EQ(p.maxz, q.maxz);
 }
 
+// This provides no guarantees but is highly likely to work, and it's just for test purposes.
+Tempfile::Tempfile()
+{
+    Utils::Random r;
+    m_name = temppath() + "tmp";
+    for (size_t i = 0; i < 20; ++i)
+    {
+        uint8_t v = std::uniform_int_distribution<uint8_t>(0, 61)(r.generator());
+        if (v < 10)
+            m_name += ('0' + v);
+        else if (v < 36)
+            m_name += ('a' + v - 10);
+        else
+            m_name += ('A' + v - 36);
+    }
+}
+
+Tempfile::~Tempfile()
+{
+    FileUtils::deleteFile(m_name);
+}
+
+std::string Tempfile::filename()
+{
+    return m_name;
+}
+
+} // namespace Support
+} // namespace pdal

--- a/test/unit/Support.cpp
+++ b/test/unit/Support.cpp
@@ -396,7 +396,8 @@ Tempfile::Tempfile()
     m_name = temppath() + "tmp";
     for (size_t i = 0; i < 20; ++i)
     {
-        uint8_t v = std::uniform_int_distribution<uint8_t>(0, 61)(r.generator());
+        // 10 numbers + 26 lowercase + 26 uppercase = 62 values.
+        uint8_t v = (uint8_t)std::uniform_int_distribution<>(0, 61)(r.generator());
         if (v < 10)
             m_name += ('0' + v);
         else if (v < 36)

--- a/test/unit/Support.hpp
+++ b/test/unit/Support.hpp
@@ -37,110 +37,105 @@
 // support functions for unit testing
 
 #include <pdal/pdal_types.hpp>
+#include <string>
 
 namespace pdal
 {
     class PointView;
     class Stage;
     class BOX3D;
-}
 
-#include <string>
+namespace Support
+{
+// this is where the reference files (input data) live
+std::string datapath();
 
-class Support
+// returns "datapath + / + file"
+std::string datapath(const std::string& file);
+
+// this is where the reference files (input data) live
+std::string configuredpath();
+
+// returns "configuredpath + / + file"
+std::string configuredpath(const std::string& file);
+
+// this is where the temporary output files go
+std::string temppath();
+
+// returns "temppath + / + file"
+std::string temppath(const std::string& file);
+
+// this is where the pdal executables live
+std::string binpath();
+
+// return "bindir + / + file"
+std::string binpath(const std::string& file);
+
+// returns "name" on unix and "name + .exe" on windows
+std::string exename(const std::string& name);
+
+// returns number of bytes different for two binary files (or maxint
+// if a file doesn't exist)
+uint32_t diff_files(const std::string& file1, const std::string& file2);
+uint32_t diff_files(std::istream& str1, std::istream& str2);
+
+// same as diff_files, but allows for a region of the file be to be ignored
+// (region is specified with a starting offset and a length)
+uint32_t diff_files(const std::string& file1, const std::string& file2, uint32_t ignorable_start,
+    uint32_t ignorable_length);
+
+// same as above diff_files with ignorable region, but for multiple regions
+uint32_t diff_files(const std::string& file1, const std::string& file2, uint32_t* ignorable_start,
+    uint32_t* ignorable_length, uint32_t num_ignorables);
+
+// same as above diff_files with ignorable region, but for multiple regions
+uint32_t diff_files(std::istream& str1, std::istream& str2, uint32_t* ignorable_start,
+    uint32_t* ignorable_length, uint32_t num_ignorables);
+
+// returns number of lines different for two text files (or maxint
+// if a file doesn't exist) if ignoreLine is not -1, that line will
+// be "ignored" when comparing the two files
+uint32_t diff_text_files(const std::string& file1, const std::string& file2,
+    int32_t ignoreLine1=-1);
+uint32_t diff_text_files(std::istream& str1, std::istream& str2, int32_t ignoreLine1=-1);
+
+// returns true iff the two (binary or ascii) files are the same,
+// using the above diff_files/diff_text_files functions
+bool compare_files(const std::string& file1, const std::string& file2);
+bool compare_text_files(const std::string& file1, const std::string& file2);
+bool compare_text_files(std::istream& str1, std::istream& str2);
+
+void checkXYZ(const std::string& file1, const std::string& file2);
+
+// validate a point's XYZ values
+void check_pN(const pdal::PointView& data, pdal::PointId index,
+    double xref, double yref, double zref);
+
+// validate a point's XYZ, Time, and Color values
+void check_pN(const pdal::PointView& data,
+    PointId index, double xref, double yref, double zref,
+    double tref, uint16_t rref, uint16_t gref, uint16_t bref);
+
+// these are for the 1.2-with-color image
+void check_p0_p1_p2(const pdal::PointView& data);
+void check_p100_p101_p102(const pdal::PointView& data);
+
+void compareBounds(const pdal::BOX3D& p, const pdal::BOX3D& q);
+
+// This provides a reasonable temp filename. The file will be deleted (if it exists) when
+// the instance goes out of scope.
+class Tempfile
 {
 public:
-    // this is where the reference files (input data) live
-    static std::string datapath();
+    Tempfile();
+    ~Tempfile();
 
-    // returns "datapath + / + file"
-    static std::string datapath(const std::string& file);
+    std::string filename();
 
-    // this is where the reference files (input data) live
-    static std::string configuredpath();
-
-    // returns "configuredpath + / + file"
-    static std::string configuredpath(const std::string& file);
-
-
-    // this is where the temporary output files go
-    static std::string temppath();
-
-    // returns "temppath + / + file"
-    static std::string temppath(const std::string& file);
-
-    // this is where the pdal executables live
-    static std::string binpath();
-
-    // return "bindir + / + file"
-    static std::string binpath(const std::string& file);
-
-    // returns "name" on unix and "name + .exe" on windows
-    static std::string exename(const std::string& name);
-
-    // returns number of bytes different for two binary files (or maxint
-    // if a file doesn't exist)
-    static uint32_t diff_files(const std::string& file1,
-       const std::string& file2);
-    static uint32_t diff_files(std::istream& str1, std::istream& str2);
-
-    // same as diff_files, but allows for a region of the file be to be ignored
-    // (region is specified with a starting offset and a length)
-    static uint32_t diff_files(const std::string& file1,
-        const std::string& file2, uint32_t ignorable_start,
-        uint32_t ignorable_length);
-
-    // same as above diff_files with ignorable region, but for multiple regions
-    static uint32_t diff_files(const std::string& file1,
-        const std::string& file2, uint32_t* ignorable_start,
-        uint32_t* ignorable_length, uint32_t num_ignorables);
-
-    // same as above diff_files with ignorable region, but for multiple regions
-    static uint32_t diff_files(std::istream& str1, std::istream& str2,
-        uint32_t* ignorable_start, uint32_t* ignorable_length,
-        uint32_t num_ignorables);
-
-    // returns number of lines different for two text files (or maxint
-    // if a file doesn't exist) if ignoreLine is not -1, that line will
-    // be "ignored" when comparing the two files
-    static uint32_t diff_text_files(const std::string& file1,
-        const std::string& file2, int32_t ignoreLine1=-1);
-    static uint32_t diff_text_files(std::istream& str1, std::istream& str2,
-        int32_t ignoreLine1=-1);
-
-    // returns true iff the two (binary or ascii) files are the same,
-    // using the above diff_files/diff_text_files functions
-
-    static bool compare_files(const std::string& file1,
-        const std::string& file2);
-    static bool compare_text_files(const std::string& file1,
-        const std::string& file2);
-    static bool compare_text_files(std::istream& str1, std::istream& str2);
-
-    static void checkXYZ(const std::string& file1, const std::string& file2);
-
-    // validate a point's XYZ values
-    static void check_pN(const pdal::PointView& data,
-                         pdal::PointId index,
-                         double xref, double yref, double zref);
-
-    // validate a point's XYZ, Time, and Color values
-    static void check_pN(const pdal::PointView& data,
-        pdal::PointId index, double xref, double yref, double zref,
-        double tref, uint16_t rref, uint16_t gref, uint16_t bref);
-
-    // these are for the 1.2-with-color image
-    static void check_p0_p1_p2(const pdal::PointView& data);
-    static void check_p100_p101_p102(const pdal::PointView& data);
-    static void check_p355_p356_p357(const pdal::PointView& data);
-    static void check_p710_p711_p712(const pdal::PointView& data);
-
-    static void compareBounds(const pdal::BOX3D& p,
-        const pdal::BOX3D& q);
-
-    // executes "cmd" via popen, copying stdout into output and returning
-    // the status code note: under windows, all "/" characrters in cmd will
-    // be converted to "\\" for you
-    // static int run_command(const std::string& cmd, std::string& output);
+private:
+    std::string m_name;
 };
+
+} // namespace Support
+} // namespace pdal
 

--- a/test/unit/apps/AppPluginTest.cpp
+++ b/test/unit/apps/AppPluginTest.cpp
@@ -37,6 +37,9 @@
 
 #include "Support.hpp"
 
+namespace pdal
+{
+
 namespace
 {
 std::string appName()
@@ -44,9 +47,6 @@ std::string appName()
     return Support::binpath("pdal");
 }
 } // unnamed namespace
-
-namespace pdal
-{
 
 // The Cmake file makes sure we're building the hexbin plugin.
 TEST(PdalAppPlugin, load)

--- a/test/unit/apps/AppTest.cpp
+++ b/test/unit/apps/AppTest.cpp
@@ -37,6 +37,9 @@
 
 #include "Support.hpp"
 
+namespace pdal
+{
+
 namespace
 {
 std::string appName()
@@ -44,9 +47,6 @@ std::string appName()
     return Support::binpath("pdal");
 }
 } // unnamed namespace
-
-namespace pdal
-{
 
 TEST(PdalApp, load)
 {

--- a/test/unit/apps/pcpipelineTestJSON.cpp
+++ b/test/unit/apps/pcpipelineTestJSON.cpp
@@ -46,6 +46,9 @@
 #include <sstream>
 #include <string>
 
+namespace pdal
+{
+
 namespace
 {
 
@@ -106,9 +109,6 @@ void run_pipeline_stdin(std::string const& pipelineFile)
 }
 
 } // unnamed namespace
-
-namespace pdal
-{
 
 TEST(pipelineBaseTest, no_input)
 {


### PR DESCRIPTION
The only change of note is the addition of Support::Tempfile. It will generate a temp filename. You still have to open the file yourself. When the Tempfile object goes out of scope, an attempt to delete the file will be made.

This will allow us to eliminate a bunch of made-up tempfile names that limit our ability to run multiple test jobs at once.