### PR TITLE
Add optional debug argument to CSF filter

### DIFF
--- a/filters/CSFilter.cpp
+++ b/filters/CSFilter.cpp
@@ -79,6 +79,7 @@ struct CSArgs
     int m_iterations;
     std::vector<DimRange> m_ignored;
     StringList m_returns;
+    bool m_debug;
     std::string m_dir;
 };
 
@@ -102,6 +103,7 @@ void CSFilter::addArgs(ProgramArgs& args)
     args.add("ignore", "Ignore values", m_args->m_ignored);
     args.add("returns", "Include last returns?", m_args->m_returns,
              {"last", "only"});
+    args.add("debug", "Enable debugging output and use the dir argument", m_args->m_debug, false);
     args.add("dir", "Optional output directory for debugging", m_args->m_dir);
 }
 
@@ -230,6 +232,7 @@ PointViewSet CSFilter::run(PointViewPtr view)
     c.params.cloth_resolution = m_args->m_resolution;
     c.params.rigidness = m_args->m_rigid;
     c.params.interations = m_args->m_iterations;
+    c.params.debug = m_args->m_debug;
     c.params.m_dir = m_args->m_dir;
     std::vector<int> groundIdx, offGroundIdx;
     c.setLog(log());

--- a/filters/private/csf/CSF.cpp
+++ b/filters/private/csf/CSF.cpp
@@ -155,6 +155,7 @@ void CSF::do_filtering(std::vector<int>& groundIndexes,
         9999,
         params.rigidness,
         params.time_step,
+        params.debug,
         params.m_dir
     );
 

--- a/filters/private/csf/CSF.h
+++ b/filters/private/csf/CSF.h
@@ -50,6 +50,7 @@ struct Params {
     double cloth_resolution;
     int rigidness;
     int interations;
+    bool debug;
     std::string m_dir;
 };
 

--- a/filters/private/csf/Cloth.cpp
+++ b/filters/private/csf/Cloth.cpp
@@ -29,10 +29,12 @@ Cloth::Cloth(const Vec3& _origin_pos,
              double      _heightThreshold,
              int         rigidness,
              double      time_step,
+             bool        debug,
              string      output_dir)
     : constraint_iterations(rigidness),
     smoothThreshold(_smoothThreshold),
     heightThreshold(_heightThreshold),
+    debug(debug),
     m_outputDir(output_dir),
     origin_pos(_origin_pos),
     step_x(_step_x),
@@ -367,7 +369,7 @@ void Cloth::handle_slop_connected(vector<int> edgePoints, vector<XY> connected, 
 }
 
 void Cloth::saveToFile(string path) {
-    if (m_outputDir.empty())
+    if (m_outputDir.empty() || debug == false)
         return;
 
     string filepath = "cloth_nodes.txt";

--- a/filters/private/csf/Cloth.h
+++ b/filters/private/csf/Cloth.h
@@ -86,6 +86,7 @@ private:
     double smoothThreshold;
     double heightThreshold;
     string m_outputDir;
+    bool debug;
 
 public:
 
@@ -135,6 +136,7 @@ public:
           double      heightThreshold,
           int         rigidness,
           double      time_step,
+          bool        debug,
           string      output_dir);
 
     /* this is an important methods where the time is progressed one


### PR DESCRIPTION
Add a new optional boolean debug argument to the CSF filter to enable debug output to the location provided by the dir argument. The default value of this argument will be false so that this debug output is not written by default.

This will fix issue #3951 and issue #3690