### PR TITLE
 export pdal::StageExtensions::defaultReader

### DIFF
--- a/pdal/StageExtensions.hpp
+++ b/pdal/StageExtensions.hpp
@@ -47,7 +47,7 @@ public:
     StageExtensions(LogPtr log);
 
     PDAL_DLL void set(const std::string& stage, const StringList& exts);
-    std::string defaultReader(const std::string& filename);
+    PDAL_DLL std::string defaultReader(const std::string& filename);
     std::string defaultWriter(const std::string& filename);
     PDAL_DLL StringList extensions(const std::string& stage);
 private:


### PR DESCRIPTION
 which QGIS' pdal provider uses (see jef-n/OSGeo4W@d05ac41520d9da90a26c8a1498bd4c3ff94e8266)