### PR TITLE
EPT reader filtering with both polygon and bounds

### DIFF
--- a/doc/stages/readers.ept.rst
+++ b/doc/stages/readers.ept.rst
@@ -103,11 +103,18 @@ origin
 polygon
   The clipping polygon, expressed in a well-known text string,
   eg: "POLYGON((0 0, 5000 10000, 10000 0, 0 0))".  This option can be
-  specified more than once by placing values in an array.
+  specified more than once by placing values in an array, in which case all of
+  them will be unioned together, acting as a single multipolygon.
 
 .. note::
 
     When using ``pdal info --summary``, using the ``polygon`` option will cause the resulting bounds to be clipped to the maximal extents of all provided polygons, and the resulting number of points to be an upper bound for this polygon selection.
+
+.. note::
+
+    When a ``bounds`` option is specified alongside the ``polygon`` option, only
+    the points that fall within *both* the bounds and the polygon(s) will be
+    returned.
 
 ogr
   A JSON object representing an OGR query to fetch polygons to use for filtering. The polygons

--- a/io/EptReader.cpp
+++ b/io/EptReader.cpp
@@ -580,7 +580,7 @@ bool EptReader::passesSpatialFilter(const BOX3D& tileBounds) const
     // at the same time, it seems to get corrupted. There may be other instances
     // that need to be locked.
     std::lock_guard<std::mutex> lock(m_p->mutex);
-    return boxOverlaps() || polysOverlap();
+    return boxOverlaps() && polysOverlap();
 }
 
 
@@ -701,7 +701,7 @@ bool EptReader::processPoint(PointRef& dst, const TileContents& tile)
 
     // If there is a spatial filter, make sure it passes.
     if (hasSpatialFilter())
-        if (!passesBoundsFilter(x, y, z) && !passesPolyFilter(x, y, z))
+        if (!passesBoundsFilter(x, y, z) || !passesPolyFilter(x, y, z))
             return false;
 
     for (auto& el : m_p->info->dims())

--- a/io/EptReader.cpp
+++ b/io/EptReader.cpp
@@ -556,7 +556,7 @@ bool EptReader::passesSpatialFilter(const BOX3D& tileBounds) const
     auto boxOverlaps = [this, &reproject, &tileBounds]() -> bool
     {
         if (!m_p->bounds.box.valid())
-            return false;
+            return true;
 
         // If the reprojected source bounds doesn't overlap our query bounds, we're done.
         return reproject(tileBounds, m_p->bounds.xform).overlaps(m_p->bounds.box);
@@ -566,6 +566,9 @@ bool EptReader::passesSpatialFilter(const BOX3D& tileBounds) const
     // we can skip
     auto polysOverlap = [this, &reproject, &tileBounds]() -> bool
     {
+        if (m_p->polys.empty())
+            return true;
+
         for (auto& ps : m_p->polys)
             if (!ps.poly.disjoint(reproject(tileBounds, ps.xform)))
                 return true;
@@ -675,13 +678,16 @@ bool EptReader::processPoint(PointRef& dst, const TileContents& tile)
     auto passesBoundsFilter = [this](double x, double y, double z)
     {
         if (!m_p->bounds.box.valid())
-            return false;
+            return true;
         m_p->bounds.xform.transform(x, y, z);
         return m_p->bounds.box.contains(x, y, z);
     };
 
     auto passesPolyFilter = [this](double xo, double yo, double zo)
     {
+        if (m_p->polys.empty())
+            return true;
+
         for (PolyXform& ps : m_p->polys)
         {
             double x = xo;


### PR DESCRIPTION
Version 2.3 changed the behavior of the EPT reader when both a `bounds` and `polygon` option are specified.  The correct behavior is that these are ANDed together, i.e. that you can mask a `polygon` with a `bounds` box and get points contained within the intersection of the two.  However, these options are ORed together as of #3460 (I reviewed this PR but mistakenly overlooked this aspect).

The correct logic from version 2.2 can be found [here](https://github.com/PDAL/PDAL/blob/2.2.0/io/EptReader.cpp#L549-L571) for chunk intersection logic, and [here](https://github.com/PDAL/PDAL/blob/2.2.0/io/EptReader.cpp#L652-L668) for the per-point checks.

This PR flips this logic to be ANDed instead of ORed and adds a unit test for this behavior.