### PR TITLE
writers.ogr: add option to populate feature attributes from dimensions

### DIFF
--- a/doc/stages/writers.ogr.rst
+++ b/doc/stages/writers.ogr.rst
@@ -4,15 +4,15 @@ writers.ogr
 ===========
 
 The **OGR Writer** will create files of various `vector formats`_ as supported
-by the OGR library.  PDAL points are generally stored as points in the
-output format, though PDAL will create multipoint objects instead of point
-objects if the 'multicount' argument is set to a value greater than 1.
-Points can be written with a single additional value in addition to location
-if 'measure_dim' specifies a valid PDAL dimension and the output format
-supports measure point types.
+by the OGR library.  PDAL points are generally stored as point geometries in the
+output format, though PDAL will create multipoint geometries instead if the
+multicount_ option is set to a value greater than 1.
+Points can be written with a additional measure value (POINTZM) if measure_dim_
+specifies a valid PDAL dimension, and dimensions can be set as feature
+attributes using the attr_dims_ option.
 
 By default, the OGR writer will create ESRI shapefiles.  The particular OGR
-driver can be specified with the 'ogrdriver' option.
+driver can be specified with the ``ogrdriver`` option.
 
 Example
 -------
@@ -24,7 +24,8 @@ Example
       {
           "type": "writers.ogr",
           "filename": "outfile.geojson",
-          "measure_dim": "Compression"
+          "measure_dim": "Intensity",
+          "attr_dims": "Classification"
       }
   ]
 
@@ -33,7 +34,7 @@ Options
 
 _`filename`
   Output file to write.  The writer will accept a filename containing
-  a single placeholder character (`#`).  If input to the writer consists
+  a single placeholder character (``#``).  If input to the writer consists
   of multiple PointViews, each will be written to a separate file, where
   the placeholder will be replaced with an incrementing integer.  If no
   placeholder is found, all PointViews provided to the writer are
@@ -41,33 +42,39 @@ _`filename`
   the result of multiple input files, or using :ref:`filters.splitter`,
   :ref:`filters.chipper` or :ref:`filters.divider`.
 
-  The driver will use the OGR GEOjson driver if the output filename
-  extension is 'geojson', and the ESRI shapefile driver if the output
-  filename extension is 'shp'.
+  The driver will use the OGR GeoJSON driver if the output filename
+  extension is ``.geojson``, and the ESRI Shapefile driver if the output
+  filename extension is ``.shp``.
   If neither extension is recognized, the filename is taken
-  to represent a directory in which ESRI shapefiles are written.  The
-  driver can be explicitly specified by using the 'ogrdriver' option.
+  to represent a directory in which ESRI Shapefiles are written.  The
+  driver can be explicitly specified by using the ogrdriver_ option.
 
-multicount
-  If 1, point objects will be written.  If greater than 1, specifies the
-  number of points to group into a multipoint object.  Not all OGR
-  drivers support multipoint objects. [Default: 1]
+_`multicount`
+  If 1, point features will be written.  If greater than 1, specifies the
+  number of points to group into a feature with a multipoint geometry.  Not all
+  OGR drivers support multipoint geometries. [Default: 1]
 
-measure_dim
+_`measure_dim`
   If specified, points will be written with an extra data field, the dimension
   of which is specified by this option. Not all output formats support
   measure data. [Default: None]
 
-  .. note::
+_`attr_dims`
+  List of dimensions to write as feature attributes. Separate multiple values
+  with ``,`` or repeat the option. Use ``all`` to write all dimensions.
+  ``X``, ``Y``, ``Z``, and any measure_dim_ are never written as attributes.
+  This option is incompatible with the multicount_ option. [Default: None]
 
-    The **measure_dim** option is only supported if PDAL is built with
-    GDAL version 2.1 or later.
-
-ogrdriver
+_`ogrdriver`
   The OGR driver to use for output.  This option overrides any inference made
   about output drivers from filename_.
 
+_`ogr_options`
+  List of OGR driver-specific layer creation options, formatted as an
+  ``OPTION=VALUE`` string. Separate multiple values with ``,`` or repeat the
+  option. [Default: None]
+
 .. include:: writer_opts.rst
 
-.. _vector formats: http://www.gdal.org/ogr_formats.html
+.. _vector formats: https://gdal.org/drivers/vector/index.html
 

--- a/io/OGRWriter.cpp
+++ b/io/OGRWriter.cpp
@@ -198,16 +198,17 @@ void OGRWriter::readyFile(const std::string& filename,
     if (!m_ds)
         throwError("Unable to open OGR datasource '" + filename + "': " + CPLGetLastErrorMsg());
 
-    m_layer = m_ds->CreateLayer("points", nullptr, m_geomType, nullptr);
+    // CRS
+    if (!srs.empty())
+    {
+        if (!m_srs.importFromWkt(srs.getWKT().data()))
+            throwError(std::string("Can't initialise OGR SRS: ") + CPLGetLastErrorMsg());
+    }
+
+    // Layer
+    m_layer = m_ds->CreateLayer("points", &m_srs, m_geomType, nullptr);
     if (!m_layer)
         throwError(std::string("Can't create OGR layer: ") + CPLGetLastErrorMsg());
-
-    // CRS
-    {
-        gdal::ErrorHandlerSuspender devnull;
-
-        m_ds->SetProjection(srs.getWKT().data());
-    }
 
     // Fields
     for(auto& attr : m_attrs)

--- a/io/OGRWriter.cpp
+++ b/io/OGRWriter.cpp
@@ -78,7 +78,8 @@ void OGRWriter::addArgs(ProgramArgs& args)
     args.add("measure_dim", "Use dimensions as a measure value",
         m_measureDimName);
     args.add("ogrdriver", "OGR writer driver name", m_driverName, m_driverName);
-    args.add("attr_dims", "Dimensions to use as attributes, 'all' for all. Incompatible with multicount>1", m_attrDimNames);
+    args.add("ogr_options", "OGR layer creation options", m_ogrOptions);
+    args.add("attr_dims", "Dimension to use as attributes, 'all' for all. Incompatible with multicount>1", m_attrDimNames);
 }
 
 
@@ -205,8 +206,14 @@ void OGRWriter::readyFile(const std::string& filename,
             throwError(std::string("Can't initialise OGR SRS: ") + CPLGetLastErrorMsg());
     }
 
+    // Creation options
+    std::vector<const char*> ogr_create_options;
+    for(auto&& o:m_ogrOptions)
+        ogr_create_options.push_back(o.c_str());
+    ogr_create_options.push_back(nullptr);
+
     // Layer
-    m_layer = m_ds->CreateLayer("points", &m_srs, m_geomType, nullptr);
+    m_layer = m_ds->CreateLayer("points", &m_srs, m_geomType, const_cast<char**>(ogr_create_options.data()));
     if (!m_layer)
         throwError(std::string("Can't create OGR layer: ") + CPLGetLastErrorMsg());
 

--- a/io/OGRWriter.cpp
+++ b/io/OGRWriter.cpp
@@ -181,9 +181,12 @@ bool OGRWriter::processOne(PointRef& point)
 
 void OGRWriter::doneFile()
 {
-    if (m_curCount)
+    if (m_curCount % m_multiCount > 0) {
+        m_feature->SetGeometry(&m_multiPoint);
+
         if (m_layer->CreateFeature(m_feature))
             throwError("Couldn't create feature.");
+    }
     OGRFeature::DestroyFeature(m_feature);
     GDALClose(m_ds);
     m_layer = nullptr;

--- a/io/OGRWriter.cpp
+++ b/io/OGRWriter.cpp
@@ -301,6 +301,10 @@ bool OGRWriter::processOne(PointRef& point)
 
         if (m_layer->CreateFeature(m_feature))
             throwError(std::string("Can't create OGR feature: ") + CPLGetLastErrorMsg());
+
+#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,5,0)
+        m_feature->Reset();
+#endif
     }
     return true;
 }
@@ -309,6 +313,10 @@ bool OGRWriter::processOne(PointRef& point)
 void OGRWriter::doneFile()
 {
     if (m_curCount % m_multiCount > 0) {
+#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,5,0)
+        m_feature->Reset();
+#endif
+
         m_feature->SetGeometry(&m_multiPoint);
         m_feature->SetFID(m_curCount / m_multiCount + 1);
 

--- a/io/OGRWriter.cpp
+++ b/io/OGRWriter.cpp
@@ -112,10 +112,7 @@ void OGRWriter::prepared(PointTableRef table)
 void OGRWriter::readyTable(PointTableRef table)
 {
     m_driver = GetGDALDriverManager()->GetDriverByName(m_driverName.data());
-    if (m_measureDim == Dimension::Id::Unknown)
-        m_geomType = (m_multiCount == 1) ? wkbPoint : wkbMultiPoint;
-    else
-        m_geomType = (m_multiCount == 1) ? wkbPointZM : wkbMultiPointZM;
+    m_geomType = (m_multiCount == 1) ? wkbPointZM : wkbMultiPointZM;
 }
 
 

--- a/io/OGRWriter.hpp
+++ b/io/OGRWriter.hpp
@@ -74,6 +74,8 @@ private:
     size_t m_curCount;
     std::string m_measureDimName;
     Dimension::Id m_measureDim;
+    std::vector<std::string> m_attrDimNames;
+    std::deque<std::tuple<Dimension::Id, Dimension::Type, OGRFieldDefn> > m_attrs;
 };
 
 }

--- a/io/OGRWriter.hpp
+++ b/io/OGRWriter.hpp
@@ -66,6 +66,7 @@ private:
     GDALDataset *m_ds;
     OGRLayer *m_layer;
     OGRFeature *m_feature;
+    OGRSpatialReference m_srs;
     OGRwkbGeometryType m_geomType;
     OGRMultiPoint m_multiPoint;
     std::string m_outputFilename;

--- a/io/OGRWriter.hpp
+++ b/io/OGRWriter.hpp
@@ -76,6 +76,7 @@ private:
     std::string m_measureDimName;
     Dimension::Id m_measureDim;
     std::vector<std::string> m_attrDimNames;
+    std::vector<std::string> m_ogrOptions;
     std::deque<std::tuple<Dimension::Id, Dimension::Type, OGRFieldDefn> > m_attrs;
 };
 

--- a/pdal/private/gdal/ErrorHandler.hpp
+++ b/pdal/private/gdal/ErrorHandler.hpp
@@ -37,6 +37,8 @@
 #include <cpl_conv.h>
 #include <cpl_error.h>
 
+#include <mutex>
+
 namespace pdal
 {
 namespace gdal
@@ -113,7 +115,8 @@ private:
     CPLErrorHandler m_prevHandler;
 };
 
-class ErrorHandlerSuspender
+// Exported for test support
+class PDAL_DLL ErrorHandlerSuspender
 {
 public:
     ErrorHandlerSuspender();

--- a/test/data/ogr/attrs.shp.ogrinfo
+++ b/test/data/ogr/attrs.shp.ogrinfo
@@ -1,0 +1,83 @@
+INFO: Open of `/Users/rcoup/code/point-clouds/pdal/test/data/../temp/ogr/attrs.shp'
+      using driver `ESRI Shapefile' successful.
+
+Layer name: attrs
+Geometry: 3D Point
+Feature Count: 10
+Extent: (635619.850000, 849017.320000) - (635685.330000, 852165.120000)
+Layer SRS WKT:
+(unknown)
+Classifica: Integer (9.0)
+Red: Integer (9.0)
+Green: Integer (9.0)
+Blue: Integer (9.0)
+OGRFeature(attrs):0
+  Classifica (Integer) = 1
+  Red (Integer) = 52
+  Green (Integer) = 65
+  Blue (Integer) = 68
+  POINT Z (635619.85 850064.04 447.01)
+
+OGRFeature(attrs):1
+  Classifica (Integer) = 1
+  Red (Integer) = 39
+  Green (Integer) = 57
+  Blue (Integer) = 56
+  POINT Z (635640.42 849758.79 422.74)
+
+OGRFeature(attrs):2
+  Classifica (Integer) = 2
+  Red (Integer) = 109
+  Green (Integer) = 104
+  Blue (Integer) = 122
+  POINT Z (635650.95 850244.03 424.93)
+
+OGRFeature(attrs):3
+  Classifica (Integer) = 1
+  Red (Integer) = 228
+  Green (Integer) = 220
+  Blue (Integer) = 231
+  POINT Z (635673.46 850157.55 435.73)
+
+OGRFeature(attrs):4
+  Classifica (Integer) = 1
+  Red (Integer) = 146
+  Green (Integer) = 104
+  Blue (Integer) = 140
+  POINT Z (635674.05 849017.32 428.02)
+
+OGRFeature(attrs):5
+  Classifica (Integer) = 1
+  Red (Integer) = 76
+  Green (Integer) = 87
+  Blue (Integer) = 92
+  POINT Z (635678.9 851351.44 436.45)
+
+OGRFeature(attrs):6
+  Classifica (Integer) = 2
+  Red (Integer) = 64
+  Green (Integer) = 73
+  Blue (Integer) = 78
+  POINT Z (635680.54 849362.66 421.56)
+
+OGRFeature(attrs):7
+  Classifica (Integer) = 2
+  Red (Integer) = 81
+  Green (Integer) = 84
+  Blue (Integer) = 95
+  POINT Z (635681.07 851383.76 419)
+
+OGRFeature(attrs):8
+  Classifica (Integer) = 1
+  Red (Integer) = 78
+  Green (Integer) = 88
+  Blue (Integer) = 94
+  POINT Z (635684.02 849494.39 407.12)
+
+OGRFeature(attrs):9
+  Classifica (Integer) = 1
+  Red (Integer) = 64
+  Green (Integer) = 73
+  Blue (Integer) = 78
+  POINT Z (635685.33 852165.12 421.75)
+

--- a/test/data/ogr/attrs_all.shp.ogrinfo
+++ b/test/data/ogr/attrs_all.shp.ogrinfo
@@ -1,0 +1,182 @@
+INFO: Open of `/Users/rcoup/code/point-clouds/pdal/test/data/../temp/ogr/attrs_all.shp'
+      using driver `ESRI Shapefile' successful.
+
+Layer name: attrs_all
+Geometry: 3D Point
+Feature Count: 10
+Extent: (635619.850000, 849017.320000) - (635685.330000, 852165.120000)
+Layer SRS WKT:
+(unknown)
+Intensity: Integer (9.0)
+ReturnNumb: Integer (9.0)
+NumberOfRe: Integer (9.0)
+ScanDirect: Integer (9.0)
+EdgeOfFlig: Integer (9.0)
+Classifica: Integer (9.0)
+ScanAngleR: Real (24.15)
+UserData: Integer (9.0)
+PointSourc: Integer (9.0)
+GpsTime: Real (24.15)
+Red: Integer (9.0)
+Green: Integer (9.0)
+Blue: Integer (9.0)
+OGRFeature(attrs_all):0
+  Intensity (Integer) = 1
+  ReturnNumb (Integer) = 1
+  NumberOfRe (Integer) = 2
+  ScanDirect (Integer) = 0
+  EdgeOfFlig (Integer) = 0
+  Classifica (Integer) = 1
+  ScanAngleR (Real) = 15.000000000000000
+  UserData (Integer) = 125
+  PointSourc (Integer) = 7327
+  GpsTime (Real) = 246092.207880993664730
+  Red (Integer) = 52
+  Green (Integer) = 65
+  Blue (Integer) = 68
+  POINT Z (635619.85 850064.04 447.01)
+
+OGRFeature(attrs_all):1
+  Intensity (Integer) = 25
+  ReturnNumb (Integer) = 1
+  NumberOfRe (Integer) = 1
+  ScanDirect (Integer) = 1
+  EdgeOfFlig (Integer) = 0
+  Classifica (Integer) = 1
+  ScanAngleR (Real) = 6.000000000000000
+  UserData (Integer) = 124
+  PointSourc (Integer) = 7327
+  GpsTime (Real) = 246092.682015085854800
+  Red (Integer) = 39
+  Green (Integer) = 57
+  Blue (Integer) = 56
+  POINT Z (635640.42 849758.79 422.74)
+
+OGRFeature(attrs_all):2
+  Intensity (Integer) = 33
+  ReturnNumb (Integer) = 1
+  NumberOfRe (Integer) = 1
+  ScanDirect (Integer) = 1
+  EdgeOfFlig (Integer) = 0
+  Classifica (Integer) = 2
+  ScanAngleR (Real) = -11.000000000000000
+  UserData (Integer) = 126
+  PointSourc (Integer) = 7329
+  GpsTime (Real) = 247175.609838934644358
+  Red (Integer) = 109
+  Green (Integer) = 104
+  Blue (Integer) = 122
+  POINT Z (635650.95 850244.03 424.93)
+
+OGRFeature(attrs_all):3
+  Intensity (Integer) = 70
+  ReturnNumb (Integer) = 1
+  NumberOfRe (Integer) = 1
+  ScanDirect (Integer) = 1
+  EdgeOfFlig (Integer) = 0
+  Classifica (Integer) = 1
+  ScanAngleR (Real) = 0.000000000000000
+  UserData (Integer) = 124
+  PointSourc (Integer) = 7328
+  GpsTime (Real) = 246509.078758077346720
+  Red (Integer) = 228
+  Green (Integer) = 220
+  Blue (Integer) = 231
+  POINT Z (635673.46 850157.55 435.73)
+
+OGRFeature(attrs_all):4
+  Intensity (Integer) = 153
+  ReturnNumb (Integer) = 1
+  NumberOfRe (Integer) = 1
+  ScanDirect (Integer) = 0
+  EdgeOfFlig (Integer) = 0
+  Classifica (Integer) = 1
+  ScanAngleR (Real) = -7.000000000000000
+  UserData (Integer) = 126
+  PointSourc (Integer) = 7326
+  GpsTime (Real) = 245388.610486141726142
+  Red (Integer) = 146
+  Green (Integer) = 104
+  Blue (Integer) = 140
+  POINT Z (635674.05 849017.32 428.02)
+
+OGRFeature(attrs_all):5
+  Intensity (Integer) = 6
+  ReturnNumb (Integer) = 2
+  NumberOfRe (Integer) = 2
+  ScanDirect (Integer) = 0
+  EdgeOfFlig (Integer) = 0
+  Classifica (Integer) = 1
+  ScanAngleR (Real) = 10.000000000000000
+  UserData (Integer) = 126
+  PointSourc (Integer) = 7329
+  GpsTime (Real) = 247174.372762127750320
+  Red (Integer) = 76
+  Green (Integer) = 87
+  Blue (Integer) = 92
+  POINT Z (635678.9 851351.44 436.45)
+
+OGRFeature(attrs_all):6
+  Intensity (Integer) = 58
+  ReturnNumb (Integer) = 2
+  NumberOfRe (Integer) = 2
+  ScanDirect (Integer) = 0
+  EdgeOfFlig (Integer) = 0
+  Classifica (Integer) = 2
+  ScanAngleR (Real) = -1.000000000000000
+  UserData (Integer) = 126
+  PointSourc (Integer) = 7327
+  GpsTime (Real) = 246093.418377374502597
+  Red (Integer) = 64
+  Green (Integer) = 73
+  Blue (Integer) = 78
+  POINT Z (635680.54 849362.66 421.56)
+
+OGRFeature(attrs_all):7
+  Intensity (Integer) = 99
+  ReturnNumb (Integer) = 2
+  NumberOfRe (Integer) = 2
+  ScanDirect (Integer) = 1
+  EdgeOfFlig (Integer) = 0
+  Classifica (Integer) = 2
+  ScanAngleR (Real) = -3.000000000000000
+  UserData (Integer) = 130
+  PointSourc (Integer) = 7330
+  GpsTime (Real) = 247574.175078637053957
+  Red (Integer) = 81
+  Green (Integer) = 84
+  Blue (Integer) = 95
+  POINT Z (635681.07 851383.76 419)
+
+OGRFeature(attrs_all):8
+  Intensity (Integer) = 48
+  ReturnNumb (Integer) = 1
+  NumberOfRe (Integer) = 1
+  ScanDirect (Integer) = 0
+  EdgeOfFlig (Integer) = 0
+  Classifica (Integer) = 1
+  ScanAngleR (Real) = 1.000000000000000
+  UserData (Integer) = 126
+  PointSourc (Integer) = 7327
+  GpsTime (Real) = 246093.264552279375494
+  Red (Integer) = 78
+  Green (Integer) = 88
+  Blue (Integer) = 94
+  POINT Z (635684.02 849494.39 407.12)
+
+OGRFeature(attrs_all):9
+  Intensity (Integer) = 109
+  ReturnNumb (Integer) = 1
+  NumberOfRe (Integer) = 1
+  ScanDirect (Integer) = 1
+  EdgeOfFlig (Integer) = 0
+  Classifica (Integer) = 1
+  ScanAngleR (Real) = 7.000000000000000
+  UserData (Integer) = 126
+  PointSourc (Integer) = 7332
+  GpsTime (Real) = 248689.024384217045736
+  Red (Integer) = 64
+  Green (Integer) = 73
+  Blue (Integer) = 78
+  POINT Z (635685.33 852165.12 421.75)
+

--- a/test/data/ogr/attrs_measure.shp.ogrinfo
+++ b/test/data/ogr/attrs_measure.shp.ogrinfo
@@ -1,0 +1,171 @@
+INFO: Open of `/Users/rcoup/code/point-clouds/pdal/test/data/../temp/ogr/attrs_measure.shp'
+      using driver `ESRI Shapefile' successful.
+
+Layer name: attrs_measure
+Geometry: 3D Measured Point
+Feature Count: 10
+Extent: (635619.850000, 849017.320000) - (635685.330000, 852165.120000)
+Layer SRS WKT:
+(unknown)
+Intensity: Integer (9.0)
+ReturnNumb: Integer (9.0)
+NumberOfRe: Integer (9.0)
+ScanDirect: Integer (9.0)
+EdgeOfFlig: Integer (9.0)
+ScanAngleR: Real (24.15)
+UserData: Integer (9.0)
+PointSourc: Integer (9.0)
+GpsTime: Real (24.15)
+Red: Integer (9.0)
+Green: Integer (9.0)
+Blue: Integer (9.0)
+OGRFeature(attrs_measure):0
+  Intensity (Integer) = 1
+  ReturnNumb (Integer) = 1
+  NumberOfRe (Integer) = 2
+  ScanDirect (Integer) = 0
+  EdgeOfFlig (Integer) = 0
+  ScanAngleR (Real) = 15.000000000000000
+  UserData (Integer) = 125
+  PointSourc (Integer) = 7327
+  GpsTime (Real) = 246092.207880993664730
+  Red (Integer) = 52
+  Green (Integer) = 65
+  Blue (Integer) = 68
+  POINT ZM (635619.85 850064.04 447.01 1)
+
+OGRFeature(attrs_measure):1
+  Intensity (Integer) = 25
+  ReturnNumb (Integer) = 1
+  NumberOfRe (Integer) = 1
+  ScanDirect (Integer) = 1
+  EdgeOfFlig (Integer) = 0
+  ScanAngleR (Real) = 6.000000000000000
+  UserData (Integer) = 124
+  PointSourc (Integer) = 7327
+  GpsTime (Real) = 246092.682015085854800
+  Red (Integer) = 39
+  Green (Integer) = 57
+  Blue (Integer) = 56
+  POINT ZM (635640.42 849758.79 422.74 1)
+
+OGRFeature(attrs_measure):2
+  Intensity (Integer) = 33
+  ReturnNumb (Integer) = 1
+  NumberOfRe (Integer) = 1
+  ScanDirect (Integer) = 1
+  EdgeOfFlig (Integer) = 0
+  ScanAngleR (Real) = -11.000000000000000
+  UserData (Integer) = 126
+  PointSourc (Integer) = 7329
+  GpsTime (Real) = 247175.609838934644358
+  Red (Integer) = 109
+  Green (Integer) = 104
+  Blue (Integer) = 122
+  POINT ZM (635650.95 850244.03 424.93 2)
+
+OGRFeature(attrs_measure):3
+  Intensity (Integer) = 70
+  ReturnNumb (Integer) = 1
+  NumberOfRe (Integer) = 1
+  ScanDirect (Integer) = 1
+  EdgeOfFlig (Integer) = 0
+  ScanAngleR (Real) = 0.000000000000000
+  UserData (Integer) = 124
+  PointSourc (Integer) = 7328
+  GpsTime (Real) = 246509.078758077346720
+  Red (Integer) = 228
+  Green (Integer) = 220
+  Blue (Integer) = 231
+  POINT ZM (635673.46 850157.55 435.73 1)
+
+OGRFeature(attrs_measure):4
+  Intensity (Integer) = 153
+  ReturnNumb (Integer) = 1
+  NumberOfRe (Integer) = 1
+  ScanDirect (Integer) = 0
+  EdgeOfFlig (Integer) = 0
+  ScanAngleR (Real) = -7.000000000000000
+  UserData (Integer) = 126
+  PointSourc (Integer) = 7326
+  GpsTime (Real) = 245388.610486141726142
+  Red (Integer) = 146
+  Green (Integer) = 104
+  Blue (Integer) = 140
+  POINT ZM (635674.05 849017.32 428.02 1)
+
+OGRFeature(attrs_measure):5
+  Intensity (Integer) = 6
+  ReturnNumb (Integer) = 2
+  NumberOfRe (Integer) = 2
+  ScanDirect (Integer) = 0
+  EdgeOfFlig (Integer) = 0
+  ScanAngleR (Real) = 10.000000000000000
+  UserData (Integer) = 126
+  PointSourc (Integer) = 7329
+  GpsTime (Real) = 247174.372762127750320
+  Red (Integer) = 76
+  Green (Integer) = 87
+  Blue (Integer) = 92
+  POINT ZM (635678.9 851351.44 436.45 1)
+
+OGRFeature(attrs_measure):6
+  Intensity (Integer) = 58
+  ReturnNumb (Integer) = 2
+  NumberOfRe (Integer) = 2
+  ScanDirect (Integer) = 0
+  EdgeOfFlig (Integer) = 0
+  ScanAngleR (Real) = -1.000000000000000
+  UserData (Integer) = 126
+  PointSourc (Integer) = 7327
+  GpsTime (Real) = 246093.418377374502597
+  Red (Integer) = 64
+  Green (Integer) = 73
+  Blue (Integer) = 78
+  POINT ZM (635680.54 849362.66 421.56 2)
+
+OGRFeature(attrs_measure):7
+  Intensity (Integer) = 99
+  ReturnNumb (Integer) = 2
+  NumberOfRe (Integer) = 2
+  ScanDirect (Integer) = 1
+  EdgeOfFlig (Integer) = 0
+  ScanAngleR (Real) = -3.000000000000000
+  UserData (Integer) = 130
+  PointSourc (Integer) = 7330
+  GpsTime (Real) = 247574.175078637053957
+  Red (Integer) = 81
+  Green (Integer) = 84
+  Blue (Integer) = 95
+  POINT ZM (635681.07 851383.76 419 2)
+
+OGRFeature(attrs_measure):8
+  Intensity (Integer) = 48
+  ReturnNumb (Integer) = 1
+  NumberOfRe (Integer) = 1
+  ScanDirect (Integer) = 0
+  EdgeOfFlig (Integer) = 0
+  ScanAngleR (Real) = 1.000000000000000
+  UserData (Integer) = 126
+  PointSourc (Integer) = 7327
+  GpsTime (Real) = 246093.264552279375494
+  Red (Integer) = 78
+  Green (Integer) = 88
+  Blue (Integer) = 94
+  POINT ZM (635684.02 849494.39 407.12 1)
+
+OGRFeature(attrs_measure):9
+  Intensity (Integer) = 109
+  ReturnNumb (Integer) = 1
+  NumberOfRe (Integer) = 1
+  ScanDirect (Integer) = 1
+  EdgeOfFlig (Integer) = 0
+  ScanAngleR (Real) = 7.000000000000000
+  UserData (Integer) = 126
+  PointSourc (Integer) = 7332
+  GpsTime (Real) = 248689.024384217045736
+  Red (Integer) = 64
+  Green (Integer) = 73
+  Blue (Integer) = 78
+  POINT ZM (635685.33 852165.12 421.75 1)
+

--- a/test/data/ogr/creation_options.geojson.ogrinfo
+++ b/test/data/ogr/creation_options.geojson.ogrinfo
@@ -1,0 +1,68 @@
+INFO: Open of `/Users/rcoup/code/point-clouds/pdal/test/data/../temp/ogr/creation_options.geojson'
+      using driver `GeoJSON' successful.
+
+Layer name: points
+Geometry: 3D Point
+Feature Count: 10
+Extent: (635619.800000, 849017.300000) - (635685.300000, 852165.100000)
+Layer SRS WKT:
+GEOGCRS["WGS 84",
+    ENSEMBLE["World Geodetic System 1984 ensemble",
+        MEMBER["World Geodetic System 1984 (Transit)"],
+        MEMBER["World Geodetic System 1984 (G730)"],
+        MEMBER["World Geodetic System 1984 (G873)"],
+        MEMBER["World Geodetic System 1984 (G1150)"],
+        MEMBER["World Geodetic System 1984 (G1674)"],
+        MEMBER["World Geodetic System 1984 (G1762)"],
+        MEMBER["World Geodetic System 1984 (G2139)"],
+        ELLIPSOID["WGS 84",6378137,298.257223563,
+            LENGTHUNIT["metre",1]],
+        ENSEMBLEACCURACY[2.0]],
+    PRIMEM["Greenwich",0,
+        ANGLEUNIT["degree",0.0174532925199433]],
+    CS[ellipsoidal,3],
+        AXIS["geodetic latitude (Lat)",north,
+            ORDER[1],
+            ANGLEUNIT["degree",0.0174532925199433]],
+        AXIS["geodetic longitude (Lon)",east,
+            ORDER[2],
+            ANGLEUNIT["degree",0.0174532925199433]],
+        AXIS["ellipsoidal height (h)",up,
+            ORDER[3],
+            LENGTHUNIT["metre",1]],
+    USAGE[
+        SCOPE["Geodesy. Navigation and positioning using GPS satellite system."],
+        AREA["World: Afghanistan, Albania, Algeria, American Samoa, Andorra, Angola, Anguilla, Antarctica, Antigua and Barbuda, Argentina, Armenia, Aruba, Australia, Austria, Azerbaijan, Bahamas, Bahrain, Bangladesh, Barbados, Belgium, Belgium, Belize, Benin, Bermuda, Bhutan, Bolivia, Bonaire, Saint Eustasius and Saba, Bosnia and Herzegovina, Botswana, Bouvet Island, Brazil, British Indian Ocean Territory, British Virgin Islands, Brunei Darussalam, Bulgaria, Burkina Faso, Burundi, Cambodia, Cameroon, Canada, Cape Verde, Cayman Islands, Central African Republic, Chad, Chile, China, Christmas Island, Cocos (Keeling) Islands, Comoros, Congo, Cook Islands, Costa Rica, Côte d'Ivoire (Ivory Coast), Croatia, Cuba, Curacao, Cyprus, Czechia, Denmark, Djibouti, Dominica, Dominican Republic, East Timor, Ecuador, Egypt, El Salvador, Equatorial Guinea, Eritrea, Estonia, Eswatini (Swaziland), Ethiopia, Falkland Islands (Malvinas), Faroe Islands, Fiji, Finland, France, French Guiana, French Polynesia, French Southern Territories, Gabon, Gambia, Georgia, Germany, Ghana, Gibraltar, Greece, Greenland, Grenada, Guadeloupe, Guam, Guatemala, Guinea, Guinea-Bissau, Guyana, Haiti, Heard Island and McDonald Islands, Holy See (Vatican City State), Honduras, China - Hong Kong, Hungary, Iceland, India, Indonesia, Islamic Republic of Iran, Iraq, Ireland, Israel, Italy, Jamaica, Japan, Jordan, Kazakhstan, Kenya, Kiribati, Democratic People's Republic of Korea (North Korea), Republic of Korea (South Korea), Kosovo, Kuwait, Kyrgyzstan, Lao People's Democratic Republic (Laos), Latvia, Lebanon, Lesotho, Liberia, Libyan Arab Jamahiriya, Liechtenstein, Lithuania, Luxembourg, China - Macao, Madagascar, Malawi, Malaysia, Maldives, Mali, Malta, Marshall Islands, Martinique, Mauritania, Mauritius, Mayotte, Mexico, Federated States of Micronesia, Monaco, Mongolia, Montenegro, Montserrat, Morocco, Mozambique, Myanmar (Burma), Namibia, Nauru, Nepal, Netherlands, New Caledonia, New Zealand, Nicaragua, Niger, Nigeria, Niue, Norfolk Island, North Macedonia, Northern Mariana Islands, Norway, Oman, Pakistan, Palau, Panama, Papua New Guinea (PNG), Paraguay, Peru, Philippines, Pitcairn, Poland, Portugal, Puerto Rico, Qatar, Reunion, Romania, Russian Federation, Rwanda, St Barthelemy, St Kitts and Nevis, St Helena, Ascension and Tristan da Cunha, St Lucia, St Martin, St Pierre and Miquelon, Saint Vincent and the Grenadines, Samoa, San Marino, Sao Tome and Principe, Saudi Arabia, Senegal, Serbia, Seychelles, Sierra Leone, Singapore, Slovakia (Slovak Republic), Slovenia, St Maarten, Solomon Islands, Somalia, South Africa, South Georgia and the South Sandwich Islands, South Sudan, Spain, Sri Lanka, Sudan, Suriname, Svalbard and Jan Mayen, Sweden, Switzerland, Syrian Arab Republic, Taiwan, Tajikistan, United Republic of Tanzania, Thailand, The Democratic Republic of the Congo (Zaire), Togo, Tokelau, Tonga, Trinidad and Tobago, Tunisia, Turkey, Turkmenistan, Turks and Caicos Islands, Tuvalu, Uganda, Ukraine, United Arab Emirates (UAE), United Kingdom (UK), United States (USA), United States Minor Outlying Islands, Uruguay, Uzbekistan, Vanuatu, Venezuela, Vietnam, US Virgin Islands, Wallis and Futuna, Western Sahara, Yemen, Zambia, Zimbabwe."],
+        BBOX[-90,-180,90,180]],
+    ID["EPSG",4979]]
+Data axis to CRS axis mapping: 2,1,3
+OGRFeature(points):0
+  POINT Z (635619.8 850064.0 447)
+
+OGRFeature(points):1
+  POINT Z (635640.4 849758.8 422.7)
+
+OGRFeature(points):2
+  POINT Z (635651 850244 424.9)
+
+OGRFeature(points):3
+  POINT Z (635673.5 850157.6 435.7)
+
+OGRFeature(points):4
+  POINT Z (635674.1 849017.3 428)
+
+OGRFeature(points):5
+  POINT Z (635678.9 851351.4 436.4)
+
+OGRFeature(points):6
+  POINT Z (635680.5 849362.7 421.6)
+
+OGRFeature(points):7
+  POINT Z (635681.1 851383.8 419)
+
+OGRFeature(points):8
+  POINT Z (635684.0 849494.4 407.1)
+
+OGRFeature(points):9
+  POINT Z (635685.3 852165.1 421.8)
+

--- a/test/data/ogr/geopackage.gpkg.ogrinfo
+++ b/test/data/ogr/geopackage.gpkg.ogrinfo
@@ -1,0 +1,58 @@
+INFO: Open of `/Users/rcoup/code/point-clouds/pdal/test/data/../temp/ogr/geopackage.gpkg'
+      using driver `GPKG' successful.
+
+Layer name: points
+Geometry: 3D Measured Point
+Feature Count: 10
+Extent: (635619.850000, 849017.320000) - (635685.330000, 852165.120000)
+Layer SRS WKT:
+GEOGCRS["Undefined geographic SRS",
+    DATUM["unknown",
+        ELLIPSOID["unknown",6378137,298.257223563,
+            LENGTHUNIT["metre",1,
+                ID["EPSG",9001]]]],
+    PRIMEM["Greenwich",0,
+        ANGLEUNIT["degree",0.0174532925199433,
+            ID["EPSG",9122]]],
+    CS[ellipsoidal,2],
+        AXIS["latitude",north,
+            ORDER[1],
+            ANGLEUNIT["degree",0.0174532925199433,
+                ID["EPSG",9122]]],
+        AXIS["longitude",east,
+            ORDER[2],
+            ANGLEUNIT["degree",0.0174532925199433,
+                ID["EPSG",9122]]]]
+Data axis to CRS axis mapping: 2,1
+FID Column = fid
+Geometry Column = geom
+OGRFeature(points):0
+  POINT Z (635619.85 850064.04 447.01)
+
+OGRFeature(points):1
+  POINT Z (635640.42 849758.79 422.74)
+
+OGRFeature(points):2
+  POINT Z (635650.95 850244.03 424.93)
+
+OGRFeature(points):3
+  POINT Z (635673.46 850157.55 435.73)
+
+OGRFeature(points):4
+  POINT Z (635674.05 849017.32 428.02)
+
+OGRFeature(points):5
+  POINT Z (635678.9 851351.44 436.45)
+
+OGRFeature(points):6
+  POINT Z (635680.54 849362.66 421.56)
+
+OGRFeature(points):7
+  POINT Z (635681.07 851383.76 419)
+
+OGRFeature(points):8
+  POINT Z (635684.02 849494.39 407.12)
+
+OGRFeature(points):9
+  POINT Z (635685.33 852165.12 421.75)
+

--- a/test/data/ogr/geopackage_attrs_all.gpkg.ogrinfo
+++ b/test/data/ogr/geopackage_attrs_all.gpkg.ogrinfo
@@ -1,0 +1,201 @@
+INFO: Open of `/Users/rcoup/code/point-clouds/pdal/test/data/../temp/ogr/geopackage_attrs_all.gpkg'
+      using driver `GPKG' successful.
+
+Layer name: points
+Geometry: 3D Measured Point
+Feature Count: 10
+Extent: (635619.850000, 849017.320000) - (635685.330000, 852165.120000)
+Layer SRS WKT:
+GEOGCRS["Undefined geographic SRS",
+    DATUM["unknown",
+        ELLIPSOID["unknown",6378137,298.257223563,
+            LENGTHUNIT["metre",1,
+                ID["EPSG",9001]]]],
+    PRIMEM["Greenwich",0,
+        ANGLEUNIT["degree",0.0174532925199433,
+            ID["EPSG",9122]]],
+    CS[ellipsoidal,2],
+        AXIS["latitude",north,
+            ORDER[1],
+            ANGLEUNIT["degree",0.0174532925199433,
+                ID["EPSG",9122]]],
+        AXIS["longitude",east,
+            ORDER[2],
+            ANGLEUNIT["degree",0.0174532925199433,
+                ID["EPSG",9122]]]]
+Data axis to CRS axis mapping: 2,1
+FID Column = fid
+Geometry Column = geom
+Intensity: Integer (0.0)
+ReturnNumber: Integer (0.0)
+NumberOfReturns: Integer (0.0)
+ScanDirectionFlag: Integer (0.0)
+EdgeOfFlightLine: Integer (0.0)
+Classification: Integer (0.0)
+ScanAngleRank: Real (0.0)
+UserData: Integer (0.0)
+PointSourceId: Integer (0.0)
+GpsTime: Real (0.0)
+Red: Integer (0.0)
+Green: Integer (0.0)
+Blue: Integer (0.0)
+OGRFeature(points):0
+  Intensity (Integer) = 1
+  ReturnNumber (Integer) = 1
+  NumberOfReturns (Integer) = 2
+  ScanDirectionFlag (Integer) = 0
+  EdgeOfFlightLine (Integer) = 0
+  Classification (Integer) = 1
+  ScanAngleRank (Real) = 15
+  UserData (Integer) = 125
+  PointSourceId (Integer) = 7327
+  GpsTime (Real) = 246092.207880994
+  Red (Integer) = 52
+  Green (Integer) = 65
+  Blue (Integer) = 68
+  POINT Z (635619.85 850064.04 447.01)
+
+OGRFeature(points):1
+  Intensity (Integer) = 25
+  ReturnNumber (Integer) = 1
+  NumberOfReturns (Integer) = 1
+  ScanDirectionFlag (Integer) = 1
+  EdgeOfFlightLine (Integer) = 0
+  Classification (Integer) = 1
+  ScanAngleRank (Real) = 6
+  UserData (Integer) = 124
+  PointSourceId (Integer) = 7327
+  GpsTime (Real) = 246092.682015086
+  Red (Integer) = 39
+  Green (Integer) = 57
+  Blue (Integer) = 56
+  POINT Z (635640.42 849758.79 422.74)
+
+OGRFeature(points):2
+  Intensity (Integer) = 33
+  ReturnNumber (Integer) = 1
+  NumberOfReturns (Integer) = 1
+  ScanDirectionFlag (Integer) = 1
+  EdgeOfFlightLine (Integer) = 0
+  Classification (Integer) = 2
+  ScanAngleRank (Real) = -11
+  UserData (Integer) = 126
+  PointSourceId (Integer) = 7329
+  GpsTime (Real) = 247175.609838935
+  Red (Integer) = 109
+  Green (Integer) = 104
+  Blue (Integer) = 122
+  POINT Z (635650.95 850244.03 424.93)
+
+OGRFeature(points):3
+  Intensity (Integer) = 70
+  ReturnNumber (Integer) = 1
+  NumberOfReturns (Integer) = 1
+  ScanDirectionFlag (Integer) = 1
+  EdgeOfFlightLine (Integer) = 0
+  Classification (Integer) = 1
+  ScanAngleRank (Real) = 0
+  UserData (Integer) = 124
+  PointSourceId (Integer) = 7328
+  GpsTime (Real) = 246509.078758077
+  Red (Integer) = 228
+  Green (Integer) = 220
+  Blue (Integer) = 231
+  POINT Z (635673.46 850157.55 435.73)
+
+OGRFeature(points):4
+  Intensity (Integer) = 153
+  ReturnNumber (Integer) = 1
+  NumberOfReturns (Integer) = 1
+  ScanDirectionFlag (Integer) = 0
+  EdgeOfFlightLine (Integer) = 0
+  Classification (Integer) = 1
+  ScanAngleRank (Real) = -7
+  UserData (Integer) = 126
+  PointSourceId (Integer) = 7326
+  GpsTime (Real) = 245388.610486142
+  Red (Integer) = 146
+  Green (Integer) = 104
+  Blue (Integer) = 140
+  POINT Z (635674.05 849017.32 428.02)
+
+OGRFeature(points):5
+  Intensity (Integer) = 6
+  ReturnNumber (Integer) = 2
+  NumberOfReturns (Integer) = 2
+  ScanDirectionFlag (Integer) = 0
+  EdgeOfFlightLine (Integer) = 0
+  Classification (Integer) = 1
+  ScanAngleRank (Real) = 10
+  UserData (Integer) = 126
+  PointSourceId (Integer) = 7329
+  GpsTime (Real) = 247174.372762128
+  Red (Integer) = 76
+  Green (Integer) = 87
+  Blue (Integer) = 92
+  POINT Z (635678.9 851351.44 436.45)
+
+OGRFeature(points):6
+  Intensity (Integer) = 58
+  ReturnNumber (Integer) = 2
+  NumberOfReturns (Integer) = 2
+  ScanDirectionFlag (Integer) = 0
+  EdgeOfFlightLine (Integer) = 0
+  Classification (Integer) = 2
+  ScanAngleRank (Real) = -1
+  UserData (Integer) = 126
+  PointSourceId (Integer) = 7327
+  GpsTime (Real) = 246093.418377375
+  Red (Integer) = 64
+  Green (Integer) = 73
+  Blue (Integer) = 78
+  POINT Z (635680.54 849362.66 421.56)
+
+OGRFeature(points):7
+  Intensity (Integer) = 99
+  ReturnNumber (Integer) = 2
+  NumberOfReturns (Integer) = 2
+  ScanDirectionFlag (Integer) = 1
+  EdgeOfFlightLine (Integer) = 0
+  Classification (Integer) = 2
+  ScanAngleRank (Real) = -3
+  UserData (Integer) = 130
+  PointSourceId (Integer) = 7330
+  GpsTime (Real) = 247574.175078637
+  Red (Integer) = 81
+  Green (Integer) = 84
+  Blue (Integer) = 95
+  POINT Z (635681.07 851383.76 419)
+
+OGRFeature(points):8
+  Intensity (Integer) = 48
+  ReturnNumber (Integer) = 1
+  NumberOfReturns (Integer) = 1
+  ScanDirectionFlag (Integer) = 0
+  EdgeOfFlightLine (Integer) = 0
+  Classification (Integer) = 1
+  ScanAngleRank (Real) = 1
+  UserData (Integer) = 126
+  PointSourceId (Integer) = 7327
+  GpsTime (Real) = 246093.264552279
+  Red (Integer) = 78
+  Green (Integer) = 88
+  Blue (Integer) = 94
+  POINT Z (635684.02 849494.39 407.12)
+
+OGRFeature(points):9
+  Intensity (Integer) = 109
+  ReturnNumber (Integer) = 1
+  NumberOfReturns (Integer) = 1
+  ScanDirectionFlag (Integer) = 1
+  EdgeOfFlightLine (Integer) = 0
+  Classification (Integer) = 1
+  ScanAngleRank (Real) = 7
+  UserData (Integer) = 126
+  PointSourceId (Integer) = 7332
+  GpsTime (Real) = 248689.024384217
+  Red (Integer) = 64
+  Green (Integer) = 73
+  Blue (Integer) = 78
+  POINT Z (635685.33 852165.12 421.75)
+

--- a/test/data/ogr/json.geojson.ogrinfo
+++ b/test/data/ogr/json.geojson.ogrinfo
@@ -1,0 +1,68 @@
+INFO: Open of `/Users/rcoup/code/point-clouds/pdal/test/data/../temp/ogr/json.geojson'
+      using driver `GeoJSON' successful.
+
+Layer name: points
+Geometry: 3D Point
+Feature Count: 10
+Extent: (635619.850000, 849017.320000) - (635685.330000, 852165.120000)
+Layer SRS WKT:
+GEOGCRS["WGS 84",
+    ENSEMBLE["World Geodetic System 1984 ensemble",
+        MEMBER["World Geodetic System 1984 (Transit)"],
+        MEMBER["World Geodetic System 1984 (G730)"],
+        MEMBER["World Geodetic System 1984 (G873)"],
+        MEMBER["World Geodetic System 1984 (G1150)"],
+        MEMBER["World Geodetic System 1984 (G1674)"],
+        MEMBER["World Geodetic System 1984 (G1762)"],
+        MEMBER["World Geodetic System 1984 (G2139)"],
+        ELLIPSOID["WGS 84",6378137,298.257223563,
+            LENGTHUNIT["metre",1]],
+        ENSEMBLEACCURACY[2.0]],
+    PRIMEM["Greenwich",0,
+        ANGLEUNIT["degree",0.0174532925199433]],
+    CS[ellipsoidal,3],
+        AXIS["geodetic latitude (Lat)",north,
+            ORDER[1],
+            ANGLEUNIT["degree",0.0174532925199433]],
+        AXIS["geodetic longitude (Lon)",east,
+            ORDER[2],
+            ANGLEUNIT["degree",0.0174532925199433]],
+        AXIS["ellipsoidal height (h)",up,
+            ORDER[3],
+            LENGTHUNIT["metre",1]],
+    USAGE[
+        SCOPE["Geodesy. Navigation and positioning using GPS satellite system."],
+        AREA["World: Afghanistan, Albania, Algeria, American Samoa, Andorra, Angola, Anguilla, Antarctica, Antigua and Barbuda, Argentina, Armenia, Aruba, Australia, Austria, Azerbaijan, Bahamas, Bahrain, Bangladesh, Barbados, Belgium, Belgium, Belize, Benin, Bermuda, Bhutan, Bolivia, Bonaire, Saint Eustasius and Saba, Bosnia and Herzegovina, Botswana, Bouvet Island, Brazil, British Indian Ocean Territory, British Virgin Islands, Brunei Darussalam, Bulgaria, Burkina Faso, Burundi, Cambodia, Cameroon, Canada, Cape Verde, Cayman Islands, Central African Republic, Chad, Chile, China, Christmas Island, Cocos (Keeling) Islands, Comoros, Congo, Cook Islands, Costa Rica, Côte d'Ivoire (Ivory Coast), Croatia, Cuba, Curacao, Cyprus, Czechia, Denmark, Djibouti, Dominica, Dominican Republic, East Timor, Ecuador, Egypt, El Salvador, Equatorial Guinea, Eritrea, Estonia, Eswatini (Swaziland), Ethiopia, Falkland Islands (Malvinas), Faroe Islands, Fiji, Finland, France, French Guiana, French Polynesia, French Southern Territories, Gabon, Gambia, Georgia, Germany, Ghana, Gibraltar, Greece, Greenland, Grenada, Guadeloupe, Guam, Guatemala, Guinea, Guinea-Bissau, Guyana, Haiti, Heard Island and McDonald Islands, Holy See (Vatican City State), Honduras, China - Hong Kong, Hungary, Iceland, India, Indonesia, Islamic Republic of Iran, Iraq, Ireland, Israel, Italy, Jamaica, Japan, Jordan, Kazakhstan, Kenya, Kiribati, Democratic People's Republic of Korea (North Korea), Republic of Korea (South Korea), Kosovo, Kuwait, Kyrgyzstan, Lao People's Democratic Republic (Laos), Latvia, Lebanon, Lesotho, Liberia, Libyan Arab Jamahiriya, Liechtenstein, Lithuania, Luxembourg, China - Macao, Madagascar, Malawi, Malaysia, Maldives, Mali, Malta, Marshall Islands, Martinique, Mauritania, Mauritius, Mayotte, Mexico, Federated States of Micronesia, Monaco, Mongolia, Montenegro, Montserrat, Morocco, Mozambique, Myanmar (Burma), Namibia, Nauru, Nepal, Netherlands, New Caledonia, New Zealand, Nicaragua, Niger, Nigeria, Niue, Norfolk Island, North Macedonia, Northern Mariana Islands, Norway, Oman, Pakistan, Palau, Panama, Papua New Guinea (PNG), Paraguay, Peru, Philippines, Pitcairn, Poland, Portugal, Puerto Rico, Qatar, Reunion, Romania, Russian Federation, Rwanda, St Barthelemy, St Kitts and Nevis, St Helena, Ascension and Tristan da Cunha, St Lucia, St Martin, St Pierre and Miquelon, Saint Vincent and the Grenadines, Samoa, San Marino, Sao Tome and Principe, Saudi Arabia, Senegal, Serbia, Seychelles, Sierra Leone, Singapore, Slovakia (Slovak Republic), Slovenia, St Maarten, Solomon Islands, Somalia, South Africa, South Georgia and the South Sandwich Islands, South Sudan, Spain, Sri Lanka, Sudan, Suriname, Svalbard and Jan Mayen, Sweden, Switzerland, Syrian Arab Republic, Taiwan, Tajikistan, United Republic of Tanzania, Thailand, The Democratic Republic of the Congo (Zaire), Togo, Tokelau, Tonga, Trinidad and Tobago, Tunisia, Turkey, Turkmenistan, Turks and Caicos Islands, Tuvalu, Uganda, Ukraine, United Arab Emirates (UAE), United Kingdom (UK), United States (USA), United States Minor Outlying Islands, Uruguay, Uzbekistan, Vanuatu, Venezuela, Vietnam, US Virgin Islands, Wallis and Futuna, Western Sahara, Yemen, Zambia, Zimbabwe."],
+        BBOX[-90,-180,90,180]],
+    ID["EPSG",4979]]
+Data axis to CRS axis mapping: 2,1,3
+OGRFeature(points):0
+  POINT Z (635619.85 850064.04 447.01)
+
+OGRFeature(points):1
+  POINT Z (635640.42 849758.79 422.74)
+
+OGRFeature(points):2
+  POINT Z (635650.95 850244.03 424.93)
+
+OGRFeature(points):3
+  POINT Z (635673.46 850157.55 435.73)
+
+OGRFeature(points):4
+  POINT Z (635674.05 849017.32 428.02)
+
+OGRFeature(points):5
+  POINT Z (635678.9 851351.44 436.45)
+
+OGRFeature(points):6
+  POINT Z (635680.54 849362.66 421.56)
+
+OGRFeature(points):7
+  POINT Z (635681.07 851383.76 419)
+
+OGRFeature(points):8
+  POINT Z (635684.02 849494.39 407.12)
+
+OGRFeature(points):9
+  POINT Z (635685.33 852165.12 421.75)
+

--- a/test/data/ogr/multicount.shp.ogrinfo
+++ b/test/data/ogr/multicount.shp.ogrinfo
@@ -1,0 +1,26 @@
+INFO: Open of `/Users/rcoup/code/point-clouds/pdal/test/data/../temp/ogr/multicount.shp'
+      using driver `ESRI Shapefile' successful.
+
+Layer name: multicount
+Geometry: 3D Multi Point
+Feature Count: 4
+Extent: (635619.850000, 849017.320000) - (635685.330000, 852165.120000)
+Layer SRS WKT:
+(unknown)
+FID: Integer64 (11.0)
+OGRFeature(multicount):0
+  FID (Integer64) = 0
+  MULTIPOINT Z ((635619.85 850064.04 447.01),(635640.42 849758.79 422.74),(635650.95 850244.03 424.93))
+
+OGRFeature(multicount):1
+  FID (Integer64) = 1
+  MULTIPOINT Z ((635673.46 850157.55 435.73),(635674.05 849017.32 428.02),(635678.9 851351.44 436.45))
+
+OGRFeature(multicount):2
+  FID (Integer64) = 2
+  MULTIPOINT Z ((635680.54 849362.66 421.56),(635681.07 851383.76 419),(635684.02 849494.39 407.12))
+
+OGRFeature(multicount):3
+  FID (Integer64) = 3
+  MULTIPOINT Z ((635685.33 852165.12 421.75))
+

--- a/test/data/ogr/multicount_2.shp.ogrinfo
+++ b/test/data/ogr/multicount_2.shp.ogrinfo
@@ -1,0 +1,14 @@
+INFO: Open of `/Users/rcoup/code/point-clouds/pdal/test/data/../temp/ogr/multicount_2.shp'
+      using driver `ESRI Shapefile' successful.
+
+Layer name: multicount_2
+Geometry: 3D Multi Point
+Feature Count: 1
+Extent: (635619.850000, 849017.320000) - (635685.330000, 852165.120000)
+Layer SRS WKT:
+(unknown)
+FID: Integer64 (11.0)
+OGRFeature(multicount_2):0
+  FID (Integer64) = 0
+  MULTIPOINT Z ((635619.85 850064.04 447.01),(635640.42 849758.79 422.74),(635650.95 850244.03 424.93),(635673.46 850157.55 435.73),(635674.05 849017.32 428.02),(635678.9 851351.44 436.45),(635680.54 849362.66 421.56),(635681.07 851383.76 419),(635684.02 849494.39 407.12),(635685.33 852165.12 421.75))
+

--- a/test/data/ogr/multicount_3.shp.ogrinfo
+++ b/test/data/ogr/multicount_3.shp.ogrinfo
@@ -1,0 +1,18 @@
+INFO: Open of `/Users/rcoup/code/point-clouds/pdal/test/data/../temp/ogr/multicount_3.shp'
+      using driver `ESRI Shapefile' successful.
+
+Layer name: multicount_3
+Geometry: 3D Multi Point
+Feature Count: 2
+Extent: (635619.850000, 849017.320000) - (635685.330000, 852165.120000)
+Layer SRS WKT:
+(unknown)
+FID: Integer64 (11.0)
+OGRFeature(multicount_3):0
+  FID (Integer64) = 0
+  MULTIPOINT Z ((635619.85 850064.04 447.01),(635640.42 849758.79 422.74),(635650.95 850244.03 424.93),(635673.46 850157.55 435.73),(635674.05 849017.32 428.02))
+
+OGRFeature(multicount_3):1
+  FID (Integer64) = 1
+  MULTIPOINT Z ((635678.9 851351.44 436.45),(635680.54 849362.66 421.56),(635681.07 851383.76 419),(635684.02 849494.39 407.12),(635685.33 852165.12 421.75))
+

--- a/test/data/ogr/shapefile.shp.ogrinfo
+++ b/test/data/ogr/shapefile.shp.ogrinfo
@@ -1,0 +1,50 @@
+INFO: Open of `/Users/rcoup/code/point-clouds/pdal/test/data/../temp/ogr/shapefile.shp'
+      using driver `ESRI Shapefile' successful.
+
+Layer name: shapefile
+Geometry: 3D Point
+Feature Count: 10
+Extent: (635619.850000, 849017.320000) - (635685.330000, 852165.120000)
+Layer SRS WKT:
+(unknown)
+FID: Integer64 (11.0)
+OGRFeature(shapefile):0
+  FID (Integer64) = 0
+  POINT Z (635619.85 850064.04 447.01)
+
+OGRFeature(shapefile):1
+  FID (Integer64) = 1
+  POINT Z (635640.42 849758.79 422.74)
+
+OGRFeature(shapefile):2
+  FID (Integer64) = 2
+  POINT Z (635650.95 850244.03 424.93)
+
+OGRFeature(shapefile):3
+  FID (Integer64) = 3
+  POINT Z (635673.46 850157.55 435.73)
+
+OGRFeature(shapefile):4
+  FID (Integer64) = 4
+  POINT Z (635674.05 849017.32 428.02)
+
+OGRFeature(shapefile):5
+  FID (Integer64) = 5
+  POINT Z (635678.9 851351.44 436.45)
+
+OGRFeature(shapefile):6
+  FID (Integer64) = 6
+  POINT Z (635680.54 849362.66 421.56)
+
+OGRFeature(shapefile):7
+  FID (Integer64) = 7
+  POINT Z (635681.07 851383.76 419)
+
+OGRFeature(shapefile):8
+  FID (Integer64) = 8
+  POINT Z (635684.02 849494.39 407.12)
+
+OGRFeature(shapefile):9
+  FID (Integer64) = 9
+  POINT Z (635685.33 852165.12 421.75)
+

--- a/test/data/ogr/shapefile_measure.shp.ogrinfo
+++ b/test/data/ogr/shapefile_measure.shp.ogrinfo
@@ -1,0 +1,50 @@
+INFO: Open of `/Users/rcoup/code/point-clouds/pdal/test/data/../temp/ogr/shapefile_measure.shp'
+      using driver `ESRI Shapefile' successful.
+
+Layer name: shapefile_measure
+Geometry: 3D Measured Point
+Feature Count: 10
+Extent: (635619.850000, 849017.320000) - (635685.330000, 852165.120000)
+Layer SRS WKT:
+(unknown)
+FID: Integer64 (11.0)
+OGRFeature(shapefile_measure):0
+  FID (Integer64) = 0
+  POINT ZM (635619.85 850064.04 447.01 1)
+
+OGRFeature(shapefile_measure):1
+  FID (Integer64) = 1
+  POINT ZM (635640.42 849758.79 422.74 1)
+
+OGRFeature(shapefile_measure):2
+  FID (Integer64) = 2
+  POINT ZM (635650.95 850244.03 424.93 2)
+
+OGRFeature(shapefile_measure):3
+  FID (Integer64) = 3
+  POINT ZM (635673.46 850157.55 435.73 1)
+
+OGRFeature(shapefile_measure):4
+  FID (Integer64) = 4
+  POINT ZM (635674.05 849017.32 428.02 1)
+
+OGRFeature(shapefile_measure):5
+  FID (Integer64) = 5
+  POINT ZM (635678.9 851351.44 436.45 1)
+
+OGRFeature(shapefile_measure):6
+  FID (Integer64) = 6
+  POINT ZM (635680.54 849362.66 421.56 2)
+
+OGRFeature(shapefile_measure):7
+  FID (Integer64) = 7
+  POINT ZM (635681.07 851383.76 419 2)
+
+OGRFeature(shapefile_measure):8
+  FID (Integer64) = 8
+  POINT ZM (635684.02 849494.39 407.12 1)
+
+OGRFeature(shapefile_measure):9
+  FID (Integer64) = 9
+  POINT ZM (635685.33 852165.12 421.75 1)
+

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -166,6 +166,14 @@ PDAL_ADD_TEST(pdal_io_gdal_writer_test
     INCLUDES
         ${GDAL_INCLUDE_DIR}
 )
+PDAL_ADD_TEST(pdal_io_ogr_writer_test
+    FILES
+        io/OGRWriterTest.cpp
+    LINK_WITH
+        ${GDAL_LIBRARY}
+    INCLUDES
+        ${GDAL_INCLUDE_DIR}
+)
 PDAL_ADD_TEST(pdal_io_las_reader_test
     FILES
         io/LasReaderTest.cpp

--- a/test/unit/io/OGRWriterTest.cpp
+++ b/test/unit/io/OGRWriterTest.cpp
@@ -1,0 +1,436 @@
+/******************************************************************************
+* Copyright (c) 2016, Hobu Inc. (info@hobu.co)
+*
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following
+* conditions are met:
+*
+*     * Redistributions of source code must retain the above copyright
+*       notice, this list of conditions and the following disclaimer.
+*     * Redistributions in binary form must reproduce the above copyright
+*       notice, this list of conditions and the following disclaimer in
+*       the documentation and/or other materials provided
+*       with the distribution.
+*     * Neither the name of Hobu, Inc. nor the
+*       names of its contributors may be used to endorse or promote
+*       products derived from this software without specific prior
+*       written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+* FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+* COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+* BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+* OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+* AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+* OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+* OF SUCH DAMAGE.
+****************************************************************************/
+
+#include <pdal/pdal_test_main.hpp>
+#include <pdal/util/FileUtils.hpp>
+#include <pdal/private/gdal/ErrorHandler.hpp>
+#include <filters/HeadFilter.hpp>
+#include <filters/RangeFilter.hpp>
+#include <filters/SortFilter.hpp>
+#include <io/BufferReader.hpp>
+#include <io/FauxReader.hpp>
+#include <io/OGRWriter.hpp>
+#include <io/LasReader.hpp>
+#include "Support.hpp"
+
+#include <iostream>
+#include <sstream>
+
+namespace pdal
+{
+
+namespace
+{
+
+void runOgrWriterInfo(const Options& wo, const std::string& infile,
+    const std::string& infofile, const std::string suffix, int featureCount = 10,
+    uint32_t(*compare)(const std::string&, const std::string&, int32_t) = &Support::diff_text_files
+)
+{
+    FileUtils::createDirectory(Support::temppath("ogr"));
+    std::string outfile(Support::temppath(std::string("ogr/") + FileUtils::stem(FileUtils::stem(FileUtils::getFilename(infofile))) + suffix));
+    std::string outinfofile(outfile + ".ogrinfo");
+
+    if(FileUtils::isDirectory(outfile)) {
+        FileUtils::deleteDirectory(outfile);
+    } else {
+        FileUtils::deleteFile(outfile);
+    }
+    FileUtils::deleteFile(outinfofile);
+
+    Options readerOpts;
+    readerOpts.add("filename", infile);
+
+    LasReader reader;
+    reader.setOptions(readerOpts);
+
+    Options sortOpts;
+    SortFilter sortFilter;
+    sortOpts.add("dimension", "X");
+    sortFilter.setOptions(sortOpts);
+    sortFilter.setInput(reader);
+
+    Options writerOpts;
+    writerOpts.add("filename", outfile);
+
+    OGRWriter writer;
+    writer.setOptions(wo);
+    writer.addOptions(writerOpts);
+
+    HeadFilter headFilter;
+    if (featureCount > 0) {
+        Options headOpts;
+        headOpts.add("count", featureCount);
+        headFilter.setOptions(headOpts);
+        headFilter.setInput(sortFilter);
+        writer.setInput(headFilter);
+    } else {
+        writer.setInput(sortFilter);
+    }
+
+    PointTable t;
+    writer.prepare(t);
+    writer.execute(t);
+
+    std::string cmd = "ogrinfo -nomd -al " + outfile;
+    if (featureCount == 0) {
+        cmd += " -so";
+    }
+    cmd += " 2>&1";
+    std::string info;
+    if (Utils::run_shell_command(cmd, info)) {
+        std::cerr << "WARNING: error running ogrinfo, skipping test" << std::endl;
+        return;
+    }
+
+    auto handle = FileUtils::createFile(outinfofile);
+    *handle << info;
+    FileUtils::closeFile(handle);
+
+    EXPECT_EQ(compare(infofile, outinfofile, 1), 0) \
+        << "  (" << infofile << " <-> " << outinfofile << ")";
+}
+
+uint32_t diff_geojson(const std::string& file1, const std::string& file2, int32_t ignoreLine1=-1)
+{
+    // GeoJSON files depend on PROJ version, later versions write a much different
+    // SRS format. Crudely ignore lines between ^GEOGCRS[ and ^OGRFeature
+
+    if (!Utils::fileExists(file1) || !Utils::fileExists(file2))
+        return (std::numeric_limits<uint32_t>::max)();
+    if (!Utils::fileExists(file1) || !Utils::fileExists(file2))
+        return (std::numeric_limits<uint32_t>::max)();
+
+    std::istream *istr1 = Utils::openFile(file1, false);
+    std::istream *istr2 = Utils::openFile(file2, false);
+    std::istream& str1 = *istr1;
+    std::istream& str2 = *istr2;
+
+    uint32_t numdiffs = 0;
+    int32_t currLine = 1;
+    bool buf1ignore = false;
+    bool buf2ignore = false;
+    std::string buf1;
+    std::string buf2;
+
+    while (!str1.eof() && !str2.eof())
+    {
+        if (currLine == ignoreLine1)
+        {
+            std::getline(str1, buf1);
+            std::getline(str2, buf2);
+            ++currLine;
+            continue;
+        }
+
+        if (!(buf1ignore ^ buf2ignore))
+        {
+            std::getline(str1, buf1);
+            std::getline(str2, buf2);
+        }
+        else if (!buf2ignore)
+            std::getline(str1, buf1);
+        else if (!buf1ignore)
+            std::getline(str2, buf2);
+
+        // EOF handling won't work properly if we're in an ignored block. NBD
+        if (str1.eof() && str2.eof())
+        {
+            // hit end on both together
+            break;
+        }
+        else if (str1.eof() && !str2.eof())
+        {
+            // str1 ended, but str2 still going
+            while (!str2.eof())
+            {
+                std::getline(str2, buf2);
+                ++numdiffs;
+            }
+            break;
+        }
+        else if (!str1.eof() && str2.eof())
+        {
+            // str2 ended, but str1 still going
+            while (!str1.eof())
+            {
+                std::getline(str1, buf1);
+                ++numdiffs;
+            }
+            break;
+        }
+
+        if (buf1ignore && buf1.rfind("OGRFeature", 0) == 0)
+            buf1ignore = false;
+        else if (buf1.rfind("GEOGCRS[", 0) == 0)
+            buf1ignore = true;
+
+        if (buf2ignore && buf2.rfind("OGRFeature", 0) == 0)
+            buf2ignore = false;
+        else if (buf2.rfind("GEOGCRS[", 0) == 0)
+            buf2ignore = true;
+
+        if (!buf1ignore && !buf2ignore && buf1 != buf2)
+            ++numdiffs;
+
+        ++currLine;
+    }
+
+    assert(str1.eof());
+    assert(str2.eof());
+
+    Utils::closeFile(istr1);
+    Utils::closeFile(istr2);
+
+    return numdiffs;
+}
+
+}
+
+TEST(OGRWriterTest, shapefile)
+{
+    std::string infile = Support::datapath("las/simple.las");
+    std::string infofile = Support::datapath("ogr/shapefile.shp.ogrinfo");
+
+    Options wo;
+    wo.add("ogrdriver", "ESRI Shapefile");
+
+    runOgrWriterInfo(wo, infile, infofile, ".shp");
+}
+
+TEST(OGRWriterTest, json)
+{
+    std::string infile = Support::datapath("las/simple.las");
+    std::string infofile = Support::datapath("ogr/json.geojson.ogrinfo");
+
+    Options wo;
+    wo.add("ogrdriver", "GeoJSON");
+
+    runOgrWriterInfo(wo, infile, infofile, ".geojson", 10, &diff_geojson);
+}
+
+TEST(OGRWriterTest, geopackage)
+{
+    std::string infile = Support::datapath("las/simple.las");
+    std::string infofile = Support::datapath("ogr/geopackage.gpkg.ogrinfo");
+
+    Options wo;
+    wo.add("ogrdriver", "GPKG");
+
+    runOgrWriterInfo(wo, infile, infofile, ".gpkg");
+}
+
+TEST(OGRWriterTest, creation_options)
+{
+    std::string infile = Support::datapath("las/simple.las");
+    std::string infofile = Support::datapath("ogr/creation_options.geojson.ogrinfo");
+
+    Options wo;
+    wo.add("ogrdriver", "GeoJSON");
+    wo.add("ogr_options", "WRITE_BBOX=YES");
+    wo.add("ogr_options", "COORDINATE_PRECISION=1");
+
+    runOgrWriterInfo(wo, infile, infofile, ".geojson", 10, &diff_geojson);
+}
+
+TEST(OGRWriterTest, shapefile_measure)
+{
+    std::string infile = Support::datapath("las/simple.las");
+    std::string infofile = Support::datapath("ogr/shapefile_measure.shp.ogrinfo");
+
+    Options wo;
+    wo.add("ogrdriver", "ESRI Shapefile");
+    wo.add("measure_dim", "Classification");
+
+    runOgrWriterInfo(wo, infile, infofile, ".shp");
+}
+
+TEST(OGRWriterTest, attrs_all)
+{
+    std::string infile = Support::datapath("las/simple.las");
+    std::string infofile = Support::datapath("ogr/attrs_all.shp.ogrinfo");
+
+    Options wo;
+    wo.add("ogrdriver", "ESRI Shapefile");
+    wo.add("attr_dims", "all");
+
+    runOgrWriterInfo(wo, infile, infofile, ".shp");
+}
+
+TEST(OGRWriterTest, geopackage_attrs_all)
+{
+    std::string infile = Support::datapath("las/simple.las");
+    std::string infofile = Support::datapath("ogr/geopackage_attrs_all.gpkg.ogrinfo");
+
+    Options wo;
+    wo.add("ogrdriver", "GPKG");
+    wo.add("attr_dims", "all");
+
+    runOgrWriterInfo(wo, infile, infofile, ".gpkg");
+}
+
+TEST(OGRWriterTest, attrs)
+{
+    std::string infile = Support::datapath("las/simple.las");
+    std::string infofile = Support::datapath("ogr/attrs.shp.ogrinfo");
+
+    Options wo;
+    wo.add("ogrdriver", "ESRI Shapefile");
+    wo.add("attr_dims", "Classification,Red,Green,Blue");
+
+    runOgrWriterInfo(wo, infile, infofile, ".shp");
+}
+
+TEST(OGRWriterTest, attrs_measure)
+{
+    std::string infile = Support::datapath("las/simple.las");
+    std::string infofile = Support::datapath("ogr/attrs_measure.shp.ogrinfo");
+
+    Options wo;
+    wo.add("ogrdriver", "ESRI Shapefile");
+    wo.add("measure_dim", "Classification");
+    wo.add("attr_dims", "all");
+
+    runOgrWriterInfo(wo, infile, infofile, ".shp");
+}
+
+TEST(OGRWriterTest, multicount)
+{
+    std::string infile = Support::datapath("las/simple.las");
+    std::string infofile = Support::datapath("ogr/multicount.shp.ogrinfo");
+
+    Options wo;
+    wo.add("ogrdriver", "ESRI Shapefile");
+    wo.add("multicount", "3");
+
+    runOgrWriterInfo(wo, infile, infofile, ".shp");
+}
+
+TEST(OGRWriterTest, multicount_2)
+{
+    // feature count < multicount
+    std::string infile = Support::datapath("las/simple.las");
+    std::string infofile = Support::datapath("ogr/multicount_2.shp.ogrinfo");
+
+    Options wo;
+    wo.add("ogrdriver", "ESRI Shapefile");
+    wo.add("multicount", "20");
+
+    runOgrWriterInfo(wo, infile, infofile, ".shp");
+}
+
+TEST(OGRWriterTest, multicount_3)
+{
+    // feature count == exact multiple of multicount
+    std::string infile = Support::datapath("las/simple.las");
+    std::string infofile = Support::datapath("ogr/multicount_3.shp.ogrinfo");
+
+    Options wo;
+    wo.add("ogrdriver", "ESRI Shapefile");
+    wo.add("multicount", "5");
+
+    runOgrWriterInfo(wo, infile, infofile, ".shp");
+}
+
+TEST(OGRWriterTest, error_multicount_attrs)
+{
+    std::string infile = Support::datapath("las/simple.las");
+    std::string infofile = Support::datapath("ogr/error");
+
+    Options wo;
+    wo.add("ogrdriver", "GeoJSON");
+    wo.add("multicount", "3");
+    wo.add("attr_dims", "all");
+
+    try
+    {
+        runOgrWriterInfo(wo, infile, infofile, ".geojson");
+        FAIL() << "Expected an exception for an invalid arg combination";
+    }
+    catch (pdal_error const & err)
+    {
+        EXPECT_EQ("writers.ogr: multicount > 1 incompatible with attr_dims",
+            std::string(err.what()));
+    }
+}
+
+TEST(OGRWriterTest, error_unknown_attr)
+{
+    std::string infile = Support::datapath("las/simple.las");
+    std::string infofile = Support::datapath("ogr/error");
+
+    Options wo;
+    wo.add("ogrdriver", "GeoJSON");
+    wo.add("attr_dims", "bananas");
+
+    try
+    {
+        runOgrWriterInfo(wo, infile, infofile, ".geojson");
+        FAIL() << "Expected an exception for an invalid arg combination";
+    }
+    catch (pdal_error const & err)
+    {
+        EXPECT_EQ("writers.ogr: Dimension 'bananas' (attr_dims) not found.",
+            std::string(err.what()));
+    }
+}
+
+TEST(OGRWriterTest, error_ogr)
+{
+    std::string infile = Support::datapath("las/simple.las");
+    std::string infofile = Support::datapath("ogr/error");
+
+    Options wo;
+    wo.add("ogrdriver", "GeoJSON");
+
+    // RFC7946 GeoJSON doesn't allow non-WGS84 CRS, and will throw an error
+    wo.add("ogr_options", "RFC7946=YES");
+
+    try
+    {
+        {
+            gdal::ErrorHandlerSuspender devnull;
+
+            runOgrWriterInfo(wo, infile, infofile, ".geojson");
+        }
+        FAIL() << "Expected an exception from OGR";
+    }
+    catch (pdal_error const & err)
+    {
+        EXPECT_EQ("writers.ogr: Can't create OGR layer: Failed to create coordinate transformation between the input coordinate system and WGS84.",
+            std::string(err.what()));
+    }
+}
+
+} // namespace pdal


### PR DESCRIPTION
Adds the ability to write OGR datasets with point dimensions as feature attributes. Do some other tidying up of the writers.ogr driver along the way, and adds tests.

1. always create 3D/Z geometries. If there's a specific format that doesn't work with `wkbPointZM` maybe that's something we should document rather than hobbling the default output to 2D? **This is a backwards-incompatible change, previously you needed `measure_dim` to get 3D XYZ output.**
2.  fixes a bug using `multicount` where the final geometry (eg `multicount=10` with 15x points → the final 5x) didn't get its geometry set.
3. calls `SetFID()` for each feature with a sane value. Previously, creating a GeoPackage (at least) crashed because there was no primary key. The value either uses the pointId or when using `multipoint` synthesises a value.
5. adds a new `attr_dims` option:

   > List of dimensions to write as feature attributes. Separate multiple values with ``,`` or use ``all`` to write all dimensions. ``X``, ``Y``, ``Z``, and any `measure_dim` are never written as attributes. This option is incompatible with the `multicount` option. [Default: None]
```
  [
      "inputfile.las",
      {
          "type": "writers.ogr",
          "filename": "outfile.geojson",
          "measure_dim": "Intensity",
          "attr_dims": "Classification"
      }
  ]

  [
      "inputfile.las",
      {
          "type": "writers.ogr",
          "filename": "outfile.geojson",
          "attr_dims": "Classification,Red,Green,Blue"
      }
  ]

  [
      "inputfile.las",
      {
          "type": "writers.ogr",
          "filename": "outfile.geojson",
          "attr_dims": "all"
      }
  ]
```

6. Adds the ability to set OGR layer creation options via `ogr_options`:

   > List of OGR driver-specific layer creation options, formatted as an ``OPTION=VALUE`` string. Separate multiple values with ``,`` or repeat the option. [Default: None]
```
  [
      "inputfile.las",
      {
          "type": "writers.ogr",
          "filename": "outfile.shp",
          "ogrdriver": "ESRI Shapefile",
          "ogr_options": "2GB_LIMIT=YES"
      }
  ]
```
8. Improves OGR CRS initialisation and reports errors
9. Adds a pile of writers.ogr tests using `ogrinfo` output.
10. Refreshes the docs for writers.ogr and adds the `attr_dims` option
