### PR TITLE
Provide proper dimension size from PointLayout for writers.draco

### DIFF
--- a/plugins/draco/io/DracoWriter.cpp
+++ b/plugins/draco/io/DracoWriter.cpp
@@ -183,7 +183,7 @@ void DracoWriter::parseDimensions(BasePointTable &table)
         log()->get(LogLevel::Info) << "Key: " << dimString << ", Value: "
             << dataType << std::endl;
         const auto it = dimMap.find(dim);
-        Dimension::Type pdalType = Dimension::type(dataType);
+        Dimension::Type pdalType = layout->dimType(dim);
         if (it != dimMap.end())
         {
             //get draco type associated with the current dimension in loop

--- a/plugins/draco/test/DracoWriterTest.cpp
+++ b/plugins/draco/test/DracoWriterTest.cpp
@@ -212,8 +212,7 @@ namespace pdal
         PointTable table;
         writer.prepare(table);
 
-        if (pass) writer.execute(table);
-        else EXPECT_THROW(writer.execute(table), pdal_error);
+        writer.execute(table);
     }
 
     void testZeroFill() {


### PR DESCRIPTION
We weren't properly mapping the dimension type and this was causing UB reads due to the sizes being incorrect.