### PR TITLE
fix: PDALConfig.cmake install location

### DIFF
--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -6,7 +6,7 @@ include(CMakePackageConfigHelpers)
 configure_package_config_file(
   PDALConfig.cmake.in
   ${CMAKE_CURRENT_BINARY_DIR}/PDALConfig.cmake
-  INSTALL_DESTINATION ${LIB_INSTALL_DIR}/cmake/PDAL
+  INSTALL_DESTINATION ${PDAL_LIB_INSTALL_DIR}/cmake/PDAL
   PATH_VARS INCLUDE_INSTALL_DIR LIB_INSTALL_DIR)
 
 write_basic_package_version_file(
@@ -17,4 +17,4 @@ write_basic_package_version_file(
 install(FILES
   ${CMAKE_CURRENT_BINARY_DIR}/PDALConfig.cmake
   ${CMAKE_CURRENT_BINARY_DIR}/PDALConfigVersion.cmake
-  DESTINATION ${LIB_INSTALL_DIR}/cmake/PDAL)
+  DESTINATION ${PDAL_LIB_INSTALL_DIR}/cmake/PDAL)


### PR DESCRIPTION
PDALConfig{,Version}.cmake shall be installed at the same location
as PDALTargets.cmake
Without this patch these files end up in lib, with the others end up in
lib64