### PR TITLE
Forward query/headers properly during HEAD requests

### DIFF
--- a/vendor/arbiter/arbiter.hpp
+++ b/vendor/arbiter/arbiter.hpp
@@ -4059,6 +4059,18 @@ public:
             http::Headers headers = http::Headers(),
             http::Query query = http::Query()) const;
 
+    /* Perform an HTTP HEAD request. */
+    std::size_t getSize(
+            std::string path,
+            http::Headers headers,
+            http::Query query = http::Query()) const;
+
+    /* Perform an HTTP HEAD request. */
+    std::unique_ptr<std::size_t> tryGetSize(
+            std::string path,
+            http::Headers headers,
+            http::Query query = http::Query()) const;
+
     /** Perform an HTTP GET request. */
     std::vector<char> getBinary(
             std::string path,
@@ -5045,6 +5057,22 @@ public:
             std::string path,
             http::Headers headers,
             http::Query query = http::Query()) const;
+
+    /** Passthrough to
+     * drivers::Http::getSize(std::string, http::Headers, http::Query) const.
+     */
+    std::size_t getSize(
+            std::string subpath,
+            http::Headers headers,
+            http::Query = http::Query()) const;
+
+    /** Passthrough to
+     * drivers::Http::tryGetSize(std::string, http::Headers, http::Query) const.
+     */
+    std::unique_ptr<std::size_t> tryGetSize(
+            std::string subpath,
+            http::Headers headers,
+            http::Query = http::Query()) const;
 
     /** Passthrough to
      * drivers::Http::put(std::string, const std::string&, http::Headers, http::Query) const.


### PR DESCRIPTION
For HTTP based drivers, in one spot query/header parameters were not forwarded to the endpoint.

Also fixes this warning:
```
../vendor/arbiter/arbiter.cpp:1287:14: note: use reference type 'const std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> &' to prevent copying
        for (const auto d : walk(pre)) dirs.push_back(d + post);
             ^~~~~~~~~~~~~~
                        &
```