### PR TITLE
Do not error on warning on spell target

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -147,7 +147,7 @@ publish: clone
 	cd $(OUTPUTDIR) ; git checkout master; git add  "*" ; git commit -m "update for $(DATE)" . ; git push
 
 spell:
-	$(SPHINXBUILD) -b spelling $(ALLSPHINXOPTS) -d $(BUILDDIR)/doctrees build/spelling
+	$(SPHINXBUILD) -E -b spelling . -d $(BUILDDIR)/doctrees build/spelling 
 
 pdf:
 	$(SPHINXBUILD) -b pdf $(ALLSPHINXOPTS) $(BUILDDIR)/pdf


### PR DESCRIPTION
Identical commit to the PR in #3788 to disable error on warning during the spell check target of the makefile in the doc build CI process.