### PR TITLE
Add target link to PDAL 2.4.2 download

### DIFF
--- a/doc/download.rst
+++ b/doc/download.rst
@@ -15,6 +15,7 @@ Current Release(s)
 
 * **2022-06-06** `PDAL-2.4.2-src.tar.gz`_ `Release Notes`_ (`md5`_)
 
+.. _`PDAL-2.4.2-src.tar.gz`: https://github.com/PDAL/PDAL/releases/download/2.4.2/PDAL-2.4.2-src.tar.gz
 .. _`Release Notes`: https://github.com/PDAL/PDAL/releases/tag/2.4.2
 .. _`md5`: https://github.com/PDAL/PDAL/releases/download/2.4.2/PDAL-2.4.2-src.tar.gz.md5
 


### PR DESCRIPTION
Fix documentation build issue where target was missing for link to PDAL 2.4.2