### PR TITLE
Fix conda version on Download page in documentation

### DIFF
--- a/doc/download.rst
+++ b/doc/download.rst
@@ -71,7 +71,7 @@ required dependencies and build PDAL from source.
    :widths: 20, 20, 20, 20, 20, 20
 
    "Platform(s)", "linux", "linux", "linux", "linux", "win64, mac, linux"
-   "PDAL version", "2.3", "", "", "2.2", "2.2"
+   "PDAL version", "2.3", "", "", "2.2", "2.3"
    "CPD", "", "", "", "X", ""
    "E57", "X", "", "", "", "X"
    "HDF", "X", "", "", "", "X"


### PR DESCRIPTION
The table on the [Download](https://pdal.io/download.html#binaries) docpage states the current PDAL version on conda-forge is 2.2. However it is now 2.3, since this [PR](https://github.com/conda-forge/pdal-feedstock/pull/132) on the conda-forge feedstock.