### PR TITLE
Do not error on warning on spell target during doc build CI stage

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -147,7 +147,7 @@ publish: clone
 	cd $(OUTPUTDIR) ; git checkout master; git add  "*" ; git commit -m "update for $(DATE)" . ; git push
 
 spell:
-	$(SPHINXBUILD) -b spelling $(ALLSPHINXOPTS) -d $(BUILDDIR)/doctrees build/spelling
+	$(SPHINXBUILD) -E -b spelling . -d $(BUILDDIR)/doctrees build/spelling 
 
 pdf:
 	$(SPHINXBUILD) -b pdf $(ALLSPHINXOPTS) $(BUILDDIR)/pdf


### PR DESCRIPTION
This PR makes it so sphinx-build with for the spell check step does not run with `-Werror`, so that the spell checking task does not error when it encounters misspelled words, and generates a warning instead.