### PR TITLE
Testing for TileDB 1.x and 2.x

### DIFF
--- a/plugins/tiledb/test/TileDBReaderTest.cpp
+++ b/plugins/tiledb/test/TileDBReaderTest.cpp
@@ -204,9 +204,9 @@ TEST_F(TileDBReaderTest, read)
     std::vector<double> ys(count);
     std::vector<double> zs(count);
     
-    q.set_data_buffer("X", xs)
-        .set_data_buffer("Y", ys)
-        .set_data_buffer("Z", zs);
+    q.set_buffer("X", xs)
+        .set_buffer("Y", ys)
+        .set_buffer("Z", zs);
 #endif
 
     q.submit();

--- a/plugins/tiledb/test/TileDBReaderTimeDimTest.cpp
+++ b/plugins/tiledb/test/TileDBReaderTimeDimTest.cpp
@@ -201,10 +201,10 @@ TEST_F(TileDBReaderTimeDimTest, read_4d)
     std::vector<double> zs(count);
     std::vector<double> ts(count);
     
-    q.set_data_buffer("X", xs)
-        .set_data_buffer("Y", ys)
-        .set_data_buffer("Z", zs)
-        .set_data_buffer("GpsTime", ts);
+    q.set_buffer("X", xs)
+        .set_buffer("Y", ys)
+        .set_buffer("Z", zs)
+        .set_buffer("GpsTime", ts);
 #endif
 
     q.submit();

--- a/plugins/tiledb/test/TileDBWriterTest.cpp
+++ b/plugins/tiledb/test/TileDBWriterTest.cpp
@@ -154,9 +154,9 @@ namespace pdal
         std::vector<double> ys(count);
         std::vector<double> zs(count);
         
-        q.set_data_buffer("X", xs)
-            .set_data_buffer("Y", ys)
-            .set_data_buffer("Z", zs);
+        q.set_buffer("X", xs)
+            .set_buffer("Y", ys)
+            .set_buffer("Z", zs);
 #endif
         q.submit();
         array.close();
@@ -240,9 +240,9 @@ namespace pdal
         std::vector<double> ys(count * 2);
         std::vector<double> zs(count * 2);
         
-        q.set_data_buffer("X", xs)
-            .set_data_buffer("Y", ys)
-            .set_data_buffer("Z", zs);
+        q.set_buffer("X", xs)
+            .set_buffer("Y", ys)
+            .set_buffer("Z", zs);
 #endif
 
         q.submit();
@@ -532,9 +532,9 @@ namespace pdal
         std::vector<double> zs(count*2);
 
         q.set_subarray(subarray)
-            .set_data_buffer("X", xs)
-            .set_data_buffer("Y", ys)
-            .set_data_buffer("Z", zs);
+            .set_buffer("X", xs)
+            .set_buffer("Y", ys)
+            .set_buffer("Z", zs);
 
         q.submit();
         array.close();
@@ -591,6 +591,9 @@ namespace pdal
 
         tiledb::Context ctx;
         std::string pth = Support::temppath("tiledb_test_sf_curve_ts");
+
+        if (FileUtils::directoryExists(pth))
+            FileUtils::deleteDirectory(pth);
 
         Options writer_options = getTileDBOptions();
         writer_options.add("array_name", pth);

--- a/plugins/tiledb/test/TileDBWriterTimeDimTest.cpp
+++ b/plugins/tiledb/test/TileDBWriterTimeDimTest.cpp
@@ -229,10 +229,10 @@ TEST_F(TileDBWriterTimeDimTest, write_with_time)
     std::vector<double> zs(count);
     std::vector<double> ts(count);
     
-    q.set_data_buffer("X", xs)
-        .set_data_buffer("Y", ys)
-        .set_data_buffer("Z", zs)
-        .set_data_buffer("GpsTime", ts);
+    q.set_buffer("X", xs)
+        .set_buffer("Y", ys)
+        .set_buffer("Z", zs)
+        .set_buffer("GpsTime", ts);
 #endif
 
     q.submit();
@@ -310,10 +310,10 @@ TEST_F(TileDBWriterTimeDimTest, write_append_with_time)
     std::vector<double> zs(count * 2);
     std::vector<double> ts(count * 2);
     
-    q.set_data_buffer("X", xs)
-        .set_data_buffer("Y", ys)
-        .set_data_buffer("Z", zs)
-        .set_data_buffer("GpsTime", ts);
+    q.set_buffer("X", xs)
+        .set_buffer("Y", ys)
+        .set_buffer("Z", zs)
+        .set_buffer("GpsTime", ts);
 #endif
 
     q.submit();
@@ -488,10 +488,10 @@ TEST_F(TileDBWriterTimeDimTest, append_write_with_time)
     std::vector<double> zs(count * 2);
     std::vector<double> ts(count * 2);
     
-    q.set_data_buffer("X", xs)
-        .set_data_buffer("Y", ys)
-        .set_data_buffer("Z", zs)
-        .set_data_buffer("GpsTime", ts);
+    q.set_buffer("X", xs)
+        .set_buffer("Y", ys)
+        .set_buffer("Z", zs)
+        .set_buffer("GpsTime", ts);
 
     q.submit();
     array.close();


### PR DESCRIPTION
@abellgithub We can merge this into your branch and then into master.

`set_buffer` is deprecated. After all the tests pass and we merged master I will create a separate PR that makes CI only work with TileDB 2.5+.