### PR TITLE
fix box3d equal and clip

### DIFF
--- a/pdal/util/Bounds.hpp
+++ b/pdal/util/Bounds.hpp
@@ -424,7 +424,7 @@ public:
     */
     bool equal(const BOX3D& other) const
     {
-        return  BOX2D::contains(other) &&
+        return  BOX2D::equal(other) &&
             minz == other.minz && maxz == other.maxz;
     }
 
@@ -489,8 +489,8 @@ public:
     void clip(const BOX3D& other)
     {
         BOX2D::clip(other);
-        if (other.minz < minz) minz = other.minz;
-        if (other.maxz > maxz) maxz = other.maxz;
+        if (other.minz > minz) minz = other.minz;
+        if (other.maxz < maxz) maxz = other.maxz;
     }
 
     /**


### PR DESCRIPTION
I think the equal in BOX3D was accidentally referencing the contains rather than equal from BOX2D for x and y. I also put in a little edit for the clip in BOX3D, where I think the signs were reversed (minz and maxz fixed to less and more than other.minz and other.maxz, respectively).