### PR TITLE
CMake: Allow to use CMAKE_CROSSCOMPILING_EMULATOR

### DIFF
--- a/cmake/dimension.cmake
+++ b/cmake/dimension.cmake
@@ -5,15 +5,11 @@
 set(DIMENSION_INFILE ${PDAL_SRC_DIR}/Dimension.json)
 set(DIMENSION_OUTFILE ${CMAKE_CURRENT_BINARY_DIR}/include/pdal/Dimension.hpp)
 
-# In cross compiling scenarios, the location of the native DIMBUILDER_EXECUTABLE
-# must be provided to the CMake invocation.
-IF (CMAKE_CROSSCOMPILING)
-    SET(DIMBUILDER "${DIMBUILDER_EXECUTABLE}")
-ELSE (CMAKE_CROSSCOMPILING)
-    SET(DIMBUILDER dimbuilder)
-ENDIF (CMAKE_CROSSCOMPILING)
+# In cross compiling scenarios, the location of the native dimbuilder executable
+# can be provided to the CMake invocation (in cases not suitable for CMAKE_CROSSCOMPILING_EMULATOR).
+set (DIMBUILDER_EXECUTABLE dimbuilder CACHE STRING "native dimbuilder executable")
 
 add_custom_command(OUTPUT ${DIMENSION_OUTFILE}
-    COMMAND ${DIMBUILDER} ${DIMENSION_INFILE} ${DIMENSION_OUTFILE}
+    COMMAND ${DIMBUILDER_EXECUTABLE} ${DIMENSION_INFILE} ${DIMENSION_OUTFILE}
         DEPENDS ${DIMENSION_INFILE} dimbuilder)
 add_custom_target(generate_dimension_hpp DEPENDS ${DIMENSION_OUTFILE})


### PR DESCRIPTION
For cross-compiling scenarios, we can either choose to use DIMBUILDER_EXECUTABLE
or run through CMAKE_CROSSCOMPILING_EMULATOR.