### PR TITLE
Return line length of 80 if terminal window column size is 0

### DIFF
--- a/pdal/util/Utils.cpp
+++ b/pdal/util/Utils.cpp
@@ -538,6 +538,9 @@ int Utils::screenWidth()
     if (ioctl(0, TIOCGWINSZ, &ws))
         return 80;
 
+    if (!ws.ws_col)
+      return 80;
+
     return ws.ws_col;
 #endif
 }

--- a/pdal/util/Utils.cpp
+++ b/pdal/util/Utils.cpp
@@ -539,7 +539,7 @@ int Utils::screenWidth()
         return 80;
 
     if (!ws.ws_col)
-      return 80;
+        return 80;
 
     return ws.ws_col;
 #endif


### PR DESCRIPTION
Fixes bug found in #3870 by checking size and returning 80 as a default.