### PR TITLE
tests passing against tiledb 2.5.x

### DIFF
--- a/plugins/tiledb/test/TileDBReaderTest.cpp
+++ b/plugins/tiledb/test/TileDBReaderTest.cpp
@@ -36,6 +36,7 @@
 
 #include <pdal/Filter.hpp>
 #include <pdal/pdal_test_main.hpp>
+#include <pdal/util/FileUtils.hpp>
 
 #include <pdal/StageFactory.hpp>
 #include <io/FauxReader.hpp>
@@ -57,14 +58,13 @@ class TileDBReaderTest : public ::testing::Test
 protected:
     virtual void SetUp()
     {
-        tiledb::Context ctx;
         FauxReader rdr;
         TileDBWriter writer;
         Options writer_options;
         Options reader_options;
 
-        if (Utils::fileExists(data_path))
-            tiledb::Object::remove(ctx, data_path);
+        if (FileUtils::directoryExists(data_path))
+            FileUtils::deleteDirectory(data_path);
 
         writer_options.add("array_name", data_path);
         writer_options.add("x_tile_size", 1);
@@ -101,10 +101,7 @@ TEST_F(TileDBReaderTest, findStage)
 }
 
 TEST_F(TileDBReaderTest, read_bbox)
-{
-    tiledb::Context ctx;
-    tiledb::VFS vfs(ctx);
-  
+{ 
     Options options;
     options.add("array_name", data_path);
     options.add("bbox3d", "([0, 0.5], [0, 0.5], [0, 0.5])");
@@ -120,8 +117,6 @@ TEST_F(TileDBReaderTest, read_bbox)
 
 TEST_F(TileDBReaderTest, read_zero_bbox)
 {
-    tiledb::Context ctx;
-    tiledb::VFS vfs(ctx);
     Options options;
     options.add("array_name", data_path);
     options.add("bbox3d", "([1.1, 1.2], [1.1, 1.2], [1.1, 1.2])");
@@ -185,7 +180,6 @@ TEST_F(TileDBReaderTest, read)
     };
 
     tiledb::Context ctx;
-    tiledb::VFS vfs(ctx);
     Options options;
     options.add("array_name", data_path);
 
@@ -200,15 +194,20 @@ TEST_F(TileDBReaderTest, read)
     }
 
     tiledb::Query q(ctx, array, TILEDB_READ);
+    q.set_subarray(subarray);
 
+#if TILEDB_VERSION_MAJOR == 1
+    std::vector<double> coords(count  * 3);
+    q.set_coordinates(coords);
+#else
     std::vector<double> xs(count);
     std::vector<double> ys(count);
     std::vector<double> zs(count);
-
-    q.set_subarray(subarray)
-        .set_data_buffer("X", xs)
+    
+    q.set_data_buffer("X", xs)
         .set_data_buffer("Y", ys)
         .set_data_buffer("Z", zs);
+#endif
 
     q.submit();
     array.close();
@@ -228,8 +227,6 @@ TEST_F(TileDBReaderTest, read)
 
 TEST_F(TileDBReaderTest, spatial_reference)
 {
-    tiledb::Context ctx;
-    tiledb::VFS vfs(ctx);
     std::string pth = Support::temppath("tiledb_test_srs");
 
     Options options;
@@ -243,10 +240,8 @@ TEST_F(TileDBReaderTest, spatial_reference)
     writer_options.add("y_tile_size", 1);
     writer_options.add("z_tile_size", 1);
 
-    if (vfs.is_dir(pth))
-    {
-        vfs.remove_dir(pth);
-    }
+    if (FileUtils::directoryExists(pth))
+        FileUtils::deleteDirectory(pth);
 
     FauxReader reader;
     Options reader_options;


### PR DESCRIPTION
TileDB 2.5 removed `max_buffer_elements`. I have updated the tests to use larger buffers and then adding a check on the result buffer size. The plugin itself was not using `max_buffer_elements`.

I also took the opportunity to do a minor refactor on the tests by setting the `count` and making the test names match.