### PR TITLE
Update filters.optimalneighborhood.rst

### DIFF
--- a/doc/stages/filters.optimalneighborhood.rst
+++ b/doc/stages/filters.optimalneighborhood.rst
@@ -44,4 +44,4 @@ min_k
 
 max_k
   The maximum number of k nearest neighbors to consider for optimal
-  neighborhood selection. [Default: 100]
+  neighborhood selection. [Default: 14]


### PR DESCRIPTION
Per
https://github.com/PDAL/PDAL/blob/72fad99ad3f4e019648174d74899c13ccb23f434/filters/OptimalNeighborhoodFilter.cpp#L64
the default `max_k` should be 14.