### PR TITLE
ICP Tune-Up and Scale Option

### DIFF
--- a/doc/stages/filters.icp.rst
+++ b/doc/stages/filters.icp.rst
@@ -120,21 +120,23 @@ max_iter
 max_similar
   Maximum number of similar transforms to consider converged. [Default: **0**]
 
-max_dist
-  Maximum distance between closest points to be included. [Default: no maximum]
-
-init
-  Initial transformation matrix guess. A whitespace-delimited matrix presented in row-major order. Only matrices with sixteen elements are allowed. [Default: no guess]
-
 mse_abs
-  Absolute change in MSE threshold. [Default: **1e-12**]
+  Absolute change in MSE convergence threshold. [Default: **1e-12**]
 
 rt
-  Rotation threshold. [Default: **0.99999**]
+  Rotation convergence threshold. [Default: **0.99999**]
 
 tt
-  Translation threshold. [Default: **9e-8**]
+  Translation convergence threshold. [Default: **9e-8**]
 
+max_dist
+  Maximum distance between closest points to be included in the transformation solution. [Default: no maximum]
+
+init
+  Initial transformation matrix guess. A whitespace-delimited matrix presented in row-major order. Only matrices with sixteen elements are allowed. [Default: no initial transformation matrix]
+
+scale
+  Include a scale factor in the transformation solution. [Default: `false`]
 
 
 .. include:: filter_opts.rst

--- a/doc/stages/filters.icp.rst
+++ b/doc/stages/filters.icp.rst
@@ -118,16 +118,24 @@ max_iter
   Maximum number of iterations. [Default: **100**]
 
 max_similar
-  Max number of similar transforms to consider converged. [Default: **0**]
+  Maximum number of similar transforms to consider converged. [Default: **0**]
+
+max_dist
+  Maximum distance between closest points to be included. [Default: no maximum]
+
+init
+  Initial transformation matrix guess. A whitespace-delimited matrix presented in row-major order. Only matrices with sixteen elements are allowed. [Default: no guess]
 
 mse_abs
-  Absolute threshold for MSE. [Default: **1e-12**]
+  Absolute change in MSE threshold. [Default: **1e-12**]
 
 rt
   Rotation threshold. [Default: **0.99999**]
 
 tt
   Translation threshold. [Default: **9e-8**]
+
+
 
 .. include:: filter_opts.rst
 

--- a/filters/IterativeClosestPoint.cpp
+++ b/filters/IterativeClosestPoint.cpp
@@ -208,7 +208,7 @@ PointViewPtr IterativeClosestPoint::icp(PointViewPtr fixed,
                                      << "dy: " << T.coeff(1, 3) << std::endl;
 
         // Update the final_transformation and log the X and Y translations.
-        final_transformation = final_transformation * T;
+        final_transformation = T * final_transformation;
         log()->get(LogLevel::Debug2)
             << "Cumulative dx: " << final_transformation.coeff(0, 3) << ", "
             << "dy: " << final_transformation.coeff(1, 3) << std::endl;

--- a/filters/IterativeClosestPoint.cpp
+++ b/filters/IterativeClosestPoint.cpp
@@ -131,7 +131,8 @@ PointViewPtr IterativeClosestPoint::icp(PointViewPtr fixed,
     // Apply initial guess to moving PointView
     if (m_matrixArg->set())
     {
-        Matrix4d initial_transformation = Eigen::Map<const Matrix4d>(m_vec.data());
+        Matrix4d initial_transformation =
+            Eigen::Map<const Matrix4d>(m_vec.data());
         math::transformInPlace(*moving, initial_transformation.data());
     }
 
@@ -236,7 +237,8 @@ PointViewPtr IterativeClosestPoint::icp(PointViewPtr fixed,
             if (num_similar >= m_max_similar)
             {
                 converged = true;
-                log()->get(LogLevel::Debug2) << "converged via absolute change in MSE\n";
+                log()->get(LogLevel::Debug2)
+                    << "converged via absolute change in MSE\n";
                 break;
             }
             is_similar = true;
@@ -272,17 +274,17 @@ PointViewPtr IterativeClosestPoint::icp(PointViewPtr fixed,
         double y = p.getFieldAs<double>(Id::Y) - centroid.y();
         double z = p.getFieldAs<double>(Id::Z) - centroid.z();
         p.setField(Id::X, x * final_transformation.coeff(0, 0) +
-                              y * final_transformation.coeff(0, 1) +
-                              z * final_transformation.coeff(0, 2) +
-                              final_transformation.coeff(0, 3) + centroid.x());
+                          y * final_transformation.coeff(0, 1) +
+                          z * final_transformation.coeff(0, 2) +
+                          final_transformation.coeff(0, 3) + centroid.x());
         p.setField(Id::Y, x * final_transformation.coeff(1, 0) +
-                              y * final_transformation.coeff(1, 1) +
-                              z * final_transformation.coeff(1, 2) +
-                              final_transformation.coeff(1, 3) + centroid.y());
+                          y * final_transformation.coeff(1, 1) +
+                          z * final_transformation.coeff(1, 2) +
+                          final_transformation.coeff(1, 3) + centroid.y());
         p.setField(Id::Z, x * final_transformation.coeff(2, 0) +
-                              y * final_transformation.coeff(2, 1) +
-                              z * final_transformation.coeff(2, 2) +
-                              final_transformation.coeff(2, 3) + centroid.z());
+                          y * final_transformation.coeff(2, 1) +
+                          z * final_transformation.coeff(2, 2) +
+                          final_transformation.coeff(2, 3) + centroid.z());
     }
 
     // Compute the MSE one last time, using the unaltered, fixed PointView and
@@ -320,12 +322,14 @@ PointViewPtr IterativeClosestPoint::icp(PointViewPtr fixed,
     Matrix4d composed_transformation =
         posttrans * final_transformation * pretrans;
 
-    // Update the composed_transformation if an initial transformation was 
+    // Update the composed_transformation if an initial transformation was
     // supplied.
     if (m_matrixArg->set())
     {
-        Matrix4d initial_transformation = Eigen::Map<const Matrix4d>(m_vec.data());
-        composed_transformation = composed_transformation * initial_transformation;
+        Matrix4d initial_transformation =
+            Eigen::Map<const Matrix4d>(m_vec.data());
+        composed_transformation =
+            composed_transformation * initial_transformation;
     }
 
     // Populate metadata nodes to capture the final transformation, convergence

--- a/filters/IterativeClosestPoint.hpp
+++ b/filters/IterativeClosestPoint.hpp
@@ -53,6 +53,7 @@ private:
     double m_rotation_threshold;
     double m_translation_threshold;
     double m_mse_abs;
+    bool m_scale;
     Arg *m_maxdistArg;
     double m_maxdist;
     Arg *m_matrixArg;


### PR DESCRIPTION
Tune-Up:
- Moved the application of the initial transformation guess to before the "fixed" and "moving" clouds are demeaned by the "fixed" cloud centroid. This means the initial guess is now relative to the coordinate origin of the "moving" cloud, not to the "fixed" cloud centroid (as it was before). Open for debate on this. I can see how making an initial guess relative to the centroid location of the "fixed" cloud is intuitive if the "fixed" and "moving" clouds cover the same area (one is not much larger/smaller than the other in terms of areal extent and they are not significantly displaced). But if this is not the case, or if a user has a rough transformation matrix from a prior coarse registration (I stumbled over this issue for this use case), then I think it makes more sense for the initial guess to be a "true" transformation in terms of the coordinate values of the "moving" cloud.
- The MSE (mean square error) computation was an average distance error, rather than an average squared distance error. I updated the MSE computations to be an average squared distance error.
- Corrected the matrix multiplication order when updating the transformation between iterations.

Scale Option:
- Added an option to include a single scale factor (same scale factor applied in all three dimensions) in the solved transformation.