### PR TITLE
Use mambaforge and cache conda packages in CI

### DIFF
--- a/.github/workflows/alpine.yml
+++ b/.github/workflows/alpine.yml
@@ -5,35 +5,33 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
     strategy:
       fail-fast: true
     container: pdal/alpinebase:latest
     steps:
     - uses: actions/checkout@v2
     - name: Setup
-      shell: bash -l {0}
       run: |
           source ./scripts/ci/alpine/setup.sh
 
     - name: CMake
-      shell: bash -l {0}
       run: |
           source ../scripts/ci/alpine/cmake.sh
       working-directory: ./build
 
     - name: Compile
-      shell: bash -l {0}
       run: |
           source ../scripts/ci/alpine/compile.sh
       working-directory: ./build
 
     - name: Test
-      shell: bash -l {0}
       run: |
           source ../scripts/ci/alpine/test.sh
       working-directory: ./build
 
     - name: Examples
-      shell: bash -l {0}
       run: |
           source ./scripts/ci/alpine/examples.sh

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -16,20 +16,25 @@ jobs:
 
     env:
       PDAL_PLATFORM: ${{ matrix.platform }}
-
+      CACHE_NUMBER: 0
     steps:
     - uses: actions/checkout@v2
 
     - name: Support longpaths
       run: git config --system core.longpaths true
       if: matrix.platform == 'windows-latest'
-
+    - name: Cache Conda Environment
+      uses: actions/cache@v2
+      with:
+        path: ~/conda_pkgs_dir
+        key: ${{ runner.os }}-${{ steps.get-date.outputs.today }}-conda-${{ env.CACHE_NUMBER }}
     - uses: conda-incubator/setup-miniconda@v2
       with:
         miniforge-variant: Mambaforge
         miniforge-version: latest
         use-mamba: true
         auto-update-conda: true
+        use-only-tar-bz2: true
 
     - name: Setup
       run: |
@@ -39,7 +44,6 @@ jobs:
       run: |
           source ../scripts/ci/conda/compile.sh
       working-directory: ./pdal-feedstock
-
     - uses: ilammy/msvc-dev-cmd@v1
       if: matrix.platform == 'windows-latest'
     - name: Test

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -5,7 +5,9 @@ on: [push, pull_request]
 jobs:
   build:
     name: Conda ${{ matrix.platform }}
-
+    defaults:
+      run:
+        shell: bash -l {0}
     runs-on: ${{ matrix.platform }}
     strategy:
       fail-fast: true
@@ -30,12 +32,10 @@ jobs:
         auto-update-conda: true
 
     - name: Setup
-      shell: bash -l {0}
       run: |
           source ./scripts/ci/conda/setup.sh
 
     - name: Build
-      shell: bash -l {0}
       run: |
           source ../scripts/ci/conda/compile.sh
       working-directory: ./pdal-feedstock
@@ -43,7 +43,6 @@ jobs:
     - uses: ilammy/msvc-dev-cmd@v1
       if: matrix.platform == 'windows-latest'
     - name: Test
-      shell: bash -l {0}
       run: |
           source ./scripts/ci/conda/examples.sh
 
@@ -54,7 +53,6 @@ jobs:
 
     - name: Deploy to pdal-master Conda channel
       if: github.ref == 'refs/heads/master'
-      shell: bash -l {0}
       env:
         ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
       run: |

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -24,7 +24,9 @@ jobs:
 
     - uses: conda-incubator/setup-miniconda@v2
       with:
-        channels: conda-forge
+        miniforge-variant: Mambaforge
+        miniforge-version: latest
+        use-mamba: true
         auto-update-conda: true
 
     - name: Setup

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -44,6 +44,13 @@ jobs:
       run: |
           source ../scripts/ci/conda/compile.sh
       working-directory: ./pdal-feedstock
+
+    - name: Debug
+      run: |
+          conda activate test
+          conda info
+          conda list
+
     - uses: ilammy/msvc-dev-cmd@v1
       if: matrix.platform == 'windows-latest'
     - name: Test

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,36 +11,32 @@ jobs:
       fail-fast: true
     container:
       image: ghcr.io/osgeo/proj-docs:latest
-
+    defaults:
+      run:
+        shell: bash -l {0}
     steps:
     - uses: actions/checkout@v2
     - name: Print versions
-      shell: bash -l {0}
       run: |
           python3 --version
           sphinx-build --version
     - name: Lint .rst files
-      shell: bash -l {0}
       run: |
         if find . -name '*.rst' | xargs grep -P '\t'; then echo 'Tabs are bad, please use four spaces in .rst files.'; false; fi
       working-directory: ./doc
     - name: Doxygen
-      shell: bash -l {0}
       run: |
         make doxygen
       working-directory: ./doc
     - name: HTML
-      shell: bash -l {0}
       run: |
         make html
       working-directory: ./doc
     - name: PDF
-      shell: bash -l {0}
       run: |
         make latexpdf
       working-directory: ./doc
     - name: Spelling
-      shell: bash -l {0}
       run: |
         make spell
       working-directory: ./doc
@@ -60,7 +56,6 @@ jobs:
     - name: Deploy docs
       env:
         API_TOKEN_GITHUB: ${{ secrets.DOCS_SECRET_KEY}}
-      shell: bash -l {0}
       if: contains(github.ref, '2.4-maintenance')
 
       run: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -18,7 +18,9 @@ jobs:
     - uses: actions/checkout@v2
     - uses: conda-incubator/setup-miniconda@v2
       with:
-        channels: conda-forge
+        miniforge-variant: Mambaforge
+        miniforge-version: latest
+        use-mamba: true
         auto-update-conda: true
 
     - name: Setup

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -5,7 +5,9 @@ on: [push, pull_request]
 jobs:
   build:
     name: Linux ${{ matrix.type }}
-
+    defaults:
+      run:
+        shell: bash -l {0}
     runs-on: 'ubuntu-latest'
     strategy:
       fail-fast: false
@@ -24,30 +26,25 @@ jobs:
         auto-update-conda: true
 
     - name: Setup
-      shell: bash -l {0}
       run: |
           source ./scripts/ci/linux/setup.sh
 
     - name: CMake
-      shell: bash -l {0}
       run: |
           source ../scripts/ci/linux/cmake.sh
       working-directory: ./build
 
     - name: Compile
-      shell: bash -l {0}
       run: |
           source ../scripts/ci/linux/compile.sh
       working-directory: ./build
 
     - name: Test
-      shell: bash -l {0}
       run: |
           source ../scripts/ci/linux/test.sh
       working-directory: ./build
 
     - name: Examples
-      shell: bash -l {0}
       run: |
           source ./scripts/ci/linux/examples.sh
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -15,15 +15,21 @@ jobs:
         type: ['floating','fixed']
     env:
       BUILD_TYPE: ${{ matrix.type }}
-
+      CACHE_NUMBER: 0
     steps:
     - uses: actions/checkout@v2
+    - name: Cache Conda Environment
+      uses: actions/cache@v2
+      with:
+        path: ~/conda_pkgs_dir
+        key: ${{ runner.os }}-${{ steps.get-date.outputs.today }}-conda-${{ env.CACHE_NUMBER }}
     - uses: conda-incubator/setup-miniconda@v2
       with:
         miniforge-variant: Mambaforge
         miniforge-version: latest
         use-mamba: true
         auto-update-conda: true
+        use-only-tar-bz2: true
 
     - name: Setup
       run: |

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -18,7 +18,9 @@ jobs:
     - uses: actions/checkout@v2
     - uses: conda-incubator/setup-miniconda@v2
       with:
-        channels: conda-forge
+        miniforge-variant: Mambaforge
+        miniforge-version: latest
+        use-mamba: true
         auto-update-conda: true
 
     - name: Setup

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -19,12 +19,18 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Cache Conda Environment
+      uses: actions/cache@v2
+      with:
+        path: ~/conda_pkgs_dir
+        key: ${{ runner.os }}-${{ steps.get-date.outputs.today }}-conda-${{ env.CACHE_NUMBER }}
     - uses: conda-incubator/setup-miniconda@v2
       with:
         miniforge-variant: Mambaforge
         miniforge-version: latest
         use-mamba: true
         auto-update-conda: true
+        use-only-tar-bz2: true
 
     - name: Setup
       run: |

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -13,6 +13,9 @@ jobs:
         type: ['floating','fixed']
     env:
       BUILD_TYPE: ${{ matrix.type }}
+    defaults:
+      run:
+        shell: bash -l {0}
 
     steps:
     - uses: actions/checkout@v2
@@ -24,30 +27,25 @@ jobs:
         auto-update-conda: true
 
     - name: Setup
-      shell: bash -l {0}
       run: |
           source ./scripts/ci/osx/setup.sh
 
     - name: CMake
-      shell: bash -l {0}
       run: |
           source ../scripts/ci/osx/cmake.sh
       working-directory: ./build
 
     - name: Compile
-      shell: bash -l {0}
       run: |
           source ../scripts/ci/osx/compile.sh
       working-directory: ./build
 
     - name: Test
-      shell: bash -l {0}
       run: |
           source ../scripts/ci/osx/test.sh
       working-directory: ./build
 
     - name: Examples
-      shell: bash -l {0}
       run: |
           source ./scripts/ci/osx/examples.sh
 

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -19,7 +19,9 @@ jobs:
     - uses: ilammy/msvc-dev-cmd@v1
     - uses: conda-incubator/setup-miniconda@v2
       with:
-        channels: conda-forge
+        miniforge-variant: Mambaforge
+        miniforge-version: latest
+        use-mamba: true
         auto-update-conda: true
         python-version: '3.8'
 

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -20,6 +20,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: ilammy/msvc-dev-cmd@v1
+    - name: Cache Conda Environment
+      uses: actions/cache@v2
+      with:
+        path: ~/conda_pkgs_dir
+        key: ${{ runner.os }}-${{ steps.get-date.outputs.today }}-conda-${{ env.CACHE_NUMBER }}
     - uses: conda-incubator/setup-miniconda@v2
       with:
         miniforge-variant: Mambaforge
@@ -27,6 +32,7 @@ jobs:
         use-mamba: true
         auto-update-conda: true
         python-version: '3.8'
+        use-only-tar-bz2: true
 
     - name: Setup
       run: |

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -11,6 +11,9 @@ jobs:
       fail-fast: true
       matrix:
         type: ['floating','fixed']
+    defaults:
+      run:
+        shell: bash -l {0}
     env:
       BUILD_TYPE: ${{ matrix.type }}
 
@@ -26,30 +29,25 @@ jobs:
         python-version: '3.8'
 
     - name: Setup
-      shell: bash -l {0}
       run: |
           source ./scripts/ci/win/setup.sh
 
     - name: CMake
-      shell: bash -l {0}
       working-directory: ./build
       run: |
           source ../scripts/ci/win/cmake.sh
 
     - name: Compile
-      shell: bash -l {0}
       working-directory: ./build
       run: |
           source ../scripts/ci/win/compile.sh
 
     - name: Test
-      shell: bash -l {0}
       working-directory: ./build
       run: |
           source ../scripts/ci/win/test.sh
 
     - name: Examples
-      shell: bash -l {0}
       run: |
           source ./scripts/ci/win/examples.sh
 


### PR DESCRIPTION
Modification to CI setups to use mambaforce instead of miniconda, and to cache the conda packages directory.