### PR TITLE
add filters.transformation stream test

### DIFF
--- a/test/unit/filters/TransformationFilterTest.cpp
+++ b/test/unit/filters/TransformationFilterTest.cpp
@@ -257,6 +257,25 @@ TEST_F(TransformationFilterTest, SrsReset)
     EXPECT_EQ(view->spatialReference(), "EPSG:3857");
 }
 
+TEST_F(TransformationFilterTest, StreamsTest)
+{
+    TransformationFilter::Transform n { { 1, 0, 0, 0,
+                                          0, 1, 0, 0,
+                                          0, 0, 1, 0,
+                                          0, 0, 0, 1 } };
+
+    Utils::StringStreamClassicLocale oss;
+    oss << n;
+
+    Utils::StringStreamClassicLocale iss(oss.str());
+    TransformationFilter::Transform m;
+    iss >> m;
+
+    check(m);
+
+}
+
+
 TEST(TransformationMatrix, init_file_oneline)
 {
 


### PR DESCRIPTION
explicit stream io'ing test for filters.transformation to protect against new locale-aware stuff.