### PR TITLE
Adds inline comments for enums in generated dimensions header

### DIFF
--- a/dimbuilder/DimBuilder.cpp
+++ b/dimbuilder/DimBuilder.cpp
@@ -379,9 +379,14 @@ void DimBuilder::writeIds(std::ostream& out)
     {
         DimSpec& d = *di;
         out << "    " << d.m_name;
+        size_t line_size = 4 + d.m_name.size();
         if (di + 1 != m_dims.end())
+        {
             out << ",";
-        out << "\n";
+            line_size += 1;
+        }
+        out << " ///< \\brief " << d.m_description << "\n"
+            << std::string(line_size, ' ') << " ///< \\default " << getTypename(d.m_type) << "\n";
     }
     out << "};\n";
     out << "typedef std::vector<Id> IdList;\n";


### PR DESCRIPTION
This is handy for contextual help in your IDE.

The enum in `Dimension.hpp` will appear as below after this change
```cpp

enum class Id
{
    Unknown,
    X, ///< \brief X coordinate
       ///< \default Double
    Y, ///< \brief Y coordinate
       ///< \default Double
    Z, ///< \brief Z coordinate
       ///< \default Double
    W, ///< \brief W coordinate
       ///< \default Double
    Intensity, ///< \brief Representation of the pulse return magnitude
               ///< \default Unsigned16
    Amplitude, ///< \brief This is the ratio of the received power to the power received at the detection limit expressed in dB
               ///< \default Float
...
```

In CLion this gives me the following contextual documentation:
![image](https://user-images.githubusercontent.com/2761756/187068596-bc9a4cc5-8dd2-4a70-b0bd-797abde22bfd.png)
