### PR TITLE
TileDB time traveling

### DIFF
--- a/doc/stages/readers.tiledb.rst
+++ b/doc/stages/readers.tiledb.rst
@@ -47,10 +47,10 @@ bbox3d
 timestamp
   Opens the array at a particular TileDB timestamp [Optional]
 
-start_timestamp
+end_timestamp
   Opens the array at a particular TileDB timestamp [Optional]
 
-end_timestamp
+start_timestamp
   Opens the array between a timestamp range of start_timestamp and end_timestamp [Optional]
 
 .. include:: reader_opts.rst

--- a/doc/stages/readers.tiledb.rst
+++ b/doc/stages/readers.tiledb.rst
@@ -44,6 +44,15 @@ stats
 bbox3d
   TileDB subarray to read in format ([minx, maxx], [miny, maxy], [minz, maxz]) [Optional]
 
+timestamp
+  Opens the array at a particular TileDB timestamp [Optional]
+
+start_timestamp
+  Opens the array at a particular TileDB timestamp [Optional]
+
+end_timestamp
+  Opens the array between a timestamp range of start_timestamp and end_timestamp [Optional]
+
 .. include:: reader_opts.rst
 
 .. _TileDB: https://tiledb.io

--- a/doc/stages/writers.tiledb.rst
+++ b/doc/stages/writers.tiledb.rst
@@ -86,6 +86,9 @@ stats
 filters
   JSON array or object of compression filters for either `coords` or `attributes` of the form {coords/attributename : {"compression": name, compression_options: value, ...}} [Optional]
 
+timestamp
+  Sets the TileDB timestamp for this write
+
 .. include:: writer_opts.rst
 
 By default TileDB will use the following set of compression filters for coordinates and attributes;

--- a/plugins/tiledb/io/TileDBReader.cpp
+++ b/plugins/tiledb/io/TileDBReader.cpp
@@ -108,7 +108,7 @@ void TileDBReader::addArgs(ProgramArgs& args)
     args.add("end_timestamp", "TileDB array timestamp", m_endTimeStamp,
         point_count_t(0));
     args.addSynonym("end_timestamp", "timestamp");
-#if TILEDB_VERSION_MAJOR > 1 || TILEDB_VERSION_MINOR >= 3
+#if TILEDB_VERSION_MAJOR > 2 || (TILEDB_VERSION_MAJOR == 2 && TILEDB_VERSION_MINOR >= 3)
     args.add("start_timestamp", "TileDB array timestamp", m_startTimeStamp,
         point_count_t(0));
 #endif
@@ -139,7 +139,7 @@ void TileDBReader::initialize()
 
         if (m_endTimeStamp)
         {
-#if TILEDB_VERSION_MAJOR > 1 && TILEDB_VERSION_MINOR >= 3
+#if TILEDB_VERSION_MAJOR > 2 || (TILEDB_VERSION_MAJOR == 2 && TILEDB_VERSION_MINOR >= 3)
             if (m_startTimeStamp)
             {
                 m_array.reset(new tiledb::Array(*m_ctx, m_filename, TILEDB_READ));

--- a/plugins/tiledb/io/TileDBReader.cpp
+++ b/plugins/tiledb/io/TileDBReader.cpp
@@ -139,7 +139,7 @@ void TileDBReader::initialize()
 
         if (m_endTimeStamp)
         {
-#if TILEDB_VERSION_MAJOR > 1 || TILEDB_VERSION_MINOR >= 3
+#if TILEDB_VERSION_MAJOR > 1 && TILEDB_VERSION_MINOR >= 3
             if (m_startTimeStamp)
             {
                 m_array.reset(new tiledb::Array(*m_ctx, m_filename, TILEDB_READ));

--- a/plugins/tiledb/io/TileDBReader.hpp
+++ b/plugins/tiledb/io/TileDBReader.hpp
@@ -100,6 +100,8 @@ private:
     point_count_t m_chunkSize;
     point_count_t m_offset;
     point_count_t m_resultSize;
+    point_count_t m_startTimeStamp;
+    point_count_t m_endTimeStamp;
     bool m_complete;
     bool m_stats;
     BOX3D m_bbox;

--- a/plugins/tiledb/io/TileDBWriter.cpp
+++ b/plugins/tiledb/io/TileDBWriter.cpp
@@ -80,7 +80,7 @@ struct TileDBWriter::Args
     NL::json m_filters;
     NL::json m_defaults;
     bool m_append;
-    point_count_t m_timeStamp;
+    point_count_t m_timeStamp = 0;
 };
 
 CREATE_SHARED_STAGE(TileDBWriter, s_info)

--- a/plugins/tiledb/io/TileDBWriter.cpp
+++ b/plugins/tiledb/io/TileDBWriter.cpp
@@ -80,6 +80,7 @@ struct TileDBWriter::Args
     NL::json m_filters;
     NL::json m_defaults;
     bool m_append;
+    point_count_t m_timeStamp;
 };
 
 CREATE_SHARED_STAGE(TileDBWriter, s_info)
@@ -300,6 +301,8 @@ void TileDBWriter::addArgs(ProgramArgs& args)
         m_args->m_filters, NL::json({}));
     args.add("append", "Append to existing TileDB array",
         m_args->m_append, false);
+    args.add("timestamp", "TileDB array timestamp", m_args->m_timeStamp,
+        point_count_t(0));
 }
 
 
@@ -446,8 +449,12 @@ void TileDBWriter::ready(pdal::BasePointTable &table)
     }
     else
     {
-        m_array.reset(new tiledb::Array(*m_ctx, m_args->m_arrayName,
-            TILEDB_WRITE));
+        if (m_args->m_timeStamp)
+            m_array.reset(new tiledb::Array(*m_ctx, m_args->m_arrayName,
+                TILEDB_WRITE, m_args->m_timeStamp));
+        else
+            m_array.reset(new tiledb::Array(*m_ctx, m_args->m_arrayName,
+                TILEDB_WRITE));
     }
 
     for (const auto& d : all)
@@ -502,8 +509,13 @@ void TileDBWriter::ready(pdal::BasePointTable &table)
     if (!m_args->m_append)
     {
         tiledb::Array::create(m_args->m_arrayName, *m_schema);
-        m_array.reset(new tiledb::Array(*m_ctx, m_args->m_arrayName,
-            TILEDB_WRITE));
+
+        if (m_args->m_timeStamp)
+            m_array.reset(new tiledb::Array(*m_ctx, m_args->m_arrayName,
+                TILEDB_WRITE, m_args->m_timeStamp));
+        else
+            m_array.reset(new tiledb::Array(*m_ctx, m_args->m_arrayName,
+                TILEDB_WRITE));
     }
 
     m_current_idx = 0;

--- a/plugins/tiledb/io/TileDBWriter.cpp
+++ b/plugins/tiledb/io/TileDBWriter.cpp
@@ -301,8 +301,10 @@ void TileDBWriter::addArgs(ProgramArgs& args)
         m_args->m_filters, NL::json({}));
     args.add("append", "Append to existing TileDB array",
         m_args->m_append, false);
+#if TILEDB_VERSION_MAJOR >= 2
     args.add("timestamp", "TileDB array timestamp", m_args->m_timeStamp,
         point_count_t(0));
+#endif
 }
 
 

--- a/plugins/tiledb/test/TileDBWriterTest.cpp
+++ b/plugins/tiledb/test/TileDBWriterTest.cpp
@@ -457,7 +457,7 @@ namespace pdal
         filter2.setInput(rdr2);
         EXPECT_EQ(200U, mgr2.execute());
 
-#if TILEDB_VERSION_MAJOR > 1 || TILEDB_VERSION_MINOR >= 3
+#if TILEDB_VERSION_MAJOR > 1 && TILEDB_VERSION_MINOR >= 3
         PipelineManager mgrSlice;
         optsR.remove(Option("timestamp", 2));
         optsR.add("start_timestamp", 2);

--- a/plugins/tiledb/test/TileDBWriterTest.cpp
+++ b/plugins/tiledb/test/TileDBWriterTest.cpp
@@ -404,6 +404,7 @@ namespace pdal
         EXPECT_EQ(flAtts.nfilters(), 0U);
     }
 
+#if TILEDB_VERSION_MAJOR >= 2
     TEST_F(TileDBWriterTest, write_timestamp)
     {
         tiledb::Context ctx;
@@ -457,7 +458,7 @@ namespace pdal
         filter2.setInput(rdr2);
         EXPECT_EQ(200U, mgr2.execute());
 
-#if TILEDB_VERSION_MAJOR > 1 && TILEDB_VERSION_MINOR >= 3
+#if TILEDB_VERSION_MAJOR >= 2 && TILEDB_VERSION_MINOR >= 3
         PipelineManager mgrSlice;
         optsR.remove(Option("timestamp", 2));
         optsR.add("start_timestamp", 2);
@@ -470,6 +471,7 @@ namespace pdal
         EXPECT_EQ(100U, mgrSlice.execute());
 #endif
     }
+#endif
 
 
 #if TILEDB_VERSION_MAJOR > 1

--- a/plugins/tiledb/test/TileDBWriterTest.cpp
+++ b/plugins/tiledb/test/TileDBWriterTest.cpp
@@ -404,6 +404,74 @@ namespace pdal
         EXPECT_EQ(flAtts.nfilters(), 0U);
     }
 
+    TEST_F(TileDBWriterTest, write_timestamp)
+    {
+        tiledb::Context ctx;
+        tiledb::VFS vfs(ctx);
+        std::string pth = Support::temppath("tiledb_test_ts_out");
+
+        if (vfs.is_dir(pth))
+        {
+            vfs.remove_dir(pth);
+        }
+
+        Options options = getTileDBOptions();
+        options.add("array_name", pth);
+        options.add("timestamp", 1);
+
+        TileDBWriter writer;
+        writer.setOptions(options);
+        writer.setInput(m_reader);
+
+        FixedPointTable table(100);
+        writer.prepare(table);
+        writer.execute(table);
+
+        options.replace("timestamp", 2);
+        options.add("append", true);
+        TileDBWriter append_writer;
+        append_writer.setOptions(options);
+        append_writer.setInput(m_reader2);
+
+        FixedPointTable table2(100);
+        append_writer.prepare(table2);
+        append_writer.execute(table2);
+
+        PipelineManager mgr1;
+        PipelineManager mgr2;
+
+        Options optsR;
+        optsR.add("filename", pth);
+        optsR.add("timestamp", 1);
+        Stage& rdr1 = mgr1.addReader("readers.tiledb");
+        rdr1.setOptions(optsR);
+        Stage& filter1 = mgr1.addFilter("filters.stats");
+        filter1.setInput(rdr1);
+        EXPECT_EQ(100U, mgr1.execute());
+
+        optsR.replace("timestamp", 2);
+
+        Stage& rdr2 = mgr2.addReader("readers.tiledb");
+        rdr2.setOptions(optsR);
+        Stage& filter2 = mgr2.addFilter("filters.stats");
+        filter2.setInput(rdr2);
+        EXPECT_EQ(200U, mgr2.execute());
+
+#if TILEDB_VERSION_MAJOR > 1 || TILEDB_VERSION_MINOR >= 3
+        PipelineManager mgrSlice;
+        optsR.remove(Option("timestamp", 2));
+        optsR.add("start_timestamp", 2);
+        optsR.add("end_timestamp", 2);
+
+        Stage& rdrSlice = mgrSlice.addReader("readers.tiledb");
+        rdrSlice.setOptions(optsR);
+        Stage& filterSlice = mgrSlice.addFilter("filters.stats");
+        filterSlice.setInput(rdrSlice);
+        EXPECT_EQ(100U, mgrSlice.execute());
+#endif
+    }
+
+
 #if TILEDB_VERSION_MAJOR > 1
     TEST_F(TileDBWriterTest, dup_points)
     {

--- a/plugins/tiledb/test/TileDBWriterTest.cpp
+++ b/plugins/tiledb/test/TileDBWriterTest.cpp
@@ -458,7 +458,7 @@ namespace pdal
         filter2.setInput(rdr2);
         EXPECT_EQ(200U, mgr2.execute());
 
-#if TILEDB_VERSION_MAJOR >= 2 && TILEDB_VERSION_MINOR >= 3
+#if TILEDB_VERSION_MAJOR > 2 || (TILEDB_VERSION_MAJOR == 2 && TILEDB_VERSION_MINOR >= 3)
         PipelineManager mgrSlice;
         optsR.remove(Option("timestamp", 2));
         optsR.add("start_timestamp", 2);


### PR DESCRIPTION
This PR adds [TileDB time traveling](https://docs.tiledb.com/main/solutions/tiledb-embedded/internal-mechanics/reading#time-traveling) to both the PDAL TileDB reader and writer.

I have added a test that shows how the total array has 200 points but each TileDB fragment only contains 100 points. 