### PR TITLE
Fix WKT export from HexGrid using low precision

### DIFF
--- a/filters/private/hexer/HexGrid.cpp
+++ b/filters/private/hexer/HexGrid.cpp
@@ -372,24 +372,21 @@ void HexGrid::cleanPossibleRoot(Segment s, Path *p)
 
 void HexGrid::toWKT(std::ostream& out) const
 {
-    pdal::Utils::StringStreamClassicLocale ss;
-
-    auto writePath = [this, &ss](size_t pathNum)
+    auto writePath = [this, &out](size_t pathNum)
     {
-       rootPaths()[pathNum]->toWKT(ss);
+       rootPaths()[pathNum]->toWKT(out);
     };
 
-    ss << "MULTIPOLYGON (";
+    out << "MULTIPOLYGON (";
 
     if (rootPaths().size())
         writePath(0);
     for (size_t pi = 1; pi < rootPaths().size(); ++pi)
     {
-        ss << ",";
+        out << ",";
         writePath(pi);
     }
-    ss << ")";
-    out << ss.str();
+    out << ")";
 }
 
 size_t HexGrid::densePointCount() const

--- a/test/unit/filters/HexbinFilterTest.cpp
+++ b/test/unit/filters/HexbinFilterTest.cpp
@@ -123,7 +123,7 @@ TEST(HexbinFilterTest, issue_2507)
     grid.findShapes();
     grid.findParentPaths();
 
-    std::ostringstream oss;
+    pdal::Utils::OStringStreamClassicLocale oss;
     grid.toWKT(oss);
     std::string s(oss.str());
 


### PR DESCRIPTION
Fixes #3921

This rolls back changes in HextGrid::toWKT from #3873. It seems safe not to construct another stream in HexGrid::toWKT and one can expect that the caller will provide stream that is actually `OStringStreamClassicLocale`