### PR TITLE
fix readers.las.nosrs

### DIFF
--- a/io/LasReader.cpp
+++ b/io/LasReader.cpp
@@ -224,7 +224,7 @@ void LasReader::initializeLocal(PointTableRef table, MetadataNode& m)
     d->header.fill(headerBuf, las::Header::Size14);
 
     uint64_t fileSize = Utils::fileSize(m_filename);
-    StringList errors = d->header.validate(fileSize);
+    StringList errors = d->header.validate(fileSize, d->opts.nosrs);
     if (errors.size())
         throwError(errors.front());
 

--- a/io/private/las/Header.cpp
+++ b/io/private/las/Header.cpp
@@ -115,15 +115,16 @@ std::vector<char> Header::data() const
     return buf;
 }
 
-StringList Header::validate(uint64_t fileSize) const
+StringList Header::validate(uint64_t fileSize, bool nosrs) const
 {
     StringList errors;
 
     if (magic != "LASF")
         errors.push_back("Invalid file signature. Was expecting 'LASF', Check the first four "
             " bytes of the file.");
-    if (has14PointFormat() && !useWkt())
-        errors.push_back("Global encoding WKT flag not set for point format 6 - 10.");
+    if (!nosrs)
+        if (has14PointFormat() && !useWkt())
+            errors.push_back("Global encoding WKT flag not set for point format 6 - 10.");
     if (!dataCompressed() && (pointOffset > fileSize))
         errors.push_back("Invalid point offset - exceeds file size.");
     if (!dataCompressed() && (pointOffset + pointCount() * pointSize > fileSize))

--- a/io/private/las/Header.hpp
+++ b/io/private/las/Header.hpp
@@ -106,7 +106,7 @@ struct Header
 
     void fill(const char *buf, size_t bufsize);
     std::vector<char> data() const;
-    StringList validate(uint64_t fileSize) const;
+    StringList validate(uint64_t fileSize, bool nosrs) const;
 
     int size() const
         { return versionMinor >= 4 ? Size14 : versionMinor == 3 ? Size13 : Size12; }


### PR DESCRIPTION
`readers.las.nosrs` does not work if the global encoding bit is set for WKT but it was using GeoTIFF keys. This patch allows the user to 🔨 it and move on.