### PR TITLE
Fix include path

### DIFF
--- a/filters/ColorinterpFilter.hpp
+++ b/filters/ColorinterpFilter.hpp
@@ -36,7 +36,7 @@
 
 #include <pdal/Filter.hpp>
 #include <pdal/Streamable.hpp>
-#include <filters/StatsFilter.hpp>
+#include <pdal/filters/StatsFilter.hpp>
 
 #include <map>
 


### PR DESCRIPTION
While using PDAL as a library and including `pdal/filters/ColorinterpFilter.hpp` I get:

```
/usr/local/include/pdal/filters/ColorinterpFilter.hpp:39: error: filters/StatsFilter.hpp: No such file or directory
In file included from /home/piero/Documents/ddb/src/epttiler.cpp:14:
/usr/local/include/pdal/filters/ColorinterpFilter.hpp:39:10: fatal error: filters/StatsFilter.hpp: No such file or directory
   39 | #include <filters/StatsFilter.hpp>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~
```

It should be safe to explicitly set the `pdal` directory in the include directive here.