### PR TITLE
Streamable iterator

### DIFF
--- a/pdal/PipelineExecutor.cpp
+++ b/pdal/PipelineExecutor.cpp
@@ -140,4 +140,28 @@ std::string PipelineExecutor::getLog() const
 }
 
 
+point_count_t PipelineStreamableExecutor::execute()
+{
+    point_count_t count = 0;
+    while (PointViewPtr view = executeNext())
+        count += view->size();
+    return count;
+}
+
+
+PointViewPtr PipelineStreamableExecutor::executeNext()
+{
+    if (!m_itPtr)
+        m_itPtr = std::unique_ptr<StreamableIterator>(m_managerPtr->executeStream());
+
+    StreamableIterator& it = *m_itPtr;
+    if (!it) {
+        m_executed = true;
+        return nullptr;
+    }
+    ++it;
+    return *it;
+}
+
+
 } //namespace pdal

--- a/pdal/PipelineExecutor.hpp
+++ b/pdal/PipelineExecutor.hpp
@@ -121,9 +121,31 @@ public:
     */
     PipelineManager & getManager() { return *m_managerPtr; }
 
-private:
+protected:
     pdal::PipelineManagerPtr m_managerPtr;
     bool m_executed;
 };
 
-}
+class PDAL_DLL PipelineStreamableExecutor : public PipelineExecutor
+{
+
+public:
+    PipelineStreamableExecutor(std::string const& json,
+                               point_count_t streamLimit = 10000)
+        : PipelineExecutor(json, streamLimit), m_itPtr(nullptr) {}
+
+    virtual point_count_t execute();
+
+    /**
+      Execute the pipeline
+
+    \return a point view to next batch of processed points,
+        or null if execution has finished.
+    */
+    PointViewPtr executeNext();
+
+private:
+    std::unique_ptr<StreamableIterator> m_itPtr;
+};
+
+} // namespace pdal

--- a/pdal/PipelineExecutor.hpp
+++ b/pdal/PipelineExecutor.hpp
@@ -36,7 +36,7 @@
 
 #include <pdal/PipelineManager.hpp>
 #include <pdal/PipelineWriter.hpp>
-#include <pdal/util/FileUtils.hpp>
+#include <pdal/Streamable.hpp>
 #include <pdal/pdal_export.hpp>
 
 #include <string>
@@ -51,27 +51,22 @@ namespace pdal
   It is constructed with JSON defining a pipeline.
 */
 
-class PDAL_DLL PipelineExecutor {
+class PDAL_DLL PipelineExecutor
+{
 public:
-
     /**
       Construct a PipelineExecutor
 
       \param json Pipeline JSON defining the PDAL operations
     */
-    PipelineExecutor(std::string const& json);
-
-    /**
-      dtor
-    */
-    ~PipelineExecutor(){};
+    PipelineExecutor(std::string const& json, point_count_t streamLimit = 0);
 
     /**
       Execute the pipeline
 
       \return total number of points produced by the pipeline.
     */
-    int64_t execute();
+    virtual point_count_t execute();
 
     /**
       Validate the pipeline
@@ -114,31 +109,21 @@ public:
     /**
       \return has the pipeline been executed
     */
-    inline bool executed() const
-    {
-        return m_executed;
-    }
-
+    bool executed() const { return m_executed;}
 
     /**
-      \return a const reference to the pipeline manager
+      \return the resulting views.
     */
-    PipelineManager const& getManagerConst() const { return m_manager; }
+    const PointViewSet& views() const;
 
     /**
       \return a reference to the pipeline manager
     */
-    PipelineManager & getManager() { return m_manager; }
+    PipelineManager & getManager() { return *m_managerPtr; }
 
 private:
-    void setLogStream(std::ostream& strm);
-
-    std::string m_json;
-    pdal::PipelineManager m_manager;
+    pdal::PipelineManagerPtr m_managerPtr;
     bool m_executed;
-    std::stringstream m_logStream;
-    pdal::LogLevel m_logLevel;
-
 };
 
 }

--- a/pdal/PipelineManager.cpp
+++ b/pdal/PipelineManager.cpp
@@ -37,6 +37,7 @@
 #include <pdal/StageFactory.hpp>
 #include <pdal/PipelineReaderJSON.hpp>
 #include <pdal/PDALUtils.hpp>
+#include <pdal/Streamable.hpp>
 #include <pdal/util/Algorithm.hpp>
 #include <pdal/util/FileUtils.hpp>
 
@@ -289,15 +290,17 @@ point_count_t PipelineManager::execute()
 }
 
 
-void PipelineManager::executeStream(StreamPointTable& table)
+StreamableIterator* PipelineManager::executeStream()
 {
     validateStageOptions();
     Stage *s = getStage();
     if (!s)
-        return;
-
-    s->prepare(table);
-    s->execute(table);
+        return new StreamableIterator(m_streamTable);
+    s->assertStreamable();
+    Streamable *streamable = dynamic_cast<Streamable *>(s);
+    streamable->prepare(m_streamTable);
+    m_streamTable.finalize();
+    return new StreamableIterator(m_streamTable, streamable);
 }
 
 

--- a/pdal/PipelineManager.hpp
+++ b/pdal/PipelineManager.hpp
@@ -39,8 +39,8 @@
 #include <pdal/Options.hpp>
 #include <pdal/Log.hpp>
 
-#include <vector>
 #include <string>
+#include <vector>
 
 namespace pdal
 {
@@ -48,6 +48,7 @@ namespace pdal
 struct QuickInfo;
 class Stage;
 class StageFactory;
+class StreamableIterator;
 
 struct StageCreationOptions
 {
@@ -127,7 +128,7 @@ public:
     void prepare() const;
     ExecResult execute(ExecMode mode);
     point_count_t execute();
-    void executeStream(StreamPointTable& table);
+    StreamableIterator* executeStream();
     void validateStageOptions() const;
     bool pipelineStreamable() const;
     bool hasReader() const;

--- a/pdal/PointView.hpp
+++ b/pdal/PointView.hpp
@@ -97,6 +97,7 @@ public:
     bool empty() const
         { return m_size == 0; }
 
+    inline void appendPoint(PointId rawId);
     inline void appendPoint(const PointView& buffer, PointId id);
     void append(const PointView& buf)
     {
@@ -596,13 +597,17 @@ void PointView::setField(Dimension::Id dim, PointId idx, T val)
     }
 }
 
-inline void PointView::appendPoint(const PointView& buffer, PointId id)
+inline void PointView::appendPoint(PointId rawId)
 {
-    // Invalid 'id' is a programmer error.
-    PointId rawId = buffer.m_index[id];
     m_index.push_back(rawId);
     m_size++;
     assert(m_temps.empty());
+}
+
+inline void PointView::appendPoint(const PointView& buffer, PointId id)
+{
+    // Invalid 'id' is a programmer error.
+    appendPoint(buffer.m_index[id]);
 }
 
 

--- a/pdal/Stage.hpp
+++ b/pdal/Stage.hpp
@@ -156,8 +156,10 @@ public:
       \return  nullptr if the stage is streamable, a pointer to this stage
         otherwise.
     */
-    virtual const Stage *findNonstreamable() const
-    { return this; }
+    virtual void assertStreamable() const
+    { throwError("Attempting to use stream mode with a stage that doesn't "
+                 "support streaming.");
+    }
 
     /**
       Set the spatial reference of a stage.

--- a/pdal/Streamable.cpp
+++ b/pdal/Streamable.cpp
@@ -51,24 +51,20 @@ bool Streamable::pipelineStreamable() const
     return true;
 }
 
-
 void Streamable::execute(StreamPointTable& table)
-{
-    for (auto it = executeStream(table); it; ++it);
-}
-
-Streamable::Iterator Streamable::executeStream(StreamPointTable& table)
 {
     assertStreamable();
     m_log->get(LogLevel::Debug)
         << "Executing pipeline in stream mode." << std::endl;
     table.finalize();
-    return Iterator(table, *this);
+    for (auto it = Iterator(table, this); it; ++it);
 }
 
 void Streamable::Iterator::populateLists(Streamable* stage,
                                          Streamable::List& currentStages)
 {
+    if (!stage)
+        return;
     currentStages.push_front(stage);
     if (stage->m_inputs.empty())
         lists.push_front(currentStages);

--- a/pdal/Streamable.cpp
+++ b/pdal/Streamable.cpp
@@ -52,19 +52,6 @@ bool Streamable::pipelineStreamable() const
 }
 
 
-const Stage *Streamable::findNonstreamable() const
-{
-    const Stage *nonstreamable;
-
-    for (const Stage *s : m_inputs)
-    {
-        nonstreamable = s->findNonstreamable();
-        if (nonstreamable)
-            return nonstreamable;
-    }
-    return nullptr;
-}
-
 void Streamable::execute(StreamPointTable& table)
 {
     for (auto it = executeStream(table); it; ++it);
@@ -72,14 +59,9 @@ void Streamable::execute(StreamPointTable& table)
 
 Streamable::Iterator Streamable::executeStream(StreamPointTable& table)
 {
+    assertStreamable();
     m_log->get(LogLevel::Debug)
         << "Executing pipeline in stream mode." << std::endl;
-
-    const Stage* nonstreaming = findNonstreamable();
-    if (nonstreaming)
-        nonstreaming->throwError("Attempting to use stream mode with a "
-                                 "stage that doesn't support streaming.");
-
     table.finalize();
     return Iterator(table, *this);
 }

--- a/pdal/Streamable.hpp
+++ b/pdal/Streamable.hpp
@@ -45,6 +45,17 @@ class StreamableWrapper;
 class PDAL_DLL Streamable : public virtual Stage
 {
     friend class StreamableWrapper;
+    struct List : public std::list<Streamable *>
+    {
+        List operator - (const List& other) const;
+        void ready(PointTableRef& table);
+        void done(PointTableRef& table);
+    };
+    using SrsMap = std::map<Streamable *, SpatialReference>;
+    point_count_t execute(StreamPointTable& table, SrsMap& srsMap,
+        Streamable *reader, const std::list<Streamable *>& filters,
+        point_count_t count);
+
 public:
     Streamable();
 
@@ -78,8 +89,6 @@ protected:
     Streamable& operator=(const Streamable&) = delete;
     Streamable(const Streamable&); // not implemented
 
-    using SrsMap = std::map<Streamable *, SpatialReference>;
-
     /**
       Process a single point (streaming mode).  Implement in subclass.
 
@@ -112,12 +121,6 @@ protected:
         a pointer to the first found stage that's not streamable.
     */
     const Stage *findNonstreamable() const;
-
-private:
-    point_count_t execute(StreamPointTable& table, SrsMap& srsMap,
-        Streamable *reader, const std::list<Streamable *>& filters,
-        point_count_t count);
-
 };
 
 } // namespace pdal

--- a/pdal/Streamable.hpp
+++ b/pdal/Streamable.hpp
@@ -133,7 +133,8 @@ protected:
       \return  NULL if the pipeline is streamable, otherwise return
         a pointer to the first found stage that's not streamable.
     */
-    const Stage* findNonstreamable() const;
+    void assertStreamable() const
+    { for (auto s : m_inputs) s->assertStreamable(); }
 };
 
 struct Streamable::List : public std::list<Streamable*>

--- a/pdal/Streamable.hpp
+++ b/pdal/Streamable.hpp
@@ -80,9 +80,6 @@ protected:
 
     using SrsMap = std::map<Streamable *, SpatialReference>;
 
-    void execute(StreamPointTable& table, std::list<Streamable *>& stages,
-        SrsMap& srsMap);
-
     /**
       Process a single point (streaming mode).  Implement in subclass.
 

--- a/pdal/Streamable.hpp
+++ b/pdal/Streamable.hpp
@@ -115,6 +115,12 @@ protected:
         a pointer to the first found stage that's not streamable.
     */
     const Stage *findNonstreamable() const;
+
+private:
+    point_count_t execute(StreamPointTable& table, SrsMap& srsMap,
+        Streamable *reader, const std::list<Streamable *>& filters,
+        point_count_t count);
+
 };
 
 } // namespace pdal

--- a/test/unit/StreamingTest.cpp
+++ b/test/unit/StreamingTest.cpp
@@ -252,7 +252,8 @@ R"(
     PipelineManager mgr;
     mgr.readPipeline(iss);
     FixedPointTable t(10000);
-    mgr.executeStream(t);
+    mgr.getStage()->prepare(t);
+    mgr.getStage()->execute(t);
     Utils::restore(std::cout, ctx);
     std::string output(oss.str());
     EXPECT_NE(output.find("DBAGEBAHEBAFBACA"), std::string::npos);
@@ -509,7 +510,8 @@ R"(
         PipelineManager mgr;
         mgr.readPipeline(iss);
         FixedPointTable t(10000);
-        mgr.executeStream(t);
+        mgr.getStage()->prepare(t);
+        mgr.getStage()->execute(t);
         Utils::restore(std::cout, ctx);
         std::string output(oss.str());
         EXPECT_NE(output.find("DBADCA"), std::string::npos);


### PR DESCRIPTION
This PR adds `PipelineStreamableExecutor` and `StreamableIterator` classes to enable streamable execution in PDAL Python (related PR coming soon). The `Streamable` and `PipelineExecutor` classes were also refactored extensively, along with a few minor necessary changes to `PipelineManager` and `PointView`.