### PR TITLE
catch up PDAL's vendored laz-perf to 3.1.0

### DIFF
--- a/vendor/lazperf/detail/field_byte10.cpp
+++ b/vendor/lazperf/detail/field_byte10.cpp
@@ -1,19 +1,22 @@
 /*
 ===============================================================================
 
+  FILE:  field_byte10.cpp
+
+  CONTENTS:
+
   PROGRAMMERS:
 
     martin.isenburg@rapidlasso.com  -  http://rapidlasso.com
     uday.karan@gmail.com - Hobu, Inc.
     andrew.bell.ia@gmail.com - Hobu Inc.
-  
+
   COPYRIGHT:
-  
+
     (c) 2007-2014, martin isenburg, rapidlasso - tools to catch reality
-    (c) 2014, Uday Verma, Hobu, Inc.
 
     This is free software; you can redistribute and/or modify it under the
-    terms of the GNU Lesser General Licence as published by the Free Software
+    terms of the Apache Public License 2.0 published by the Apache Software
     Foundation. See the COPYING file for more information.
 
     This software is distributed WITHOUT ANY WARRANTY and without even the

--- a/vendor/lazperf/detail/field_byte10.hpp
+++ b/vendor/lazperf/detail/field_byte10.hpp
@@ -6,14 +6,14 @@
     martin.isenburg@rapidlasso.com  -  http://rapidlasso.com
     uday.karan@gmail.com - Hobu, Inc.
     andrew.bell.ia@gmail.com - Hobu Inc.
- 
+
   COPYRIGHT:
 
     (c) 2007-2014, martin isenburg, rapidlasso - tools to catch reality
     (c) 2014, Uday Verma, Hobu, Inc.
 
     This is free software; you can redistribute and/or modify it under the
-    terms of the GNU Lesser General Licence as published by the Free Software
+    terms of the Apache Public License 2.0 published by the Apache Software
     Foundation. See the COPYING file for more information.
 
     This software is distributed WITHOUT ANY WARRANTY and without even the

--- a/vendor/lazperf/detail/field_byte14.cpp
+++ b/vendor/lazperf/detail/field_byte14.cpp
@@ -2,29 +2,29 @@
 ===============================================================================
 
   FILE:  field_byte14.cpp
-  
+
   CONTENTS:
-    
+
 
   PROGRAMMERS:
 
     martin.isenburg@rapidlasso.com  -  http://rapidlasso.com
     uday.karan@gmail.com - Hobu, Inc.
-  
+
   COPYRIGHT:
-  
+
     (c) 2007-2014, martin isenburg, rapidlasso - tools to catch reality
     (c) 2014, Uday Verma, Hobu, Inc.
 
     This is free software; you can redistribute and/or modify it under the
-    terms of the GNU Lesser General Licence as published by the Free Software
+    terms of the Apache Public License 2.0 published by the Apache Software
     Foundation. See the COPYING file for more information.
 
     This software is distributed WITHOUT ANY WARRANTY and without even the
     implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-  
+
   CHANGE HISTORY:
-  
+
 ===============================================================================
 */
 

--- a/vendor/lazperf/detail/field_byte14.hpp
+++ b/vendor/lazperf/detail/field_byte14.hpp
@@ -2,29 +2,29 @@
 ===============================================================================
 
   FILE:  field_byte14.hpp
-  
+
   CONTENTS:
-    
+
 
   PROGRAMMERS:
 
     martin.isenburg@rapidlasso.com  -  http://rapidlasso.com
     uday.karan@gmail.com - Hobu, Inc.
-  
+
   COPYRIGHT:
-  
+
     (c) 2007-2014, martin isenburg, rapidlasso - tools to catch reality
     (c) 2014, Uday Verma, Hobu, Inc.
 
     This is free software; you can redistribute and/or modify it under the
-    terms of the GNU Lesser General Licence as published by the Free Software
+    terms of the Apache Public License 2.0 published by the Apache Software
     Foundation. See the COPYING file for more information.
 
     This software is distributed WITHOUT ANY WARRANTY and without even the
     implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-  
+
   CHANGE HISTORY:
-  
+
 ===============================================================================
 */
 

--- a/vendor/lazperf/detail/field_gpstime.hpp
+++ b/vendor/lazperf/detail/field_gpstime.hpp
@@ -17,7 +17,7 @@
     (c) 2014, Uday Verma, Hobu, Inc.
 
     This is free software; you can redistribute and/or modify it under the
-    terms of the GNU Lesser General Licence as published by the Free Software
+    terms of the Apache Public License 2.0 published by the Apache Software
     Foundation. See the COPYING file for more information.
 
     This software is distributed WITHOUT ANY WARRANTY and without even the

--- a/vendor/lazperf/detail/field_gpstime10.cpp
+++ b/vendor/lazperf/detail/field_gpstime10.cpp
@@ -17,7 +17,7 @@
     (c) 2014, Uday Verma, Hobu, Inc.
 
     This is free software; you can redistribute and/or modify it under the
-    terms of the GNU Lesser General Licence as published by the Free Software
+    terms of the Apache Public License 2.0 published by the Apache Software
     Foundation. See the COPYING file for more information.
 
     This software is distributed WITHOUT ANY WARRANTY and without even the

--- a/vendor/lazperf/detail/field_gpstime10.hpp
+++ b/vendor/lazperf/detail/field_gpstime10.hpp
@@ -17,7 +17,7 @@
     (c) 2014, Uday Verma, Hobu, Inc.
 
     This is free software; you can redistribute and/or modify it under the
-    terms of the GNU Lesser General Licence as published by the Free Software
+    terms of the Apache Public License 2.0 published by the Apache Software
     Foundation. See the COPYING file for more information.
 
     This software is distributed WITHOUT ANY WARRANTY and without even the

--- a/vendor/lazperf/detail/field_nir14.cpp
+++ b/vendor/lazperf/detail/field_nir14.cpp
@@ -2,29 +2,29 @@
 ===============================================================================
 
   FILE:  field_nir14.hpp
-  
+
   CONTENTS:
-    
+
 
   PROGRAMMERS:
 
     martin.isenburg@rapidlasso.com  -  http://rapidlasso.com
     uday.karan@gmail.com - Hobu, Inc.
-  
+
   COPYRIGHT:
-  
+
     (c) 2007-2014, martin isenburg, rapidlasso - tools to catch reality
     (c) 2014, Uday Verma, Hobu, Inc.
 
     This is free software; you can redistribute and/or modify it under the
-    terms of the GNU Lesser General Licence as published by the Free Software
+    terms of the Apache Public License 2.0 published by the Apache Software
     Foundation. See the COPYING file for more information.
 
     This software is distributed WITHOUT ANY WARRANTY and without even the
     implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-  
+
   CHANGE HISTORY:
-  
+
 ===============================================================================
 */
 

--- a/vendor/lazperf/detail/field_nir14.hpp
+++ b/vendor/lazperf/detail/field_nir14.hpp
@@ -2,29 +2,29 @@
 ===============================================================================
 
   FILE:  field_nir14.hpp
-  
+
   CONTENTS:
-    
+
 
   PROGRAMMERS:
 
     martin.isenburg@rapidlasso.com  -  http://rapidlasso.com
     uday.karan@gmail.com - Hobu, Inc.
-  
+
   COPYRIGHT:
-  
+
     (c) 2007-2014, martin isenburg, rapidlasso - tools to catch reality
     (c) 2014, Uday Verma, Hobu, Inc.
 
     This is free software; you can redistribute and/or modify it under the
-    terms of the GNU Lesser General Licence as published by the Free Software
+    terms of the Apache Public License 2.0 published by the Apache Software
     Foundation. See the COPYING file for more information.
 
     This software is distributed WITHOUT ANY WARRANTY and without even the
     implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-  
+
   CHANGE HISTORY:
-  
+
 ===============================================================================
 */
 

--- a/vendor/lazperf/detail/field_point10.cpp
+++ b/vendor/lazperf/detail/field_point10.cpp
@@ -17,7 +17,7 @@
     (c) 2014, Uday Verma, Hobu, Inc.
 
     This is free software; you can redistribute and/or modify it under the
-    terms of the GNU Lesser General Licence as published by the Free Software
+    terms of the Apache Public License 2.0 published by the Apache Software
     Foundation. See the COPYING file for more information.
 
     This software is distributed WITHOUT ANY WARRANTY and without even the

--- a/vendor/lazperf/detail/field_point10.hpp
+++ b/vendor/lazperf/detail/field_point10.hpp
@@ -17,7 +17,7 @@
     (c) 2014, Uday Verma, Hobu, Inc.
 
     This is free software; you can redistribute and/or modify it under the
-    terms of the GNU Lesser General Licence as published by the Free Software
+    terms of the Apache Public License 2.0 published by the Apache Software
     Foundation. See the COPYING file for more information.
 
     This software is distributed WITHOUT ANY WARRANTY and without even the

--- a/vendor/lazperf/detail/field_point14.cpp
+++ b/vendor/lazperf/detail/field_point14.cpp
@@ -5,19 +5,16 @@
 
   CONTENTS:
 
-
   PROGRAMMERS:
 
     martin.isenburg@rapidlasso.com  -  http://rapidlasso.com
-    uday.karan@gmail.com - Hobu, Inc.
 
   COPYRIGHT:
 
     (c) 2007-2014, martin isenburg, rapidlasso - tools to catch reality
-    (c) 2014, Uday Verma, Hobu, Inc.
 
     This is free software; you can redistribute and/or modify it under the
-    terms of the GNU Lesser General Licence as published by the Free Software
+    terms of the Apache Public License 2.0 published by the Apache Software
     Foundation. See the COPYING file for more information.
 
     This software is distributed WITHOUT ANY WARRANTY and without even the
@@ -404,7 +401,7 @@ void Point14Compressor::encodeGpsTime(const las::point14& point, ChannelCtx& c)
 
     gpstime_enc_.makeValid();
 
-    loop: 
+    loop:
     if (c.last_gpstime_diff_[c.last_gps_seq_] == 0)
     {
         int32_t diff;  // Difference between current time and last time in the sequence,

--- a/vendor/lazperf/detail/field_point14.hpp
+++ b/vendor/lazperf/detail/field_point14.hpp
@@ -17,7 +17,7 @@
     (c) 2014, Uday Verma, Hobu, Inc.
 
     This is free software; you can redistribute and/or modify it under the
-    terms of the GNU Lesser General Licence as published by the Free Software
+    terms of the Apache Public License 2.0 published by the Apache Software
     Foundation. See the COPYING file for more information.
 
     This software is distributed WITHOUT ANY WARRANTY and without even the
@@ -81,11 +81,11 @@ protected:
         std::array<int32_t, 4> last_gpstime_diff_;
         std::array<int32_t, 4> multi_extreme_counter_;
         bool gps_time_change_;
-         
+
         ChannelCtx() : changed_values_model_(8, models::arithmetic(128)),
             scanner_channel_model_(3), rn_gps_same_model_(13),
             nr_model_(16, models::arithmetic(16)), rn_model_(16, models::arithmetic(16)),
-            class_model_(64, models::arithmetic(256)), flag_model_(64, models::arithmetic(64)), 
+            class_model_(64, models::arithmetic(256)), flag_model_(64, models::arithmetic(64)),
             user_data_model_(64, models::arithmetic(256)), gpstime_multi_model_(515),
             gpstime_0diff_model_(5),
             dx_compr_(32, 2), dy_compr_(32, 22), z_compr_(32, 20), intensity_compr_(16, 4),
@@ -104,7 +104,7 @@ protected:
             intensity_compr_.init();
             scan_angle_compr_.init();
             point_source_id_compr_.init();
-            gpstime_compr_.init(); 
+            gpstime_compr_.init();
 
             dx_decomp_.init();
             dy_decomp_.init();
@@ -112,7 +112,7 @@ protected:
             intensity_decomp_.init();
             scan_angle_decomp_.init();
             point_source_id_decomp_.init();
-            gpstime_decomp_.init(); 
+            gpstime_decomp_.init();
 
             for (auto& xd : last_x_diff_median5_)
                 xd.init();
@@ -155,7 +155,7 @@ class Point14Decompressor : public Point14Base
 public:
     Point14Decompressor(InCbStream& stream) : stream_(stream)
     {}
-   
+
     void dumpSums();
     void readSizes();
     void readData();

--- a/vendor/lazperf/detail/field_rgb10.cpp
+++ b/vendor/lazperf/detail/field_rgb10.cpp
@@ -12,7 +12,7 @@
     (c) 2014, Uday Verma, Hobu, Inc.
 
     This is free software; you can redistribute and/or modify it under the
-    terms of the GNU Lesser General Licence as published by the Free Software
+    terms of the Apache Public License 2.0 published by the Apache Software
     Foundation. See the COPYING file for more information.
 
     This software is distributed WITHOUT ANY WARRANTY and without even the
@@ -47,9 +47,9 @@ unsigned int color_diff_bits(const las::rgb& this_val, const las::rgb& last)
                     (__flag_diff(a.g, b.g, 0xFF00) << 3) |
                     (__flag_diff(a.b, b.b, 0x00FF) << 4) |
                     (__flag_diff(a.b, b.b, 0xFF00) << 5) |
-                    (__flag_diff(b.r, b.g, 0x00FF) |
-                     __flag_diff(b.r, b.b, 0x00FF) |
-                     __flag_diff(b.r, b.g, 0xFF00) |
+                    (__flag_diff(b.r, b.g, 0x00FF) ||
+                     __flag_diff(b.r, b.b, 0x00FF) ||
+                     __flag_diff(b.r, b.g, 0xFF00) ||
                      __flag_diff(b.r, b.b, 0xFF00)) << 6;
 #undef __flag_diff
 

--- a/vendor/lazperf/detail/field_rgb10.hpp
+++ b/vendor/lazperf/detail/field_rgb10.hpp
@@ -5,14 +5,14 @@
 
     martin.isenburg@rapidlasso.com  -  http://rapidlasso.com
     uday.karan@gmail.com - Hobu, Inc.
-  
+
   COPYRIGHT:
-  
+
     (c) 2007-2014, martin isenburg, rapidlasso - tools to catch reality
     (c) 2014, Uday Verma, Hobu, Inc.
 
     This is free software; you can redistribute and/or modify it under the
-    terms of the GNU Lesser General Licence as published by the Free Software
+    terms of the Apache Public License 2.0 published by the Apache Software
     Foundation. See the COPYING file for more information.
 
     This software is distributed WITHOUT ANY WARRANTY and without even the

--- a/vendor/lazperf/detail/field_rgb14.cpp
+++ b/vendor/lazperf/detail/field_rgb14.cpp
@@ -2,29 +2,29 @@
 ===============================================================================
 
   FILE:  field_rgb14.cpp
-  
+
   CONTENTS:
-    
+
 
   PROGRAMMERS:
 
     martin.isenburg@rapidlasso.com  -  http://rapidlasso.com
     uday.karan@gmail.com - Hobu, Inc.
-  
+
   COPYRIGHT:
-  
+
     (c) 2007-2014, martin isenburg, rapidlasso - tools to catch reality
     (c) 2014, Uday Verma, Hobu, Inc.
 
     This is free software; you can redistribute and/or modify it under the
-    terms of the GNU Lesser General Licence as published by the Free Software
+    terms of the Apache Public License 2.0 published by the Apache Software
     Foundation. See the COPYING file for more information.
 
     This software is distributed WITHOUT ANY WARRANTY and without even the
     implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-  
+
   CHANGE HISTORY:
-  
+
 ===============================================================================
 */
 

--- a/vendor/lazperf/detail/field_rgb14.hpp
+++ b/vendor/lazperf/detail/field_rgb14.hpp
@@ -2,29 +2,29 @@
 ===============================================================================
 
   FILE:  field_rgb14.hpp
-  
+
   CONTENTS:
-    
+
 
   PROGRAMMERS:
 
     martin.isenburg@rapidlasso.com  -  http://rapidlasso.com
     uday.karan@gmail.com - Hobu, Inc.
-  
+
   COPYRIGHT:
-  
+
     (c) 2007-2014, martin isenburg, rapidlasso - tools to catch reality
     (c) 2014, Uday Verma, Hobu, Inc.
 
     This is free software; you can redistribute and/or modify it under the
-    terms of the GNU Lesser General Licence as published by the Free Software
+    terms of the Apache Public License 2.0 published by the Apache Software
     Foundation. See the COPYING file for more information.
 
     This software is distributed WITHOUT ANY WARRANTY and without even the
     implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-  
+
   CHANGE HISTORY:
-  
+
 ===============================================================================
 */
 

--- a/vendor/lazperf/detail/field_xyz.hpp
+++ b/vendor/lazperf/detail/field_xyz.hpp
@@ -18,7 +18,7 @@
     (c) 2014, Uday Verma, Hobu, Inc.
 
     This is free software; you can redistribute and/or modify it under the
-    terms of the GNU Lesser General Licence as published by the Free Software
+    terms of the Apache Public License 2.0 published by the Apache Software
     Foundation. See the COPYING file for more information.
 
     This software is distributed WITHOUT ANY WARRANTY and without even the

--- a/vendor/lazperf/lazperf.hpp
+++ b/vendor/lazperf/lazperf.hpp
@@ -77,7 +77,7 @@ protected:
     std::unique_ptr<Private> p_;
 };
 
-class point_compressor_0 : public point_compressor_base_1_2
+class point_compressor_0 final : public point_compressor_base_1_2
 {
 public:
     LAZPERF_EXPORT point_compressor_0(OutputCb cb, size_t ebCount = 0);
@@ -86,7 +86,7 @@ public:
     LAZPERF_EXPORT virtual const char *compress(const char *in);
 };
 
-class point_compressor_1 : public point_compressor_base_1_2
+class point_compressor_1 final : public point_compressor_base_1_2
 {
 public:
     LAZPERF_EXPORT point_compressor_1(OutputCb cb, size_t ebCount = 0);
@@ -95,7 +95,7 @@ public:
     LAZPERF_EXPORT virtual const char *compress(const char *in);
 };
 
-class point_compressor_2 : public point_compressor_base_1_2
+class point_compressor_2 final : public point_compressor_base_1_2
 {
 public:
     LAZPERF_EXPORT point_compressor_2(OutputCb cb, size_t ebCount = 0);
@@ -104,7 +104,7 @@ public:
     LAZPERF_EXPORT virtual const char *compress(const char *in);
 };
 
-class point_compressor_3 : public point_compressor_base_1_2
+class point_compressor_3 final : public point_compressor_base_1_2
 {
 public:
     LAZPERF_EXPORT point_compressor_3(OutputCb cb, size_t ebCount = 0);
@@ -127,7 +127,7 @@ protected:
 };
 
 
-class point_compressor_6 : public point_compressor_base_1_4
+class point_compressor_6 final : public point_compressor_base_1_4
 {
 public:
     LAZPERF_EXPORT point_compressor_6(OutputCb cb, size_t ebCount = 0);
@@ -137,7 +137,7 @@ public:
     LAZPERF_EXPORT virtual void done();
 };
 
-class point_compressor_7 : public point_compressor_base_1_4
+class point_compressor_7 final : public point_compressor_base_1_4
 {
 public:
     LAZPERF_EXPORT point_compressor_7(OutputCb cb, size_t ebCount = 0);
@@ -147,7 +147,7 @@ public:
     LAZPERF_EXPORT virtual void done();
 };
 
-class point_compressor_8 : public point_compressor_base_1_4
+class point_compressor_8 final : public point_compressor_base_1_4
 {
 public:
     LAZPERF_EXPORT point_compressor_8(OutputCb cb, size_t ebCount = 0);
@@ -175,7 +175,7 @@ protected:
     std::unique_ptr<Private> p_;
 };
 
-class point_decompressor_0 : public point_decompressor_base_1_2
+class point_decompressor_0 final : public point_decompressor_base_1_2
 {
 public:
     LAZPERF_EXPORT point_decompressor_0(InputCb cb, size_t ebCount = 0);
@@ -184,7 +184,7 @@ public:
     LAZPERF_EXPORT virtual char *decompress(char *in);
 };
 
-class point_decompressor_1 : public point_decompressor_base_1_2
+class point_decompressor_1 final : public point_decompressor_base_1_2
 {
 public:
     LAZPERF_EXPORT point_decompressor_1(InputCb cb, size_t ebCount = 0);
@@ -193,7 +193,7 @@ public:
     LAZPERF_EXPORT virtual char *decompress(char *out);
 };
 
-class point_decompressor_2 : public point_decompressor_base_1_2
+class point_decompressor_2 final : public point_decompressor_base_1_2
 {
 public:
     LAZPERF_EXPORT point_decompressor_2(InputCb cb, size_t ebCount = 0);
@@ -202,7 +202,7 @@ public:
     LAZPERF_EXPORT virtual char *decompress(char *out);
 };
 
-class point_decompressor_3 : public point_decompressor_base_1_2
+class point_decompressor_3 final : public point_decompressor_base_1_2
 {
 public:
     LAZPERF_EXPORT point_decompressor_3(InputCb cb, size_t ebCount = 0);
@@ -224,7 +224,7 @@ protected:
     std::unique_ptr<Private> p_;
 };
 
-class point_decompressor_6 : public point_decompressor_base_1_4
+class point_decompressor_6 final : public point_decompressor_base_1_4
 {
 public:
     LAZPERF_EXPORT point_decompressor_6(InputCb cb, size_t ebCount = 0);
@@ -233,7 +233,7 @@ public:
     LAZPERF_EXPORT virtual char *decompress(char *out);
 };
 
-class point_decompressor_7 : public point_decompressor_base_1_4
+class point_decompressor_7 final : public point_decompressor_base_1_4
 {
 public:
     LAZPERF_EXPORT point_decompressor_7(InputCb cb, size_t ebCount = 0);
@@ -242,7 +242,7 @@ public:
     LAZPERF_EXPORT virtual char *decompress(char *out);
 };
 
-struct point_decompressor_8 : public point_decompressor_base_1_4
+struct point_decompressor_8 final : public point_decompressor_base_1_4
 {
 public:
     LAZPERF_EXPORT ~point_decompressor_8();

--- a/vendor/lazperf/lazperf_base.hpp
+++ b/vendor/lazperf/lazperf_base.hpp
@@ -2,17 +2,14 @@
 #pragma once
 
 #define LAZPERF_MAJOR_VERSION 3
-#define LAZPERF_MINOR_VERSION 0
+#define LAZPERF_MINOR_VERSION 1
 #define LAZPERF_REVISION 0
-#define LAZPERF_VERSION 3.0.0
+#define LAZPERF_VERSION 3.1.0
 
-/**
 #ifdef _WIN32
 #define LAZPERF_EXPORT __declspec(dllexport)
 #else
 // This may not be necessary. The GCC doc says it take __declspec((dllexport))
 #define LAZPERF_EXPORT __attribute__((visibility ("default")))
 #endif
-**/
-#define LAZPERF_EXPORT
 

--- a/vendor/lazperf/vlr.cpp
+++ b/vendor/lazperf/vlr.cpp
@@ -325,8 +325,13 @@ eb_vlr::eb_vlr()
 
 eb_vlr::eb_vlr(int ebCount)
 {
-    while (ebCount--)
-        addField();
+    for (int i = 0; i < ebCount; ++i)
+    {
+        eb_vlr::ebfield field;
+
+        field.name = "FIELD_" + std::to_string(i);
+        addField(field);
+    }
 }
 
 eb_vlr::~eb_vlr()

--- a/vendor/lazperf/vlr.hpp
+++ b/vendor/lazperf/vlr.hpp
@@ -108,8 +108,8 @@ public:
     uint16_t revision;
     uint32_t options;
     uint32_t chunk_size;
-    uint64_t num_points;
-    uint64_t num_bytes;
+    uint64_t num_points;    // This is *not* the number of points. It's garbage.
+    uint64_t num_bytes;     // This is *not* the number of bytes. It's garbage.
     std::vector<laz_item> items;
 
     laz_vlr();

--- a/vendor/lazperf/writers.cpp
+++ b/vendor/lazperf/writers.cpp
@@ -196,7 +196,15 @@ void basic_file::Private::close()
 void basic_file::Private::writeHeader()
 {
     laz_vlr lazVlr(head14.pointFormat(), head14.ebCount(), chunk_size);
-    eb_vlr ebVlr(head14.ebCount());
+    eb_vlr ebVlr;
+
+    for (int i = 0; i < head14.ebCount(); ++i)
+    {
+        eb_vlr::ebfield field;
+
+        field.name = "FIELD_" + std::to_string(i);
+        ebVlr.addField(field);
+    }
 
     // Set the version number to 2 in order to write something reasonable.
     if (head14.version.minor < 2 || head14.version.minor > 4)


### PR DESCRIPTION
This should fix https://github.com/PDAL/PDAL/pull/3675#discussion_r922800902 and there were a few other missing small bits of laz-perf.