### PR TITLE
Sbet writer not streamable

### DIFF
--- a/doc/stages/writers.sbet.rst
+++ b/doc/stages/writers.sbet.rst
@@ -7,8 +7,6 @@ The **SBET writer** writes files in the SBET format, used for exchange data from
 
 .. embed::
 
-.. streamable::
-
 Example
 -------
 


### PR DESCRIPTION
Update documentation that wrongly states that `writers.sbet` is streamable when it's not.