### PR TITLE
change the output path of gitsha.cpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,7 +150,7 @@ get_git_head_revision(GIT_REFSPEC GIT_SHA1)
 
 configure_file(
   "${PROJECT_SOURCE_DIR}/gitsha.cpp.in"
-  "${PROJECT_SOURCE_DIR}/pdal/gitsha.cpp")
+  "${CMAKE_CURRENT_BINARY_DIR}/pdal/gitsha.cpp")
 
 # needs to come before configuration of pdal_features
 if(APPLE)
@@ -204,6 +204,7 @@ if (APPLE)
 endif()
 
 file(GLOB BASE_SRCS
+    ${CMAKE_CURRENT_BINARY_DIR}/pdal/gitsha.cpp
     ${PDAL_FILTERS_DIR}/*.cpp
     ${PDAL_IO_DIR}/*.cpp
     ${PDAL_KERNELS_DIR}/*.cpp


### PR DESCRIPTION
In vcpkg, files with configure_file are not allowed to be output to PROJECT_SOURCE_DIR.
If it is modified here, there is no need to make a patch for this in vcpkg.