### PR TITLE
Make sure we write the correct chunk table position.

### DIFF
--- a/pdal/compression/LazPerfVlrCompression.cpp
+++ b/pdal/compression/LazPerfVlrCompression.cpp
@@ -108,6 +108,16 @@ public:
             newChunk();
         }
 
+        // If we didn't write any points, chunk info pos will be 0 and we need to
+        // set the chunk info pos. Could do this as an "else" case of the
+        // above, but this seems safer in case some other compressor creation logic
+        // comes about.
+        if (m_chunkInfoPos == 0)
+        {
+            m_chunkInfoPos = m_stream.tellp();
+            m_stream.seekp(sizeof(uint64_t), std::ios::cur);
+        }
+
         // Save our current position.  Go to the location where we need
         // to write the chunk table offset at the beginning of the point data.
         std::streampos chunkTablePos = m_stream.tellp();
@@ -212,7 +222,8 @@ public:
 
         bool variable = (m_vlr.chunk_size == lazperf::VariableChunkSize);
 
-        m_chunks = lazperf::decompress_chunk_table(m_fileStream.cb(), numChunks, variable);
+        if (numChunks)
+            m_chunks = lazperf::decompress_chunk_table(m_fileStream.cb(), numChunks, variable);
 
         // If the chunk size is fixed, set the counts to the chunk size since
         // they aren't stored in the chunk table..

--- a/test/unit/io/LasWriterTest.cpp
+++ b/test/unit/io/LasWriterTest.cpp
@@ -1715,14 +1715,14 @@ TEST(LasWriterTest, issue3652)
 {
     std::string outfile(Support::temppath("3652.laz"));
 
-    auto test = [&outfile](const std::string& compression)
+    auto test = [&outfile](const std::string& writeCompression, const std::string& readCompression)
     {
         FileUtils::deleteFile(outfile);
         {
             LasWriter w;
             Options wo;
             wo.add("filename", outfile);
-            wo.add("compression", compression);
+            wo.add("compression", writeCompression);
             w.setOptions(wo);
 
             PointTable t;
@@ -1735,6 +1735,7 @@ TEST(LasWriterTest, issue3652)
             LasReader r;
             Options ro;
             ro.add("filename", outfile);
+            ro.add("compression", readCompression);
             r.setOptions(ro);
 
             PointTable t;
@@ -1746,10 +1747,14 @@ TEST(LasWriterTest, issue3652)
         }
     };
 #if defined(PDAL_HAVE_LAZPERF)
-    test("lazperf");
+    test("lazperf", "lazperf");
 #endif
 #if defined(PDAL_HAVE_LASZIP)
-    test("laszip");
+    test("laszip", "laszip");
+#endif
+#if defined(PDAL_HAVE_LAZPERF) && defined(PDAL_HAVE_LASZIP)
+    test("lazperf", "laszip");
+    test("laszip", "lazperf");
 #endif
 }
 #endif


### PR DESCRIPTION
Don't decompress an empty chunk table.