### PR TITLE
Add CI debug task after build and before test

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -38,6 +38,12 @@ jobs:
           source ../scripts/ci/conda/compile.sh
       working-directory: ./pdal-feedstock
 
+    - name: Debug
+      shell: bash -l {0}
+      run: |
+          conda activate test
+          conda list
+
     - uses: ilammy/msvc-dev-cmd@v1
       if: matrix.platform == 'windows-latest'
     - name: Test


### PR DESCRIPTION
All the debug task does is list all conda installed packages and their
associated versions, this will be helpful in cases where a change in a
dependency causes a breakage.