### PR TITLE
Generalize filters.transformation to all homographies.

### DIFF
--- a/doc/stages/filters.transformation.rst
+++ b/doc/stages/filters.transformation.rst
@@ -3,11 +3,8 @@
 filters.transformation
 ======================
 
-The transformation filter applies an arbitrary rotation+translation
+The transformation filter applies an arbitrary homography
 transformation, represented as a 4x4 matrix_, to each xyz triplet.
-
-The filter does *no* checking to ensure the matrix is a valid affine
-transformation.
 
 .. note::
 
@@ -59,10 +56,11 @@ A full tutorial about transformation matrices is beyond the scope of this
 documentation. Instead, we will provide a few pointers to introduce core
 concepts, especially as pertains to PDAL's handling of the ``matrix`` argument.
 
-Transformations in a 3-dimensional coordinate system can be represented as an
-affine transformation using homogeneous coordinates. This 4x4 matrix can
-represent transformations describing operations like translation, rotation, and
-scaling of coordinates.
+Transformations in a 3-dimensional coordinate system can be represented
+as a homography transformation using homogeneous coordinates. This 4x4
+matrix can represent affine transformations describing operations like
+translation, rotation, and scaling of coordinates.  In addition it can
+represent perspective transformations modeling a pinhole camera.
 
 The transformation filter's ``matrix`` argument is a space delimited, 16
 element string. This string is simply a row-major representation of the 4x4

--- a/filters/TransformationFilter.cpp
+++ b/filters/TransformationFilter.cpp
@@ -190,15 +190,16 @@ bool TransformationFilter::processOne(PointRef& point)
     double x = point.getFieldAs<double>(Dimension::Id::X);
     double y = point.getFieldAs<double>(Dimension::Id::Y);
     double z = point.getFieldAs<double>(Dimension::Id::Z);
+    double s = x * matrix[12] + y * matrix[13] + z * matrix[14] + matrix[15];
 
     point.setField(Dimension::Id::X,
-        x * matrix[0] + y * matrix[1] + z * matrix[2] + matrix[3]);
+       (x * matrix[0] + y * matrix[1] + z * matrix[2] + matrix[3]) / s);
 
     point.setField(Dimension::Id::Y,
-        x * matrix[4] + y * matrix[5] + z * matrix[6] + matrix[7]);
+       (x * matrix[4] + y * matrix[5] + z * matrix[6] + matrix[7]) / s);
 
     point.setField(Dimension::Id::Z,
-        x * matrix[8] + y * matrix[9] + z * matrix[10] + matrix[11]);
+       (x * matrix[8] + y * matrix[9] + z * matrix[10] + matrix[11]) / s);
     return true;
 }
 


### PR DESCRIPTION
Include the normalizing step in filters.transformation to allow general
homographies and update the documentation.  All the examples in the
documentation are unaffected (since the last row of the matrix is
[0,0,0,1]).  Homographies allow (painfully!), perspective images of a
point cloud to be created by following the transformation filter by
writers.gdal.  This setup is not ideal, because the effective camera
matrix isn't stored with the the output image.