### PR TITLE
Make writers.ogr use transactions if they are available

### DIFF
--- a/io/OGRWriter.hpp
+++ b/io/OGRWriter.hpp
@@ -78,6 +78,7 @@ private:
     std::vector<std::string> m_attrDimNames;
     std::vector<std::string> m_ogrOptions;
     std::deque<std::tuple<Dimension::Id, Dimension::Type, OGRFieldDefn> > m_attrs;
+    bool m_inTransaction;
 };
 
 }


### PR DESCRIPTION
This significantly speeds up saving of points to GeoPackage

Writing ~300K points, the time to write a GPKG goes from ~23 seconds down to ~3 seconds on my laptop.

Also tested with shapefile driver which does not support transactions (writing SHP for my test dataset is still faster... ~1.5 secs).

Closes #3889