### PR TITLE
doc update: filters.overlay is streamable

### DIFF
--- a/doc/stages/filters.overlay.rst
+++ b/doc/stages/filters.overlay.rst
@@ -8,6 +8,8 @@ based on an OGR-readable polygon or multi-polygon.
 
 .. embed::
 
+.. streamable::
+
 OGR SQL support
 ----------------
 


### PR DESCRIPTION
From the code it looks like the overlay filter is streamable, but the docs do not say so...