### PR TITLE
Make sure to setup LogPtr for internal NormalFilter used b…

### DIFF
--- a/filters/GreedyProjection.cpp
+++ b/filters/GreedyProjection.cpp
@@ -126,7 +126,9 @@ void GreedyProjection::addTriangle(PointId a, PointId b, PointId c)
 
 void GreedyProjection::filter(PointView& view)
 {
-    NormalFilter().doFilter(view);
+    NormalFilter nf;
+    nf.setLog(log());
+    nf.doFilter(view);
 
     KD3Index& tree = view.build3dIndex();
 


### PR DESCRIPTION
confirmed the segfault with the following traceback:

```
  * frame #0: 0x000000010597e064 libpdalcpp.14.dylib`pdal::Log::get(this=0x0000000000000000, level=Debug) at Log.cpp:121:39
    frame #1: 0x0000000105265aa4 libpdalcpp.14.dylib`pdal::NormalFilter::compute(pdal::PointView&, pdal::KD3Index&) + 100
    frame #2: 0x0000000105266fb4 libpdalcpp.14.dylib`pdal::NormalFilter::filter(pdal::PointView&) + 60
    frame #3: 0x0000000105265838 libpdalcpp.14.dylib`pdal::NormalFilter::doFilter(pdal::PointView&, int) + 112
    frame #4: 0x0000000105040a0c libpdalcpp.14.dylib`pdal::GreedyProjection::filter(pdal::PointView&) + 120
    frame #5: 0x0000000105946aac libpdalcpp.14.dylib`pdal::Filter::run(std::__1::shared_ptr<pdal::PointView>) + 96
    frame #6: 0x0000000105c7693c libpdalcpp.14.dylib`pdal::StageRunner::run() + 92
    frame #7: 0x0000000105a5dc7c libpdalcpp.14.dylib`pdal::Stage::execute(pdal::BasePointTable&, std::__1::set<std::__1::shared_ptr<pdal::PointView>, pdal::PointViewLess, std::__1::allocator<std::__1::shared_ptr<pdal::PointView> > >&) + 1108
```

When filters use other filters internally, they need to wire up their logs.