### PR TITLE
Arbiter on demand drivers

### DIFF
--- a/pdal/PDALUtils.cpp
+++ b/pdal/PDALUtils.cpp
@@ -296,13 +296,7 @@ std::ostream *createFile(const std::string& path, bool asBinary)
 
 bool isRemote(const std::string& path)
 {
-    const StringList prefixes
-        { "s3://", "gs://", "dropbox://", "http://", "https://", "az://" };
-
-    for (const string& prefix : prefixes)
-        if (Utils::startsWith(path, prefix))
-            return true;
-    return false;
+    return path.find("://") != std::string::npos;
 }
 
 

--- a/vendor/arbiter/arbiter.cpp
+++ b/vendor/arbiter/arbiter.cpp
@@ -87,8 +87,7 @@ namespace
         json in(s.size() ? json::parse(s) : json::object());
 
         json config;
-        std::string path("~/.arbiter/config.json");
-
+        std::string path = in.value("configFile", "~/.arbiter/config.json");
         if      (auto p = env("ARBITER_CONFIG_FILE")) path = *p;
         else if (auto p = env("ARBITER_CONFIG_PATH")) path = *p;
 
@@ -101,10 +100,10 @@ namespace
     }
 }
 
-Arbiter::Arbiter() : Arbiter(json().dump()) { }
+Arbiter::Arbiter() : Arbiter("") { }
 
 Arbiter::Arbiter(const std::string s)
-    : m_drivers()
+    : m_config(s)
 #ifdef ARBITER_CURL
     , m_pool(
             new http::Pool(
@@ -112,108 +111,53 @@ Arbiter::Arbiter(const std::string s)
                 httpRetryCount,
                 getConfig(s).dump()))
 #endif
-{
-    using namespace drivers;
+{ }
 
-    const json c(getConfig(s));
-
-    if (auto d = Fs::create())
-    {
-        m_drivers[d->type()] = std::move(d);
-    }
-
-    if (auto d = Test::create())
-    {
-        m_drivers[d->type()] = std::move(d);
-    }
-
-#ifdef ARBITER_CURL
-    if (auto d = Http::create(*m_pool))
-    {
-        m_drivers[d->type()] = std::move(d);
-    }
-
-    if (auto d = Https::create(*m_pool))
-    {
-        m_drivers[d->type()] = std::move(d);
-    }
-
-    {
-        auto dlist(S3::create(*m_pool, c.value("s3", json()).dump()));
-        for (auto& d : dlist) m_drivers[d->type()] = std::move(d);
-    }
-
-    {
-        auto dlist(AZ::create(*m_pool, c.value("az", json()).dump()));
-        for (auto& d : dlist) m_drivers[d->type()] = std::move(d);
-    }
-
-    // Credential-based drivers should probably all do something similar to the
-    // S3 driver to support multiple profiles.
-    if (auto d = Dropbox::create(*m_pool, c.value("dropbox", json()).dump()))
-    {
-        m_drivers[d->type()] = std::move(d);
-    }
-
-#ifdef ARBITER_OPENSSL
-    if (auto d = Google::create(*m_pool, c.value("gs", json()).dump()))
-    {
-        m_drivers[d->type()] = std::move(d);
-    }
-#endif
-
-#endif
-}
-
-bool Arbiter::hasDriver(const std::string path) const
-{
-    return m_drivers.count(getProtocol(path));
-}
-
-void Arbiter::addDriver(const std::string type, std::unique_ptr<Driver> driver)
+void Arbiter::addDriver(const std::string type, std::shared_ptr<Driver> driver)
 {
     if (!driver) throw ArbiterError("Cannot add empty driver for " + type);
-    m_drivers[type] = std::move(driver);
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_drivers[type] = driver;
 }
 
 std::string Arbiter::get(const std::string path) const
 {
-    return getDriver(path).get(stripProtocol(path));
+    return getDriver(path)->get(stripProtocol(path));
 }
 
 std::vector<char> Arbiter::getBinary(const std::string path) const
 {
-    return getDriver(path).getBinary(stripProtocol(path));
+    return getDriver(path)->getBinary(stripProtocol(path));
 }
 
 std::unique_ptr<std::string> Arbiter::tryGet(std::string path) const
 {
-    return getDriver(path).tryGet(stripProtocol(path));
+    return getDriver(path)->tryGet(stripProtocol(path));
 }
 
 std::unique_ptr<std::vector<char>> Arbiter::tryGetBinary(std::string path) const
 {
-    return getDriver(path).tryGetBinary(stripProtocol(path));
+    return getDriver(path)->tryGetBinary(stripProtocol(path));
 }
 
 std::size_t Arbiter::getSize(const std::string path) const
 {
-    return getDriver(path).getSize(stripProtocol(path));
+    return getDriver(path)->getSize(stripProtocol(path));
 }
 
 std::unique_ptr<std::size_t> Arbiter::tryGetSize(const std::string path) const
 {
-    return getDriver(path).tryGetSize(stripProtocol(path));
+    return getDriver(path)->tryGetSize(stripProtocol(path));
 }
 
 void Arbiter::put(const std::string path, const std::string& data) const
 {
-    return getDriver(path).put(stripProtocol(path), data);
+    return getDriver(path)->put(stripProtocol(path), data);
 }
 
 void Arbiter::put(const std::string path, const std::vector<char>& data) const
 {
-    return getDriver(path).put(stripProtocol(path), data);
+    return getDriver(path)->put(stripProtocol(path), data);
 }
 
 std::string Arbiter::get(
@@ -221,7 +165,7 @@ std::string Arbiter::get(
         const http::Headers headers,
         const http::Query query) const
 {
-    return getHttpDriver(path).get(stripProtocol(path), headers, query);
+    return getHttpDriver(path)->get(stripProtocol(path), headers, query);
 }
 
 std::unique_ptr<std::string> Arbiter::tryGet(
@@ -229,7 +173,7 @@ std::unique_ptr<std::string> Arbiter::tryGet(
         const http::Headers headers,
         const http::Query query) const
 {
-    return getHttpDriver(path).tryGet(stripProtocol(path), headers, query);
+    return getHttpDriver(path)->tryGet(stripProtocol(path), headers, query);
 }
 
 std::vector<char> Arbiter::getBinary(
@@ -237,7 +181,7 @@ std::vector<char> Arbiter::getBinary(
         const http::Headers headers,
         const http::Query query) const
 {
-    return getHttpDriver(path).getBinary(stripProtocol(path), headers, query);
+    return getHttpDriver(path)->getBinary(stripProtocol(path), headers, query);
 }
 
 std::unique_ptr<std::vector<char>> Arbiter::tryGetBinary(
@@ -245,7 +189,7 @@ std::unique_ptr<std::vector<char>> Arbiter::tryGetBinary(
         const http::Headers headers,
         const http::Query query) const
 {
-    return getHttpDriver(path).tryGetBinary(stripProtocol(path), headers, query);
+    return getHttpDriver(path)->tryGetBinary(stripProtocol(path), headers, query);
 }
 
 void Arbiter::put(
@@ -254,7 +198,7 @@ void Arbiter::put(
         const http::Headers headers,
         const http::Query query) const
 {
-    return getHttpDriver(path).put(stripProtocol(path), data, headers, query);
+    return getHttpDriver(path)->put(stripProtocol(path), data, headers, query);
 }
 
 void Arbiter::put(
@@ -263,7 +207,7 @@ void Arbiter::put(
         const http::Headers headers,
         const http::Query query) const
 {
-    return getHttpDriver(path).put(stripProtocol(path), data, headers, query);
+    return getHttpDriver(path)->put(stripProtocol(path), data, headers, query);
 }
 
 void Arbiter::copy(
@@ -344,11 +288,11 @@ void Arbiter::copyFile(
 
     if (dstEndpoint.isLocal()) mkdirp(getDirname(dst));
 
-    if (getEndpoint(file).type() == dstEndpoint.type())
+    if (getEndpoint(file).profiledProtocol() == dstEndpoint.profiledProtocol())
     {
         // If this copy is within the same driver domain, defer to the
         // hopefully specialized copy method.
-        getDriver(file).copy(stripProtocol(file), stripProtocol(dst));
+        getDriver(file)->copy(stripProtocol(file), stripProtocol(dst));
     }
     else
     {
@@ -359,7 +303,7 @@ void Arbiter::copyFile(
 
 bool Arbiter::isRemote(const std::string path) const
 {
-    return getDriver(path).isRemote();
+    return getDriver(path)->isRemote();
 }
 
 bool Arbiter::isLocal(const std::string path) const
@@ -381,34 +325,46 @@ std::vector<std::string> Arbiter::resolve(
         const std::string path,
         const bool verbose) const
 {
-    return getDriver(path).resolve(stripProtocol(path), verbose);
+    return getDriver(path)->resolve(stripProtocol(path), verbose);
 }
 
 Endpoint Arbiter::getEndpoint(const std::string root) const
 {
-    return Endpoint(getDriver(root), stripProtocol(root));
+    return Endpoint(*getDriver(root), stripProtocol(root));
 }
 
-const Driver& Arbiter::getDriver(const std::string path) const
+std::shared_ptr<Driver> Arbiter::getDriver(const std::string path) const
 {
     const auto type(getProtocol(path));
 
-    if (!m_drivers.count(type))
     {
-        throw ArbiterError("No driver for " + path);
+        std::lock_guard<std::mutex> lock(m_mutex);
+        auto it = m_drivers.find(type);
+        if (it != m_drivers.end()) return it->second;
     }
 
-    return *m_drivers.at(type);
+    const json config = getConfig(m_config);
+    if (auto driver = Driver::create(*m_pool, type, config.dump()))
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        m_drivers[type] = driver;
+        return driver;
+    }
+
+    throw ArbiterError("No driver for " + path);
 }
 
-const drivers::Http* Arbiter::tryGetHttpDriver(const std::string path) const
+std::shared_ptr<drivers::Http> Arbiter::tryGetHttpDriver(
+    const std::string path) const
 {
-    return dynamic_cast<const drivers::Http*>(&getDriver(path));
+    std::shared_ptr<Driver> driver = getDriver(path);
+    if (!driver) return std::shared_ptr<drivers::Http>();
+    return std::dynamic_pointer_cast<drivers::Http>(driver);
 }
 
-const drivers::Http& Arbiter::getHttpDriver(const std::string path) const
+std::shared_ptr<drivers::Http> Arbiter::getHttpDriver(const std::string path) const
 {
-    if (auto d = tryGetHttpDriver(path)) return *d;
+    if (auto d = tryGetHttpDriver(path)) return d;
     else throw ArbiterError("Cannot get driver for " + path + " as HTTP");
 }
 
@@ -461,6 +417,8 @@ LocalHandle Arbiter::getLocalHandle(
 #include <arbiter/driver.hpp>
 
 #include <arbiter/arbiter.hpp>
+#include <arbiter/util/json.hpp>
+#include <arbiter/util/util.hpp>
 #endif
 
 #ifdef ARBITER_CUSTOM_NAMESPACE
@@ -470,6 +428,34 @@ namespace ARBITER_CUSTOM_NAMESPACE
 
 namespace arbiter
 {
+
+std::shared_ptr<Driver> Driver::create(
+    http::Pool& pool,
+    const std::string protocol,
+    const std::string s)
+{
+    using namespace drivers;
+
+    const json config = json::parse(s);
+    const json entry = config.value(protocol, json());
+
+    const std::string profile = getProfile(protocol);
+    const std::string type = stripProfile(protocol);
+
+    if (type == "file") return Fs::create();
+    if (type == "test") return Test::create();
+#ifdef ARBITER_CURL
+    if (type == "http") return Http::create(pool);
+    if (type == "https") return Https::create(pool);
+    if (type == "s3") return S3::create(pool, entry.dump(), profile);
+    if (type == "az") return AZ::create(pool, entry.dump(), profile);
+    if (type == "dbx") return Dropbox::create(pool, entry.dump(), profile);
+#ifdef ARBITER_OPENSSL
+    if (type == "gs") return Google::create(pool, entry.dump(), profile);
+#endif
+#endif
+    return std::shared_ptr<Driver>();
+}
 
 std::string Driver::get(const std::string path) const
 {
@@ -525,8 +511,8 @@ std::vector<std::string> Driver::resolve(
     {
         if (verbose)
         {
-            std::cout << "Resolving [" << type() << "]: " << path << " ..." <<
-                std::flush;
+            std::cout << "Resolving [" << profiledProtocol() << "]: "
+                << path << " ..." << std::flush;
         }
 
         results = glob(path, verbose);
@@ -539,7 +525,7 @@ std::vector<std::string> Driver::resolve(
     }
     else
     {
-        if (isRemote()) path = type() + "://" + path;
+        if (isRemote()) path = profiledProtocol() + "://" + path;
         else path = expandTilde(path);
 
         results.push_back(path);
@@ -625,9 +611,19 @@ std::string Endpoint::prefixedRoot() const
     return softPrefix() + root();
 }
 
-std::string Endpoint::type() const
+std::string Endpoint::protocol() const
 {
-    return m_driver->type();
+    return m_driver->protocol();
+}
+
+std::string Endpoint::profile() const
+{
+    return m_driver->profile();
+}
+
+std::string Endpoint::profiledProtocol() const
+{
+    return m_driver->profiledProtocol();
 }
 
 bool Endpoint::isRemote() const
@@ -869,7 +865,7 @@ Endpoint Endpoint::getSubEndpoint(std::string subpath) const
 
 std::string Endpoint::softPrefix() const
 {
-    return isRemote() ? type() + "://" : "";
+    return isRemote() ? profiledProtocol() + "://" : "";
 }
 
 const drivers::Http* Endpoint::tryGetHttpDriver() const
@@ -880,7 +876,8 @@ const drivers::Http* Endpoint::tryGetHttpDriver() const
 const drivers::Http& Endpoint::getHttpDriver() const
 {
     if (auto d = tryGetHttpDriver()) return *d;
-    else throw ArbiterError("Cannot get driver of type " + type() + " as HTTP");
+    else throw ArbiterError(
+        "Cannot get driver of type " + profiledProtocol() + " as HTTP");
 }
 
 } // namespace arbiter
@@ -1370,8 +1367,14 @@ namespace drivers
 
 using namespace http;
 
-Http::Http(Pool& pool)
-    : m_pool(pool)
+Http::Http(
+        Pool& pool,
+        const std::string driverProtocol,
+        const std::string httpProtocol,
+        const std::string profile)
+    : Driver(driverProtocol, profile)
+    , m_pool(pool)
+    , m_httpProtocol(httpProtocol)
 {
 #ifndef ARBITER_CURL
     throw ArbiterError("Cannot create HTTP driver - no curl support was built");
@@ -1571,7 +1574,7 @@ Response Http::internalPost(
 std::string Http::typedPath(const std::string& p) const
 {
     if (getProtocol(p) != "file") return p;
-    else return type() + "://" + p;
+    else return m_httpProtocol + "://" + p;
 }
 
 } // namespace drivers
@@ -1707,73 +1710,36 @@ S3::S3(
         std::string profile,
         std::unique_ptr<Auth> auth,
         std::unique_ptr<Config> config)
-    : Http(pool)
-    , m_profile(profile)
+    : Http(pool, "s3", "http", profile == "default" ? "" : profile)
     , m_auth(std::move(auth))
     , m_config(std::move(config))
 { }
 
-std::vector<std::unique_ptr<S3>> S3::create(Pool& pool, const std::string s)
+std::unique_ptr<S3> S3::create(
+    Pool& pool,
+    const std::string s,
+    std::string profile)
 {
-    std::vector<std::unique_ptr<S3>> result;
-
-    const json config(s.size() ? json::parse(s) : json());
-
-    if (config.is_array())
+    if (profile.empty())
     {
-        for (const json& curr : config)
-        {
-            if (auto s = createOne(pool, curr.dump()))
-            {
-                result.push_back(std::move(s));
-            }
-        }
-    }
-    else if (auto s = createOne(pool, config.dump()))
-    {
-        result.push_back(std::move(s));
+        profile = "default";
+        if (auto p = env("AWS_DEFAULT_PROFILE")) profile = *p;
+        if (auto p = env("AWS_PROFILE")) profile = *p;
     }
 
-    return result;
-}
-
-std::unique_ptr<S3> S3::createOne(Pool& pool, const std::string s)
-{
-    const json j(s.size() ? json::parse(s) : json());
-    const std::string profile(extractProfile(j.dump()));
-
-    auto auth(Auth::create(j.dump(), profile));
+    auto auth(Auth::create(s, profile));
     if (!auth) return std::unique_ptr<S3>();
 
-    std::unique_ptr<Config> config(new Config(j.dump(), profile));
-    auto s3 = makeUnique<S3>(pool, profile, std::move(auth), std::move(config));
-    return s3;
-}
-
-std::string S3::extractProfile(const std::string s)
-{
-    const json config(s.size() ? json::parse(s) : json());
-
-    if (
-            !config.is_null() &&
-            config.count("profile") &&
-            config["profile"].get<std::string>().size())
-    {
-        return config["profile"].get<std::string>();
-    }
-
-    if (auto p = env("AWS_PROFILE")) return *p;
-    if (auto p = env("AWS_DEFAULT_PROFILE")) return *p;
-    else return "default";
+    auto config = makeUnique<Config>(s, profile);
+    return makeUnique<S3>(pool, profile, std::move(auth), std::move(config));
 }
 
 std::unique_ptr<S3::Auth> S3::Auth::create(
-        const std::string s,
-        const std::string profile)
+    const std::string s,
+    const std::string profile)
 {
-    const json config(s.size() ? json::parse(s) : json());
+    const json config = s.size() ? json::parse(s) : json();
 
-    // Try explicit JSON configuration first.
     if (
             !config.is_null() &&
             config.count("access") &&
@@ -1787,7 +1753,8 @@ std::unique_ptr<S3::Auth> S3::Auth::create(
                 config.value("token", ""));
     }
 
-    // Try environment settings next.
+    // Try environment settings next - this only works for the default profile.
+    if (profile == "default")
     {
         auto access(env("AWS_ACCESS_KEY_ID"));
         auto hidden(env("AWS_SECRET_ACCESS_KEY"));
@@ -1812,7 +1779,7 @@ std::unique_ptr<S3::Auth> S3::Auth::create(
             env("AWS_CREDENTIAL_FILE") ?
                 *env("AWS_CREDENTIAL_FILE") : "~/.aws/credentials");
 
-    // Finally, try reading credentials file.
+    // Try reading credentials file.
     drivers::Fs fsDriver;
     if (std::unique_ptr<std::string> c = fsDriver.tryGet(credPath))
     {
@@ -1843,18 +1810,9 @@ std::unique_ptr<S3::Auth> S3::Auth::create(
 
     // Nothing found in the environment or on the filesystem.  However we may
     // be running in an EC2 instance with an instance profile set up.
-    //
-    // By default we won't search for this since we don't really want to make
-    // an HTTP request on every Arbiter construction - but if we're allowed,
-    // see if we can request an instance profile configuration.
-    if (
-        (!config.is_null() && config.value("allowInstanceProfile", false)) ||
-        env("AWS_ALLOW_INSTANCE_PROFILE"))
+    if (const auto iamRole = httpDriver.tryGet(ec2CredBase))
     {
-        if (const auto iamRole = httpDriver.tryGet(ec2CredBase))
-        {
-            return makeUnique<Auth>(ec2CredBase + "/" + *iamRole);
-        }
+        return makeUnique<Auth>(ec2CredBase + "/" + *iamRole);
     }
 
     // We also may be running in Fargate, which looks very similar but with a
@@ -1907,8 +1865,8 @@ S3::Config::Config(const std::string s, const std::string profile)
 }
 
 std::string S3::Config::extractRegion(
-        const std::string s,
-        const std::string profile)
+    const std::string s,
+    const std::string profile)
 {
     const std::string configPath(
             env("AWS_CONFIG_FILE") ?
@@ -1949,8 +1907,8 @@ std::string S3::Config::extractRegion(
 }
 
 std::string S3::Config::extractBaseUrl(
-        const std::string s,
-        const std::string region)
+    const std::string s,
+    const std::string region)
 {
     const json c(s.size() ? json::parse(s) : json());
 
@@ -1967,10 +1925,6 @@ std::string S3::Config::extractBaseUrl(
     if (const auto e = env("AWS_ENDPOINTS_FILE"))
     {
         endpointsPath = *e;
-    }
-    else if (c.count("endpointsFile"))
-    {
-        endpointsPath = c["endpointsFile"].get<std::string>();
     }
 
     std::string dnsSuffix("amazonaws.com");
@@ -2045,12 +1999,6 @@ S3::AuthFields S3::Auth::fields() const
 #endif
 
     return S3::AuthFields(m_access, m_hidden, m_token);
-}
-
-std::string S3::type() const
-{
-    if (m_profile == "default") return "s3";
-    else return m_profile + "@s3";
 }
 
 std::unique_ptr<std::size_t> S3::tryGetSize(std::string rawPath) const
@@ -2242,7 +2190,8 @@ std::vector<std::string> S3::glob(std::string path, bool verbose) const
                         if (recursive || !isSubdir)
                         {
                             results.push_back(
-                                    type() + "://" + bucket + "/" + key);
+                                    profiledProtocol() + "://" +
+                                    bucket + "/" + key);
                         }
 
                         if (more)
@@ -2597,72 +2546,28 @@ AZ::AZ(
         Pool& pool,
         std::string profile,
         std::unique_ptr<Config> config)
-    : Http(pool)
-    , m_profile(profile)
+    : Http(pool, "az", profile == "default" ? "" : profile)
     , m_config(std::move(config))
 { }
 
-std::vector<std::unique_ptr<AZ>> AZ::create(Pool& pool, const std::string s)
+std::unique_ptr<AZ> AZ::create(
+    Pool& pool,
+    const std::string s,
+    std::string profile)
 {
-    std::vector<std::unique_ptr<AZ>> result;
+    if (profile.empty()) profile = "default";
+    if (auto p = env("AZ_DEFAULT_PROFILE")) profile = *p;
+    if (auto p = env("AZ_PROFILE")) profile = *p;
 
-    const json config(s.size() ? json::parse(s) : json());
-
-    if (config.is_array())
-    {
-        for (const json& curr : config)
-        {
-            if (auto s = createOne(pool, curr.dump()))
-            {
-                result.push_back(std::move(s));
-            }
-        }
-    }
-    else if (auto s = createOne(pool, config.dump()))
-    {
-        result.push_back(std::move(s));
-    }
-
-    return result;
+    std::unique_ptr<Config> config(new Config(s));
+    return makeUnique<AZ>(pool, profile, std::move(config));
 }
 
-std::unique_ptr<AZ> AZ::createOne(Pool& pool, const std::string s)
-{
-    try
-    {
-        const json j(s.size() ? json::parse(s) : json());
-        const std::string profile(extractProfile(j.dump()));
-
-        std::unique_ptr<Config> config(new Config(j.dump(), profile));
-        return makeUnique<AZ>(pool, profile, std::move(config));
-    }
-    catch (...) { }
-
-    return std::unique_ptr<AZ>();
-}
-
-std::string AZ::extractProfile(const std::string s)
-{
-    const json config(s.size() ? json::parse(s) : json());
-
-    if (
-            !config.is_null() &&
-            config.count("profile") &&
-            config["profile"].get<std::string>().size())
-    {
-        return config["profile"].get<std::string>();
-    }
-
-    if (auto p = env("AZ_PROFILE")) return *p;
-    if (auto p = env("AZ_DEFAULT_PROFILE")) return *p;
-    else return "default";
-}
-
-AZ::Config::Config(const std::string s, const std::string profile)
-    : m_service(extractService(s, profile))
-    , m_storageAccount(extractStorageAccount(s,profile))
-    , m_storageAccessKey(extractStorageAccessKey(s,profile))
-    , m_endpoint(extractEndpoint(s, profile))
+AZ::Config::Config(const std::string s)
+    : m_service(extractService(s))
+    , m_storageAccount(extractStorageAccount(s))
+    , m_storageAccessKey(extractStorageAccessKey(s))
+    , m_endpoint(extractEndpoint(s))
     , m_baseUrl(extractBaseUrl(s, m_service, m_endpoint, m_storageAccount))
 {
     const std::string sasString = extractSasToken(s);
@@ -2700,9 +2605,7 @@ AZ::Config::Config(const std::string s, const std::string profile)
     }
 }
 
-std::string AZ::Config::extractStorageAccount(
-    const std::string s,
-    const std::string profile)
+std::string AZ::Config::extractStorageAccount(const std::string s)
 {
     const json c(s.size() ? json::parse(s) : json());
 
@@ -2722,9 +2625,7 @@ std::string AZ::Config::extractStorageAccount(
    throw ArbiterError("Couldn't find Azure Storage account value - this is mandatory");
 }
 
-std::string AZ::Config::extractStorageAccessKey(
-    const std::string s,
-    const std::string profile)
+std::string AZ::Config::extractStorageAccessKey(const std::string s)
 {
     const json c(s.size() ? json::parse(s) : json());
 
@@ -2768,9 +2669,7 @@ std::string AZ::Config::extractSasToken(const std::string s)
     return "";
 }
 
-std::string AZ::Config::extractService(
-        const std::string s,
-        const std::string profile)
+std::string AZ::Config::extractService(const std::string s)
 {
     const json c(s.size() ? json::parse(s) : json());
 
@@ -2803,9 +2702,7 @@ std::string AZ::Config::extractService(
     return "blob";
 }
 
-std::string AZ::Config::extractEndpoint(
-    const std::string s,
-    const std::string profile)
+std::string AZ::Config::extractEndpoint(const std::string s)
 {
     const json c(s.size() ? json::parse(s) : json());
 
@@ -2837,12 +2734,6 @@ std::string AZ::Config::extractBaseUrl(
      const std::string account)
 {
     return account + "." + service + "." + endpoint + "/";
-}
-
-std::string AZ::type() const
-{
-    if (m_profile == "default") return "az";
-    else return m_profile + "@az";
 }
 
 std::unique_ptr<std::size_t> AZ::tryGetSize(std::string rawPath) const
@@ -3066,14 +2957,11 @@ std::vector<std::string> AZ::glob(std::string path, bool verbose) const
                         if (recursive || !isSubdir)
                         {
                             results.push_back(
-                                    type() + "://" + bucket + "/" + key);
+                                    profiledProtocol() + "://" +
+                                    bucket + "/" + key);
                         }
                     }
                 }
-            }
-            else
-            {
-                throw ArbiterError("No blob node");
             }
         }
         else
@@ -3408,16 +3296,22 @@ namespace
 namespace drivers
 {
 
-Google::Google(http::Pool& pool, std::unique_ptr<Auth> auth)
-    : Https(pool)
+Google::Google(
+        http::Pool& pool,
+        std::unique_ptr<Auth> auth,
+        const std::string profile)
+    : Https(pool, "gs", profile == "default" ? "" : profile)
     , m_auth(std::move(auth))
 { }
 
-std::unique_ptr<Google> Google::create(http::Pool& pool, const std::string s)
+std::unique_ptr<Google> Google::create(
+    http::Pool& pool,
+    const std::string s,
+    const std::string profile)
 {
     if (auto auth = Auth::create(s))
     {
-        return makeUnique<Google>(pool, std::move(auth));
+        return makeUnique<Google>(pool, std::move(auth), profile);
     }
 
     return std::unique_ptr<Google>();
@@ -3525,7 +3419,7 @@ std::vector<std::string> Google::glob(std::string path, bool verbose) const
         for (const json& item : j.at("items"))
         {
             results.push_back(
-                    type() + "://" +
+                    profiledProtocol() + "://" +
                     resource.bucket() + item.at("name").get<std::string>());
         }
 
@@ -3787,12 +3681,18 @@ namespace drivers
 
 using namespace http;
 
-Dropbox::Dropbox(Pool& pool, const Dropbox::Auth& auth)
-    : Http(pool)
+Dropbox::Dropbox(
+        Pool& pool,
+        const Dropbox::Auth& auth,
+        const std::string profile)
+    : Http(pool, "dbx", profile)
     , m_auth(auth)
 { }
 
-std::unique_ptr<Dropbox> Dropbox::create(Pool& pool, const std::string s)
+std::unique_ptr<Dropbox> Dropbox::create(
+    Pool& pool,
+    const std::string s,
+    const std::string profile)
 {
     const json j(json::parse(s));
     if (!j.is_null())
@@ -3801,11 +3701,15 @@ std::unique_ptr<Dropbox> Dropbox::create(Pool& pool, const std::string s)
         {
             return makeUnique<Dropbox>(
                     pool,
-                    Auth(j.at("token").get<std::string>()));
+                    Auth(j.at("token").get<std::string>()),
+                    profile);
         }
         else if (j.is_string())
         {
-            return makeUnique<Dropbox>(pool, Auth(j.get<std::string>()));
+            return makeUnique<Dropbox>(
+                    pool,
+                    Auth(j.get<std::string>()),
+                    profile);
         }
     }
 
@@ -4044,7 +3948,9 @@ std::vector<std::string> Dropbox::glob(std::string path, bool verbose) const
             {
                 // Results already begin with a slash.
                 results.push_back(
-                        type() + ":/" + v.at("path_lower").get<std::string>());
+                        profiledProtocol() +
+                        ":/" +
+                        v.at("path_lower").get<std::string>());
             }
         }
     };
@@ -5846,6 +5752,24 @@ std::string stripExtension(const std::string path)
 {
     const std::size_t pos(path.find_last_of('.'));
     return path.substr(0, pos);
+}
+
+std::string getProfile(std::string protocol)
+{
+    const std::size_t pos(protocol.find_last_of('@'));
+
+    if (pos != std::string::npos) return protocol.substr(0, pos);
+    return "";
+}
+
+std::string stripProfile(std::string protocol)
+{
+    const std::string profile = getProfile(protocol);
+    if (profile.size() && protocol.size() >= profile.size() + 1)
+    {
+        return protocol.substr(profile.size() + 1);
+    }
+    return protocol;
 }
 
 } // namespace arbiter

--- a/vendor/arbiter/arbiter.cpp
+++ b/vendor/arbiter/arbiter.cpp
@@ -120,6 +120,17 @@ void Arbiter::addDriver(const std::string type, std::shared_ptr<Driver> driver)
     m_drivers[type] = driver;
 }
 
+bool Arbiter::hasDriver(const std::string path) const
+{
+    try
+    {
+        getDriver(path);
+        return true;
+    }
+    catch (...) { }
+    return false;
+}
+
 std::string Arbiter::get(const std::string path) const
 {
     return getDriver(path)->get(stripProtocol(path));

--- a/vendor/arbiter/arbiter.hpp
+++ b/vendor/arbiter/arbiter.hpp
@@ -5258,6 +5258,9 @@ public:
      */
     void addDriver(std::string type, std::shared_ptr<Driver> driver);
 
+    /** Returns true if a driver from this path is available. */
+    bool hasDriver(std::string path) const;
+
     /** Get data or throw if inaccessible. */
     std::string get(std::string path) const;
 

--- a/vendor/arbiter/arbiter.hpp
+++ b/vendor/arbiter/arbiter.hpp
@@ -1,7 +1,7 @@
 /// Arbiter amalgamated header (https://github.com/connormanning/arbiter).
 /// It is intended to be used with #include "arbiter.hpp"
 
-// Git SHA: 67761eb4ddfeac89e1a0d73aab21f2f081e1f484
+// Git SHA: f17a62f31d4df0ec23636971f56f152a8c52b72c
 
 // //////////////////////////////////////////////////////////////////////
 // Beginning of content of file: LICENSE
@@ -3684,6 +3684,15 @@ ARBITER_DLL std::string getExtension(std::string path);
  * '.' if one exists, otherwise return the full path. */
 ARBITER_DLL std::string stripExtension(std::string path);
 
+/** Get the characters up to the last instance of "@" in the protocol, or an
+ * empty string if no "@" character exists. */
+ARBITER_DLL std::string getProfile(std::string protocol);
+
+/** Get the characters following the last instance of "@" in the protocol, or
+ * the original @p protocol if no profile exists.
+*/
+ARBITER_DLL std::string stripProfile(std::string protocol);
+
 } // namespace arbiter
 
 #ifdef ARBITER_CUSTOM_NAMESPACE
@@ -3709,6 +3718,7 @@ ARBITER_DLL std::string stripExtension(std::string path);
 #include <iostream>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -3723,8 +3733,8 @@ namespace ARBITER_CUSTOM_NAMESPACE
 
 namespace arbiter
 {
+namespace http { class Pool; }
 
-class HttpPool;
 
 /** @brief Base class for interacting with a storage type.
  *
@@ -3744,17 +3754,24 @@ class HttpPool;
 class ARBITER_DLL Driver
 {
 public:
+    Driver(std::string protocol, std::string profile = "")
+        : m_profile(profile)
+        , m_protocol(protocol)
+    { }
+
     virtual ~Driver() { }
 
-    /**
-     * Returns a string identifying this driver type, which should be unique
-     * among all other drivers.  Paths that begin with the substring
-     * `<type>://` will be routed to this driver.  For example, `fs`, `s3`, or
-     * `http`.
-     *
-     * @note Derived classes must override.
-     */
-    virtual std::string type() const = 0;
+    static std::shared_ptr<Driver> create(
+        http::Pool& pool,
+        std::string protocol,
+        std::string config);
+
+    std::string profile() const { return m_profile; }
+    std::string protocol() const { return m_protocol; }
+    std::string profiledProtocol() const
+    {
+        return m_profile.size() ? m_profile + "@" + m_protocol : m_protocol;
+    }
 
     /** Get string data. */
     std::string get(std::string path) const;
@@ -3828,9 +3845,12 @@ protected:
      * @param[out] data Empty vector in which to write resulting data.
      */
     virtual bool get(std::string path, std::vector<char>& data) const = 0;
+
+    const std::string m_profile;
+    const std::string m_protocol;
 };
 
-typedef std::map<std::string, std::unique_ptr<Driver>> DriverMap;
+typedef std::map<std::string, std::shared_ptr<Driver>> DriverMap;
 
 } // namespace arbiter
 
@@ -3948,13 +3968,11 @@ namespace drivers
 class ARBITER_DLL Fs : public Driver
 {
 public:
-    Fs() { }
+    Fs(std::string protocol = "file"): Driver(protocol) { }
 
     using Driver::get;
 
     static std::unique_ptr<Fs> create();
-
-    virtual std::string type() const override { return "file"; }
 
     virtual std::unique_ptr<std::size_t> tryGetSize(
             std::string path) const override;
@@ -4028,11 +4046,12 @@ namespace drivers
 class ARBITER_DLL Http : public Driver
 {
 public:
-    Http(http::Pool& pool);
+    Http(
+            http::Pool& pool,
+            std::string protocol = "http",
+            std::string httpProtocol = "http",
+            std::string profile = "");
     static std::unique_ptr<Http> create(http::Pool& pool);
-
-    // Inherited from Driver.
-    virtual std::string type() const override { return "http"; }
 
     /** By default, performs a HEAD request and returns the contents of the
      * Content-Length header.
@@ -4157,6 +4176,7 @@ protected:
             http::Query query) const;
 
     http::Pool& m_pool;
+    std::string m_httpProtocol;
 
 private:
     virtual bool get(
@@ -4175,14 +4195,18 @@ private:
 class Https : public Http
 {
 public:
-    Https(http::Pool& pool) : Http(pool) { }
+    Https(
+            http::Pool& pool,
+            std::string driverProtocol = "https",
+            std::string httpProtocol = "https",
+            std::string profile = "")
+        : Http(pool, driverProtocol, httpProtocol, profile)
+    { }
 
     static std::unique_ptr<Https> create(http::Pool& pool)
     {
         return std::unique_ptr<Https>(new Https(pool));
     }
-
-    virtual std::string type() const override { return "https"; }
 };
 
 } // namespace drivers
@@ -4247,20 +4271,17 @@ public:
     /** Try to construct an S3 driver.  The configuration/credential discovery
      * follows, in order:
      *      - Environment settings.
-     *      - Arbiter JSON configuration.
+     *      - JSON configuration
      *      - Well-known files or their environment overrides, like
      *          `~/.aws/credentials` or the file at AWS_CREDENTIAL_FILE.
      *      - EC2 instance profile.
      */
-    static std::vector<std::unique_ptr<S3>> create(
-            http::Pool& pool,
-            std::string j);
-
-    static std::unique_ptr<S3> createOne(http::Pool& pool, std::string j);
+    static std::unique_ptr<S3> create(
+        http::Pool& pool,
+        std::string json,
+        std::string profile = "default");
 
     // Overrides.
-    virtual std::string type() const override;
-
     virtual std::unique_ptr<std::size_t> tryGetSize(
             std::string path) const override;
 
@@ -4274,14 +4295,6 @@ public:
     virtual void copy(std::string src, std::string dst) const override;
 
 private:
-    static std::string extractProfile(std::string j);
-
-    /*
-    static std::unique_ptr<Config> extractConfig(
-            std::string j,
-            std::string profile);
-
-            */
     /** Inherited from Drivers::Http. */
     virtual bool get(
             std::string path,
@@ -4296,7 +4309,6 @@ private:
     class ApiV4;
     class Resource;
 
-    std::string m_profile;
     std::unique_ptr<Auth> m_auth;
     std::unique_ptr<Config> m_config;
 };
@@ -4331,7 +4343,7 @@ public:
         : m_credUrl(internal::makeUnique<std::string>(credUrl))
     { }
 
-    static std::unique_ptr<Auth> create(std::string j, std::string profile);
+    static std::unique_ptr<Auth> create(std::string profile, std::string s);
 
     AuthFields fields() const;
 
@@ -4348,7 +4360,7 @@ private:
 class S3::Config
 {
 public:
-    Config(std::string j, std::string profile);
+    Config(std::string json, std::string profile);
 
     const std::string& region() const { return m_region; }
     const std::string& baseUrl() const { return m_baseUrl; }
@@ -4356,8 +4368,8 @@ public:
     bool precheck() const { return m_precheck; }
 
 private:
-    static std::string extractRegion(std::string j, std::string profile);
-    static std::string extractBaseUrl(std::string j, std::string region);
+    static std::string extractRegion(std::string json, std::string profile);
+    static std::string extractBaseUrl(std::string json, std::string region);
 
     const std::string m_region;
     const std::string m_baseUrl;
@@ -4489,20 +4501,17 @@ public:
             std::string profile,
             std::unique_ptr<Config> config);
 
-    /** Try to construct an Azure blob driver.  The configuration/credential discovery
-     * follows, in order:
+    /** Try to construct an Azure blob driver.  The configuration/credential
+     * discovery follows, in order:
      *      - Environment settings.
-     *      - Arbiter JSON configuration.
+     *      - JSON configuration.
      */
-    static std::vector<std::unique_ptr<AZ>> create(
+    static std::unique_ptr<AZ> create(
             http::Pool& pool,
-            std::string j);
-
-    static std::unique_ptr<AZ> createOne(http::Pool& pool, std::string j);
+            std::string j,
+            std::string profile);
 
     // Overrides.
-    virtual std::string type() const override;
-
     virtual std::unique_ptr<std::size_t> tryGetSize(
             std::string path) const override;
 
@@ -4516,14 +4525,6 @@ public:
     virtual void copy(std::string src, std::string dst) const override;
 
 private:
-    static std::string extractProfile(std::string j);
-
-    /*
-    static std::unique_ptr<Config> extractConfig(
-            std::string j,
-            std::string profile);
-
-            */
     /** Inherited from Drivers::Http. */
     virtual bool get(
             std::string path,
@@ -4538,7 +4539,6 @@ private:
     class ApiV1;
     class Resource;
 
-    std::string m_profile;
     std::unique_ptr<Config> m_config;
 };
 
@@ -4561,7 +4561,7 @@ class AZ::Config
 {
 
 public:
-    Config(std::string j, std::string profile);
+    Config(std::string j);
 
     const http::Query& sasToken() const { return m_sasToken; }
     bool hasSasToken() const { return m_sasToken.size() > 0; }
@@ -4575,11 +4575,11 @@ public:
     AuthFields authFields() const { return AuthFields(m_storageAccount, m_storageAccessKey); }
 
 private:
-    static std::string extractService(std::string j, std::string profile);
-    static std::string extractEndpoint(std::string j, std::string profile);
+    static std::string extractService(std::string j);
+    static std::string extractEndpoint(std::string j);
     static std::string extractBaseUrl(std::string j, std::string endpoint, std::string service, std::string account);
-    static std::string extractStorageAccount(std::string j, std::string profile);
-    static std::string extractStorageAccessKey(std::string j, std::string profile);
+    static std::string extractStorageAccount(std::string j);
+    static std::string extractStorageAccessKey(std::string j);
     static std::string extractSasToken(std::string j);
 
     http::Query m_sasToken;
@@ -4700,13 +4700,17 @@ class Google : public Https
 {
     class Auth;
 public:
-    Google(http::Pool& pool, std::unique_ptr<Auth> auth);
+    Google(
+            http::Pool& pool,
+            std::unique_ptr<Auth> auth,
+            std::string profile = "");
 
-    static std::unique_ptr<Google> create(http::Pool& pool, std::string j);
+    static std::unique_ptr<Google> create(
+            http::Pool& pool,
+            std::string j,
+            std::string profile);
 
     // Overrides.
-    virtual std::string type() const override { return "gs"; }  // Match gsutil.
-
     virtual std::unique_ptr<std::size_t> tryGetSize(
             std::string path) const override;
 
@@ -4799,15 +4803,17 @@ class Dropbox : public Http
 {
 public:
     class Auth;
-    Dropbox(http::Pool& pool, const Auth& auth);
+    Dropbox(http::Pool& pool, const Auth& auth, std::string profile);
 
     /** Try to construct a %Dropbox Driver.  @p j may be stringified JSON, in
      * which the key `token` will be used to construct the Dropbox auth, or
      * may simply be the token string itself.
      */
-    static std::unique_ptr<Dropbox> create(http::Pool& pool, std::string j);
+    static std::unique_ptr<Dropbox> create(
+        http::Pool& pool,
+        std::string j,
+        std::string profile);
 
-    virtual std::string type() const override { return "dropbox"; }
     virtual void put(
             std::string path,
             const std::vector<char>& data,
@@ -4895,12 +4901,13 @@ namespace drivers
 class Test : public Fs
 {
 public:
+    Test(): Fs("test") { }
+
     static std::unique_ptr<Test> create()
     {
         return std::unique_ptr<Test>(new Test());
     }
 
-    virtual std::string type() const override { return "test"; }
     virtual bool isRemote() const override { return true; }
 
 private:
@@ -4909,7 +4916,7 @@ private:
             bool verbose) const override
     {
         auto results(Fs::glob(path, verbose));
-        for (auto& p : results) p = type() + "://" + p;
+        for (auto& p : results) p = profiledProtocol() + "://" + p;
         return results;
     }
 };
@@ -4995,8 +5002,12 @@ public:
 
     // Driver passthroughs.
 
-    /** Passthrough to Driver::type. */
-    std::string type() const;
+    /** Passthrough to Driver::protocol. */
+    std::string protocol() const;
+    /** Passthrough to Driver::profile. */
+    std::string profile() const;
+    /** Passthrough to Driver::profiledProtocol. */
+    std::string profiledProtocol() const;
 
     /** Passthrough to Driver::isRemote. */
     bool isRemote() const;
@@ -5234,9 +5245,6 @@ public:
     /** @brief Construct an Arbiter with driver configurations. */
     Arbiter(std::string stringifiedJson);
 
-    /** True if a Driver has been registered for this file type. */
-    bool hasDriver(std::string path) const;
-
     /** @brief Add a custom driver for the supplied type.
      *
      * After this operation completes, future requests into arbiter beginning
@@ -5248,7 +5256,7 @@ public:
      *
      * @note This operation is not thread-safe.
      */
-    void addDriver(std::string type, std::unique_ptr<Driver> driver);
+    void addDriver(std::string type, std::shared_ptr<Driver> driver);
 
     /** Get data or throw if inaccessible. */
     std::string get(std::string path) const;
@@ -5411,7 +5419,7 @@ public:
      *
      * Optionally, filesystem paths may be explicitly prefixed with `file://`.
      */
-    const Driver& getDriver(std::string path) const;
+    std::shared_ptr<Driver> getDriver(std::string path) const;
 
     /** @brief Get a LocalHandle to a possibly remote file.
      *
@@ -5462,10 +5470,12 @@ public:
     http::Pool& httpPool() { return *m_pool; }
 
 private:
-    const drivers::Http* tryGetHttpDriver(std::string path) const;
-    const drivers::Http& getHttpDriver(std::string path) const;
+    std::shared_ptr<drivers::Http> tryGetHttpDriver(std::string path) const;
+    std::shared_ptr<drivers::Http> getHttpDriver(std::string path) const;
 
-    DriverMap m_drivers;
+    std::string m_config;
+    mutable std::mutex m_mutex;
+    mutable DriverMap m_drivers;
     std::unique_ptr<http::Pool> m_pool;
 };
 


### PR DESCRIPTION
Update arbiter for on-demand driver wakeup (previously drivers were awoken on initialization) and improved profile support.  Also replace PDAL's `isRemote` check which looked for well-known prefixes like `s3://` (but would give incorrect results for things like `profile@s3://...`) with a simple check for `://` within the filename string.  Closes #3792.