### PR TITLE
Support skipping over unsupported TileDB attributes in reader

### DIFF
--- a/doc/stages/readers.tiledb.rst
+++ b/doc/stages/readers.tiledb.rst
@@ -53,6 +53,9 @@ end_timestamp
 start_timestamp
   Opens the array between a timestamp range of start_timestamp and end_timestamp [Optional]
 
+strict
+  Raise an error if the array contains a TileDB attribute not supported by PDAL, the default is set to true to raise an error for unsupported attribute types [Optional]
+
 .. include:: reader_opts.rst
 
 .. _TileDB: https://tiledb.io

--- a/plugins/tiledb/io/TileDBReader.hpp
+++ b/plugins/tiledb/io/TileDBReader.hpp
@@ -103,6 +103,7 @@ private:
     point_count_t m_resultSize;
     point_count_t m_startTimeStamp;
     point_count_t m_endTimeStamp;
+    bool m_strict;
     bool m_complete;
     bool m_stats;
     BOX4D m_bbox;

--- a/plugins/tiledb/test/TileDBReaderTest.cpp
+++ b/plugins/tiledb/test/TileDBReaderTest.cpp
@@ -46,6 +46,8 @@
 #include "../io/TileDBReader.hpp"
 #include "../io/TileDBWriter.hpp"
 
+#include <tiledb/array_schema_evolution.h>
+
 namespace pdal
 {
 
@@ -260,5 +262,70 @@ TEST_F(TileDBReaderTest, spatial_reference)
     rdr.execute(table2);
     EXPECT_TRUE(rdr.getSpatialReference().equals(utm16));
 };
+
+TEST_F(TileDBReaderTest, unsupported_attribute)
+{
+    std::string pth = Support::temppath("tiledb_test_unsupported");
+
+    Options writer_options;
+    writer_options.add("array_name", pth);
+    writer_options.add("x_tile_size", 1);
+    writer_options.add("y_tile_size", 1);
+    writer_options.add("z_tile_size", 1);
+
+    if (FileUtils::directoryExists(pth))
+        FileUtils::deleteDirectory(pth);
+
+    FauxReader reader;
+    Options reader_options;
+    reader_options.add("mode", "ramp");
+    reader_options.add("count", 50);
+    reader.addOptions(reader_options);
+
+    TileDBWriter writer;
+    writer.setOptions(writer_options);
+    writer.setInput(reader);
+
+    FixedPointTable table(count);
+    writer.prepare(table);
+    writer.execute(table);
+
+    // now evolve the schema to add a string attribute
+    tiledb::Context ctx;
+    tiledb::ArraySchemaEvolution evolution(ctx);
+
+    // add a new attribute a1
+    auto a1 = tiledb::Attribute::create<std::string>(ctx, "a1");
+    evolution.add_attribute(a1);
+
+    uint64_t now = tiledb_timestamp_now_ms();
+    now = now + 1;
+    evolution.set_timestamp_range({now, now});
+
+    // evolve array
+    evolution.array_evolve(pth);
+
+    // read schema
+    auto read_schema = tiledb::Array::load_schema(ctx, pth);
+
+    auto attrs = read_schema.attributes();
+    EXPECT_TRUE(attrs.count("a1") == 1);
+
+    // read the points from the array, and check we skip over the unsupported attribute
+    TileDBReader rdr;
+    Options options;
+    options.add("array_name", pth);
+    rdr.setOptions(options);
+    FixedPointTable table2(count);
+    EXPECT_THROW(rdr.prepare(table2), pdal_error);
+
+    TileDBReader rdr2;
+    options.add("strict", false);
+    rdr2.setOptions(options);
+    rdr2.prepare(table2);
+    rdr2.execute(table2);  
+
+    EXPECT_EQ(table.numPoints(), 50);
+}
 
 }; //pdal namespace


### PR DESCRIPTION
It is possible that a user creates a TileDB array outside of PDAL with the correct dimensions to be read by the PDAL driver. They may have attribute types that are not supported by the PDAL driver. This PR allows a user to skip over unsupported PDAL dimension (attribute) types. 

The option `strict` toggles this behaviour on/off, the default being on,  unrecognized attributes will cause an error to be thrown.