### PR TITLE
[doc] Fix example for filters.poisson

### DIFF
--- a/doc/stages/filters.poisson.rst
+++ b/doc/stages/filters.poisson.rst
@@ -39,6 +39,7 @@ Example
       },
       {
           "type":"writers.ply",
+          "faces":true,
           "filename":"isosurface.ply"
       }
   ]


### PR DESCRIPTION
Without faces=true option in PLY writer, only points (without triangles) are written to the output PLY file