### PR TITLE
readers.copc was reading past its buffer

### DIFF
--- a/io/CopcReader.cpp
+++ b/io/CopcReader.cpp
@@ -270,7 +270,7 @@ std::vector<char> CopcReader::fetch(uint64_t offset, int32_t size)
 void CopcReader::fetchHeader()
 {
     // Read the LAS header, COPC info VLR header and COPC VLR
-    int size = 549;
+    int size = 589;
     std::vector<char> data = fetch(0, size);
 
     const char *d = data.data();
@@ -289,6 +289,14 @@ void CopcReader::fetchHeader()
     // Read VLR payload into COPC struct.
     d += las::Vlr::HeaderSize;
     size -= las::Vlr::HeaderSize;
+
+    if (size != 160)
+    {
+        std::stringstream msg;
+        msg << "Fetched COPC VLR size is in correct. It should "
+            << "be 160 and it is " << size;
+        throwError(msg.str());
+    }
     m_p->copc_info.fill(d, size);
 
     m_p->rootNodeExtent = BOX3D(

--- a/scripts/conda/osx.sh
+++ b/scripts/conda/osx.sh
@@ -23,6 +23,8 @@ CFLAGS= CXXFLAGS="-Werror=strict-aliasing" CC=/usr/bin/cc CXX=/usr/bin/c++ cmake
         -DBUILD_PLUGIN_HDF=ON \
         -DBUILD_PLUGIN_DRACO=ON \
         -DBUILD_PLUGIN_ICEBRIDGE=ON \
+        -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address" \
+        -DCMAKE_CXX_FLAGS="-fsanitize=address" \
         -DBUILD_PLUGIN_TILEDB=ON \
         -DWITH_ZSTD=ON \
         ..


### PR DESCRIPTION
When doing fetchHeader due to using an old byte offset size, 549, instead of the proper buffer size 589 (375 for header, 54 for VLR header, and 160 for COPC VLR contents). This was causing us to read off the end.

We should fix this
* Provide an option to readers.copc to hint it how much header bytes it should grab
* Search through all of the VLRs and find our COPC one in case a bad reader doesn't put it exactly starting at byte 374