### PR TITLE
Remove duplicate top-level header in memoryview

### DIFF
--- a/doc/stages/readers.memoryview.rst
+++ b/doc/stages/readers.memoryview.rst
@@ -15,7 +15,7 @@ Note that the memoryview reader does not currently work with columnar
 data (data where individual dimensions are packed into arrays).
 
 Usage
-=====
+-----
 
 The memoryview reader cannot be used from the command-line.  It is for use
 by software using the PDAL API.


### PR DESCRIPTION
It was showing up in the left sidebar.
![Screenshot 2022-08-27 at 11-02-35 readers buffer — pdal io](https://user-images.githubusercontent.com/58314/187023375-bdedceb7-a1a6-4e49-94e0-d9cd9e5a4d43.png)

