### PR TITLE
Handle quick info inspect for ply reader (#3704)

### DIFF
--- a/io/PlyReader.cpp
+++ b/io/PlyReader.cpp
@@ -289,6 +289,28 @@ std::string PlyReader::getName() const
     return s_info.name;
 }
 
+QuickInfo PlyReader::inspect()
+{
+    QuickInfo qi;
+
+    initialize();
+
+    if (m_vertexElt)
+    {
+        // Get quick info information from the vertex element (if initialised). We ignore the bounds 
+        // since calculating that would require reading the entire file. We also ignore the spatial
+        // reference since we don't have that.
+
+        qi.m_valid = true;
+        qi.m_pointCount = static_cast<point_count_t>(m_vertexElt->m_count);
+        for (auto& prop : m_vertexElt->m_properties)
+        {
+            qi.m_dimNames.push_back(prop->m_name);
+        }
+    }
+
+    return qi;
+}
 
 void PlyReader::initialize()
 {

--- a/io/PlyReader.hpp
+++ b/io/PlyReader.hpp
@@ -127,6 +127,7 @@ private:
     PointId m_index;
     Element *m_vertexElt;
 
+    virtual QuickInfo inspect();
     virtual void initialize();
     virtual void addDimensions(PointLayoutPtr layout);
     virtual void ready(PointTableRef table);

--- a/test/unit/io/PlyReaderTest.cpp
+++ b/test/unit/io/PlyReaderTest.cpp
@@ -199,4 +199,19 @@ TEST(PlyReader, NoVertex)
     EXPECT_THROW(reader.prepare(table), pdal_error);
 }
 
+TEST(PlyReader, inspect)
+{
+    PlyReader reader;
+    Options options;
+    options.add("filename", Support::datapath("ply/text_extradim.ply"));
+    reader.setOptions(options);
+
+    const QuickInfo qi = reader.preview();
+    EXPECT_TRUE(qi.m_valid);
+    EXPECT_EQ(qi.m_pointCount, 1u);
+    EXPECT_TRUE(std::find(qi.m_dimNames.begin(), qi.m_dimNames.end(), "x") != qi.m_dimNames.end());
+    EXPECT_TRUE(std::find(qi.m_dimNames.begin(), qi.m_dimNames.end(), "nx") != qi.m_dimNames.end());
+    EXPECT_TRUE(std::find(qi.m_dimNames.begin(), qi.m_dimNames.end(), "red") != qi.m_dimNames.end());
+}
+
 }


### PR DESCRIPTION
- Added implementation for inspect() to PlyReader. We can get
  everything we need from the vertex element setup by initialize().

- We ignore bounds to avoid having to read the entire file. We also
  avoid spatial reference.

- Added inspect test to PlyReaderTest unit tests.