### PR TITLE
EPT and COPC fixes

### DIFF
--- a/io/EptReader.cpp
+++ b/io/EptReader.cpp
@@ -829,6 +829,11 @@ void EptReader::process(PointViewPtr dstView, const ept::TileContents& tile,
     }
 }
 
+void EptReader::done(PointTableRef)
+{
+    m_p->connector.reset();
+}
+
 
 bool EptReader::processOne(PointRef& point)
 {

--- a/io/EptReader.hpp
+++ b/io/EptReader.hpp
@@ -77,6 +77,8 @@ private:
     virtual void ready(PointTableRef table) override;
     virtual point_count_t read(PointViewPtr view, point_count_t count) override;
     virtual bool processOne(PointRef& point) override;
+    virtual void done(PointTableRef) override;
+
 
     // If argument "origin" is specified, this function will clip the query
     // bounds to the bounds of the specified origin and set m_queryOriginId to

--- a/pdal/util/ThreadPool.cpp
+++ b/pdal/util/ThreadPool.cpp
@@ -74,33 +74,14 @@ void ThreadPool::work()
 
             std::string err;
 
-            // task();
+            task();
 
-            auto release = [this, &lock]()
-            {
-                lock.lock();
-                --m_outstanding;
-                lock.unlock();
+            lock.lock();
+            --m_outstanding;
+            lock.unlock();
 
-                // Notify await(), which may be waiting for a running task.
-                m_produceCv.notify_all();
-            };
-
-            try
-            {
-                task();
-                release();
-            }
-            catch (std::exception& e)
-            {
-                release();
-                throw e;
-            }
-            catch (...)
-            {
-                release();
-                throw std::runtime_error("Unknown error");
-            }
+            // Notify await(), which may be waiting for a running task.
+            m_produceCv.notify_all();
         }
         else if (!m_running)
         {

--- a/pdal/util/ThreadPool.hpp
+++ b/pdal/util/ThreadPool.hpp
@@ -55,7 +55,7 @@ public:
     PDAL_DLL ThreadPool(std::size_t numThreads, int64_t queueSize = -1,
             bool verbose = true) :
         m_queueSize(queueSize),
-        m_numThreads(std::max<std::size_t>(numThreads, 1)), m_verbose(verbose)
+        m_numThreads(std::max<std::size_t>(numThreads, 1))
     {
         assert(m_queueSize != 0);
         go();
@@ -118,10 +118,6 @@ public:
         go();
     }
 
-    // Not thread-safe, pool should be joined before calling.
-    const std::vector<std::string>& errors() const
-    { return m_errors; }
-
     // Add a threaded task, blocking until a thread is available.  If join() is
     // called, add() may not be called again until go() is called and completes.
     PDAL_DLL void add(std::function<void()> task)
@@ -156,7 +152,6 @@ private:
 
     int64_t m_queueSize;
     std::size_t m_numThreads;
-    bool m_verbose;
     std::vector<std::thread> m_threads;
     std::queue<std::function<void()>> m_tasks;
 

--- a/pdal/util/ThreadPool.hpp
+++ b/pdal/util/ThreadPool.hpp
@@ -160,9 +160,6 @@ private:
     std::vector<std::thread> m_threads;
     std::queue<std::function<void()>> m_tasks;
 
-    std::vector<std::string> m_errors;
-    std::mutex m_errorMutex;
-
     std::size_t m_outstanding = 0;
     bool m_running = false;
 

--- a/vendor/arbiter/arbiter.cpp
+++ b/vendor/arbiter/arbiter.cpp
@@ -4300,7 +4300,7 @@ int Curl::perform()
     if (code != CURLE_OK)
     {
         std::cerr << "Curl failure: " << curl_easy_strerror(code) << std::endl;
-        httpCode = 450;
+        httpCode = 550;
     }
 
     return httpCode;

--- a/vendor/arbiter/arbiter.cpp
+++ b/vendor/arbiter/arbiter.cpp
@@ -4492,12 +4492,14 @@ Response Curl::post(
 #include <curl/curl.h>
 #endif
 
+#include <chrono>
 #include <cctype>
 #include <iomanip>
 #include <iostream>
 #include <numeric>
 #include <set>
 #include <sstream>
+#include <thread>
 
 #ifdef ARBITER_CUSTOM_NAMESPACE
 namespace ARBITER_CUSTOM_NAMESPACE
@@ -4618,6 +4620,11 @@ Response Resource::exec(std::function<Response()> f)
 
     do
     {
+        if (tries)
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(tries * 500));
+        }
+
         res = f();
     }
     while (res.serverError() && tries++ < m_retry);

--- a/vendor/arbiter/arbiter.cpp
+++ b/vendor/arbiter/arbiter.cpp
@@ -4297,7 +4297,11 @@ int Curl::perform()
     curl_easy_getinfo(m_curl, CURLINFO_RESPONSE_CODE, &httpCode);
     curl_easy_reset(m_curl);
 
-    if (code != CURLE_OK) httpCode = 500;
+    if (code != CURLE_OK)
+    {
+        std::cerr << "Curl failure: " << curl_easy_strerror(code) << std::endl;
+        httpCode = 450;
+    }
 
     return httpCode;
 #else
@@ -4622,7 +4626,8 @@ Response Resource::exec(std::function<Response()> f)
     {
         if (tries)
         {
-            std::this_thread::sleep_for(std::chrono::milliseconds(tries * 500));
+            std::this_thread::sleep_for(
+                std::chrono::milliseconds((int)std::pow(2, tries) * 500));
         }
 
         res = f();


### PR DESCRIPTION
* Add `done()` method to `readers.ept` and reset the connector with it
* Reset the connector in `readers.copc`
* Add exponential backoff for retries in arbiter (needs to be upstreamed)
* Release thread back to pool in case of exception in ThreadPool
* Log non-server Curl messages (like when you run out of sockets)

All this to fix running out of sockets 😄 