### PR TITLE
add Polygon intersection method

### DIFF
--- a/pdal/Polygon.cpp
+++ b/pdal/Polygon.cpp
@@ -406,4 +406,9 @@ std::vector<Polygon::Ring> Polygon::interiorRings() const
     return rings;
 }
 
+Polygon Polygon::intersection(const pdal::Polygon& p) const
+{
+    return Polygon(m_geom->Intersection(p.m_geom.get()));
+}
+
 } // namespace pdal

--- a/pdal/Polygon.hpp
+++ b/pdal/Polygon.hpp
@@ -62,6 +62,7 @@ public:
     Polygon(OGRGeometryH g, const SpatialReference& srs);
     Polygon(const Polygon& poly);
     Polygon& operator=(const Polygon& src);
+    Polygon intersection(const Polygon& p) const;
 
     virtual void modified() override;
     virtual void clear() override;


### PR DESCRIPTION
Having the possibility to build the intersection of two polygons might come handy.

This could also be an override of a virtual method from `pdal::Geometry` if prefered.