### PR TITLE
Specify release build type in ubuntu Dockerfile

### DIFF
--- a/scripts/docker/ubuntu/Dockerfile
+++ b/scripts/docker/ubuntu/Dockerfile
@@ -7,6 +7,7 @@ RUN git clone http://github.com/PDAL/PDAL.git pdal && \
     mkdir -p pdal/build && \
     cd pdal/build  && \
     LDFLAGS="-Wl,-rpath-link,$CONDA_PREFIX/lib" cmake -G Ninja  \
+        -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_LIBRARY_PATH:FILEPATH="$CONDA_PREFIX/lib" \
         -DCMAKE_INCLUDE_PATH:FILEPATH="$CONDA_PREFIX/include" \
         -DCMAKE_INSTALL_PREFIX="$CONDA_PREFIX" \


### PR DESCRIPTION
I'm actually not very familiar with cmake, but I think the default mode is probably debug. The performance is much better after adding Release mode.