### PR TITLE
cmake: GCC 8 Compatibility

### DIFF
--- a/pdal/util/CMakeLists.txt
+++ b/pdal/util/CMakeLists.txt
@@ -46,3 +46,10 @@ set_target_properties(${PDAL_UTIL_LIB_NAME} PROPERTIES
     CLEAN_DIRECT_OUTPUT 1)
 
 set_property(GLOBAL PROPERTY _UTIL_INCLUDED TRUE)
+
+# Compatibility for GCC8: std::filesystem requires linking with libstdc++fs
+target_link_libraries(
+  ${PDAL_UTIL_LIB_NAME}
+  PRIVATE
+  "$<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,9.0>>:-lstdc++fs>"
+)


### PR DESCRIPTION
GCC 8 requires linking with `libstdc++fs` for access to `std::filesystem` under C++17. Doing this via `CMAKE_*_LINKER_FLAGS`, `LDFLAGS`, etc ends up with the library too early on the link line, so it's not solvable without altering the CMake code.

Add `libstdc++fs` as a link library for `libpdal_util` when compiling with GCC 8

Fixes https://github.com/PDAL/PDAL/issues/3826