### PR TITLE
Export beam origin and direction

### DIFF
--- a/pdal/Dimension.json
+++ b/pdal/Dimension.json
@@ -538,17 +538,17 @@
     "description": "Beam origin Z coordinate of current laser shot"
     },
     {
-    "name": "BeamDirectoyX",
+    "name": "BeamDirectionX",
     "type": "double",
     "description": "Beam direction unit vector X coordinate"
     },
     {
-    "name": "BeamDirectoyY",
+    "name": "BeamDirectionY",
     "type": "double",
     "description": "Beam direction unit vector Y coordinate"
     },
     {
-    "name": "BeamDirectoyZ",
+    "name": "BeamDirectionZ",
     "type": "double",
     "description": "Beam direction unit vector Z coordinate"
     }

--- a/pdal/Dimension.json
+++ b/pdal/Dimension.json
@@ -521,5 +521,35 @@
     "name": "RadialDensity",
     "type": "double",
     "description": "Estimate of radial point density"
+    },
+    {
+    "name": "BeamOriginX",
+    "type": "double",
+    "description": "Beam origin X coordinate of current laser shot"
+    },
+    {
+    "name": "BeamOriginY",
+    "type": "double",
+    "description": "Beam origin Y coordinate of current laser shot"
+    },
+    {
+    "name": "BeamOriginZ",
+    "type": "double",
+    "description": "Beam origin Z coordinate of current laser shot"
+    },
+    {
+    "name": "BeamDirectoyX",
+    "type": "double",
+    "description": "Beam direction unit vector X coordinate"
+    },
+    {
+    "name": "BeamDirectoyY",
+    "type": "double",
+    "description": "Beam direction unit vector Y coordinate"
+    },
+    {
+    "name": "BeamDirectoyZ",
+    "type": "double",
+    "description": "Beam direction unit vector Z coordinate"
     }
 ] }

--- a/plugins/rxp/io/RxpPointcloud.cpp
+++ b/plugins/rxp/io/RxpPointcloud.cpp
@@ -52,11 +52,27 @@ Dimension::Id getTimeDimensionId(bool syncToPps)
 }
 
 
-Point::Point(scanlib::target target, unsigned int returnNumber, unsigned int numberOfReturns, bool edgeOfFlightLine)
+Point::Point(
+        scanlib::target target,
+        unsigned int returnNumber,
+        unsigned int numberOfReturns,
+        bool edgeOfFlightLine,
+        double beamOriginX,
+        double beamOriginY,
+        double beamOriginZ,
+        double beamDirectionX,
+        double beamDirectionY,
+        double beamDirectionZ)
     : target(target)
     , returnNumber(returnNumber)
     , numberOfReturns(numberOfReturns)
     , edgeOfFlightLine(edgeOfFlightLine)
+    , beamOriginX(beamOriginX)
+    , beamOriginY(beamOriginY)
+    , beamOriginZ(beamOriginZ)
+    , beamDirectionX(beamDirectionX)
+    , beamDirectionY(beamDirectionY)
+    , beamDirectionZ(beamDirectionZ)
 {}
 
 
@@ -174,7 +190,7 @@ void RxpPointcloud::on_echo_transformed(echo_type echo)
     {
         //Only first return is marked as edge of flight line
         m_points.emplace_back(targets[i], returnNumber, target_count, m_edge, beam_origin[0], 
-        beam_origin[1], beam_origin[2], , beam_direction[0], beam_direction[1], beam_direction[2]);
+        beam_origin[1], beam_origin[2], beam_direction[0], beam_direction[1], beam_direction[2]);
         if (m_edge)
             m_edge = false;
     }

--- a/plugins/rxp/io/RxpPointcloud.cpp
+++ b/plugins/rxp/io/RxpPointcloud.cpp
@@ -133,6 +133,12 @@ void RxpPointcloud::copyPoint(const Point& from, PointRef& to) const {
     to.setField(Id::BackgroundRadiation, from.target.background_radiation);
     to.setField(Id::IsPpsLocked, from.target.is_pps_locked);
     to.setField(Id::EdgeOfFlightLine, from.edgeOfFlightLine ? 1 : 0);
+    to.setField(Id::BeamDirectionX,beamDirectionX);
+    to.setField(Id::BeamDirectionY,beamDirectionY);
+    to.setField(Id::BeamDirectionZ,beamDirectionZ);
+    to.setField(Id::BeamOriginX,beamOriginX);
+    to.setField(Id::BeamOriginY,beamOriginY);
+    to.setField(Id::BeamOriginZ,beamOriginZ);
 
     if (m_reflectanceAsIntensity) {
         uint16_t intensity;
@@ -167,7 +173,8 @@ void RxpPointcloud::on_echo_transformed(echo_type echo)
     for (scanlib::pointcloud::target_count_type i = 0; i < target_count; ++i, ++returnNumber)
     {
         //Only first return is marked as edge of flight line
-        m_points.emplace_back(targets[i], returnNumber, target_count, m_edge);
+        m_points.emplace_back(targets[i], returnNumber, target_count, m_edge, beam_origin[0], 
+        beam_origin[1], beam_origin[2], , beam_direction[0], beam_direction[1], beam_direction[2]);
         if (m_edge)
             m_edge = false;
     }

--- a/plugins/rxp/io/RxpPointcloud.cpp
+++ b/plugins/rxp/io/RxpPointcloud.cpp
@@ -133,12 +133,12 @@ void RxpPointcloud::copyPoint(const Point& from, PointRef& to) const {
     to.setField(Id::BackgroundRadiation, from.target.background_radiation);
     to.setField(Id::IsPpsLocked, from.target.is_pps_locked);
     to.setField(Id::EdgeOfFlightLine, from.edgeOfFlightLine ? 1 : 0);
-    to.setField(Id::BeamDirectionX,beamDirectionX);
-    to.setField(Id::BeamDirectionY,beamDirectionY);
-    to.setField(Id::BeamDirectionZ,beamDirectionZ);
-    to.setField(Id::BeamOriginX,beamOriginX);
-    to.setField(Id::BeamOriginY,beamOriginY);
-    to.setField(Id::BeamOriginZ,beamOriginZ);
+    to.setField(Id::BeamDirectionX, from.beamDirectionX);
+    to.setField(Id::BeamDirectionY, from.beamDirectionY);
+    to.setField(Id::BeamDirectionZ, from.beamDirectionZ);
+    to.setField(Id::BeamOriginX, from.beamOriginX);
+    to.setField(Id::BeamOriginY, from.beamOriginY);
+    to.setField(Id::BeamOriginZ, from.beamOriginZ);
 
     if (m_reflectanceAsIntensity) {
         uint16_t intensity;

--- a/plugins/rxp/io/RxpPointcloud.hpp
+++ b/plugins/rxp/io/RxpPointcloud.hpp
@@ -54,7 +54,17 @@ namespace pdal
 Dimension::Id getTimeDimensionId(bool syncToPps);
 
 struct Point {
-    Point(scanlib::target target, unsigned int returnNumber, unsigned int numberOfReturns, bool edgeOfFlightLine);
+    Point(
+        scanlib::target target,
+        unsigned int returnNumber,
+        unsigned int numberOfReturns,
+        bool edgeOfFlightLine,
+        double beamOriginX,
+        double beamOriginY,
+        double beamOriginZ,
+        double beamDirectionX,
+        double beamDirectionY,
+        double beamDirectionZ);
 
     scanlib::target target;
     unsigned int returnNumber;

--- a/plugins/rxp/io/RxpPointcloud.hpp
+++ b/plugins/rxp/io/RxpPointcloud.hpp
@@ -60,6 +60,8 @@ struct Point {
     unsigned int returnNumber;
     unsigned int numberOfReturns;
     bool edgeOfFlightLine;
+    double beamOriginX, beamOriginY, beamOriginZ;
+    double beamDirectionX, beamDirectionY, beamDirectionZ;
 };
 
 

--- a/plugins/rxp/io/RxpReader.cpp
+++ b/plugins/rxp/io/RxpReader.cpp
@@ -75,6 +75,12 @@ Dimension::IdList getRxpDimensions(bool syncToPps, bool reflectanceAsIntensity)
     ids.push_back(Id::BackgroundRadiation);
     ids.push_back(Id::IsPpsLocked);
     ids.push_back(Id::EdgeOfFlightLine);
+    ids.push_back(Id::BeamDirectionX);
+    ids.push_back(Id::BeamDirectionY);
+    ids.push_back(Id::BeamDirectionZ);
+    ids.push_back(Id::BeamOriginX);
+    ids.push_back(Id::BeamOriginY);
+    ids.push_back(Id::BeamOriginZ);
     if (reflectanceAsIntensity) {
         ids.push_back(Id::Intensity);
     }


### PR DESCRIPTION
rivlib `pointcloud` class allow access to `double[3] beam_direction` and `double[3] beam_origin` which are respectively the beam direction and origin of the current laster shot.

Then each taget from `std::vector<target> targets` contains :
> `float vertex;`
Cartesian coordinates in scanners own coordinate system. vertex[i] = beam_origin[i] + echo_range * beam_direction[i]
`double echo_range;`
The distance from the laser origin to the target. Note that this is not the same as sqrt(vertex[0]^2 + vertex[1]^2 + vertex[2]^2).

Exposing these values, enables further MTA correction.