### PR TITLE
Add link to autzen.laz file

### DIFF
--- a/doc/workshop/exercises/analysis/clipping/clipping.rst
+++ b/doc/workshop/exercises/analysis/clipping/clipping.rst
@@ -16,7 +16,8 @@ This exercise uses PDAL to apply to clip data with polygon geometries.
 Exercise
 --------------------------------------------------------------------------------
 
-The ``autzen.laz`` file is a staple in PDAL and libLAS examples. We will
+The ``autzen.laz`` file is a staple in PDAL and libLAS examples. You can [download this file here] 
+(https://github.com/PDAL/data/blob/master/autzen/autzen.laz) We will
 use this file to demonstrate clipping points with a geometry. We're going to
 clip out the stadium into a new LAS file.
 


### PR DESCRIPTION
There's no link to the autzen.laz file referenced in the tutorial and it's not a part of the PDAL workshop download. Suggest adding a hyperlink to this page directing you to https://github.com/PDAL/data/blob/master/autzen/autzen.laz

as well - I followed the link to the tutorial mentioned on the line "This exercise is an adaption of the PDAL tutorial." There is a link to autzen.laz there but it is broken (it directs you, incorrectly, to here: https://github.com/PDAL/data/autzen/autzen.laz)