### PR TITLE
Add cached ept plugin

### DIFF
--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -64,6 +64,11 @@ option(BUILD_PLUGIN_RIVLIB
 add_feature_info("RiVLib plugin" BUILD_PLUGIN_RIVLIB
     "read data in the RXP format")
 
+option(BUILD_PLUGIN_CACHEDEPT
+    "Choose if cached ept support should be built" FALSE)
+add_feature_info("CachedEpt plugin" BUILD_PLUGIN_CACHEDEPT
+    "read and cache entwine data")
+
 option(BUILD_PLUGIN_RDBLIB
     "Choose if rdblib support should be built" FALSE)
 add_feature_info("rdblib plugin" BUILD_PLUGIN_RDBLIB

--- a/pdal/private/gdal/GDALUtils.hpp
+++ b/pdal/private/gdal/GDALUtils.hpp
@@ -67,7 +67,7 @@ PDAL_DLL std::string lastError();
 OGRGeometry *createFromWkt(const std::string& s, std::string& srs);
 OGRGeometry *createFromGeoJson(const std::string& s, std::string& srs);
 
-std::vector<Polygon> getPolygons(const NL::json& ogr);
+PDAL_DLL std::vector<Polygon> getPolygons(const NL::json& ogr);
 
 inline OGRGeometry *fromHandle(OGRGeometryH geom)
 { return reinterpret_cast<OGRGeometry *>(geom); }

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -81,6 +81,10 @@ if(BUILD_PLUGIN_TILEDB)
     add_subdirectory(tiledb)
 endif()
 
+if(BUILD_PLUGIN_CACHEDEPT)
+    add_subdirectory(cachedept)
+endif()
+
 if(BUILD_PLUGIN_E57)
     add_subdirectory(e57)
 endif()


### PR DESCRIPTION
When using pdal in some applications that are intensely reading entwine dataset, it appears some already fetched data could be cached.

This could be done in many way, this implementation is one amongst many that could be improved in many ways.

The idea is to use a [thread safe LRU cache](https://github.com/tstarling/thread-safe-lru), build around TBB.

The plugin is merely a copy of `readers.ept` but caches `TilesContents` and all the hierarchy fetched as `NL::json`.