### PR TITLE
writers.ogr: don't set OGR FID

### DIFF
--- a/io/OGRWriter.cpp
+++ b/io/OGRWriter.cpp
@@ -270,7 +270,6 @@ bool OGRWriter::processOne(PointRef& point)
         else
         {
             m_feature->SetGeometry(&pt);
-            m_feature->SetFID(point.pointId());
 
             for (auto it = std::begin(m_attrs); it != std::end(m_attrs); ++it)
             {
@@ -325,7 +324,6 @@ void OGRWriter::doneFile()
 #endif
 
         m_feature->SetGeometry(&m_multiPoint);
-        m_feature->SetFID(m_curCount / m_multiCount + 1);
 
         if (m_layer->CreateFeature(m_feature))
             throwError(std::string("Can't create OGR feature: ") + CPLGetLastErrorMsg());

--- a/io/OGRWriter.cpp
+++ b/io/OGRWriter.cpp
@@ -264,7 +264,6 @@ bool OGRWriter::processOne(PointRef& point)
         if (m_multiCount > 1)
         {
             m_feature->SetGeometry(&m_multiPoint);
-            m_feature->SetFID(m_curCount / m_multiCount);
             m_multiPoint.empty();
         }
         else
@@ -310,6 +309,8 @@ bool OGRWriter::processOne(PointRef& point)
 
 #if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,5,0)
         m_feature->Reset();
+#else
+        m_feature->SetFID(OGRNullFID);
 #endif
     }
     return true;
@@ -321,6 +322,8 @@ void OGRWriter::doneFile()
     if (m_curCount % m_multiCount > 0) {
 #if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,5,0)
         m_feature->Reset();
+#else
+        m_feature->SetFID(OGRNullFID);
 #endif
 
         m_feature->SetGeometry(&m_multiPoint);

--- a/test/data/ogr/geopackage.gpkg.ogrinfo
+++ b/test/data/ogr/geopackage.gpkg.ogrinfo
@@ -47,6 +47,6 @@ PROJCRS["NAD83 / UTM zone 15N",
 Data axis to CRS axis mapping: 1,2
 FID Column = fid
 Geometry Column = geom
-OGRFeature(points):0
+OGRFeature(points):1
   POINT Z (470692.44 4602888.9 16)
 

--- a/test/data/ogr/geopackage_attrs_all.gpkg.ogrinfo
+++ b/test/data/ogr/geopackage_attrs_all.gpkg.ogrinfo
@@ -39,7 +39,7 @@ GpsTime: Real (0.0)
 Red: Integer (0.0)
 Green: Integer (0.0)
 Blue: Integer (0.0)
-OGRFeature(points):0
+OGRFeature(points):1
   Intensity (Integer) = 1
   ReturnNumber (Integer) = 1
   NumberOfReturns (Integer) = 2
@@ -55,7 +55,7 @@ OGRFeature(points):0
   Blue (Integer) = 68
   POINT Z (635619.85 850064.04 447.01)
 
-OGRFeature(points):1
+OGRFeature(points):2
   Intensity (Integer) = 25
   ReturnNumber (Integer) = 1
   NumberOfReturns (Integer) = 1
@@ -71,7 +71,7 @@ OGRFeature(points):1
   Blue (Integer) = 56
   POINT Z (635640.42 849758.79 422.74)
 
-OGRFeature(points):2
+OGRFeature(points):3
   Intensity (Integer) = 33
   ReturnNumber (Integer) = 1
   NumberOfReturns (Integer) = 1
@@ -87,7 +87,7 @@ OGRFeature(points):2
   Blue (Integer) = 122
   POINT Z (635650.95 850244.03 424.93)
 
-OGRFeature(points):3
+OGRFeature(points):4
   Intensity (Integer) = 70
   ReturnNumber (Integer) = 1
   NumberOfReturns (Integer) = 1
@@ -103,7 +103,7 @@ OGRFeature(points):3
   Blue (Integer) = 231
   POINT Z (635673.46 850157.55 435.73)
 
-OGRFeature(points):4
+OGRFeature(points):5
   Intensity (Integer) = 153
   ReturnNumber (Integer) = 1
   NumberOfReturns (Integer) = 1
@@ -119,7 +119,7 @@ OGRFeature(points):4
   Blue (Integer) = 140
   POINT Z (635674.05 849017.32 428.02)
 
-OGRFeature(points):5
+OGRFeature(points):6
   Intensity (Integer) = 6
   ReturnNumber (Integer) = 2
   NumberOfReturns (Integer) = 2
@@ -135,7 +135,7 @@ OGRFeature(points):5
   Blue (Integer) = 92
   POINT Z (635678.9 851351.44 436.45)
 
-OGRFeature(points):6
+OGRFeature(points):7
   Intensity (Integer) = 58
   ReturnNumber (Integer) = 2
   NumberOfReturns (Integer) = 2
@@ -151,7 +151,7 @@ OGRFeature(points):6
   Blue (Integer) = 78
   POINT Z (635680.54 849362.66 421.56)
 
-OGRFeature(points):7
+OGRFeature(points):8
   Intensity (Integer) = 99
   ReturnNumber (Integer) = 2
   NumberOfReturns (Integer) = 2
@@ -167,7 +167,7 @@ OGRFeature(points):7
   Blue (Integer) = 95
   POINT Z (635681.07 851383.76 419)
 
-OGRFeature(points):8
+OGRFeature(points):9
   Intensity (Integer) = 48
   ReturnNumber (Integer) = 1
   NumberOfReturns (Integer) = 1
@@ -183,7 +183,7 @@ OGRFeature(points):8
   Blue (Integer) = 94
   POINT Z (635684.02 849494.39 407.12)
 
-OGRFeature(points):9
+OGRFeature(points):10
   Intensity (Integer) = 109
   ReturnNumber (Integer) = 1
   NumberOfReturns (Integer) = 1


### PR DESCRIPTION
OGR FIDs need to be unique, but if a pipeline includes a merge filter `pointId`s may not be. OGR will generate a unique sequence anyway, and the user can always pass `pointId` as a dimension to create an attribute if they want it explicitly.

An additional change on top of #3863, since they both edit the same testcase.