### PR TITLE
Cast point_count_t to into on ostream<< #3902 

### DIFF
--- a/io/LasWriter.cpp
+++ b/io/LasWriter.cpp
@@ -1004,7 +1004,7 @@ void LasWriter::finishOutput()
 {
     if (d->opts.compression == las::Compression::True)
         finishLazPerfOutput();
-    log()->get(LogLevel::Debug) << "Wrote " << d->summary.getTotalNumPoints() <<
+    log()->get(LogLevel::Debug) << "Wrote " << (int)d->summary.getTotalNumPoints() <<
         " points to the LAS file" << std::endl;
 
     // addVlr prevents any evlrs from being added before version 1.4.

--- a/pdal/util/Utils.cpp
+++ b/pdal/util/Utils.cpp
@@ -549,13 +549,9 @@ int Utils::screenWidth()
            throw std::runtime_error("Inaccessible memory access in ioctl");
        else if (errno  == EINVAL)
            throw std::runtime_error("Request invalid in gathering screenWidth");
-       else if (errno == ENOTTY)
-       {
+       else
            // we are not a tty, so just return 80 *shrug*
            return 80;
-       }
-       else
-           throw std::runtime_error("Unknown error code from ioctl!");
    }
 
 #endif


### PR DESCRIPTION
made one PR instead of two to save CI churn.

Back off #3892 and default to 80 instead of throwing an error
Fix #3902
