### PR TITLE
Specify hilbert domain and optimize compression choices

### DIFF
--- a/doc/stages/writers.tiledb.rst
+++ b/doc/stages/writers.tiledb.rst
@@ -20,6 +20,9 @@ Example
           "array_name":"input.las"
       },
       {
+          "type":"filters.stats"
+      },
+      {
           "type":"writers.tiledb",
           "array_name":"output_array"
       }
@@ -39,13 +42,31 @@ tile_data_capacity
   Number of points per tile [Optional]
 
 x_tile_size
-  Tile size (x) in a Cartesian projection [Optional]
+  Tile size (x) [Optional]
 
 y_tile_size
-  Tile size (y) in a Cartesian projection [Optional]
+  Tile size (y) [Optional]
 
 z_tile_size
-  Tile size (z) in a Cartesian projection [Optional]
+  Tile size (z) [Optional]
+
+x_domain_st
+  Domain minimum in x [Optional]
+
+x_domain_end
+  Domain maximum in x [Optional]
+
+y_domain_st
+  Domain minimum in y [Optional]
+
+y_domain_end
+  Domain maximum in y [Optional]
+
+z_domain_st
+  Domain minimum in z [Optional]
+
+z_domain_end
+  Domain maximum in z [Optional]
 
 chunk_size
   Point cache size for chunked writes [Optional]
@@ -73,24 +94,22 @@ By default TileDB will use the following set of compression filters for coordina
 
   {
       "coords":[
-          {"compression": "bit-shuffle"},
-          {"compression": "gzip", "compression_level": 9}
+        {"compression": "zstd", "compression_level": 7}
       ],
       "Intensity":{"compression": "bzip2", "compression_level": 5},
-      "ReturnNumber": {"compression": "zstd", "compression_level": 75},
-      "NumberOfReturns": {"compression": "zstd", "compression_level": 75},
+      "ReturnNumber": {"compression": "zstd", "compression_level": 7},
+      "NumberOfReturns": {"compression": "zstd", "compression_level": 7},
       "ScanDirectionFlag": {"compression": "bzip2", "compression_level": 5},
       "EdgeOfFlightLine": {"compression": "bzip2", "compression_level": 5},
       "Classification": {"compression": "gzip", "compression_level": 9},
       "ScanAngleRank": {"compression": "bzip2", "compression_level": 5},
       "UserData": {"compression": "gzip", "compression_level": 9},
       "PointSourceId": {"compression": "bzip2"},
-      "Red": {"compression": "rle"},
-      "Green": {"compression": "rle"},
-      "Blue": {"compression": "rle"},
-      "GpsTime": [
-          {"compression": "bit-shuffle"},
-          {"compression": "zstd", "compression_level": 75}
+      "Red": {"compression": "zstd", "compression_level": 7},
+      "Green": {{"compression": "zstd", "compression_level": 7},
+      "Blue": {{"compression": "zstd", "compression_level": 7},
+      "GpsTime": [  
+        {"compression": "zstd", "compression_level": 7}
       ]
   }
 

--- a/plugins/tiledb/io/TileDBWriter.cpp
+++ b/plugins/tiledb/io/TileDBWriter.cpp
@@ -372,9 +372,7 @@ void TileDBWriter::ready(pdal::BasePointTable &table)
              (m_args->m_y_tile_size > 0) &&
              (m_args->m_z_tile_size > 0) )
         {
-            if ( ((m_args->m_x_domain_end  - m_args->m_x_domain_st ) > 0) &&
-                 ((m_args->m_y_domain_end  - m_args->m_y_domain_st ) > 0) &&
-                 ((m_args->m_z_domain_end  - m_args->m_z_domain_st ) > 0) )
+            if (isValidDomain(*m_args))
             {
                 domain.add_dimension(tiledb::Dimension::create<double>(*m_ctx, "X",
                     {{m_args->m_x_domain_st, m_args->m_x_domain_end}}, m_args->m_x_tile_size))
@@ -413,9 +411,7 @@ void TileDBWriter::ready(pdal::BasePointTable &table)
     #if ((TILEDB_VERSION_MINOR > 1) || (TILEDB_VERSION_MAJOR > 2))
         else
         {
-            if ( ((m_args->m_x_domain_end  - m_args->m_x_domain_st ) > 0) &&
-                 ((m_args->m_y_domain_end  - m_args->m_y_domain_st ) > 0) &&
-                 ((m_args->m_z_domain_end  - m_args->m_z_domain_st ) > 0) )
+            if (isValidDomain(*m_args))
             {
                 domain.add_dimension(tiledb::Dimension::create<double>(*m_ctx, "X",
                     {{m_args->m_x_domain_st, m_args->m_x_domain_end}}))
@@ -600,6 +596,14 @@ void TileDBWriter::done(PointTableRef table)
     else{
         throwError("Unable to flush points to TileDB array");
     }
+}
+
+
+bool TileDBWriter::isValidDomain(TileDBWriter::Args& args)
+{
+    return ((( args.m_x_domain_end  - args.m_x_domain_st ) > 0) &&
+            (( args.m_y_domain_end  - args.m_y_domain_st ) > 0) &&
+            (( args.m_z_domain_end  - args.m_z_domain_st ) > 0));
 }
 
 

--- a/plugins/tiledb/io/TileDBWriter.hpp
+++ b/plugins/tiledb/io/TileDBWriter.hpp
@@ -73,6 +73,7 @@ private:
     bool flushCache(size_t size);
 
     struct Args;
+    bool isValidDomain(TileDBWriter::Args& args);
     std::unique_ptr<TileDBWriter::Args> m_args;
 
     size_t m_current_idx;

--- a/plugins/tiledb/test/TileDBWriterTest.cpp
+++ b/plugins/tiledb/test/TileDBWriterTest.cpp
@@ -39,6 +39,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include <filters/StatsFilter.hpp>
 #include <pdal/pdal_test_main.hpp>
 #include <io/FauxReader.hpp>
 #include <pdal/StageFactory.hpp>
@@ -48,6 +49,24 @@
 
 namespace pdal
 {
+
+    Options getTileDBOptions()
+    {
+        Options options;
+
+        options.add("x_tile_size", 1);
+        options.add("y_tile_size", 1);
+        options.add("z_tile_size", 1);
+        options.add("x_domain_st", 0.);
+        options.add("x_domain_end", 1.);
+        options.add("y_domain_st", 0.);
+        options.add("y_domain_end", 1.);
+        options.add("z_domain_st", 0.);
+        options.add("z_domain_end", 1.);
+
+        return options;
+    }
+
     size_t count = 100;
     class TileDBWriterTest : public ::testing::Test
     {
@@ -84,13 +103,10 @@ namespace pdal
         tiledb::VFS vfs(ctx);
         std::string pth = Support::temppath("tiledb_test_out");
 
-        Options options;
+        Options options = getTileDBOptions();
         std::string sidecar = pth + "/pdal.json";
         options.add("array_name", pth);
         options.add("chunk_size", 80);
-        options.add("x_tile_size", 1);
-        options.add("y_tile_size", 1);
-        options.add("z_tile_size", 1);
 
         if (vfs.is_dir(pth))
         {
@@ -153,13 +169,10 @@ namespace pdal
         tiledb::VFS vfs(ctx);
         std::string pth = Support::temppath("tiledb_test_append_out");
 
-        Options options;
+        Options options = getTileDBOptions();
         std::string sidecar = pth + "/pdal.json";
         options.add("array_name", pth);
         options.add("chunk_size", 80);
-        options.add("x_tile_size", 1);
-        options.add("y_tile_size", 1);
-        options.add("z_tile_size", 1);
 
         if (vfs.is_dir(pth))
         {
@@ -224,13 +237,10 @@ namespace pdal
         tiledb::VFS vfs(ctx);
         std::string pth = Support::temppath("tiledb_test_compress_simple_out");
 
-        Options options;
+        Options options = getTileDBOptions();
         options.add("array_name", pth);
         options.add("compression", "zstd");
         options.add("compression_level", 7);
-        options.add("x_tile_size", 1);
-        options.add("y_tile_size", 1);
-        options.add("z_tile_size", 1);
 
         if (vfs.is_dir(pth))
         {
@@ -263,7 +273,7 @@ namespace pdal
         tiledb::VFS vfs(ctx);
         std::string pth = Support::temppath("tiledb_test_write_options");
 
-        Options options;
+        Options options = getTileDBOptions();
         NL::json jsonOptions;
 
         // add an array filter
@@ -275,9 +285,6 @@ namespace pdal
 
         options.add("array_name", pth);
         options.add("filters", jsonOptions);
-        options.add("x_tile_size", 1);
-        options.add("y_tile_size", 1);
-        options.add("z_tile_size", 1);
 
         if (vfs.is_dir(pth))
         {
@@ -318,7 +325,7 @@ namespace pdal
         tiledb::VFS vfs(ctx);
         std::string pth = Support::temppath("tiledb_test_write_options");
 
-        Options options;
+        Options options = getTileDBOptions();
         NL::json jsonOptions;
 
         // add an array filter
@@ -331,9 +338,6 @@ namespace pdal
         options.add("compression", "zstd");
         options.add("compression_level", 7);
         options.add("filters", jsonOptions);
-        options.add("x_tile_size", 1);
-        options.add("y_tile_size", 1);
-        options.add("z_tile_size", 1);
 
         if (vfs.is_dir(pth))
         {
@@ -368,11 +372,8 @@ namespace pdal
         tiledb::VFS vfs(ctx);
         std::string pth = Support::temppath("tiledb_test_write_options");
 
-        Options options;
+        Options options = getTileDBOptions();
         options.add("array_name", pth);
-        options.add("x_tile_size", 1);
-        options.add("y_tile_size", 1);
-        options.add("z_tile_size", 1);
 
         if (vfs.is_dir(pth))
         {
@@ -390,15 +391,13 @@ namespace pdal
         tiledb::Array array(ctx, pth, TILEDB_READ);
 
         tiledb::FilterList fl = array.schema().coords_filter_list();
-        EXPECT_EQ(fl.nfilters(), 2U);
+        EXPECT_EQ(fl.nfilters(), 1U);
 
         tiledb::Filter f1 = fl.filter(0);
-        EXPECT_EQ(f1.filter_type(), TILEDB_FILTER_BITSHUFFLE);
-        tiledb::Filter f2 = fl.filter(1);
-        EXPECT_EQ(f2.filter_type(), TILEDB_FILTER_GZIP);
+        EXPECT_EQ(f1.filter_type(), TILEDB_FILTER_ZSTD);
         int32_t compressionLevel;
-        f2.get_option(TILEDB_COMPRESSION_LEVEL, &compressionLevel);
-        EXPECT_EQ(compressionLevel, 9);
+        f1.get_option(TILEDB_COMPRESSION_LEVEL, &compressionLevel);
+        EXPECT_EQ(compressionLevel, 7);
 
         tiledb::Attribute att = array.schema().attributes().begin()->second;
         tiledb::FilterList flAtts = att.filter_list();
@@ -420,7 +419,7 @@ namespace pdal
         tiledb::VFS vfs(ctx);
         std::string pth = Support::temppath("tiledb_test_dups");
 
-        Options writer_options;
+        Options writer_options = getTileDBOptions();
         writer_options.add("array_name", pth);
 
         if (vfs.is_dir(pth))
@@ -491,15 +490,9 @@ namespace pdal
 
         FixedPointTable table(count);
         writer.prepare(table);
-        writer.execute(table);
 
-        EXPECT_EQ(true,
-            tiledb::Object::object(ctx, pth).type() == tiledb::Object::Type::Array);
-
-        tiledb::Array array(ctx, pth, TILEDB_READ);
-        EXPECT_EQ(true,
-            array.schema().cell_order() == TILEDB_HILBERT);
-        array.close();
+        // check that error is thrown if the tile size or domain is not specified
+        EXPECT_THROW(writer.execute(table), pdal_error);
     }
 
     TEST_F(TileDBWriterTest, tile_sizes)
@@ -514,14 +507,10 @@ namespace pdal
 
         tiledb::Context ctx;
         tiledb::VFS vfs(ctx);
-        std::string pth = Support::temppath("tiledb_test_sf_curve");
+        std::string pth = Support::temppath("tiledb_test_sf_curve_ts");
 
-        Options writer_options;
+        Options writer_options = getTileDBOptions();
         writer_options.add("array_name", pth);
-        writer_options.add("x_tile_size", 1);
-        writer_options.add("y_tile_size", 1);
-        writer_options.add("z_tile_size", 1);
-
 
         if (vfs.is_dir(pth))
         {
@@ -542,6 +531,42 @@ namespace pdal
         tiledb::Array array(ctx, pth, TILEDB_READ);
         EXPECT_EQ(true,
             array.schema().cell_order() == TILEDB_ROW_MAJOR);
+        array.close();
+    }
+
+    TEST_F(TileDBWriterTest, sf_curve_stats)
+    {
+        tiledb::Context ctx;
+        tiledb::VFS vfs(ctx);
+        std::string pth = Support::temppath("tiledb_test_sf_curve_stats");
+
+        if (vfs.is_dir(pth))
+        {
+            vfs.remove_dir(pth);
+        }
+
+        PipelineManager mgr;
+
+        Options optsR;
+        optsR.add("filename", Support::datapath("las/1.2-with-color.las"));
+        Stage& reader = mgr.addReader("readers.las");
+        reader.setOptions(optsR);
+
+        Stage& filter = mgr.addFilter("filters.stats");
+        filter.setInput(reader);
+
+        Options optsW;
+        optsW.add("array_name", pth);
+        Stage& writer = mgr.addWriter("writers.tiledb");
+        writer.setInput(filter);
+        writer.setOptions(optsW);
+
+        point_count_t np = mgr.execute();
+        EXPECT_EQ(1065U, np);
+
+        tiledb::Array array(ctx, pth, TILEDB_READ);
+        EXPECT_EQ(true,
+            array.schema().cell_order() == TILEDB_HILBERT);
         array.close();
     }
     #endif


### PR DESCRIPTION
This PR allows a user to optimally pick the hilbert domain when using TileDB. This can be inputted manually or by running a stats stage prior to writing.