### PR TITLE
Fixed bounds comparisons. 

### DIFF
--- a/test/data/stac/test_item_collection.json
+++ b/test/data/stac/test_item_collection.json
@@ -4,2167 +4,6 @@
         {
             "type": "Feature",
             "stac_version": "1.0.0",
-            "id": "AK_BrooksCamp_2012",
-            "properties": {
-                "description": "A USGS Lidar pointcloud in Entwine/EPT format",
-                "pc:count": 529285317,
-                "pc:type": "lidar",
-                "pc:encoding": "ept",
-                "pc:schemas": [
-                    {
-                        "name": "X",
-                        "offset": -17334459,
-                        "scale": 0.01,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Y",
-                        "offset": 8078265,
-                        "scale": 0.01,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Z",
-                        "offset": 486,
-                        "scale": 0.01,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Intensity",
-                        "size": 2,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ReturnNumber",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "NumberOfReturns",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ScanDirectionFlag",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "EdgeOfFlightLine",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "Classification",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ScanAngleRank",
-                        "size": 4,
-                        "type": "floating"
-                    },
-                    {
-                        "name": "UserData",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "PointSourceId",
-                        "size": 2,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "GpsTime",
-                        "size": 8,
-                        "type": "floating"
-                    },
-                    {
-                        "name": "OriginId",
-                        "size": 4,
-                        "type": "unsigned"
-                    }
-                ],
-                "proj:epsg": 3857,
-                "proj:projjson": {
-                    "$schema": "https://proj.org/schemas/v0.5/projjson.schema.json",
-                    "type": "ProjectedCRS",
-                    "name": "WGS 84 / Pseudo-Mercator",
-                    "base_crs": {
-                        "name": "WGS 84",
-                        "datum_ensemble": {
-                            "name": "World Geodetic System 1984 ensemble",
-                            "members": [
-                                {
-                                    "name": "World Geodetic System 1984 (Transit)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1166
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G730)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1152
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G873)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1153
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1150)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1154
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1674)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1155
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1762)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1156
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G2139)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1309
-                                    }
-                                }
-                            ],
-                            "ellipsoid": {
-                                "name": "WGS 84",
-                                "semi_major_axis": 6378137,
-                                "inverse_flattening": 298.257223563
-                            },
-                            "accuracy": "2.0",
-                            "id": {
-                                "authority": "EPSG",
-                                "code": 6326
-                            }
-                        },
-                        "coordinate_system": {
-                            "subtype": "ellipsoidal",
-                            "axis": [
-                                {
-                                    "name": "Geodetic latitude",
-                                    "abbreviation": "Lat",
-                                    "direction": "north",
-                                    "unit": "degree"
-                                },
-                                {
-                                    "name": "Geodetic longitude",
-                                    "abbreviation": "Lon",
-                                    "direction": "east",
-                                    "unit": "degree"
-                                }
-                            ]
-                        },
-                        "id": {
-                            "authority": "EPSG",
-                            "code": 4326
-                        }
-                    },
-                    "conversion": {
-                        "name": "Popular Visualisation Pseudo-Mercator",
-                        "method": {
-                            "name": "Popular Visualisation Pseudo Mercator",
-                            "id": {
-                                "authority": "EPSG",
-                                "code": 1024
-                            }
-                        },
-                        "parameters": [
-                            {
-                                "name": "Latitude of natural origin",
-                                "value": 0,
-                                "unit": "degree",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8801
-                                }
-                            },
-                            {
-                                "name": "Longitude of natural origin",
-                                "value": 0,
-                                "unit": "degree",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8802
-                                }
-                            },
-                            {
-                                "name": "False easting",
-                                "value": 0,
-                                "unit": "metre",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8806
-                                }
-                            },
-                            {
-                                "name": "False northing",
-                                "value": 0,
-                                "unit": "metre",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8807
-                                }
-                            }
-                        ]
-                    },
-                    "coordinate_system": {
-                        "subtype": "Cartesian",
-                        "axis": [
-                            {
-                                "name": "Easting",
-                                "abbreviation": "X",
-                                "direction": "east",
-                                "unit": "metre"
-                            },
-                            {
-                                "name": "Northing",
-                                "abbreviation": "Y",
-                                "direction": "north",
-                                "unit": "metre"
-                            }
-                        ]
-                    },
-                    "scope": "Web mapping and visualisation.",
-                    "area": "World between 85.06°S and 85.06°N.",
-                    "bbox": {
-                        "south_latitude": -85.06,
-                        "west_longitude": -180,
-                        "north_latitude": 85.06,
-                        "east_longitude": 180
-                    },
-                    "id": {
-                        "authority": "EPSG",
-                        "code": 3857
-                    }
-                },
-                "datetime": "2023-01-11T17:08:49.052569Z"
-            },
-            "geometry": {
-                "type": "MultiPolygon",
-                "coordinates": [
-                    [
-                        [
-                            [
-                                -155.62734312337346,
-                                58.46319052724474
-                            ],
-                            [
-                                -155.60039366485617,
-                                58.46319052724474
-                            ],
-                            [
-                                -155.59590208843736,
-                                58.48353019488535
-                            ],
-                            [
-                                -155.61386839411526,
-                                58.49979345560825
-                            ],
-                            [
-                                -155.63632627621195,
-                                58.50385809421266
-                            ],
-                            [
-                                -155.64081785263164,
-                                58.51604918678722
-                            ],
-                            [
-                                -155.67675046398747,
-                                58.51604918678722
-                            ],
-                            [
-                                -155.69471676966535,
-                                58.53229739060048
-                            ],
-                            [
-                                -155.69471676966535,
-                                58.5566555872777
-                            ],
-                            [
-                                -155.71717465176295,
-                                58.55259706332946
-                            ],
-                            [
-                                -155.74412411027936,
-                                58.560713641106254
-                            ],
-                            [
-                                -155.74412411027936,
-                                58.576941155906155
-                            ],
-                            [
-                                -155.76209041595726,
-                                58.58505209347513
-                            ],
-                            [
-                                -155.79802302731395,
-                                58.58505209347513
-                            ],
-                            [
-                                -155.83844721508854,
-                                58.57288498221513
-                            ],
-                            [
-                                -155.83844721508854,
-                                58.540418670426
-                            ],
-                            [
-                                -155.80251460373273,
-                                58.540418670426
-                            ],
-                            [
-                                -155.79802302731395,
-                                58.52011194334598
-                            ],
-                            [
-                                -155.70819149892355,
-                                58.49572834640729
-                            ],
-                            [
-                                -155.70369992250474,
-                                58.48353019488535
-                            ],
-                            [
-                                -155.62734312337346,
-                                58.46319052724474
-                            ]
-                        ]
-                    ]
-                ]
-            },
-            "links": [
-                {
-                    "rel": "self",
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-stac/ept/AK_BrooksCamp_2012.json"
-                },
-                {
-                    "rel": "parent",
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-stac/ept/catalog.json"
-                }
-            ],
-            "assets": {
-                "ept.json": {
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-public/AK_BrooksCamp_2012/ept.json",
-                    "title": "entwine",
-                    "description": "The ept.json for accessing data"
-                }
-            },
-            "bbox": [
-                -155.83844721508854,
-                58.46319052724474,
-                -155.59590208843736,
-                58.58505209347513
-            ],
-            "stac_extensions": [
-                "https://stac-extensions.github.io/pointcloud/v1.0.0/schema.json",
-                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
-            ]
-        },
-        {
-            "type": "Feature",
-            "stac_version": "1.0.0",
-            "id": "AK_Coastal_2009",
-            "properties": {
-                "description": "A USGS Lidar pointcloud in Entwine/EPT format",
-                "pc:count": 55711772,
-                "pc:type": "lidar",
-                "pc:encoding": "ept",
-                "pc:schemas": [
-                    {
-                        "name": "X",
-                        "offset": -15711199,
-                        "scale": 0.01,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Y",
-                        "offset": 10956752,
-                        "scale": 0.01,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Z",
-                        "offset": 318,
-                        "scale": 0.01,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Intensity",
-                        "size": 2,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ReturnNumber",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "NumberOfReturns",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ScanDirectionFlag",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "EdgeOfFlightLine",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "Classification",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ScanAngleRank",
-                        "size": 4,
-                        "type": "floating"
-                    },
-                    {
-                        "name": "UserData",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "PointSourceId",
-                        "size": 2,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "GpsTime",
-                        "size": 8,
-                        "type": "floating"
-                    },
-                    {
-                        "name": "OriginId",
-                        "size": 4,
-                        "type": "unsigned"
-                    }
-                ],
-                "proj:epsg": 3857,
-                "proj:projjson": {
-                    "$schema": "https://proj.org/schemas/v0.5/projjson.schema.json",
-                    "type": "ProjectedCRS",
-                    "name": "WGS 84 / Pseudo-Mercator",
-                    "base_crs": {
-                        "name": "WGS 84",
-                        "datum_ensemble": {
-                            "name": "World Geodetic System 1984 ensemble",
-                            "members": [
-                                {
-                                    "name": "World Geodetic System 1984 (Transit)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1166
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G730)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1152
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G873)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1153
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1150)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1154
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1674)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1155
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1762)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1156
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G2139)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1309
-                                    }
-                                }
-                            ],
-                            "ellipsoid": {
-                                "name": "WGS 84",
-                                "semi_major_axis": 6378137,
-                                "inverse_flattening": 298.257223563
-                            },
-                            "accuracy": "2.0",
-                            "id": {
-                                "authority": "EPSG",
-                                "code": 6326
-                            }
-                        },
-                        "coordinate_system": {
-                            "subtype": "ellipsoidal",
-                            "axis": [
-                                {
-                                    "name": "Geodetic latitude",
-                                    "abbreviation": "Lat",
-                                    "direction": "north",
-                                    "unit": "degree"
-                                },
-                                {
-                                    "name": "Geodetic longitude",
-                                    "abbreviation": "Lon",
-                                    "direction": "east",
-                                    "unit": "degree"
-                                }
-                            ]
-                        },
-                        "id": {
-                            "authority": "EPSG",
-                            "code": 4326
-                        }
-                    },
-                    "conversion": {
-                        "name": "Popular Visualisation Pseudo-Mercator",
-                        "method": {
-                            "name": "Popular Visualisation Pseudo Mercator",
-                            "id": {
-                                "authority": "EPSG",
-                                "code": 1024
-                            }
-                        },
-                        "parameters": [
-                            {
-                                "name": "Latitude of natural origin",
-                                "value": 0,
-                                "unit": "degree",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8801
-                                }
-                            },
-                            {
-                                "name": "Longitude of natural origin",
-                                "value": 0,
-                                "unit": "degree",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8802
-                                }
-                            },
-                            {
-                                "name": "False easting",
-                                "value": 0,
-                                "unit": "metre",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8806
-                                }
-                            },
-                            {
-                                "name": "False northing",
-                                "value": 0,
-                                "unit": "metre",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8807
-                                }
-                            }
-                        ]
-                    },
-                    "coordinate_system": {
-                        "subtype": "Cartesian",
-                        "axis": [
-                            {
-                                "name": "Easting",
-                                "abbreviation": "X",
-                                "direction": "east",
-                                "unit": "metre"
-                            },
-                            {
-                                "name": "Northing",
-                                "abbreviation": "Y",
-                                "direction": "north",
-                                "unit": "metre"
-                            }
-                        ]
-                    },
-                    "scope": "Web mapping and visualisation.",
-                    "area": "World between 85.06°S and 85.06°N.",
-                    "bbox": {
-                        "south_latitude": -85.06,
-                        "west_longitude": -180,
-                        "north_latitude": 85.06,
-                        "east_longitude": 180
-                    },
-                    "id": {
-                        "authority": "EPSG",
-                        "code": 3857
-                    }
-                },
-                "datetime": "2023-01-11T17:08:49.054683Z"
-            },
-            "geometry": {
-                "type": "MultiPolygon",
-                "coordinates": [
-                    [
-                        [
-                            [
-                                -141.25519886899843,
-                                69.6002521460617
-                            ],
-                            [
-                                -141.22824941048205,
-                                69.6002521460617
-                            ],
-                            [
-                                -141.21028310480324,
-                                69.61109631541747
-                            ],
-                            [
-                                -141.17435049344743,
-                                69.61109631541747
-                            ],
-                            [
-                                -141.16985891702865,
-                                69.63006033242883
-                            ],
-                            [
-                                -141.18782522270652,
-                                69.63547552021261
-                            ],
-                            [
-                                -141.16985891702865,
-                                69.6408893295334
-                            ],
-                            [
-                                -141.16985891702865,
-                                69.6517128139951
-                            ],
-                            [
-                                -141.10248527073585,
-                                69.63818259716201
-                            ],
-                            [
-                                -141.06655265938005,
-                                69.63818259716201
-                            ],
-                            [
-                                -141.06206108296124,
-                                69.63006033242883
-                            ],
-                            [
-                                -141.08002738863917,
-                                69.62464376587887
-                            ],
-                            [
-                                -141.08002738863917,
-                                69.61380649527108
-                            ],
-                            [
-                                -141.06206108296124,
-                                69.60838579060758
-                            ],
-                            [
-                                -141.02612847160458,
-                                69.60838579060758
-                            ],
-                            [
-                                -141.02163689518576,
-                                69.62193496547212
-                            ],
-                            [
-                                -140.98570428382996,
-                                69.62193496547212
-                            ],
-                            [
-                                -140.98121270741026,
-                                69.63006033242883
-                            ],
-                            [
-                                -140.95426324889294,
-                                69.63547552021261
-                            ],
-                            [
-                                -140.95426324889294,
-                                69.64630176069349
-                            ],
-                            [
-                                -140.97222955457087,
-                                69.6517128139951
-                            ],
-                            [
-                                -140.97222955457087,
-                                69.6679377097769
-                            ],
-                            [
-                                -140.95875482531267,
-                                69.67604551096919
-                            ],
-                            [
-                                -140.99468743666847,
-                                69.67604551096919
-                            ],
-                            [
-                                -141.03511162444397,
-                                69.6679377097769
-                            ],
-                            [
-                                -141.10697684715555,
-                                69.68415021572378
-                            ],
-                            [
-                                -141.12943472925315,
-                                69.68144899145793
-                            ],
-                            [
-                                -141.13392630567287,
-                                69.68955163248711
-                            ],
-                            [
-                                -141.12045157641376,
-                                69.69765117877927
-                            ],
-                            [
-                                -141.14740103493105,
-                                69.70304915751234
-                            ],
-                            [
-                                -141.16985891702865,
-                                69.70035034000024
-                            ],
-                            [
-                                -141.18782522270652,
-                                69.70574763135394
-                            ],
-                            [
-                                -141.20129995196473,
-                                69.69765117877927
-                            ],
-                            [
-                                -141.22375783406233,
-                                69.70035034000024
-                            ],
-                            [
-                                -141.24172413974023,
-                                69.69495167381193
-                            ],
-                            [
-                                -141.27765675109603,
-                                69.69495167381193
-                            ],
-                            [
-                                -141.29562305677396,
-                                69.70035034000024
-                            ],
-                            [
-                                -141.31808093887156,
-                                69.69765117877927
-                            ],
-                            [
-                                -141.31808093887156,
-                                69.67064065428579
-                            ],
-                            [
-                                -141.29562305677396,
-                                69.67334325467073
-                            ],
-                            [
-                                -141.26418202183694,
-                                69.66523442110562
-                            ],
-                            [
-                                -141.23723256332056,
-                                69.66523442110562
-                            ],
-                            [
-                                -141.25519886899843,
-                                69.65982681112568
-                            ],
-                            [
-                                -141.25070729257874,
-                                69.6517128139951
-                            ],
-                            [
-                                -141.26867359825664,
-                                69.6408893295334
-                            ],
-                            [
-                                -141.30460620961244,
-                                69.6408893295334
-                            ],
-                            [
-                                -141.32257251529032,
-                                69.63547552021261
-                            ],
-                            [
-                                -141.31808093887156,
-                                69.61651633020588
-                            ],
-                            [
-                                -141.28214832751573,
-                                69.61109631541747
-                            ],
-                            [
-                                -141.27765675109603,
-                                69.60296370596754
-                            ],
-                            [
-                                -141.25519886899843,
-                                69.6002521460617
-                            ]
-                        ]
-                    ]
-                ]
-            },
-            "links": [
-                {
-                    "rel": "self",
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-stac/ept/AK_Coastal_2009.json"
-                },
-                {
-                    "rel": "parent",
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-stac/ept/catalog.json"
-                }
-            ],
-            "assets": {
-                "ept.json": {
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-public/AK_Coastal_2009/ept.json",
-                    "title": "entwine",
-                    "description": "The ept.json for accessing data"
-                }
-            },
-            "bbox": [
-                -141.32257251529032,
-                69.6002521460617,
-                -140.95426324889294,
-                69.70574763135394
-            ],
-            "stac_extensions": [
-                "https://stac-extensions.github.io/pointcloud/v1.0.0/schema.json",
-                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
-            ]
-        },
-        {
-            "type": "Feature",
-            "stac_version": "1.0.0",
-            "id": "AK_DeltaJunction_1_2021",
-            "properties": {
-                "description": "A USGS Lidar pointcloud in Entwine/EPT format",
-                "pc:count": 19036249620,
-                "pc:type": "lidar",
-                "pc:encoding": "ept",
-                "pc:schemas": [
-                    {
-                        "name": "X",
-                        "offset": -16214003,
-                        "scale": 0.001,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Y",
-                        "offset": 9351656,
-                        "scale": 0.001,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Z",
-                        "offset": -247,
-                        "scale": 0.001,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Intensity",
-                        "size": 2,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ReturnNumber",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "NumberOfReturns",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ScanDirectionFlag",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "EdgeOfFlightLine",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "Classification",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ScanAngleRank",
-                        "size": 4,
-                        "type": "floating"
-                    },
-                    {
-                        "name": "UserData",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "PointSourceId",
-                        "size": 2,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "GpsTime",
-                        "size": 8,
-                        "type": "floating"
-                    },
-                    {
-                        "name": "ScanChannel",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ClassFlags",
-                        "size": 1,
-                        "type": "unsigned"
-                    }
-                ],
-                "proj:epsg": 3857,
-                "proj:projjson": {
-                    "$schema": "https://proj.org/schemas/v0.5/projjson.schema.json",
-                    "type": "ProjectedCRS",
-                    "name": "WGS 84 / Pseudo-Mercator",
-                    "base_crs": {
-                        "name": "WGS 84",
-                        "datum_ensemble": {
-                            "name": "World Geodetic System 1984 ensemble",
-                            "members": [
-                                {
-                                    "name": "World Geodetic System 1984 (Transit)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1166
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G730)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1152
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G873)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1153
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1150)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1154
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1674)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1155
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1762)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1156
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G2139)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1309
-                                    }
-                                }
-                            ],
-                            "ellipsoid": {
-                                "name": "WGS 84",
-                                "semi_major_axis": 6378137,
-                                "inverse_flattening": 298.257223563
-                            },
-                            "accuracy": "2.0",
-                            "id": {
-                                "authority": "EPSG",
-                                "code": 6326
-                            }
-                        },
-                        "coordinate_system": {
-                            "subtype": "ellipsoidal",
-                            "axis": [
-                                {
-                                    "name": "Geodetic latitude",
-                                    "abbreviation": "Lat",
-                                    "direction": "north",
-                                    "unit": "degree"
-                                },
-                                {
-                                    "name": "Geodetic longitude",
-                                    "abbreviation": "Lon",
-                                    "direction": "east",
-                                    "unit": "degree"
-                                }
-                            ]
-                        },
-                        "id": {
-                            "authority": "EPSG",
-                            "code": 4326
-                        }
-                    },
-                    "conversion": {
-                        "name": "Popular Visualisation Pseudo-Mercator",
-                        "method": {
-                            "name": "Popular Visualisation Pseudo Mercator",
-                            "id": {
-                                "authority": "EPSG",
-                                "code": 1024
-                            }
-                        },
-                        "parameters": [
-                            {
-                                "name": "Latitude of natural origin",
-                                "value": 0,
-                                "unit": "degree",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8801
-                                }
-                            },
-                            {
-                                "name": "Longitude of natural origin",
-                                "value": 0,
-                                "unit": "degree",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8802
-                                }
-                            },
-                            {
-                                "name": "False easting",
-                                "value": 0,
-                                "unit": "metre",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8806
-                                }
-                            },
-                            {
-                                "name": "False northing",
-                                "value": 0,
-                                "unit": "metre",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8807
-                                }
-                            }
-                        ]
-                    },
-                    "coordinate_system": {
-                        "subtype": "Cartesian",
-                        "axis": [
-                            {
-                                "name": "Easting",
-                                "abbreviation": "X",
-                                "direction": "east",
-                                "unit": "metre"
-                            },
-                            {
-                                "name": "Northing",
-                                "abbreviation": "Y",
-                                "direction": "north",
-                                "unit": "metre"
-                            }
-                        ]
-                    },
-                    "scope": "Web mapping and visualisation.",
-                    "area": "World between 85.06°S and 85.06°N.",
-                    "bbox": {
-                        "south_latitude": -85.06,
-                        "west_longitude": -180,
-                        "north_latitude": 85.06,
-                        "east_longitude": 180
-                    },
-                    "id": {
-                        "authority": "EPSG",
-                        "code": 3857
-                    }
-                },
-                "datetime": "2023-01-11T17:08:49.057105Z"
-            },
-            "geometry": {
-                "type": "MultiPolygon",
-                "coordinates": [
-                    [
-                        [
-                            [
-                                -144.72792610886253,
-                                63.628676429466424
-                            ],
-                            [
-                                -144.70995980318463,
-                                63.635586814619806
-                            ],
-                            [
-                                -144.53927989924412,
-                                63.635586814619806
-                            ],
-                            [
-                                -144.52131359356622,
-                                63.628676429466424
-                            ],
-                            [
-                                -144.49436413504984,
-                                63.635586814619806
-                            ],
-                            [
-                                -144.45843152369403,
-                                63.635586814619806
-                            ],
-                            [
-                                -144.44046521801613,
-                                63.628676429466424
-                            ],
-                            [
-                                -144.40453260666035,
-                                63.628676429466424
-                            ],
-                            [
-                                -144.38656630098245,
-                                63.635586814619806
-                            ],
-                            [
-                                -144.33715896036756,
-                                63.63213183221189
-                            ],
-                            [
-                                -144.33266738394784,
-                                63.72526894515126
-                            ],
-                            [
-                                -144.62911142763363,
-                                63.72526894515126
-                            ],
-                            [
-                                -144.63360300405333,
-                                63.7355986310586
-                            ],
-                            [
-                                -144.66055246257065,
-                                63.74248299236702
-                            ],
-                            [
-                                -144.6560608861509,
-                                63.75968656201957
-                            ],
-                            [
-                                -144.68750192108703,
-                                63.783753966418125
-                            ],
-                            [
-                                -144.76385872021834,
-                                63.8009324096157
-                            ],
-                            [
-                                -144.7818250258962,
-                                63.83525791739932
-                            ],
-                            [
-                                -144.75038399096013,
-                                63.85240499164635
-                            ],
-                            [
-                                -144.75038399096013,
-                                63.86611512922075
-                            ],
-                            [
-                                -144.768350296638,
-                                63.87981858341043
-                            ],
-                            [
-                                -144.8222492136717,
-                                63.89351535668987
-                            ],
-                            [
-                                -144.85818182502751,
-                                63.89351535668987
-                            ],
-                            [
-                                -144.8851312835439,
-                                63.90036123876159
-                            ],
-                            [
-                                -144.88962285996362,
-                                63.931147054970744
-                            ],
-                            [
-                                -144.91208074206122,
-                                63.92772807714806
-                            ],
-                            [
-                                -144.9300470477391,
-                                63.93456561581671
-                            ],
-                            [
-                                -144.9255554713194,
-                                63.96531390586004
-                            ],
-                            [
-                                -144.8851312835439,
-                                63.9687282990664
-                            ],
-                            [
-                                -144.88962285996362,
-                                64.11515366225517
-                            ],
-                            [
-                                -145.1142016809378,
-                                64.11515366225517
-                            ],
-                            [
-                                -145.1142016809378,
-                                64.1694415275832
-                            ],
-                            [
-                                -145.13216798661568,
-                                64.17622005070672
-                            ],
-                            [
-                                -145.50496882943276,
-                                64.17283099625855
-                            ],
-                            [
-                                -145.52293513511069,
-                                64.18638472907608
-                            ],
-                            [
-                                -145.518443558691,
-                                64.27094555645363
-                            ],
-                            [
-                                -145.53640986436886,
-                                64.27769926084697
-                            ],
-                            [
-                                -145.96310962421964,
-                                64.27432261518214
-                            ],
-                            [
-                                -145.98107592989754,
-                                64.28107549348687
-                            ],
-                            [
-                                -145.97658435347785,
-                                64.37207779314443
-                            ],
-                            [
-                                -145.99455065915575,
-                                64.37880674864188
-                            ],
-                            [
-                                -146.9332901308271,
-                                64.37544247684284
-                            ],
-                            [
-                                -146.90634067230977,
-                                64.35524819480328
-                            ],
-                            [
-                                -146.90634067230977,
-                                64.34177709798207
-                            ],
-                            [
-                                -146.92430697798767,
-                                64.33503907600137
-                            ],
-                            [
-                                -146.94676486008527,
-                                64.33840829315493
-                            ],
-                            [
-                                -146.97371431860256,
-                                64.33166944648265
-                            ],
-                            [
-                                -146.97371431860256,
-                                64.32492895019432
-                            ],
-                            [
-                                -146.92430697798767,
-                                64.31481511205256
-                            ],
-                            [
-                                -146.91981540156888,
-                                64.3046975605282
-                            ],
-                            [
-                                -146.84345860243758,
-                                64.28782671984719
-                            ],
-                            [
-                                -146.83896702601788,
-                                64.27769926084697
-                            ],
-                            [
-                                -146.77608495614479,
-                                64.26419019965033
-                            ],
-                            [
-                                -146.77159337972597,
-                                64.25405406549773
-                            ],
-                            [
-                                -146.62786293430278,
-                                64.22024008150264
-                            ],
-                            [
-                                -146.6233713578831,
-                                64.21008782122448
-                            ],
-                            [
-                                -146.5470145587518,
-                                64.19315911089731
-                            ],
-                            [
-                                -146.5425229823321,
-                                64.18299691707672
-                            ],
-                            [
-                                -146.4526914539426,
-                                64.16266134739597
-                            ],
-                            [
-                                -146.4481998775229,
-                                64.15248796944236
-                            ],
-                            [
-                                -146.3718430783916,
-                                64.13552404980831
-                            ],
-                            [
-                                -146.36735150197282,
-                                64.12534072249575
-                            ],
-                            [
-                                -146.27751997358334,
-                                64.10496286804042
-                            ],
-                            [
-                                -146.2730283971636,
-                                64.0947683388053
-                            ],
-                            [
-                                -146.19667159803234,
-                                64.07776915386042
-                            ],
-                            [
-                                -146.19218002161264,
-                                64.06756465945716
-                            ],
-                            [
-                                -146.1158232224813,
-                                64.050548859701
-                            ],
-                            [
-                                -146.11133164606252,
-                                64.04033439269274
-                            ],
-                            [
-                                -146.06192430544763,
-                                64.03011618404057
-                            ],
-                            [
-                                -146.05743272902882,
-                                64.01989423269913
-                            ],
-                            [
-                                -145.96760120063843,
-                                63.99943909776668
-                            ],
-                            [
-                                -145.96310962421964,
-                                63.98920591208525
-                            ],
-                            [
-                                -145.91370228360475,
-                                63.97896897953352
-                            ],
-                            [
-                                -145.76098868534305,
-                                64.01989423269913
-                            ],
-                            [
-                                -145.73853080324545,
-                                64.01648608369588
-                            ],
-                            [
-                                -145.72056449756755,
-                                64.02330196573183
-                            ],
-                            [
-                                -145.68463188621175,
-                                64.02330196573183
-                            ],
-                            [
-                                -145.66666558053387,
-                                64.01648608369588
-                            ],
-                            [
-                                -145.67115715695354,
-                                63.99943909776668
-                            ],
-                            [
-                                -145.63073296917807,
-                                63.98920591208525
-                            ],
-                            [
-                                -145.62624139275837,
-                                63.97896897953352
-                            ],
-                            [
-                                -145.59030878140257,
-                                63.97896897953352
-                            ],
-                            [
-                                -145.58581720498285,
-                                63.9687282990664
-                            ],
-                            [
-                                -145.55886774646646,
-                                63.96189909606385
-                            ],
-                            [
-                                -145.53640986436886,
-                                63.96531390586004
-                            ],
-                            [
-                                -145.518443558691,
-                                63.95165216674923
-                            ],
-                            [
-                                -145.4420867595597,
-                                63.93456561581671
-                            ],
-                            [
-                                -145.43759518313996,
-                                63.92430868230995
-                            ],
-                            [
-                                -145.4555614888179,
-                                63.91062693202944
-                            ],
-                            [
-                                -145.49149410017458,
-                                63.90378355379086
-                            ],
-                            [
-                                -145.49598567659336,
-                                63.89351535668987
-                            ],
-                            [
-                                -145.53640986436886,
-                                63.88324340296893
-                            ],
-                            [
-                                -145.53191828794917,
-                                63.804366842762974
-                            ],
-                            [
-                                -145.25344054994127,
-                                63.804366842762974
-                            ],
-                            [
-                                -145.2219995150052,
-                                63.82153273316348
-                            ],
-                            [
-                                -145.2219995150052,
-                                63.83525791739932
-                            ],
-                            [
-                                -145.1995416329076,
-                                63.838688168213
-                            ],
-                            [
-                                -145.1456427158739,
-                                63.8249646564469
-                            ],
-                            [
-                                -145.14115113945508,
-                                63.8146676319159
-                            ],
-                            [
-                                -145.0243701525483,
-                                63.78719049218124
-                            ],
-                            [
-                                -145.0243701525483,
-                                63.78031702201597
-                            ],
-                            [
-                                -145.0513196110647,
-                                63.77344187713996
-                            ],
-                            [
-                                -145.0468280346459,
-                                63.74936567726534
-                            ],
-                            [
-                                -145.0108954232901,
-                                63.74936567726534
-                            ],
-                            [
-                                -144.9839459647728,
-                                63.74248299236702
-                            ],
-                            [
-                                -144.97945438835313,
-                                63.73215582165408
-                            ],
-                            [
-                                -144.87614813070542,
-                                63.708044415545814
-                            ],
-                            [
-                                -144.8716565542857,
-                                63.697704664228006
-                            ],
-                            [
-                                -144.768350296638,
-                                63.67356388986447
-                            ],
-                            [
-                                -144.75038399096013,
-                                63.659759925265526
-                            ],
-                            [
-                                -144.75487556737983,
-                                63.64249551857748
-                            ],
-                            [
-                                -144.72792610886253,
-                                63.628676429466424
-                            ]
-                        ]
-                    ]
-                ]
-            },
-            "links": [
-                {
-                    "rel": "self",
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-stac/ept/AK_DeltaJunction_1_2021.json"
-                },
-                {
-                    "rel": "parent",
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-stac/ept/catalog.json"
-                }
-            ],
-            "assets": {
-                "ept.json": {
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-public/AK_DeltaJunction_1_2021/ept.json",
-                    "title": "entwine",
-                    "description": "The ept.json for accessing data"
-                }
-            },
-            "bbox": [
-                -146.97371431860256,
-                63.628676429466424,
-                -144.33266738394784,
-                64.37880674864188
-            ],
-            "stac_extensions": [
-                "https://stac-extensions.github.io/pointcloud/v1.0.0/schema.json",
-                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
-            ]
-        },
-        {
-            "type": "Feature",
-            "stac_version": "1.0.0",
-            "id": "AK_Fairbanks-NSBorough_2010",
-            "properties": {
-                "description": "A USGS Lidar pointcloud in Entwine/EPT format",
-                "pc:count": 1266097458,
-                "pc:type": "lidar",
-                "pc:encoding": "ept",
-                "pc:schemas": [
-                    {
-                        "name": "X",
-                        "offset": -16426445,
-                        "scale": 0.01,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Y",
-                        "offset": 9564384,
-                        "scale": 0.01,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Z",
-                        "offset": -59,
-                        "scale": 0.01,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Intensity",
-                        "size": 2,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ReturnNumber",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "NumberOfReturns",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ScanDirectionFlag",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "EdgeOfFlightLine",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "Classification",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ScanAngleRank",
-                        "size": 4,
-                        "type": "floating"
-                    },
-                    {
-                        "name": "UserData",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "PointSourceId",
-                        "size": 2,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "GpsTime",
-                        "size": 8,
-                        "type": "floating"
-                    },
-                    {
-                        "name": "OriginId",
-                        "size": 4,
-                        "type": "unsigned"
-                    }
-                ],
-                "proj:epsg": 3857,
-                "proj:projjson": {
-                    "$schema": "https://proj.org/schemas/v0.5/projjson.schema.json",
-                    "type": "ProjectedCRS",
-                    "name": "WGS 84 / Pseudo-Mercator",
-                    "base_crs": {
-                        "name": "WGS 84",
-                        "datum_ensemble": {
-                            "name": "World Geodetic System 1984 ensemble",
-                            "members": [
-                                {
-                                    "name": "World Geodetic System 1984 (Transit)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1166
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G730)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1152
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G873)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1153
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1150)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1154
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1674)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1155
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1762)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1156
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G2139)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1309
-                                    }
-                                }
-                            ],
-                            "ellipsoid": {
-                                "name": "WGS 84",
-                                "semi_major_axis": 6378137,
-                                "inverse_flattening": 298.257223563
-                            },
-                            "accuracy": "2.0",
-                            "id": {
-                                "authority": "EPSG",
-                                "code": 6326
-                            }
-                        },
-                        "coordinate_system": {
-                            "subtype": "ellipsoidal",
-                            "axis": [
-                                {
-                                    "name": "Geodetic latitude",
-                                    "abbreviation": "Lat",
-                                    "direction": "north",
-                                    "unit": "degree"
-                                },
-                                {
-                                    "name": "Geodetic longitude",
-                                    "abbreviation": "Lon",
-                                    "direction": "east",
-                                    "unit": "degree"
-                                }
-                            ]
-                        },
-                        "id": {
-                            "authority": "EPSG",
-                            "code": 4326
-                        }
-                    },
-                    "conversion": {
-                        "name": "Popular Visualisation Pseudo-Mercator",
-                        "method": {
-                            "name": "Popular Visualisation Pseudo Mercator",
-                            "id": {
-                                "authority": "EPSG",
-                                "code": 1024
-                            }
-                        },
-                        "parameters": [
-                            {
-                                "name": "Latitude of natural origin",
-                                "value": 0,
-                                "unit": "degree",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8801
-                                }
-                            },
-                            {
-                                "name": "Longitude of natural origin",
-                                "value": 0,
-                                "unit": "degree",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8802
-                                }
-                            },
-                            {
-                                "name": "False easting",
-                                "value": 0,
-                                "unit": "metre",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8806
-                                }
-                            },
-                            {
-                                "name": "False northing",
-                                "value": 0,
-                                "unit": "metre",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8807
-                                }
-                            }
-                        ]
-                    },
-                    "coordinate_system": {
-                        "subtype": "Cartesian",
-                        "axis": [
-                            {
-                                "name": "Easting",
-                                "abbreviation": "X",
-                                "direction": "east",
-                                "unit": "metre"
-                            },
-                            {
-                                "name": "Northing",
-                                "abbreviation": "Y",
-                                "direction": "north",
-                                "unit": "metre"
-                            }
-                        ]
-                    },
-                    "scope": "Web mapping and visualisation.",
-                    "area": "World between 85.06°S and 85.06°N.",
-                    "bbox": {
-                        "south_latitude": -85.06,
-                        "west_longitude": -180,
-                        "north_latitude": 85.06,
-                        "east_longitude": 180
-                    },
-                    "id": {
-                        "authority": "EPSG",
-                        "code": 3857
-                    }
-                },
-                "datetime": "2023-01-11T17:08:49.059774Z"
-            },
-            "geometry": {
-                "type": "MultiPolygon",
-                "coordinates": [
-                    [
-                        [
-                            [
-                                -147.30828683416289,
-                                64.70559351468782
-                            ],
-                            [
-                                -147.2543879171292,
-                                64.71888626284154
-                            ],
-                            [
-                                -147.2364216114513,
-                                64.73881314865444
-                            ],
-                            [
-                                -147.2139637293537,
-                                64.74213286920721
-                            ],
-                            [
-                                -147.19599742367578,
-                                64.75540767546606
-                            ],
-                            [
-                                -147.2004890000955,
-                                64.77199201531572
-                            ],
-                            [
-                                -147.14209850664213,
-                                64.80844172885374
-                            ],
-                            [
-                                -147.14659008306091,
-                                64.81837401366879
-                            ],
-                            [
-                                -147.2633710699677,
-                                64.84484221285122
-                            ],
-                            [
-                                -147.2633710699677,
-                                64.87128440067615
-                            ],
-                            [
-                                -147.28133737564562,
-                                64.877890885694
-                            ],
-                            [
-                                -147.3711689040351,
-                                64.877890885694
-                            ],
-                            [
-                                -147.38913520971298,
-                                64.87128440067615
-                            ],
-                            [
-                                -147.4385425503279,
-                                64.8745878462236
-                            ],
-                            [
-                                -147.45650885600577,
-                                64.86798054901277
-                            ],
-                            [
-                                -147.47896673810249,
-                                64.87128440067615
-                            ],
-                            [
-                                -147.50591619661978,
-                                64.86467629119447
-                            ],
-                            [
-                                -147.52388250229768,
-                                64.87128440067615
-                            ],
-                            [
-                                -147.52388250229768,
-                                64.88449574655951
-                            ],
-                            [
-                                -147.55981511365346,
-                                64.88449574655951
-                            ],
-                            [
-                                -147.59125614858957,
-                                64.8745878462236
-                            ],
-                            [
-                                -147.64066348920358,
-                                64.877890885694
-                            ],
-                            [
-                                -147.66761294772087,
-                                64.86467629119447
-                            ],
-                            [
-                                -147.71252871191606,
-                                64.877890885694
-                            ],
-                            [
-                                -147.73498659401278,
-                                64.8745878462236
-                            ],
-                            [
-                                -147.76193605253007,
-                                64.88119351912634
-                            ],
-                            [
-                                -147.88320861585566,
-                                64.8514551975935
-                            ],
-                            [
-                                -147.88770019227536,
-                                64.84153511085832
-                            ],
-                            [
-                                -147.93710753288937,
-                                64.8316113659256
-                            ],
-                            [
-                                -147.94159910930904,
-                                64.82168396174407
-                            ],
-                            [
-                                -147.98202329708457,
-                                64.81175289726254
-                            ],
-                            [
-                                -147.98202329708457,
-                                64.79187978319534
-                            ],
-                            [
-                                -147.96405699140664,
-                                64.78525215585204
-                            ],
-                            [
-                                -147.94159910930904,
-                                64.78856617306832
-                            ],
-                            [
-                                -147.91464965079265,
-                                64.78193773150754
-                            ],
-                            [
-                                -147.89668334511475,
-                                64.78856617306832
-                            ],
-                            [
-                                -147.83380127524168,
-                                64.78856617306832
-                            ],
-                            [
-                                -147.81583496956375,
-                                64.78193773150754
-                            ],
-                            [
-                                -147.73947817043248,
-                                64.78525215585204
-                            ],
-                            [
-                                -147.72151186475458,
-                                64.77862289999597
-                            ],
-                            [
-                                -147.6586297948824,
-                                64.77862289999597
-                            ],
-                            [
-                                -147.63168033636506,
-                                64.78525215585204
-                            ],
-                            [
-                                -147.60023930142899,
-                                64.77530766127829
-                            ],
-                            [
-                                -147.5777814193314,
-                                64.77862289999597
-                            ],
-                            [
-                                -147.51939092587799,
-                                64.76204263356894
-                            ],
-                            [
-                                -147.44303412674668,
-                                64.76535950149994
-                            ],
-                            [
-                                -147.4385425503279,
-                                64.75540767546606
-                            ],
-                            [
-                                -147.40260993897118,
-                                64.74877108744927
-                            ],
-                            [
-                                -147.3981183625524,
-                                64.73881314865444
-                            ],
-                            [
-                                -147.3621857511966,
-                                64.73217248449079
-                            ],
-                            [
-                                -147.35769417477692,
-                                64.72220843001637
-                            ],
-                            [
-                                -147.30828683416289,
-                                64.70559351468782
-                            ]
-                        ]
-                    ],
-                    [
-                        [
-                            [
-                                -147.6182056071069,
-                                64.94716097975092
-                            ],
-                            [
-                                -147.60023930142899,
-                                64.95374880582793
-                            ],
-                            [
-                                -147.62718875994537,
-                                64.96033501133589
-                            ],
-                            [
-                                -147.63168033636506,
-                                64.95045509538004
-                            ],
-                            [
-                                -147.6182056071069,
-                                64.94716097975092
-                            ]
-                        ]
-                    ]
-                ]
-            },
-            "links": [
-                {
-                    "rel": "self",
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-stac/ept/AK_Fairbanks-NSBorough_2010.json"
-                },
-                {
-                    "rel": "parent",
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-stac/ept/catalog.json"
-                }
-            ],
-            "assets": {
-                "ept.json": {
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-public/AK_Fairbanks-NSBorough_2010/ept.json",
-                    "title": "entwine",
-                    "description": "The ept.json for accessing data"
-                }
-            },
-            "bbox": [
-                -147.98202329708457,
-                64.70559351468782,
-                -147.14209850664213,
-                64.96033501133589
-            ],
-            "stac_extensions": [
-                "https://stac-extensions.github.io/pointcloud/v1.0.0/schema.json",
-                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
-            ]
-        },
-        {
-            "type": "Feature",
-            "stac_version": "1.0.0",
             "id": "AK_GlacierBay_4_2019",
             "properties": {
                 "description": "A USGS Lidar pointcloud in Entwine/EPT format",
@@ -9814,5836 +7653,30 @@
         {
             "type": "Feature",
             "stac_version": "1.0.0",
-            "id": "AK_NorthSlope_B10_2018",
+            "id": "IA_FullState",
             "properties": {
                 "description": "A USGS Lidar pointcloud in Entwine/EPT format",
-                "pc:count": 148956845,
+                "pc:count": 167692896718,
                 "pc:type": "lidar",
                 "pc:encoding": "ept",
                 "pc:schemas": [
                     {
                         "name": "X",
-                        "offset": -18145629,
+                        "offset": -10396104,
                         "scale": 0.01,
                         "size": 4,
                         "type": "signed"
                     },
                     {
                         "name": "Y",
-                        "offset": 10984879,
+                        "offset": 5155173,
                         "scale": 0.01,
                         "size": 4,
                         "type": "signed"
                     },
                     {
                         "name": "Z",
-                        "offset": 132,
-                        "scale": 0.01,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Intensity",
-                        "size": 2,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ReturnNumber",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "NumberOfReturns",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ScanDirectionFlag",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "EdgeOfFlightLine",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "Classification",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ScanAngleRank",
-                        "size": 4,
-                        "type": "floating"
-                    },
-                    {
-                        "name": "UserData",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "PointSourceId",
-                        "size": 2,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "GpsTime",
-                        "size": 8,
-                        "type": "floating"
-                    },
-                    {
-                        "name": "ScanChannel",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ClassFlags",
-                        "size": 1,
-                        "type": "unsigned"
-                    }
-                ],
-                "proj:epsg": 3857,
-                "proj:projjson": {
-                    "$schema": "https://proj.org/schemas/v0.5/projjson.schema.json",
-                    "type": "ProjectedCRS",
-                    "name": "WGS 84 / Pseudo-Mercator",
-                    "base_crs": {
-                        "name": "WGS 84",
-                        "datum_ensemble": {
-                            "name": "World Geodetic System 1984 ensemble",
-                            "members": [
-                                {
-                                    "name": "World Geodetic System 1984 (Transit)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1166
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G730)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1152
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G873)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1153
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1150)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1154
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1674)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1155
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1762)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1156
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G2139)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1309
-                                    }
-                                }
-                            ],
-                            "ellipsoid": {
-                                "name": "WGS 84",
-                                "semi_major_axis": 6378137,
-                                "inverse_flattening": 298.257223563
-                            },
-                            "accuracy": "2.0",
-                            "id": {
-                                "authority": "EPSG",
-                                "code": 6326
-                            }
-                        },
-                        "coordinate_system": {
-                            "subtype": "ellipsoidal",
-                            "axis": [
-                                {
-                                    "name": "Geodetic latitude",
-                                    "abbreviation": "Lat",
-                                    "direction": "north",
-                                    "unit": "degree"
-                                },
-                                {
-                                    "name": "Geodetic longitude",
-                                    "abbreviation": "Lon",
-                                    "direction": "east",
-                                    "unit": "degree"
-                                }
-                            ]
-                        },
-                        "id": {
-                            "authority": "EPSG",
-                            "code": 4326
-                        }
-                    },
-                    "conversion": {
-                        "name": "Popular Visualisation Pseudo-Mercator",
-                        "method": {
-                            "name": "Popular Visualisation Pseudo Mercator",
-                            "id": {
-                                "authority": "EPSG",
-                                "code": 1024
-                            }
-                        },
-                        "parameters": [
-                            {
-                                "name": "Latitude of natural origin",
-                                "value": 0,
-                                "unit": "degree",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8801
-                                }
-                            },
-                            {
-                                "name": "Longitude of natural origin",
-                                "value": 0,
-                                "unit": "degree",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8802
-                                }
-                            },
-                            {
-                                "name": "False easting",
-                                "value": 0,
-                                "unit": "metre",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8806
-                                }
-                            },
-                            {
-                                "name": "False northing",
-                                "value": 0,
-                                "unit": "metre",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8807
-                                }
-                            }
-                        ]
-                    },
-                    "coordinate_system": {
-                        "subtype": "Cartesian",
-                        "axis": [
-                            {
-                                "name": "Easting",
-                                "abbreviation": "X",
-                                "direction": "east",
-                                "unit": "metre"
-                            },
-                            {
-                                "name": "Northing",
-                                "abbreviation": "Y",
-                                "direction": "north",
-                                "unit": "metre"
-                            }
-                        ]
-                    },
-                    "scope": "Web mapping and visualisation.",
-                    "area": "World between 85.06°S and 85.06°N.",
-                    "bbox": {
-                        "south_latitude": -85.06,
-                        "west_longitude": -180,
-                        "north_latitude": 85.06,
-                        "east_longitude": 180
-                    },
-                    "id": {
-                        "authority": "EPSG",
-                        "code": 3857
-                    }
-                },
-                "datetime": "2023-01-11T17:08:49.088498Z"
-            },
-            "geometry": {
-                "type": "MultiPolygon",
-                "coordinates": [
-                    [
-                        [
-                            [
-                                -162.9704175856436,
-                                69.71807129177486
-                            ],
-                            [
-                                -162.96592600922386,
-                                69.76386614548304
-                            ],
-                            [
-                                -163.00635019699936,
-                                69.76655687322776
-                            ],
-                            [
-                                -163.02431650267727,
-                                69.76117507491972
-                            ],
-                            [
-                                -163.01982492625757,
-                                69.74771457850332
-                            ],
-                            [
-                                -163.03779123193547,
-                                69.74232797888533
-                            ],
-                            [
-                                -163.03779123193547,
-                                69.72615994392949
-                            ],
-                            [
-                                -163.01982492625757,
-                                69.72076785256981
-                            ],
-                            [
-                                -162.99736704416085,
-                                69.7234640699421
-                            ],
-                            [
-                                -162.9704175856436,
-                                69.71807129177486
-                            ]
-                        ]
-                    ]
-                ]
-            },
-            "links": [
-                {
-                    "rel": "self",
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-stac/ept/AK_NorthSlope_B10_2018.json"
-                },
-                {
-                    "rel": "parent",
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-stac/ept/catalog.json"
-                }
-            ],
-            "assets": {
-                "ept.json": {
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-public/AK_NorthSlope_B10_2018/ept.json",
-                    "title": "entwine",
-                    "description": "The ept.json for accessing data"
-                }
-            },
-            "bbox": [
-                -163.03779123193547,
-                69.71807129177486,
-                -162.96592600922386,
-                69.76655687322776
-            ],
-            "stac_extensions": [
-                "https://stac-extensions.github.io/pointcloud/v1.0.0/schema.json",
-                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
-            ]
-        },
-        {
-            "type": "Feature",
-            "stac_version": "1.0.0",
-            "id": "AK_NorthSlope_B11_2018",
-            "properties": {
-                "description": "A USGS Lidar pointcloud in Entwine/EPT format",
-                "pc:count": 122307792,
-                "pc:type": "lidar",
-                "pc:encoding": "ept",
-                "pc:schemas": [
-                    {
-                        "name": "X",
-                        "offset": -18564427,
-                        "scale": 0.01,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Y",
-                        "offset": 10551389,
-                        "scale": 0.01,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Z",
-                        "offset": 222,
-                        "scale": 0.01,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Intensity",
-                        "size": 2,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ReturnNumber",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "NumberOfReturns",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ScanDirectionFlag",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "EdgeOfFlightLine",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "Classification",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ScanAngleRank",
-                        "size": 4,
-                        "type": "floating"
-                    },
-                    {
-                        "name": "UserData",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "PointSourceId",
-                        "size": 2,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "GpsTime",
-                        "size": 8,
-                        "type": "floating"
-                    },
-                    {
-                        "name": "ScanChannel",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ClassFlags",
-                        "size": 1,
-                        "type": "unsigned"
-                    }
-                ],
-                "proj:epsg": 3857,
-                "proj:projjson": {
-                    "$schema": "https://proj.org/schemas/v0.5/projjson.schema.json",
-                    "type": "ProjectedCRS",
-                    "name": "WGS 84 / Pseudo-Mercator",
-                    "base_crs": {
-                        "name": "WGS 84",
-                        "datum_ensemble": {
-                            "name": "World Geodetic System 1984 ensemble",
-                            "members": [
-                                {
-                                    "name": "World Geodetic System 1984 (Transit)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1166
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G730)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1152
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G873)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1153
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1150)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1154
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1674)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1155
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1762)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1156
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G2139)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1309
-                                    }
-                                }
-                            ],
-                            "ellipsoid": {
-                                "name": "WGS 84",
-                                "semi_major_axis": 6378137,
-                                "inverse_flattening": 298.257223563
-                            },
-                            "accuracy": "2.0",
-                            "id": {
-                                "authority": "EPSG",
-                                "code": 6326
-                            }
-                        },
-                        "coordinate_system": {
-                            "subtype": "ellipsoidal",
-                            "axis": [
-                                {
-                                    "name": "Geodetic latitude",
-                                    "abbreviation": "Lat",
-                                    "direction": "north",
-                                    "unit": "degree"
-                                },
-                                {
-                                    "name": "Geodetic longitude",
-                                    "abbreviation": "Lon",
-                                    "direction": "east",
-                                    "unit": "degree"
-                                }
-                            ]
-                        },
-                        "id": {
-                            "authority": "EPSG",
-                            "code": 4326
-                        }
-                    },
-                    "conversion": {
-                        "name": "Popular Visualisation Pseudo-Mercator",
-                        "method": {
-                            "name": "Popular Visualisation Pseudo Mercator",
-                            "id": {
-                                "authority": "EPSG",
-                                "code": 1024
-                            }
-                        },
-                        "parameters": [
-                            {
-                                "name": "Latitude of natural origin",
-                                "value": 0,
-                                "unit": "degree",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8801
-                                }
-                            },
-                            {
-                                "name": "Longitude of natural origin",
-                                "value": 0,
-                                "unit": "degree",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8802
-                                }
-                            },
-                            {
-                                "name": "False easting",
-                                "value": 0,
-                                "unit": "metre",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8806
-                                }
-                            },
-                            {
-                                "name": "False northing",
-                                "value": 0,
-                                "unit": "metre",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8807
-                                }
-                            }
-                        ]
-                    },
-                    "coordinate_system": {
-                        "subtype": "Cartesian",
-                        "axis": [
-                            {
-                                "name": "Easting",
-                                "abbreviation": "X",
-                                "direction": "east",
-                                "unit": "metre"
-                            },
-                            {
-                                "name": "Northing",
-                                "abbreviation": "Y",
-                                "direction": "north",
-                                "unit": "metre"
-                            }
-                        ]
-                    },
-                    "scope": "Web mapping and visualisation.",
-                    "area": "World between 85.06°S and 85.06°N.",
-                    "bbox": {
-                        "south_latitude": -85.06,
-                        "west_longitude": -180,
-                        "north_latitude": 85.06,
-                        "east_longitude": 180
-                    },
-                    "id": {
-                        "authority": "EPSG",
-                        "code": 3857
-                    }
-                },
-                "datetime": "2023-01-11T17:08:49.090605Z"
-            },
-            "geometry": {
-                "type": "MultiPolygon",
-                "coordinates": [
-                    [
-                        [
-                            [
-                                -166.8051981524093,
-                                68.33450388250216
-                            ],
-                            [
-                                -166.7872318467314,
-                                68.34024744304044
-                            ],
-                            [
-                                -166.71087504760007,
-                                68.33737584396701
-                            ],
-                            [
-                                -166.6929087419222,
-                                68.34311867976061
-                            ],
-                            [
-                                -166.6929087419222,
-                                68.3546000038788
-                            ],
-                            [
-                                -166.71087504760007,
-                                68.36033849281992
-                            ],
-                            [
-                                -166.80070657598958,
-                                68.36033849281992
-                            ],
-                            [
-                                -166.827656034506,
-                                68.3546000038788
-                            ],
-                            [
-                                -166.84562234018387,
-                                68.34311867976061
-                            ],
-                            [
-                                -166.8051981524093,
-                                68.33450388250216
-                            ]
-                        ]
-                    ]
-                ]
-            },
-            "links": [
-                {
-                    "rel": "self",
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-stac/ept/AK_NorthSlope_B11_2018.json"
-                },
-                {
-                    "rel": "parent",
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-stac/ept/catalog.json"
-                }
-            ],
-            "assets": {
-                "ept.json": {
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-public/AK_NorthSlope_B11_2018/ept.json",
-                    "title": "entwine",
-                    "description": "The ept.json for accessing data"
-                }
-            },
-            "bbox": [
-                -166.84562234018387,
-                68.33450388250216,
-                -166.6929087419222,
-                68.36033849281992
-            ],
-            "stac_extensions": [
-                "https://stac-extensions.github.io/pointcloud/v1.0.0/schema.json",
-                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
-            ]
-        },
-        {
-            "type": "Feature",
-            "stac_version": "1.0.0",
-            "id": "AK_NorthSlope_B12_2018",
-            "properties": {
-                "description": "A USGS Lidar pointcloud in Entwine/EPT format",
-                "pc:count": 1334154425,
-                "pc:type": "lidar",
-                "pc:encoding": "ept",
-                "pc:schemas": [
-                    {
-                        "name": "X",
-                        "offset": -16888927,
-                        "scale": 0.01,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Y",
-                        "offset": 10491056,
-                        "scale": 0.01,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Z",
-                        "offset": 1325,
-                        "scale": 0.01,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Intensity",
-                        "size": 2,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ReturnNumber",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "NumberOfReturns",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ScanDirectionFlag",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "EdgeOfFlightLine",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "Classification",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ScanAngleRank",
-                        "size": 4,
-                        "type": "floating"
-                    },
-                    {
-                        "name": "UserData",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "PointSourceId",
-                        "size": 2,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "GpsTime",
-                        "size": 8,
-                        "type": "floating"
-                    },
-                    {
-                        "name": "ScanChannel",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ClassFlags",
-                        "size": 1,
-                        "type": "unsigned"
-                    }
-                ],
-                "proj:epsg": 3857,
-                "proj:projjson": {
-                    "$schema": "https://proj.org/schemas/v0.5/projjson.schema.json",
-                    "type": "ProjectedCRS",
-                    "name": "WGS 84 / Pseudo-Mercator",
-                    "base_crs": {
-                        "name": "WGS 84",
-                        "datum_ensemble": {
-                            "name": "World Geodetic System 1984 ensemble",
-                            "members": [
-                                {
-                                    "name": "World Geodetic System 1984 (Transit)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1166
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G730)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1152
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G873)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1153
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1150)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1154
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1674)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1155
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1762)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1156
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G2139)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1309
-                                    }
-                                }
-                            ],
-                            "ellipsoid": {
-                                "name": "WGS 84",
-                                "semi_major_axis": 6378137,
-                                "inverse_flattening": 298.257223563
-                            },
-                            "accuracy": "2.0",
-                            "id": {
-                                "authority": "EPSG",
-                                "code": 6326
-                            }
-                        },
-                        "coordinate_system": {
-                            "subtype": "ellipsoidal",
-                            "axis": [
-                                {
-                                    "name": "Geodetic latitude",
-                                    "abbreviation": "Lat",
-                                    "direction": "north",
-                                    "unit": "degree"
-                                },
-                                {
-                                    "name": "Geodetic longitude",
-                                    "abbreviation": "Lon",
-                                    "direction": "east",
-                                    "unit": "degree"
-                                }
-                            ]
-                        },
-                        "id": {
-                            "authority": "EPSG",
-                            "code": 4326
-                        }
-                    },
-                    "conversion": {
-                        "name": "Popular Visualisation Pseudo-Mercator",
-                        "method": {
-                            "name": "Popular Visualisation Pseudo Mercator",
-                            "id": {
-                                "authority": "EPSG",
-                                "code": 1024
-                            }
-                        },
-                        "parameters": [
-                            {
-                                "name": "Latitude of natural origin",
-                                "value": 0,
-                                "unit": "degree",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8801
-                                }
-                            },
-                            {
-                                "name": "Longitude of natural origin",
-                                "value": 0,
-                                "unit": "degree",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8802
-                                }
-                            },
-                            {
-                                "name": "False easting",
-                                "value": 0,
-                                "unit": "metre",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8806
-                                }
-                            },
-                            {
-                                "name": "False northing",
-                                "value": 0,
-                                "unit": "metre",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8807
-                                }
-                            }
-                        ]
-                    },
-                    "coordinate_system": {
-                        "subtype": "Cartesian",
-                        "axis": [
-                            {
-                                "name": "Easting",
-                                "abbreviation": "X",
-                                "direction": "east",
-                                "unit": "metre"
-                            },
-                            {
-                                "name": "Northing",
-                                "abbreviation": "Y",
-                                "direction": "north",
-                                "unit": "metre"
-                            }
-                        ]
-                    },
-                    "scope": "Web mapping and visualisation.",
-                    "area": "World between 85.06°S and 85.06°N.",
-                    "bbox": {
-                        "south_latitude": -85.06,
-                        "west_longitude": -180,
-                        "north_latitude": 85.06,
-                        "east_longitude": 180
-                    },
-                    "id": {
-                        "authority": "EPSG",
-                        "code": 3857
-                    }
-                },
-                "datetime": "2023-01-11T17:08:49.092555Z"
-            },
-            "geometry": {
-                "type": "MultiPolygon",
-                "coordinates": [
-                    [
-                        [
-                            [
-                                -151.83910633749628,
-                                68.08457821694473
-                            ],
-                            [
-                                -151.67740958639425,
-                                68.08457821694473
-                            ],
-                            [
-                                -151.65944328071635,
-                                68.09038479125705
-                            ],
-                            [
-                                -151.56961175232686,
-                                68.09038479125705
-                            ],
-                            [
-                                -151.56961175232686,
-                                68.20620950793028
-                            ],
-                            [
-                                -151.64596855145814,
-                                68.20909765054883
-                            ],
-                            [
-                                -151.66393485713604,
-                                68.2033210011646
-                            ],
-                            [
-                                -151.86156421959294,
-                                68.2033210011646
-                            ],
-                            [
-                                -151.86605579601266,
-                                68.09038479125705
-                            ],
-                            [
-                                -151.83910633749628,
-                                68.08457821694473
-                            ]
-                        ],
-                        [
-                            [
-                                -151.7672411147846,
-                                68.15416063425741
-                            ],
-                            [
-                                -151.7672411147846,
-                                68.13098987136445
-                            ],
-                            [
-                                -151.74029165626735,
-                                68.12519352990957
-                            ],
-                            [
-                                -151.70435904491157,
-                                68.13098987136445
-                            ],
-                            [
-                                -151.70435904491157,
-                                68.15416063425741
-                            ],
-                            [
-                                -151.7672411147846,
-                                68.15416063425741
-                            ]
-                        ]
-                    ]
-                ]
-            },
-            "links": [
-                {
-                    "rel": "self",
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-stac/ept/AK_NorthSlope_B12_2018.json"
-                },
-                {
-                    "rel": "parent",
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-stac/ept/catalog.json"
-                }
-            ],
-            "assets": {
-                "ept.json": {
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-public/AK_NorthSlope_B12_2018/ept.json",
-                    "title": "entwine",
-                    "description": "The ept.json for accessing data"
-                }
-            },
-            "bbox": [
-                -151.86605579601266,
-                68.08457821694473,
-                -151.56961175232686,
-                68.20909765054883
-            ],
-            "stac_extensions": [
-                "https://stac-extensions.github.io/pointcloud/v1.0.0/schema.json",
-                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
-            ]
-        },
-        {
-            "type": "Feature",
-            "stac_version": "1.0.0",
-            "id": "AK_NorthSlope_B13_2018",
-            "properties": {
-                "description": "A USGS Lidar pointcloud in Entwine/EPT format",
-                "pc:count": 257243550,
-                "pc:type": "lidar",
-                "pc:encoding": "ept",
-                "pc:schemas": [
-                    {
-                        "name": "X",
-                        "offset": -18143006,
-                        "scale": 0.01,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Y",
-                        "offset": 10984717,
-                        "scale": 0.01,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Z",
-                        "offset": 157,
-                        "scale": 0.01,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Intensity",
-                        "size": 2,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ReturnNumber",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "NumberOfReturns",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ScanDirectionFlag",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "EdgeOfFlightLine",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "Classification",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ScanAngleRank",
-                        "size": 4,
-                        "type": "floating"
-                    },
-                    {
-                        "name": "UserData",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "PointSourceId",
-                        "size": 2,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "GpsTime",
-                        "size": 8,
-                        "type": "floating"
-                    },
-                    {
-                        "name": "ScanChannel",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ClassFlags",
-                        "size": 1,
-                        "type": "unsigned"
-                    }
-                ],
-                "proj:epsg": 3857,
-                "proj:projjson": {
-                    "$schema": "https://proj.org/schemas/v0.5/projjson.schema.json",
-                    "type": "ProjectedCRS",
-                    "name": "WGS 84 / Pseudo-Mercator",
-                    "base_crs": {
-                        "name": "WGS 84",
-                        "datum_ensemble": {
-                            "name": "World Geodetic System 1984 ensemble",
-                            "members": [
-                                {
-                                    "name": "World Geodetic System 1984 (Transit)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1166
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G730)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1152
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G873)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1153
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1150)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1154
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1674)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1155
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1762)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1156
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G2139)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1309
-                                    }
-                                }
-                            ],
-                            "ellipsoid": {
-                                "name": "WGS 84",
-                                "semi_major_axis": 6378137,
-                                "inverse_flattening": 298.257223563
-                            },
-                            "accuracy": "2.0",
-                            "id": {
-                                "authority": "EPSG",
-                                "code": 6326
-                            }
-                        },
-                        "coordinate_system": {
-                            "subtype": "ellipsoidal",
-                            "axis": [
-                                {
-                                    "name": "Geodetic latitude",
-                                    "abbreviation": "Lat",
-                                    "direction": "north",
-                                    "unit": "degree"
-                                },
-                                {
-                                    "name": "Geodetic longitude",
-                                    "abbreviation": "Lon",
-                                    "direction": "east",
-                                    "unit": "degree"
-                                }
-                            ]
-                        },
-                        "id": {
-                            "authority": "EPSG",
-                            "code": 4326
-                        }
-                    },
-                    "conversion": {
-                        "name": "Popular Visualisation Pseudo-Mercator",
-                        "method": {
-                            "name": "Popular Visualisation Pseudo Mercator",
-                            "id": {
-                                "authority": "EPSG",
-                                "code": 1024
-                            }
-                        },
-                        "parameters": [
-                            {
-                                "name": "Latitude of natural origin",
-                                "value": 0,
-                                "unit": "degree",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8801
-                                }
-                            },
-                            {
-                                "name": "Longitude of natural origin",
-                                "value": 0,
-                                "unit": "degree",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8802
-                                }
-                            },
-                            {
-                                "name": "False easting",
-                                "value": 0,
-                                "unit": "metre",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8806
-                                }
-                            },
-                            {
-                                "name": "False northing",
-                                "value": 0,
-                                "unit": "metre",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8807
-                                }
-                            }
-                        ]
-                    },
-                    "coordinate_system": {
-                        "subtype": "Cartesian",
-                        "axis": [
-                            {
-                                "name": "Easting",
-                                "abbreviation": "X",
-                                "direction": "east",
-                                "unit": "metre"
-                            },
-                            {
-                                "name": "Northing",
-                                "abbreviation": "Y",
-                                "direction": "north",
-                                "unit": "metre"
-                            }
-                        ]
-                    },
-                    "scope": "Web mapping and visualisation.",
-                    "area": "World between 85.06°S and 85.06°N.",
-                    "bbox": {
-                        "south_latitude": -85.06,
-                        "west_longitude": -180,
-                        "north_latitude": 85.06,
-                        "east_longitude": 180
-                    },
-                    "id": {
-                        "authority": "EPSG",
-                        "code": 3857
-                    }
-                },
-                "datetime": "2023-01-11T17:08:49.094239Z"
-            },
-            "geometry": {
-                "type": "MultiPolygon",
-                "coordinates": [
-                    [
-                        [
-                            [
-                                -162.89995607039046,
-                                69.69199403664939
-                            ],
-                            [
-                                -162.88198976471253,
-                                69.69739345601438
-                            ],
-                            [
-                                -162.85504030619526,
-                                69.69739345601438
-                            ],
-                            [
-                                -162.85504030619526,
-                                69.7728410896319
-                            ],
-                            [
-                                -162.88648134113225,
-                                69.78628558532525
-                            ],
-                            [
-                                -162.94936341100444,
-                                69.78628558532525
-                            ],
-                            [
-                                -163.00326232803818,
-                                69.77553067400514
-                            ],
-                            [
-                                -163.02122863371605,
-                                69.75938802662048
-                            ],
-                            [
-                                -162.98978759877994,
-                                69.75669638552488
-                            ],
-                            [
-                                -162.98978759877994,
-                                69.71897738649945
-                            ],
-                            [
-                                -162.96732971668234,
-                                69.7162805976525
-                            ],
-                            [
-                                -162.93588868174626,
-                                69.69739345601438
-                            ],
-                            [
-                                -162.89995607039046,
-                                69.69199403664939
-                            ]
-                        ]
-                    ],
-                    [
-                        [
-                            [
-                                -163.07512755074976,
-                                69.70549000703213
-                            ],
-                            [
-                                -163.0706359743309,
-                                69.71897738649945
-                            ],
-                            [
-                                -163.08411070358912,
-                                69.72167383189864
-                            ],
-                            [
-                                -163.10207700926705,
-                                69.71088598946459
-                            ],
-                            [
-                                -163.07512755074976,
-                                69.70549000703213
-                            ]
-                        ]
-                    ],
-                    [
-                        [
-                            [
-                                -163.06165282149152,
-                                69.72976110778714
-                            ],
-                            [
-                                -163.04368651581365,
-                                69.73515090849997
-                            ],
-                            [
-                                -163.04817809223331,
-                                69.75400440151012
-                            ],
-                            [
-                                -163.03021178655544,
-                                69.75938802662048
-                            ],
-                            [
-                                -163.04817809223331,
-                                69.76477028020521
-                            ],
-                            [
-                                -163.0706359743309,
-                                69.76207932483469
-                            ],
-                            [
-                                -163.0706359743309,
-                                69.74592639157375
-                            ],
-                            [
-                                -163.08860228000884,
-                                69.74053933632817
-                            ],
-                            [
-                                -163.08411070358912,
-                                69.73245617977302
-                            ],
-                            [
-                                -163.06165282149152,
-                                69.72976110778714
-                            ]
-                        ]
-                    ]
-                ]
-            },
-            "links": [
-                {
-                    "rel": "self",
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-stac/ept/AK_NorthSlope_B13_2018.json"
-                },
-                {
-                    "rel": "parent",
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-stac/ept/catalog.json"
-                }
-            ],
-            "assets": {
-                "ept.json": {
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-public/AK_NorthSlope_B13_2018/ept.json",
-                    "title": "entwine",
-                    "description": "The ept.json for accessing data"
-                }
-            },
-            "bbox": [
-                -163.10207700926705,
-                69.69199403664939,
-                -162.85504030619526,
-                69.78628558532525
-            ],
-            "stac_extensions": [
-                "https://stac-extensions.github.io/pointcloud/v1.0.0/schema.json",
-                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
-            ]
-        },
-        {
-            "type": "Feature",
-            "stac_version": "1.0.0",
-            "id": "AK_NorthSlope_B14_2018",
-            "properties": {
-                "description": "A USGS Lidar pointcloud in Entwine/EPT format",
-                "pc:count": 873026233,
-                "pc:type": "lidar",
-                "pc:encoding": "ept",
-                "pc:schemas": [
-                    {
-                        "name": "X",
-                        "offset": -18524289,
-                        "scale": 0.01,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Y",
-                        "offset": 10537365,
-                        "scale": 0.01,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Z",
-                        "offset": 387,
-                        "scale": 0.01,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Intensity",
-                        "size": 2,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ReturnNumber",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "NumberOfReturns",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ScanDirectionFlag",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "EdgeOfFlightLine",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "Classification",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ScanAngleRank",
-                        "size": 4,
-                        "type": "floating"
-                    },
-                    {
-                        "name": "UserData",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "PointSourceId",
-                        "size": 2,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "GpsTime",
-                        "size": 8,
-                        "type": "floating"
-                    },
-                    {
-                        "name": "ScanChannel",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ClassFlags",
-                        "size": 1,
-                        "type": "unsigned"
-                    }
-                ],
-                "proj:epsg": 3857,
-                "proj:projjson": {
-                    "$schema": "https://proj.org/schemas/v0.5/projjson.schema.json",
-                    "type": "ProjectedCRS",
-                    "name": "WGS 84 / Pseudo-Mercator",
-                    "base_crs": {
-                        "name": "WGS 84",
-                        "datum_ensemble": {
-                            "name": "World Geodetic System 1984 ensemble",
-                            "members": [
-                                {
-                                    "name": "World Geodetic System 1984 (Transit)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1166
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G730)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1152
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G873)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1153
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1150)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1154
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1674)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1155
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1762)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1156
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G2139)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1309
-                                    }
-                                }
-                            ],
-                            "ellipsoid": {
-                                "name": "WGS 84",
-                                "semi_major_axis": 6378137,
-                                "inverse_flattening": 298.257223563
-                            },
-                            "accuracy": "2.0",
-                            "id": {
-                                "authority": "EPSG",
-                                "code": 6326
-                            }
-                        },
-                        "coordinate_system": {
-                            "subtype": "ellipsoidal",
-                            "axis": [
-                                {
-                                    "name": "Geodetic latitude",
-                                    "abbreviation": "Lat",
-                                    "direction": "north",
-                                    "unit": "degree"
-                                },
-                                {
-                                    "name": "Geodetic longitude",
-                                    "abbreviation": "Lon",
-                                    "direction": "east",
-                                    "unit": "degree"
-                                }
-                            ]
-                        },
-                        "id": {
-                            "authority": "EPSG",
-                            "code": 4326
-                        }
-                    },
-                    "conversion": {
-                        "name": "Popular Visualisation Pseudo-Mercator",
-                        "method": {
-                            "name": "Popular Visualisation Pseudo Mercator",
-                            "id": {
-                                "authority": "EPSG",
-                                "code": 1024
-                            }
-                        },
-                        "parameters": [
-                            {
-                                "name": "Latitude of natural origin",
-                                "value": 0,
-                                "unit": "degree",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8801
-                                }
-                            },
-                            {
-                                "name": "Longitude of natural origin",
-                                "value": 0,
-                                "unit": "degree",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8802
-                                }
-                            },
-                            {
-                                "name": "False easting",
-                                "value": 0,
-                                "unit": "metre",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8806
-                                }
-                            },
-                            {
-                                "name": "False northing",
-                                "value": 0,
-                                "unit": "metre",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8807
-                                }
-                            }
-                        ]
-                    },
-                    "coordinate_system": {
-                        "subtype": "Cartesian",
-                        "axis": [
-                            {
-                                "name": "Easting",
-                                "abbreviation": "X",
-                                "direction": "east",
-                                "unit": "metre"
-                            },
-                            {
-                                "name": "Northing",
-                                "abbreviation": "Y",
-                                "direction": "north",
-                                "unit": "metre"
-                            }
-                        ]
-                    },
-                    "scope": "Web mapping and visualisation.",
-                    "area": "World between 85.06°S and 85.06°N.",
-                    "bbox": {
-                        "south_latitude": -85.06,
-                        "west_longitude": -180,
-                        "north_latitude": 85.06,
-                        "east_longitude": 180
-                    },
-                    "id": {
-                        "authority": "EPSG",
-                        "code": 3857
-                    }
-                },
-                "datetime": "2023-01-11T17:08:49.096234Z"
-            },
-            "geometry": {
-                "type": "MultiPolygon",
-                "coordinates": [
-                    [
-                        [
-                            [
-                                -166.05968297435462,
-                                68.21548004406637
-                            ],
-                            [
-                                -165.97883459880455,
-                                68.21548004406637
-                            ],
-                            [
-                                -165.96086829312665,
-                                68.2270257557307
-                            ],
-                            [
-                                -165.96086829312665,
-                                68.28466703482647
-                            ],
-                            [
-                                -165.97883459880455,
-                                68.2904231694905
-                            ],
-                            [
-                                -165.96086829312665,
-                                68.29617785207088
-                            ],
-                            [
-                                -165.97434302238486,
-                                68.29905464892592
-                            ],
-                            [
-                                -165.99230932806273,
-                                68.29330069227193
-                            ],
-                            [
-                                -166.02824193941854,
-                                68.29330069227193
-                            ],
-                            [
-                                -166.05519139793583,
-                                68.29905464892592
-                            ],
-                            [
-                                -166.0821408564522,
-                                68.29330069227193
-                            ],
-                            [
-                                -166.10909031496954,
-                                68.29905464892592
-                            ],
-                            [
-                                -166.13603977348595,
-                                68.29330069227193
-                            ],
-                            [
-                                -166.16298923200324,
-                                68.29905464892592
-                            ],
-                            [
-                                -166.16748080842203,
-                                68.25009971581122
-                            ],
-                            [
-                                -166.149514502745,
-                                68.2385656454896
-                            ],
-                            [
-                                -166.11358189138835,
-                                68.23279642819386
-                            ],
-                            [
-                                -166.10909031496954,
-                                68.22413987371462
-                            ],
-                            [
-                                -166.05968297435462,
-                                68.21548004406637
-                            ]
-                        ]
-                    ],
-                    [
-                        [
-                            [
-                                -166.46392485210782,
-                                68.31343319039048
-                            ],
-                            [
-                                -166.4324838171717,
-                                68.32205596240787
-                            ],
-                            [
-                                -166.11358189138835,
-                                68.3191820677175
-                            ],
-                            [
-                                -166.09561558571042,
-                                68.3249294945014
-                            ],
-                            [
-                                -166.09561558571042,
-                                68.37659111197594
-                            ],
-                            [
-                                -166.1270566206474,
-                                68.38518997672838
-                            ],
-                            [
-                                -166.378584900138,
-                                68.38518997672838
-                            ],
-                            [
-                                -166.3965512058159,
-                                68.37945776204089
-                            ],
-                            [
-                                -166.4459585464299,
-                                68.38232405027888
-                            ],
-                            [
-                                -166.49087431062512,
-                                68.37085672621147
-                            ],
-                            [
-                                -166.51333219272271,
-                                68.37372410004586
-                            ],
-                            [
-                                -166.5672311097564,
-                                68.36225243289947
-                            ],
-                            [
-                                -166.5672311097564,
-                                68.35651442713272
-                            ],
-                            [
-                                -166.5447732276588,
-                                68.35938361106417
-                            ],
-                            [
-                                -166.52680692198092,
-                                68.35364488106595
-                            ],
-                            [
-                                -166.53129849840062,
-                                68.34503406967058
-                            ],
-                            [
-                                -166.558247956917,
-                                68.33929171735966
-                            ],
-                            [
-                                -166.5807058390146,
-                                68.34216307467872
-                            ],
-                            [
-                                -166.59867214469253,
-                                68.35364488106595
-                            ],
-                            [
-                                -166.61214687395068,
-                                68.34503406967058
-                            ],
-                            [
-                                -166.6750289438238,
-                                68.34503406967058
-                            ],
-                            [
-                                -166.6929952495017,
-                                68.35651442713272
-                            ],
-                            [
-                                -166.71994470801812,
-                                68.35077497282566
-                            ],
-                            [
-                                -166.7154531315993,
-                                68.34216307467872
-                            ],
-                            [
-                                -166.688503673082,
-                                68.3364199976742
-                            ],
-                            [
-                                -166.6660457909844,
-                                68.33929171735966
-                            ],
-                            [
-                                -166.6480794853065,
-                                68.33354791558416
-                            ],
-                            [
-                                -166.5851974154343,
-                                68.33354791558416
-                            ],
-                            [
-                                -166.5402816512391,
-                                68.32205596240787
-                            ],
-                            [
-                                -166.5178237691415,
-                                68.3249294945014
-                            ],
-                            [
-                                -166.46392485210782,
-                                68.31343319039048
-                            ]
-                        ]
-                    ],
-                    [
-                        [
-                            [
-                                -166.8412172713446,
-                                68.3364199976742
-                            ],
-                            [
-                                -166.8277425420855,
-                                68.33929171735966
-                            ],
-                            [
-                                -166.8142678128273,
-                                68.35364488106595
-                            ],
-                            [
-                                -166.8367256949249,
-                                68.35077497282566
-                            ],
-                            [
-                                -166.8546920006028,
-                                68.33929171735966
-                            ],
-                            [
-                                -166.8412172713446,
-                                68.3364199976742
-                            ]
-                        ]
-                    ],
-                    [
-                        [
-                            [
-                                -166.7738436250527,
-                                68.35077497282566
-                            ],
-                            [
-                                -166.73341943727718,
-                                68.35364488106595
-                            ],
-                            [
-                                -166.72892786085748,
-                                68.36225243289947
-                            ],
-                            [
-                                -166.6660457909844,
-                                68.37372410004586
-                            ],
-                            [
-                                -166.6660457909844,
-                                68.37945776204089
-                            ],
-                            [
-                                -166.70646997875988,
-                                68.37085672621147
-                            ],
-                            [
-                                -166.72892786085748,
-                                68.37372410004586
-                            ],
-                            [
-                                -166.79630150714937,
-                                68.35938361106417
-                            ],
-                            [
-                                -166.79630150714937,
-                                68.35364488106595
-                            ],
-                            [
-                                -166.7738436250527,
-                                68.35077497282566
-                            ]
-                        ]
-                    ]
-                ]
-            },
-            "links": [
-                {
-                    "rel": "self",
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-stac/ept/AK_NorthSlope_B14_2018.json"
-                },
-                {
-                    "rel": "parent",
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-stac/ept/catalog.json"
-                }
-            ],
-            "assets": {
-                "ept.json": {
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-public/AK_NorthSlope_B14_2018/ept.json",
-                    "title": "entwine",
-                    "description": "The ept.json for accessing data"
-                }
-            },
-            "bbox": [
-                -166.8546920006028,
-                68.21548004406637,
-                -165.96086829312665,
-                68.38518997672838
-            ],
-            "stac_extensions": [
-                "https://stac-extensions.github.io/pointcloud/v1.0.0/schema.json",
-                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
-            ]
-        },
-        {
-            "type": "Feature",
-            "stac_version": "1.0.0",
-            "id": "AK_NorthSlope_B1_2018",
-            "properties": {
-                "description": "A USGS Lidar pointcloud in Entwine/EPT format",
-                "pc:count": 65787971,
-                "pc:type": "lidar",
-                "pc:encoding": "ept",
-                "pc:schemas": [
-                    {
-                        "name": "X",
-                        "offset": -15986993,
-                        "scale": 0.01,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Y",
-                        "offset": 11109197,
-                        "scale": 0.01,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Z",
-                        "offset": 27,
-                        "scale": 0.01,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Intensity",
-                        "size": 2,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ReturnNumber",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "NumberOfReturns",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ScanDirectionFlag",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "EdgeOfFlightLine",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "Classification",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ScanAngleRank",
-                        "size": 4,
-                        "type": "floating"
-                    },
-                    {
-                        "name": "UserData",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "PointSourceId",
-                        "size": 2,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "GpsTime",
-                        "size": 8,
-                        "type": "floating"
-                    },
-                    {
-                        "name": "ScanChannel",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ClassFlags",
-                        "size": 1,
-                        "type": "unsigned"
-                    }
-                ],
-                "proj:epsg": 3857,
-                "proj:projjson": {
-                    "$schema": "https://proj.org/schemas/v0.5/projjson.schema.json",
-                    "type": "ProjectedCRS",
-                    "name": "WGS 84 / Pseudo-Mercator",
-                    "base_crs": {
-                        "name": "WGS 84",
-                        "datum_ensemble": {
-                            "name": "World Geodetic System 1984 ensemble",
-                            "members": [
-                                {
-                                    "name": "World Geodetic System 1984 (Transit)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1166
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G730)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1152
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G873)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1153
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1150)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1154
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1674)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1155
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1762)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1156
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G2139)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1309
-                                    }
-                                }
-                            ],
-                            "ellipsoid": {
-                                "name": "WGS 84",
-                                "semi_major_axis": 6378137,
-                                "inverse_flattening": 298.257223563
-                            },
-                            "accuracy": "2.0",
-                            "id": {
-                                "authority": "EPSG",
-                                "code": 6326
-                            }
-                        },
-                        "coordinate_system": {
-                            "subtype": "ellipsoidal",
-                            "axis": [
-                                {
-                                    "name": "Geodetic latitude",
-                                    "abbreviation": "Lat",
-                                    "direction": "north",
-                                    "unit": "degree"
-                                },
-                                {
-                                    "name": "Geodetic longitude",
-                                    "abbreviation": "Lon",
-                                    "direction": "east",
-                                    "unit": "degree"
-                                }
-                            ]
-                        },
-                        "id": {
-                            "authority": "EPSG",
-                            "code": 4326
-                        }
-                    },
-                    "conversion": {
-                        "name": "Popular Visualisation Pseudo-Mercator",
-                        "method": {
-                            "name": "Popular Visualisation Pseudo Mercator",
-                            "id": {
-                                "authority": "EPSG",
-                                "code": 1024
-                            }
-                        },
-                        "parameters": [
-                            {
-                                "name": "Latitude of natural origin",
-                                "value": 0,
-                                "unit": "degree",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8801
-                                }
-                            },
-                            {
-                                "name": "Longitude of natural origin",
-                                "value": 0,
-                                "unit": "degree",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8802
-                                }
-                            },
-                            {
-                                "name": "False easting",
-                                "value": 0,
-                                "unit": "metre",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8806
-                                }
-                            },
-                            {
-                                "name": "False northing",
-                                "value": 0,
-                                "unit": "metre",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8807
-                                }
-                            }
-                        ]
-                    },
-                    "coordinate_system": {
-                        "subtype": "Cartesian",
-                        "axis": [
-                            {
-                                "name": "Easting",
-                                "abbreviation": "X",
-                                "direction": "east",
-                                "unit": "metre"
-                            },
-                            {
-                                "name": "Northing",
-                                "abbreviation": "Y",
-                                "direction": "north",
-                                "unit": "metre"
-                            }
-                        ]
-                    },
-                    "scope": "Web mapping and visualisation.",
-                    "area": "World between 85.06°S and 85.06°N.",
-                    "bbox": {
-                        "south_latitude": -85.06,
-                        "west_longitude": -180,
-                        "north_latitude": 85.06,
-                        "east_longitude": 180
-                    },
-                    "id": {
-                        "authority": "EPSG",
-                        "code": 3857
-                    }
-                },
-                "datetime": "2023-01-11T17:08:49.097748Z"
-            },
-            "geometry": {
-                "type": "MultiPolygon",
-                "coordinates": [
-                    [
-                        [
-                            [
-                                -143.60949682825785,
-                                70.10636346119495
-                            ],
-                            [
-                                -143.60500525183815,
-                                70.11430359266538
-                            ],
-                            [
-                                -143.57805579332086,
-                                70.11959532419213
-                            ],
-                            [
-                                -143.57805579332086,
-                                70.13017473390622
-                            ],
-                            [
-                                -143.60949682825785,
-                                70.13810574570115
-                            ],
-                            [
-                                -143.64542943961362,
-                                70.13810574570115
-                            ],
-                            [
-                                -143.64992101603335,
-                                70.11430359266538
-                            ],
-                            [
-                                -143.60949682825785,
-                                70.10636346119495
-                            ]
-                        ]
-                    ]
-                ]
-            },
-            "links": [
-                {
-                    "rel": "self",
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-stac/ept/AK_NorthSlope_B1_2018.json"
-                },
-                {
-                    "rel": "parent",
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-stac/ept/catalog.json"
-                }
-            ],
-            "assets": {
-                "ept.json": {
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-public/AK_NorthSlope_B1_2018/ept.json",
-                    "title": "entwine",
-                    "description": "The ept.json for accessing data"
-                }
-            },
-            "bbox": [
-                -143.64992101603335,
-                70.10636346119495,
-                -143.57805579332086,
-                70.13810574570115
-            ],
-            "stac_extensions": [
-                "https://stac-extensions.github.io/pointcloud/v1.0.0/schema.json",
-                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
-            ]
-        },
-        {
-            "type": "Feature",
-            "stac_version": "1.0.0",
-            "id": "AK_NorthSlope_B2_2018",
-            "properties": {
-                "description": "A USGS Lidar pointcloud in Entwine/EPT format",
-                "pc:count": 298602840,
-                "pc:type": "lidar",
-                "pc:encoding": "ept",
-                "pc:schemas": [
-                    {
-                        "name": "X",
-                        "offset": -16809191,
-                        "scale": 0.01,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Y",
-                        "offset": 11138784,
-                        "scale": 0.01,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Z",
-                        "offset": 629,
-                        "scale": 0.01,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Intensity",
-                        "size": 2,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ReturnNumber",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "NumberOfReturns",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ScanDirectionFlag",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "EdgeOfFlightLine",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "Classification",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ScanAngleRank",
-                        "size": 4,
-                        "type": "floating"
-                    },
-                    {
-                        "name": "UserData",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "PointSourceId",
-                        "size": 2,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "GpsTime",
-                        "size": 8,
-                        "type": "floating"
-                    },
-                    {
-                        "name": "ScanChannel",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ClassFlags",
-                        "size": 1,
-                        "type": "unsigned"
-                    }
-                ],
-                "proj:epsg": 3857,
-                "proj:projjson": {
-                    "$schema": "https://proj.org/schemas/v0.5/projjson.schema.json",
-                    "type": "ProjectedCRS",
-                    "name": "WGS 84 / Pseudo-Mercator",
-                    "base_crs": {
-                        "name": "WGS 84",
-                        "datum_ensemble": {
-                            "name": "World Geodetic System 1984 ensemble",
-                            "members": [
-                                {
-                                    "name": "World Geodetic System 1984 (Transit)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1166
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G730)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1152
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G873)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1153
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1150)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1154
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1674)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1155
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1762)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1156
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G2139)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1309
-                                    }
-                                }
-                            ],
-                            "ellipsoid": {
-                                "name": "WGS 84",
-                                "semi_major_axis": 6378137,
-                                "inverse_flattening": 298.257223563
-                            },
-                            "accuracy": "2.0",
-                            "id": {
-                                "authority": "EPSG",
-                                "code": 6326
-                            }
-                        },
-                        "coordinate_system": {
-                            "subtype": "ellipsoidal",
-                            "axis": [
-                                {
-                                    "name": "Geodetic latitude",
-                                    "abbreviation": "Lat",
-                                    "direction": "north",
-                                    "unit": "degree"
-                                },
-                                {
-                                    "name": "Geodetic longitude",
-                                    "abbreviation": "Lon",
-                                    "direction": "east",
-                                    "unit": "degree"
-                                }
-                            ]
-                        },
-                        "id": {
-                            "authority": "EPSG",
-                            "code": 4326
-                        }
-                    },
-                    "conversion": {
-                        "name": "Popular Visualisation Pseudo-Mercator",
-                        "method": {
-                            "name": "Popular Visualisation Pseudo Mercator",
-                            "id": {
-                                "authority": "EPSG",
-                                "code": 1024
-                            }
-                        },
-                        "parameters": [
-                            {
-                                "name": "Latitude of natural origin",
-                                "value": 0,
-                                "unit": "degree",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8801
-                                }
-                            },
-                            {
-                                "name": "Longitude of natural origin",
-                                "value": 0,
-                                "unit": "degree",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8802
-                                }
-                            },
-                            {
-                                "name": "False easting",
-                                "value": 0,
-                                "unit": "metre",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8806
-                                }
-                            },
-                            {
-                                "name": "False northing",
-                                "value": 0,
-                                "unit": "metre",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8807
-                                }
-                            }
-                        ]
-                    },
-                    "coordinate_system": {
-                        "subtype": "Cartesian",
-                        "axis": [
-                            {
-                                "name": "Easting",
-                                "abbreviation": "X",
-                                "direction": "east",
-                                "unit": "metre"
-                            },
-                            {
-                                "name": "Northing",
-                                "abbreviation": "Y",
-                                "direction": "north",
-                                "unit": "metre"
-                            }
-                        ]
-                    },
-                    "scope": "Web mapping and visualisation.",
-                    "area": "World between 85.06°S and 85.06°N.",
-                    "bbox": {
-                        "south_latitude": -85.06,
-                        "west_longitude": -180,
-                        "north_latitude": 85.06,
-                        "east_longitude": 180
-                    },
-                    "id": {
-                        "authority": "EPSG",
-                        "code": 3857
-                    }
-                },
-                "datetime": "2023-01-11T17:08:49.098863Z"
-            },
-            "geometry": {
-                "type": "MultiPolygon",
-                "coordinates": [
-                    [
-                        [
-                            [
-                                -151.02380230268042,
-                                70.18439050297658
-                            ],
-                            [
-                                -150.96990338564672,
-                                70.18439050297658
-                            ],
-                            [
-                                -150.9519370799688,
-                                70.18966433456201
-                            ],
-                            [
-                                -150.9564286563876,
-                                70.23969858350513
-                            ],
-                            [
-                                -151.0507517611968,
-                                70.23706822910995
-                            ],
-                            [
-                                -151.0507517611968,
-                                70.18966433456201
-                            ],
-                            [
-                                -151.02380230268042,
-                                70.18439050297658
-                            ]
-                        ]
-                    ]
-                ]
-            },
-            "links": [
-                {
-                    "rel": "self",
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-stac/ept/AK_NorthSlope_B2_2018.json"
-                },
-                {
-                    "rel": "parent",
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-stac/ept/catalog.json"
-                }
-            ],
-            "assets": {
-                "ept.json": {
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-public/AK_NorthSlope_B2_2018/ept.json",
-                    "title": "entwine",
-                    "description": "The ept.json for accessing data"
-                }
-            },
-            "bbox": [
-                -151.0507517611968,
-                70.18439050297658,
-                -150.9519370799688,
-                70.23969858350513
-            ],
-            "stac_extensions": [
-                "https://stac-extensions.github.io/pointcloud/v1.0.0/schema.json",
-                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
-            ]
-        },
-        {
-            "type": "Feature",
-            "stac_version": "1.0.0",
-            "id": "AK_NorthSlope_B3_2018",
-            "properties": {
-                "description": "A USGS Lidar pointcloud in Entwine/EPT format",
-                "pc:count": 1425929011,
-                "pc:type": "lidar",
-                "pc:encoding": "ept",
-                "pc:schemas": [
-                    {
-                        "name": "X",
-                        "offset": -17466480,
-                        "scale": 0.01,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Y",
-                        "offset": 11379307,
-                        "scale": 0.01,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Z",
-                        "offset": 395,
-                        "scale": 0.01,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Intensity",
-                        "size": 2,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ReturnNumber",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "NumberOfReturns",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ScanDirectionFlag",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "EdgeOfFlightLine",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "Classification",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ScanAngleRank",
-                        "size": 4,
-                        "type": "floating"
-                    },
-                    {
-                        "name": "UserData",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "PointSourceId",
-                        "size": 2,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "GpsTime",
-                        "size": 8,
-                        "type": "floating"
-                    },
-                    {
-                        "name": "ScanChannel",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ClassFlags",
-                        "size": 1,
-                        "type": "unsigned"
-                    }
-                ],
-                "proj:epsg": 3857,
-                "proj:projjson": {
-                    "$schema": "https://proj.org/schemas/v0.5/projjson.schema.json",
-                    "type": "ProjectedCRS",
-                    "name": "WGS 84 / Pseudo-Mercator",
-                    "base_crs": {
-                        "name": "WGS 84",
-                        "datum_ensemble": {
-                            "name": "World Geodetic System 1984 ensemble",
-                            "members": [
-                                {
-                                    "name": "World Geodetic System 1984 (Transit)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1166
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G730)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1152
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G873)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1153
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1150)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1154
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1674)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1155
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1762)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1156
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G2139)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1309
-                                    }
-                                }
-                            ],
-                            "ellipsoid": {
-                                "name": "WGS 84",
-                                "semi_major_axis": 6378137,
-                                "inverse_flattening": 298.257223563
-                            },
-                            "accuracy": "2.0",
-                            "id": {
-                                "authority": "EPSG",
-                                "code": 6326
-                            }
-                        },
-                        "coordinate_system": {
-                            "subtype": "ellipsoidal",
-                            "axis": [
-                                {
-                                    "name": "Geodetic latitude",
-                                    "abbreviation": "Lat",
-                                    "direction": "north",
-                                    "unit": "degree"
-                                },
-                                {
-                                    "name": "Geodetic longitude",
-                                    "abbreviation": "Lon",
-                                    "direction": "east",
-                                    "unit": "degree"
-                                }
-                            ]
-                        },
-                        "id": {
-                            "authority": "EPSG",
-                            "code": 4326
-                        }
-                    },
-                    "conversion": {
-                        "name": "Popular Visualisation Pseudo-Mercator",
-                        "method": {
-                            "name": "Popular Visualisation Pseudo Mercator",
-                            "id": {
-                                "authority": "EPSG",
-                                "code": 1024
-                            }
-                        },
-                        "parameters": [
-                            {
-                                "name": "Latitude of natural origin",
-                                "value": 0,
-                                "unit": "degree",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8801
-                                }
-                            },
-                            {
-                                "name": "Longitude of natural origin",
-                                "value": 0,
-                                "unit": "degree",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8802
-                                }
-                            },
-                            {
-                                "name": "False easting",
-                                "value": 0,
-                                "unit": "metre",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8806
-                                }
-                            },
-                            {
-                                "name": "False northing",
-                                "value": 0,
-                                "unit": "metre",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8807
-                                }
-                            }
-                        ]
-                    },
-                    "coordinate_system": {
-                        "subtype": "Cartesian",
-                        "axis": [
-                            {
-                                "name": "Easting",
-                                "abbreviation": "X",
-                                "direction": "east",
-                                "unit": "metre"
-                            },
-                            {
-                                "name": "Northing",
-                                "abbreviation": "Y",
-                                "direction": "north",
-                                "unit": "metre"
-                            }
-                        ]
-                    },
-                    "scope": "Web mapping and visualisation.",
-                    "area": "World between 85.06°S and 85.06°N.",
-                    "bbox": {
-                        "south_latitude": -85.06,
-                        "west_longitude": -180,
-                        "north_latitude": 85.06,
-                        "east_longitude": 180
-                    },
-                    "id": {
-                        "authority": "EPSG",
-                        "code": 3857
-                    }
-                },
-                "datetime": "2023-01-11T17:08:49.100350Z"
-            },
-            "geometry": {
-                "type": "MultiPolygon",
-                "coordinates": [
-                    [
-                        [
-                            [
-                                -157.37876920868285,
-                                70.45770634340835
-                            ],
-                            [
-                                -157.37876920868285,
-                                70.49410605730766
-                            ],
-                            [
-                                -157.44165127855598,
-                                70.49410605730766
-                            ],
-                            [
-                                -157.46860073707236,
-                                70.4889100901632
-                            ],
-                            [
-                                -157.46860073707236,
-                                70.46291029601005
-                            ],
-                            [
-                                -157.40571866720018,
-                                70.46291029601005
-                            ],
-                            [
-                                -157.37876920868285,
-                                70.45770634340835
-                            ]
-                        ]
-                    ],
-                    [
-                        [
-                            [
-                                -156.8128305798286,
-                                71.21857274463133
-                            ],
-                            [
-                                -156.75893166279488,
-                                71.22858906206305
-                            ],
-                            [
-                                -156.71401589859968,
-                                71.25360733217262
-                            ],
-                            [
-                                -156.6646085579857,
-                                71.26110654285266
-                            ],
-                            [
-                                -156.6196927937905,
-                                71.28608302883511
-                            ],
-                            [
-                                -156.57028545317652,
-                                71.29356971354588
-                            ],
-                            [
-                                -156.56579387675683,
-                                71.30105351028007
-                            ],
-                            [
-                                -156.5433359946601,
-                                71.30354746758934
-                            ],
-                            [
-                                -156.5433359946601,
-                                71.31352008978946
-                            ],
-                            [
-                                -156.52536968898224,
-                                71.32348758248406
-                            ],
-                            [
-                                -156.55681072391832,
-                                71.33593973854528
-                            ],
-                            [
-                                -156.55231914749862,
-                                71.34340718870394
-                            ],
-                            [
-                                -156.50291180688464,
-                                71.35087175745801
-                            ],
-                            [
-                                -156.49842023046492,
-                                71.35833344579324
-                            ],
-                            [
-                                -156.47596234836732,
-                                71.36082003531541
-                            ],
-                            [
-                                -156.45799604268944,
-                                71.3707631947621
-                            ],
-                            [
-                                -156.4085887020754,
-                                71.36330630493696
-                            ],
-                            [
-                                -156.40409712565574,
-                                71.35584653633393
-                            ],
-                            [
-                                -156.36816451429993,
-                                71.35584653633393
-                            ],
-                            [
-                                -156.35019820862206,
-                                71.35087175745801
-                            ],
-                            [
-                                -156.33672347936383,
-                                71.35335930690103
-                            ],
-                            [
-                                -156.34121505578352,
-                                71.3657922546943
-                            ],
-                            [
-                                -156.47147077194765,
-                                71.39311660141851
-                            ],
-                            [
-                                -156.49842023046492,
-                                71.38815141463922
-                            ],
-                            [
-                                -156.51638653614285,
-                                71.37821720679464
-                            ],
-                            [
-                                -156.51638653614285,
-                                71.36827788462368
-                            ],
-                            [
-                                -156.6870664400833,
-                                71.33842920881503
-                            ],
-                            [
-                                -156.69155801650214,
-                                71.33095983717303
-                            ],
-                            [
-                                -156.7948642741507,
-                                71.30853442002352
-                            ],
-                            [
-                                -156.8128305798286,
-                                71.29356971354588
-                            ],
-                            [
-                                -156.8352884619262,
-                                71.29107447291057
-                            ],
-                            [
-                                -156.86672949686232,
-                                71.26860286127959
-                            ],
-                            [
-                                -156.88918737895992,
-                                71.26610440977115
-                            ],
-                            [
-                                -156.920628413896,
-                                71.24860625109073
-                            ],
-                            [
-                                -156.90266210821812,
-                                71.23860023010243
-                            ],
-                            [
-                                -156.8263053090868,
-                                71.2260854655521
-                            ],
-                            [
-                                -156.8128305798286,
-                                71.21857274463133
-                            ]
-                        ]
-                    ]
-                ]
-            },
-            "links": [
-                {
-                    "rel": "self",
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-stac/ept/AK_NorthSlope_B3_2018.json"
-                },
-                {
-                    "rel": "parent",
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-stac/ept/catalog.json"
-                }
-            ],
-            "assets": {
-                "ept.json": {
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-public/AK_NorthSlope_B3_2018/ept.json",
-                    "title": "entwine",
-                    "description": "The ept.json for accessing data"
-                }
-            },
-            "bbox": [
-                -157.46860073707236,
-                70.45770634340835,
-                -156.33672347936383,
-                71.39311660141851
-            ],
-            "stac_extensions": [
-                "https://stac-extensions.github.io/pointcloud/v1.0.0/schema.json",
-                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
-            ]
-        },
-        {
-            "type": "Feature",
-            "stac_version": "1.0.0",
-            "id": "AK_NorthSlope_B4_2018",
-            "properties": {
-                "description": "A USGS Lidar pointcloud in Entwine/EPT format",
-                "pc:count": 245802864,
-                "pc:type": "lidar",
-                "pc:encoding": "ept",
-                "pc:schemas": [
-                    {
-                        "name": "X",
-                        "offset": -17812503,
-                        "scale": 0.01,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Y",
-                        "offset": 11279165,
-                        "scale": 0.01,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Z",
-                        "offset": 47,
-                        "scale": 0.01,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Intensity",
-                        "size": 2,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ReturnNumber",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "NumberOfReturns",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ScanDirectionFlag",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "EdgeOfFlightLine",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "Classification",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ScanAngleRank",
-                        "size": 4,
-                        "type": "floating"
-                    },
-                    {
-                        "name": "UserData",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "PointSourceId",
-                        "size": 2,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "GpsTime",
-                        "size": 8,
-                        "type": "floating"
-                    },
-                    {
-                        "name": "ScanChannel",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ClassFlags",
-                        "size": 1,
-                        "type": "unsigned"
-                    }
-                ],
-                "proj:epsg": 3857,
-                "proj:projjson": {
-                    "$schema": "https://proj.org/schemas/v0.5/projjson.schema.json",
-                    "type": "ProjectedCRS",
-                    "name": "WGS 84 / Pseudo-Mercator",
-                    "base_crs": {
-                        "name": "WGS 84",
-                        "datum_ensemble": {
-                            "name": "World Geodetic System 1984 ensemble",
-                            "members": [
-                                {
-                                    "name": "World Geodetic System 1984 (Transit)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1166
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G730)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1152
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G873)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1153
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1150)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1154
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1674)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1155
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1762)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1156
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G2139)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1309
-                                    }
-                                }
-                            ],
-                            "ellipsoid": {
-                                "name": "WGS 84",
-                                "semi_major_axis": 6378137,
-                                "inverse_flattening": 298.257223563
-                            },
-                            "accuracy": "2.0",
-                            "id": {
-                                "authority": "EPSG",
-                                "code": 6326
-                            }
-                        },
-                        "coordinate_system": {
-                            "subtype": "ellipsoidal",
-                            "axis": [
-                                {
-                                    "name": "Geodetic latitude",
-                                    "abbreviation": "Lat",
-                                    "direction": "north",
-                                    "unit": "degree"
-                                },
-                                {
-                                    "name": "Geodetic longitude",
-                                    "abbreviation": "Lon",
-                                    "direction": "east",
-                                    "unit": "degree"
-                                }
-                            ]
-                        },
-                        "id": {
-                            "authority": "EPSG",
-                            "code": 4326
-                        }
-                    },
-                    "conversion": {
-                        "name": "Popular Visualisation Pseudo-Mercator",
-                        "method": {
-                            "name": "Popular Visualisation Pseudo Mercator",
-                            "id": {
-                                "authority": "EPSG",
-                                "code": 1024
-                            }
-                        },
-                        "parameters": [
-                            {
-                                "name": "Latitude of natural origin",
-                                "value": 0,
-                                "unit": "degree",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8801
-                                }
-                            },
-                            {
-                                "name": "Longitude of natural origin",
-                                "value": 0,
-                                "unit": "degree",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8802
-                                }
-                            },
-                            {
-                                "name": "False easting",
-                                "value": 0,
-                                "unit": "metre",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8806
-                                }
-                            },
-                            {
-                                "name": "False northing",
-                                "value": 0,
-                                "unit": "metre",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8807
-                                }
-                            }
-                        ]
-                    },
-                    "coordinate_system": {
-                        "subtype": "Cartesian",
-                        "axis": [
-                            {
-                                "name": "Easting",
-                                "abbreviation": "X",
-                                "direction": "east",
-                                "unit": "metre"
-                            },
-                            {
-                                "name": "Northing",
-                                "abbreviation": "Y",
-                                "direction": "north",
-                                "unit": "metre"
-                            }
-                        ]
-                    },
-                    "scope": "Web mapping and visualisation.",
-                    "area": "World between 85.06°S and 85.06°N.",
-                    "bbox": {
-                        "south_latitude": -85.06,
-                        "west_longitude": -180,
-                        "north_latitude": 85.06,
-                        "east_longitude": 180
-                    },
-                    "id": {
-                        "authority": "EPSG",
-                        "code": 3857
-                    }
-                },
-                "datetime": "2023-01-11T17:08:49.101646Z"
-            },
-            "geometry": {
-                "type": "MultiPolygon",
-                "coordinates": [
-                    [
-                        [
-                            [
-                                -160.04392036865232,
-                                70.6167008389315
-                            ],
-                            [
-                                -159.999004604458,
-                                70.62702601185843
-                            ],
-                            [
-                                -159.94959726384312,
-                                70.61928262813191
-                            ],
-                            [
-                                -159.94959726384312,
-                                70.65539297342012
-                            ],
-                            [
-                                -160.01247933371621,
-                                70.65539297342012
-                            ],
-                            [
-                                -160.03942879223354,
-                                70.6502383168516
-                            ],
-                            [
-                                -160.0573950979114,
-                                70.63476642055291
-                            ],
-                            [
-                                -160.0843445564278,
-                                70.6296064785996
-                            ],
-                            [
-                                -160.07985298000813,
-                                70.62186408666184
-                            ],
-                            [
-                                -160.04392036865232,
-                                70.6167008389315
-                            ]
-                        ]
-                    ]
-                ]
-            },
-            "links": [
-                {
-                    "rel": "self",
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-stac/ept/AK_NorthSlope_B4_2018.json"
-                },
-                {
-                    "rel": "parent",
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-stac/ept/catalog.json"
-                }
-            ],
-            "assets": {
-                "ept.json": {
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-public/AK_NorthSlope_B4_2018/ept.json",
-                    "title": "entwine",
-                    "description": "The ept.json for accessing data"
-                }
-            },
-            "bbox": [
-                -160.0843445564278,
-                70.6167008389315,
-                -159.94959726384312,
-                70.65539297342012
-            ],
-            "stac_extensions": [
-                "https://stac-extensions.github.io/pointcloud/v1.0.0/schema.json",
-                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
-            ]
-        },
-        {
-            "type": "Feature",
-            "stac_version": "1.0.0",
-            "id": "AK_NorthSlope_B5_2018",
-            "properties": {
-                "description": "A USGS Lidar pointcloud in Entwine/EPT format",
-                "pc:count": 105090115,
-                "pc:type": "lidar",
-                "pc:encoding": "ept",
-                "pc:schemas": [
-                    {
-                        "name": "X",
-                        "offset": -15993643,
-                        "scale": 0.01,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Y",
-                        "offset": 11104356,
-                        "scale": 0.01,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Z",
-                        "offset": 460,
-                        "scale": 0.01,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Intensity",
-                        "size": 2,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ReturnNumber",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "NumberOfReturns",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ScanDirectionFlag",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "EdgeOfFlightLine",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "Classification",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ScanAngleRank",
-                        "size": 4,
-                        "type": "floating"
-                    },
-                    {
-                        "name": "UserData",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "PointSourceId",
-                        "size": 2,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "GpsTime",
-                        "size": 8,
-                        "type": "floating"
-                    },
-                    {
-                        "name": "ScanChannel",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ClassFlags",
-                        "size": 1,
-                        "type": "unsigned"
-                    }
-                ],
-                "proj:epsg": 3857,
-                "proj:projjson": {
-                    "$schema": "https://proj.org/schemas/v0.5/projjson.schema.json",
-                    "type": "ProjectedCRS",
-                    "name": "WGS 84 / Pseudo-Mercator",
-                    "base_crs": {
-                        "name": "WGS 84",
-                        "datum_ensemble": {
-                            "name": "World Geodetic System 1984 ensemble",
-                            "members": [
-                                {
-                                    "name": "World Geodetic System 1984 (Transit)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1166
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G730)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1152
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G873)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1153
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1150)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1154
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1674)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1155
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1762)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1156
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G2139)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1309
-                                    }
-                                }
-                            ],
-                            "ellipsoid": {
-                                "name": "WGS 84",
-                                "semi_major_axis": 6378137,
-                                "inverse_flattening": 298.257223563
-                            },
-                            "accuracy": "2.0",
-                            "id": {
-                                "authority": "EPSG",
-                                "code": 6326
-                            }
-                        },
-                        "coordinate_system": {
-                            "subtype": "ellipsoidal",
-                            "axis": [
-                                {
-                                    "name": "Geodetic latitude",
-                                    "abbreviation": "Lat",
-                                    "direction": "north",
-                                    "unit": "degree"
-                                },
-                                {
-                                    "name": "Geodetic longitude",
-                                    "abbreviation": "Lon",
-                                    "direction": "east",
-                                    "unit": "degree"
-                                }
-                            ]
-                        },
-                        "id": {
-                            "authority": "EPSG",
-                            "code": 4326
-                        }
-                    },
-                    "conversion": {
-                        "name": "Popular Visualisation Pseudo-Mercator",
-                        "method": {
-                            "name": "Popular Visualisation Pseudo Mercator",
-                            "id": {
-                                "authority": "EPSG",
-                                "code": 1024
-                            }
-                        },
-                        "parameters": [
-                            {
-                                "name": "Latitude of natural origin",
-                                "value": 0,
-                                "unit": "degree",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8801
-                                }
-                            },
-                            {
-                                "name": "Longitude of natural origin",
-                                "value": 0,
-                                "unit": "degree",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8802
-                                }
-                            },
-                            {
-                                "name": "False easting",
-                                "value": 0,
-                                "unit": "metre",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8806
-                                }
-                            },
-                            {
-                                "name": "False northing",
-                                "value": 0,
-                                "unit": "metre",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8807
-                                }
-                            }
-                        ]
-                    },
-                    "coordinate_system": {
-                        "subtype": "Cartesian",
-                        "axis": [
-                            {
-                                "name": "Easting",
-                                "abbreviation": "X",
-                                "direction": "east",
-                                "unit": "metre"
-                            },
-                            {
-                                "name": "Northing",
-                                "abbreviation": "Y",
-                                "direction": "north",
-                                "unit": "metre"
-                            }
-                        ]
-                    },
-                    "scope": "Web mapping and visualisation.",
-                    "area": "World between 85.06°S and 85.06°N.",
-                    "bbox": {
-                        "south_latitude": -85.06,
-                        "west_longitude": -180,
-                        "north_latitude": 85.06,
-                        "east_longitude": 180
-                    },
-                    "id": {
-                        "authority": "EPSG",
-                        "code": 3857
-                    }
-                },
-                "datetime": "2023-01-11T17:08:49.102999Z"
-            },
-            "geometry": {
-                "type": "MultiPolygon",
-                "coordinates": [
-                    [
-                        [
-                            [
-                                -143.6658934211138,
-                                70.07806486779106
-                            ],
-                            [
-                                -143.6479271154359,
-                                70.08336585145338
-                            ],
-                            [
-                                -143.6479271154359,
-                                70.09396375928054
-                            ],
-                            [
-                                -143.6119945040801,
-                                70.09926068404593
-                            ],
-                            [
-                                -143.5940281984022,
-                                70.1151433453493
-                            ],
-                            [
-                                -143.62546923333832,
-                                70.12308011429919
-                            ],
-                            [
-                                -143.62546923333832,
-                                70.13894453385645
-                            ],
-                            [
-                                -143.71530076172868,
-                                70.13894453385645
-                            ],
-                            [
-                                -143.7467417966648,
-                                70.13101384346398
-                            ],
-                            [
-                                -143.7467417966648,
-                                70.1151433453493
-                            ],
-                            [
-                                -143.7063176088893,
-                                70.10720353560257
-                            ],
-                            [
-                                -143.6883513032114,
-                                70.09661239072766
-                            ],
-                            [
-                                -143.6928428796311,
-                                70.08336585145338
-                            ],
-                            [
-                                -143.6658934211138,
-                                70.07806486779106
-                            ]
-                        ]
-                    ]
-                ]
-            },
-            "links": [
-                {
-                    "rel": "self",
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-stac/ept/AK_NorthSlope_B5_2018.json"
-                },
-                {
-                    "rel": "parent",
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-stac/ept/catalog.json"
-                }
-            ],
-            "assets": {
-                "ept.json": {
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-public/AK_NorthSlope_B5_2018/ept.json",
-                    "title": "entwine",
-                    "description": "The ept.json for accessing data"
-                }
-            },
-            "bbox": [
-                -143.7467417966648,
-                70.07806486779106,
-                -143.5940281984022,
-                70.13894453385645
-            ],
-            "stac_extensions": [
-                "https://stac-extensions.github.io/pointcloud/v1.0.0/schema.json",
-                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
-            ]
-        },
-        {
-            "type": "Feature",
-            "stac_version": "1.0.0",
-            "id": "AK_NorthSlope_B6_2018",
-            "properties": {
-                "description": "A USGS Lidar pointcloud in Entwine/EPT format",
-                "pc:count": 1130865095,
-                "pc:type": "lidar",
-                "pc:encoding": "ept",
-                "pc:schemas": [
-                    {
-                        "name": "X",
-                        "offset": -16661969,
-                        "scale": 0.01,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Y",
-                        "offset": 11144724,
-                        "scale": 0.01,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Z",
-                        "offset": 622,
-                        "scale": 0.01,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Intensity",
-                        "size": 2,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ReturnNumber",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "NumberOfReturns",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ScanDirectionFlag",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "EdgeOfFlightLine",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "Classification",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ScanAngleRank",
-                        "size": 4,
-                        "type": "floating"
-                    },
-                    {
-                        "name": "UserData",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "PointSourceId",
-                        "size": 2,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "GpsTime",
-                        "size": 8,
-                        "type": "floating"
-                    },
-                    {
-                        "name": "ScanChannel",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ClassFlags",
-                        "size": 1,
-                        "type": "unsigned"
-                    }
-                ],
-                "proj:epsg": 3857,
-                "proj:projjson": {
-                    "$schema": "https://proj.org/schemas/v0.5/projjson.schema.json",
-                    "type": "ProjectedCRS",
-                    "name": "WGS 84 / Pseudo-Mercator",
-                    "base_crs": {
-                        "name": "WGS 84",
-                        "datum_ensemble": {
-                            "name": "World Geodetic System 1984 ensemble",
-                            "members": [
-                                {
-                                    "name": "World Geodetic System 1984 (Transit)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1166
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G730)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1152
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G873)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1153
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1150)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1154
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1674)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1155
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1762)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1156
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G2139)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1309
-                                    }
-                                }
-                            ],
-                            "ellipsoid": {
-                                "name": "WGS 84",
-                                "semi_major_axis": 6378137,
-                                "inverse_flattening": 298.257223563
-                            },
-                            "accuracy": "2.0",
-                            "id": {
-                                "authority": "EPSG",
-                                "code": 6326
-                            }
-                        },
-                        "coordinate_system": {
-                            "subtype": "ellipsoidal",
-                            "axis": [
-                                {
-                                    "name": "Geodetic latitude",
-                                    "abbreviation": "Lat",
-                                    "direction": "north",
-                                    "unit": "degree"
-                                },
-                                {
-                                    "name": "Geodetic longitude",
-                                    "abbreviation": "Lon",
-                                    "direction": "east",
-                                    "unit": "degree"
-                                }
-                            ]
-                        },
-                        "id": {
-                            "authority": "EPSG",
-                            "code": 4326
-                        }
-                    },
-                    "conversion": {
-                        "name": "Popular Visualisation Pseudo-Mercator",
-                        "method": {
-                            "name": "Popular Visualisation Pseudo Mercator",
-                            "id": {
-                                "authority": "EPSG",
-                                "code": 1024
-                            }
-                        },
-                        "parameters": [
-                            {
-                                "name": "Latitude of natural origin",
-                                "value": 0,
-                                "unit": "degree",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8801
-                                }
-                            },
-                            {
-                                "name": "Longitude of natural origin",
-                                "value": 0,
-                                "unit": "degree",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8802
-                                }
-                            },
-                            {
-                                "name": "False easting",
-                                "value": 0,
-                                "unit": "metre",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8806
-                                }
-                            },
-                            {
-                                "name": "False northing",
-                                "value": 0,
-                                "unit": "metre",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8807
-                                }
-                            }
-                        ]
-                    },
-                    "coordinate_system": {
-                        "subtype": "Cartesian",
-                        "axis": [
-                            {
-                                "name": "Easting",
-                                "abbreviation": "X",
-                                "direction": "east",
-                                "unit": "metre"
-                            },
-                            {
-                                "name": "Northing",
-                                "abbreviation": "Y",
-                                "direction": "north",
-                                "unit": "metre"
-                            }
-                        ]
-                    },
-                    "scope": "Web mapping and visualisation.",
-                    "area": "World between 85.06°S and 85.06°N.",
-                    "bbox": {
-                        "south_latitude": -85.06,
-                        "west_longitude": -180,
-                        "north_latitude": 85.06,
-                        "east_longitude": 180
-                    },
-                    "id": {
-                        "authority": "EPSG",
-                        "code": 3857
-                    }
-                },
-                "datetime": "2023-01-11T17:08:49.104596Z"
-            },
-            "geometry": {
-                "type": "MultiPolygon",
-                "coordinates": [
-                    [
-                        [
-                            [
-                                -148.52511866738382,
-                                70.15026991920678
-                            ],
-                            [
-                                -148.39037137480005,
-                                70.15026991920678
-                            ],
-                            [
-                                -148.37240506912124,
-                                70.15555246605159
-                            ],
-                            [
-                                -148.33647245776544,
-                                70.15026991920678
-                            ],
-                            [
-                                -148.30952299924905,
-                                70.15555246605159
-                            ],
-                            [
-                                -148.30503142282936,
-                                70.18985614783097
-                            ],
-                            [
-                                -148.25113250579565,
-                                70.18985614783097
-                            ],
-                            [
-                                -148.25113250579565,
-                                70.23199793344281
-                            ],
-                            [
-                                -148.30503142282936,
-                                70.23199793344281
-                            ],
-                            [
-                                -148.30952299924905,
-                                70.26617475205197
-                            ],
-                            [
-                                -148.52062709096413,
-                                70.26880138700162
-                            ],
-                            [
-                                -148.54757654948145,
-                                70.26354778138085
-                            ],
-                            [
-                                -148.55206812590114,
-                                70.16083366372317
-                            ],
-                            [
-                                -148.52511866738382,
-                                70.15026991920678
-                            ]
-                        ]
-                    ],
-                    [
-                        [
-                            [
-                                -151.07184249722937,
-                                70.17930723515845
-                            ],
-                            [
-                                -151.04489303871205,
-                                70.17930723515845
-                            ],
-                            [
-                                -151.02692673303417,
-                                70.1845823652576
-                            ],
-                            [
-                                -150.9909941216784,
-                                70.1845823652576
-                            ],
-                            [
-                                -150.97302781600047,
-                                70.17930723515845
-                            ],
-                            [
-                                -150.91014574612737,
-                                70.17930723515845
-                            ],
-                            [
-                                -150.89217944044947,
-                                70.1845823652576
-                            ],
-                            [
-                                -150.86972155835275,
-                                70.18194496866744
-                            ],
-                            [
-                                -150.86972155835275,
-                                70.19776429573648
-                            ],
-                            [
-                                -150.851755252674,
-                                70.20303471080696
-                            ],
-                            [
-                                -150.77539845354357,
-                                70.20039967160008
-                            ],
-                            [
-                                -150.77539845354357,
-                                70.24251992555254
-                            ],
-                            [
-                                -150.86522998193308,
-                                70.24777890510981
-                            ],
-                            [
-                                -150.86522998193308,
-                                70.25829283272463
-                            ],
-                            [
-                                -150.88319628761096,
-                                70.26354778138085
-                            ],
-                            [
-                                -151.05387619155144,
-                                70.26354778138085
-                            ],
-                            [
-                                -151.07184249722937,
-                                70.25829283272463
-                            ],
-                            [
-                                -151.09430037932606,
-                                70.26092047495086
-                            ],
-                            [
-                                -151.09879195574575,
-                                70.1845823652576
-                            ],
-                            [
-                                -151.07184249722937,
-                                70.17930723515845
-                            ]
-                        ],
-                        [
-                            [
-                                -151.02692673303417,
-                                70.23199793344281
-                            ],
-                            [
-                                -151.03141830945384,
-                                70.19776429573648
-                            ],
-                            [
-                                -150.9909941216784,
-                                70.19512858317871
-                            ],
-                            [
-                                -150.97302781600047,
-                                70.20039967160008
-                            ],
-                            [
-                                -150.97302781600047,
-                                70.23199793344281
-                            ],
-                            [
-                                -151.02692673303417,
-                                70.23199793344281
-                            ]
-                        ]
-                    ],
-                    [
-                        [
-                            [
-                                -148.55206812590114,
-                                70.2714276862669
-                            ],
-                            [
-                                -148.4981692088674,
-                                70.2714276862669
-                            ],
-                            [
-                                -148.46672817393045,
-                                70.27930457033298
-                            ],
-                            [
-                                -148.46672817393045,
-                                70.30029483372884
-                            ],
-                            [
-                                -148.4981692088674,
-                                70.31340285197926
-                            ],
-                            [
-                                -148.52511866738382,
-                                70.30816065008695
-                            ],
-                            [
-                                -148.55206812590114,
-                                70.31340285197926
-                            ],
-                            [
-                                -148.56554285515932,
-                                70.31078191857618
-                            ],
-                            [
-                                -148.56554285515932,
-                                70.27405364988579
-                            ],
-                            [
-                                -148.55206812590114,
-                                70.2714276862669
-                            ]
-                        ]
-                    ]
-                ]
-            },
-            "links": [
-                {
-                    "rel": "self",
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-stac/ept/AK_NorthSlope_B6_2018.json"
-                },
-                {
-                    "rel": "parent",
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-stac/ept/catalog.json"
-                }
-            ],
-            "assets": {
-                "ept.json": {
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-public/AK_NorthSlope_B6_2018/ept.json",
-                    "title": "entwine",
-                    "description": "The ept.json for accessing data"
-                }
-            },
-            "bbox": [
-                -151.09879195574575,
-                70.15026991920678,
-                -148.25113250579565,
-                70.31340285197926
-            ],
-            "stac_extensions": [
-                "https://stac-extensions.github.io/pointcloud/v1.0.0/schema.json",
-                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
-            ]
-        },
-        {
-            "type": "Feature",
-            "stac_version": "1.0.0",
-            "id": "AK_NorthSlope_B7_2018",
-            "properties": {
-                "description": "A USGS Lidar pointcloud in Entwine/EPT format",
-                "pc:count": 1936889647,
-                "pc:type": "lidar",
-                "pc:encoding": "ept",
-                "pc:schemas": [
-                    {
-                        "name": "X",
-                        "offset": -17465713,
-                        "scale": 0.01,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Y",
-                        "offset": 11359703,
-                        "scale": 0.01,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Z",
-                        "offset": 491,
-                        "scale": 0.01,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Intensity",
-                        "size": 2,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ReturnNumber",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "NumberOfReturns",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ScanDirectionFlag",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "EdgeOfFlightLine",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "Classification",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ScanAngleRank",
-                        "size": 4,
-                        "type": "floating"
-                    },
-                    {
-                        "name": "UserData",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "PointSourceId",
-                        "size": 2,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "GpsTime",
-                        "size": 8,
-                        "type": "floating"
-                    },
-                    {
-                        "name": "ScanChannel",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ClassFlags",
-                        "size": 1,
-                        "type": "unsigned"
-                    }
-                ],
-                "proj:epsg": 3857,
-                "proj:projjson": {
-                    "$schema": "https://proj.org/schemas/v0.5/projjson.schema.json",
-                    "type": "ProjectedCRS",
-                    "name": "WGS 84 / Pseudo-Mercator",
-                    "base_crs": {
-                        "name": "WGS 84",
-                        "datum_ensemble": {
-                            "name": "World Geodetic System 1984 ensemble",
-                            "members": [
-                                {
-                                    "name": "World Geodetic System 1984 (Transit)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1166
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G730)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1152
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G873)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1153
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1150)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1154
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1674)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1155
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1762)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1156
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G2139)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1309
-                                    }
-                                }
-                            ],
-                            "ellipsoid": {
-                                "name": "WGS 84",
-                                "semi_major_axis": 6378137,
-                                "inverse_flattening": 298.257223563
-                            },
-                            "accuracy": "2.0",
-                            "id": {
-                                "authority": "EPSG",
-                                "code": 6326
-                            }
-                        },
-                        "coordinate_system": {
-                            "subtype": "ellipsoidal",
-                            "axis": [
-                                {
-                                    "name": "Geodetic latitude",
-                                    "abbreviation": "Lat",
-                                    "direction": "north",
-                                    "unit": "degree"
-                                },
-                                {
-                                    "name": "Geodetic longitude",
-                                    "abbreviation": "Lon",
-                                    "direction": "east",
-                                    "unit": "degree"
-                                }
-                            ]
-                        },
-                        "id": {
-                            "authority": "EPSG",
-                            "code": 4326
-                        }
-                    },
-                    "conversion": {
-                        "name": "Popular Visualisation Pseudo-Mercator",
-                        "method": {
-                            "name": "Popular Visualisation Pseudo Mercator",
-                            "id": {
-                                "authority": "EPSG",
-                                "code": 1024
-                            }
-                        },
-                        "parameters": [
-                            {
-                                "name": "Latitude of natural origin",
-                                "value": 0,
-                                "unit": "degree",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8801
-                                }
-                            },
-                            {
-                                "name": "Longitude of natural origin",
-                                "value": 0,
-                                "unit": "degree",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8802
-                                }
-                            },
-                            {
-                                "name": "False easting",
-                                "value": 0,
-                                "unit": "metre",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8806
-                                }
-                            },
-                            {
-                                "name": "False northing",
-                                "value": 0,
-                                "unit": "metre",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8807
-                                }
-                            }
-                        ]
-                    },
-                    "coordinate_system": {
-                        "subtype": "Cartesian",
-                        "axis": [
-                            {
-                                "name": "Easting",
-                                "abbreviation": "X",
-                                "direction": "east",
-                                "unit": "metre"
-                            },
-                            {
-                                "name": "Northing",
-                                "abbreviation": "Y",
-                                "direction": "north",
-                                "unit": "metre"
-                            }
-                        ]
-                    },
-                    "scope": "Web mapping and visualisation.",
-                    "area": "World between 85.06°S and 85.06°N.",
-                    "bbox": {
-                        "south_latitude": -85.06,
-                        "west_longitude": -180,
-                        "north_latitude": 85.06,
-                        "east_longitude": 180
-                    },
-                    "id": {
-                        "authority": "EPSG",
-                        "code": 3857
-                    }
-                },
-                "datetime": "2023-01-11T17:08:49.106497Z"
-            },
-            "geometry": {
-                "type": "MultiPolygon",
-                "coordinates": [
-                    [
-                        [
-                            [
-                                -157.5136230414935,
-                                70.42323366381925
-                            ],
-                            [
-                                -157.4956567358156,
-                                70.42844643664772
-                            ],
-                            [
-                                -157.4597241244598,
-                                70.42844643664772
-                            ],
-                            [
-                                -157.4417578187819,
-                                70.42323366381925
-                            ],
-                            [
-                                -157.35192629039238,
-                                70.42323366381925
-                            ],
-                            [
-                                -157.33395998471454,
-                                70.42844643664772
-                            ],
-                            [
-                                -157.2845526441005,
-                                70.42584021695554
-                            ],
-                            [
-                                -157.2845526441005,
-                                70.53501480853447
-                            ],
-                            [
-                                -157.5630303821075,
-                                70.53501480853447
-                            ],
-                            [
-                                -157.56752195852718,
-                                70.42844643664772
-                            ],
-                            [
-                                -157.5136230414935,
-                                70.42323366381925
-                            ]
-                        ],
-                        [
-                            [
-                                -157.42828308952372,
-                                70.48310009064296
-                            ],
-                            [
-                                -157.4552325480401,
-                                70.48829754476101
-                            ],
-                            [
-                                -157.4597241244598,
-                                70.4701006337684
-                            ],
-                            [
-                                -157.4417578187819,
-                                70.4648985216048
-                            ],
-                            [
-                                -157.40582520742612,
-                                70.4648985216048
-                            ],
-                            [
-                                -157.3878589017482,
-                                70.4701006337684
-                            ],
-                            [
-                                -157.3878589017482,
-                                70.48050086466583
-                            ],
-                            [
-                                -157.40582520742612,
-                                70.48569898399562
-                            ],
-                            [
-                                -157.42828308952372,
-                                70.48310009064296
-                            ]
-                        ]
-                    ],
-                    [
-                        [
-                            [
-                                -157.01505805893112,
-                                71.08729651669765
-                            ],
-                            [
-                                -156.90726022486373,
-                                71.08729651669765
-                            ],
-                            [
-                                -156.8892939191858,
-                                71.09233905347654
-                            ],
-                            [
-                                -156.86234446066854,
-                                71.08729651669765
-                            ],
-                            [
-                                -156.83539500215215,
-                                71.09233905347654
-                            ],
-                            [
-                                -156.81293712005453,
-                                71.089817947018
-                            ],
-                            [
-                                -156.81293712005453,
-                                71.1301168118979
-                            ],
-                            [
-                                -156.79497081437663,
-                                71.13514834798256
-                            ],
-                            [
-                                -156.79946239079632,
-                                71.15777426613856
-                            ],
-                            [
-                                -157.03751594102872,
-                                71.1552615672061
-                            ],
-                            [
-                                -157.04200751744844,
-                                71.10745889318524
-                            ],
-                            [
-                                -157.0240412117705,
-                                71.1024202414265
-                            ],
-                            [
-                                -157.02853278818932,
-                                71.089817947018
-                            ],
-                            [
-                                -157.01505805893112,
-                                71.08729651669765
-                            ]
-                        ]
-                    ],
-                    [
-                        [
-                            [
-                                -156.2604732204585,
-                                71.18288350359295
-                            ],
-                            [
-                                -156.22903218552239,
-                                71.19040998431947
-                            ],
-                            [
-                                -156.23352376194208,
-                                71.2680138964857
-                            ],
-                            [
-                                -156.25598164403877,
-                                71.26551536923893
-                            ],
-                            [
-                                -156.2829311025561,
-                                71.27051210247207
-                            ],
-                            [
-                                -156.31437213749214,
-                                71.26301652069516
-                            ],
-                            [
-                                -156.35030474884798,
-                                71.26301652069516
-                            ],
-                            [
-                                -156.39072893662347,
-                                71.27051210247207
-                            ],
-                            [
-                                -156.42216997155955,
-                                71.29298150566186
-                            ],
-                            [
-                                -156.44462785365715,
-                                71.29547650105414
-                            ],
-                            [
-                                -156.47157731217445,
-                                71.29048618937435
-                            ],
-                            [
-                                -156.51200149994997,
-                                71.29797117558833
-                            ],
-                            [
-                                -156.54344253488605,
-                                71.3154249163609
-                            ],
-                            [
-                                -156.55691726414426,
-                                71.30794666587178
-                            ],
-                            [
-                                -156.60632460475824,
-                                71.30046552930065
-                            ],
-                            [
-                                -156.61081618117797,
-                                71.29298150566186
-                            ],
-                            [
-                                -156.64674879253377,
-                                71.28799055215539
-                            ],
-                            [
-                                -156.66471509821164,
-                                71.27300998723459
-                            ],
-                            [
-                                -156.74107189734295,
-                                71.25551804691665
-                            ],
-                            [
-                                -156.74556347376264,
-                                71.24801668014865
-                            ],
-                            [
-                                -156.76802135586024,
-                                71.24551558150216
-                            ],
-                            [
-                                -156.79946239079632,
-                                71.22799888442123
-                            ],
-                            [
-                                -156.89378549560556,
-                                71.24551558150216
-                            ],
-                            [
-                                -156.91624337770224,
-                                71.2430141612664
-                            ],
-                            [
-                                -156.93420968338103,
-                                71.23300526369509
-                            ],
-                            [
-                                -156.92971810696133,
-                                71.20044077859748
-                            ],
-                            [
-                                -156.94768441263923,
-                                71.19542602610183
-                            ],
-                            [
-                                -156.91624337770224,
-                                71.18790147985433
-                            ],
-                            [
-                                -156.51649307636876,
-                                71.19040998431947
-                            ],
-                            [
-                                -156.49852677069086,
-                                71.1853926529577
-                            ],
-                            [
-                                -156.28742267897576,
-                                71.18790147985433
-                            ],
-                            [
-                                -156.2604732204585,
-                                71.18288350359295
-                            ]
-                        ]
-                    ]
-                ]
-            },
-            "links": [
-                {
-                    "rel": "self",
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-stac/ept/AK_NorthSlope_B7_2018.json"
-                },
-                {
-                    "rel": "parent",
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-stac/ept/catalog.json"
-                }
-            ],
-            "assets": {
-                "ept.json": {
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-public/AK_NorthSlope_B7_2018/ept.json",
-                    "title": "entwine",
-                    "description": "The ept.json for accessing data"
-                }
-            },
-            "bbox": [
-                -157.56752195852718,
-                70.42323366381925,
-                -156.22903218552239,
-                71.3154249163609
-            ],
-            "stac_extensions": [
-                "https://stac-extensions.github.io/pointcloud/v1.0.0/schema.json",
-                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
-            ]
-        },
-        {
-            "type": "Feature",
-            "stac_version": "1.0.0",
-            "id": "AK_NorthSlope_B8_2018",
-            "properties": {
-                "description": "A USGS Lidar pointcloud in Entwine/EPT format",
-                "pc:count": 767769101,
-                "pc:type": "lidar",
-                "pc:encoding": "ept",
-                "pc:schemas": [
-                    {
-                        "name": "X",
-                        "offset": -17808699,
-                        "scale": 0.01,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Y",
-                        "offset": 11273107,
-                        "scale": 0.01,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Z",
-                        "offset": 72,
-                        "scale": 0.01,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Intensity",
-                        "size": 2,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ReturnNumber",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "NumberOfReturns",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ScanDirectionFlag",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "EdgeOfFlightLine",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "Classification",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ScanAngleRank",
-                        "size": 4,
-                        "type": "floating"
-                    },
-                    {
-                        "name": "UserData",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "PointSourceId",
-                        "size": 2,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "GpsTime",
-                        "size": 8,
-                        "type": "floating"
-                    },
-                    {
-                        "name": "ScanChannel",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ClassFlags",
-                        "size": 1,
-                        "type": "unsigned"
-                    }
-                ],
-                "proj:epsg": 3857,
-                "proj:projjson": {
-                    "$schema": "https://proj.org/schemas/v0.5/projjson.schema.json",
-                    "type": "ProjectedCRS",
-                    "name": "WGS 84 / Pseudo-Mercator",
-                    "base_crs": {
-                        "name": "WGS 84",
-                        "datum_ensemble": {
-                            "name": "World Geodetic System 1984 ensemble",
-                            "members": [
-                                {
-                                    "name": "World Geodetic System 1984 (Transit)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1166
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G730)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1152
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G873)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1153
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1150)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1154
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1674)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1155
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1762)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1156
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G2139)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1309
-                                    }
-                                }
-                            ],
-                            "ellipsoid": {
-                                "name": "WGS 84",
-                                "semi_major_axis": 6378137,
-                                "inverse_flattening": 298.257223563
-                            },
-                            "accuracy": "2.0",
-                            "id": {
-                                "authority": "EPSG",
-                                "code": 6326
-                            }
-                        },
-                        "coordinate_system": {
-                            "subtype": "ellipsoidal",
-                            "axis": [
-                                {
-                                    "name": "Geodetic latitude",
-                                    "abbreviation": "Lat",
-                                    "direction": "north",
-                                    "unit": "degree"
-                                },
-                                {
-                                    "name": "Geodetic longitude",
-                                    "abbreviation": "Lon",
-                                    "direction": "east",
-                                    "unit": "degree"
-                                }
-                            ]
-                        },
-                        "id": {
-                            "authority": "EPSG",
-                            "code": 4326
-                        }
-                    },
-                    "conversion": {
-                        "name": "Popular Visualisation Pseudo-Mercator",
-                        "method": {
-                            "name": "Popular Visualisation Pseudo Mercator",
-                            "id": {
-                                "authority": "EPSG",
-                                "code": 1024
-                            }
-                        },
-                        "parameters": [
-                            {
-                                "name": "Latitude of natural origin",
-                                "value": 0,
-                                "unit": "degree",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8801
-                                }
-                            },
-                            {
-                                "name": "Longitude of natural origin",
-                                "value": 0,
-                                "unit": "degree",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8802
-                                }
-                            },
-                            {
-                                "name": "False easting",
-                                "value": 0,
-                                "unit": "metre",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8806
-                                }
-                            },
-                            {
-                                "name": "False northing",
-                                "value": 0,
-                                "unit": "metre",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8807
-                                }
-                            }
-                        ]
-                    },
-                    "coordinate_system": {
-                        "subtype": "Cartesian",
-                        "axis": [
-                            {
-                                "name": "Easting",
-                                "abbreviation": "X",
-                                "direction": "east",
-                                "unit": "metre"
-                            },
-                            {
-                                "name": "Northing",
-                                "abbreviation": "Y",
-                                "direction": "north",
-                                "unit": "metre"
-                            }
-                        ]
-                    },
-                    "scope": "Web mapping and visualisation.",
-                    "area": "World between 85.06°S and 85.06°N.",
-                    "bbox": {
-                        "south_latitude": -85.06,
-                        "west_longitude": -180,
-                        "north_latitude": 85.06,
-                        "east_longitude": 180
-                    },
-                    "id": {
-                        "authority": "EPSG",
-                        "code": 3857
-                    }
-                },
-                "datetime": "2023-01-11T17:08:49.108467Z"
-            },
-            "geometry": {
-                "type": "MultiPolygon",
-                "coordinates": [
-                    [
-                        [
-                            [
-                                -159.92606957807547,
-                                70.54420672598609
-                            ],
-                            [
-                                -159.90810327239757,
-                                70.5493885381972
-                            ],
-                            [
-                                -159.88115381388027,
-                                70.54420672598609
-                            ],
-                            [
-                                -159.76437282697435,
-                                70.54420672598609
-                            ],
-                            [
-                                -159.74640652129648,
-                                70.5493885381972
-                            ],
-                            [
-                                -159.75089809771615,
-                                70.65016906903456
-                            ],
-                            [
-                                -159.73293179203827,
-                                70.65532374334384
-                            ],
-                            [
-                                -159.7374233684571,
-                                70.68879694977959
-                            ],
-                            [
-                                -159.84072962610566,
-                                70.68622406680485
-                            ],
-                            [
-                                -159.8586959317836,
-                                70.69136950308412
-                            ],
-                            [
-                                -159.92157800165577,
-                                70.69136950308412
-                            ],
-                            [
-                                -159.94852746017307,
-                                70.68622406680485
-                            ],
-                            [
-                                -159.95301903659185,
-                                70.67850343948905
-                            ],
-                            [
-                                -159.97547691868945,
-                                70.67592923746331
-                            ],
-                            [
-                                -159.97996849510915,
-                                70.66820465210402
-                            ],
-                            [
-                                -160.00242637720675,
-                                70.66562913043364
-                            ],
-                            [
-                                -160.00691795362644,
-                                70.65790058525181
-                            ],
-                            [
-                                -160.03386741214283,
-                                70.65274657128379
-                            ],
-                            [
-                                -160.00242637720675,
-                                70.64501307382021
-                            ],
-                            [
-                                -159.9664937658509,
-                                70.64501307382021
-                            ],
-                            [
-                                -159.9664937658509,
-                                70.62437587797781
-                            ],
-                            [
-                                -159.91259484881726,
-                                70.61404934690954
-                            ],
-                            [
-                                -159.88564539029994,
-                                70.59338040660387
-                            ],
-                            [
-                                -159.97996849510915,
-                                70.58045156123097
-                            ],
-                            [
-                                -160.01590110646498,
-                                70.58562409280535
-                            ],
-                            [
-                                -160.07429159991835,
-                                70.56751443514817
-                            ],
-                            [
-                                -160.08776632917656,
-                                70.57527770474327
-                            ],
-                            [
-                                -160.11022421127416,
-                                70.5726902795638
-                            ],
-                            [
-                                -160.12369894053234,
-                                70.58562409280535
-                            ],
-                            [
-                                -160.10124105843474,
-                                70.5882098618428
-                            ],
-                            [
-                                -160.08327475275684,
-                                70.60371752391025
-                            ],
-                            [
-                                -160.06081687066018,
-                                70.60630097590862
-                            ],
-                            [
-                                -160.05632529424042,
-                                70.61404934690954
-                            ],
-                            [
-                                -160.02937583572316,
-                                70.61921327378663
-                            ],
-                            [
-                                -160.04734214140103,
-                                70.62953715977967
-                            ],
-                            [
-                                -160.06980002349863,
-                                70.63211730487767
-                            ],
-                            [
-                                -160.09674948201595,
-                                70.62695668415897
-                            ],
-                            [
-                                -160.11471578769383,
-                                70.611466887371
-                            ],
-                            [
-                                -160.13717366979054,
-                                70.60888409704994
-                            ],
-                            [
-                                -160.16861470472753,
-                                70.58562409280535
-                            ],
-                            [
-                                -160.19107258682513,
-                                70.5830379926138
-                            ],
-                            [
-                                -160.22251362176127,
-                                70.5649260158377
-                            ],
-                            [
-                                -160.22251362176127,
-                                70.5545690237115
-                            ],
-                            [
-                                -160.20454731608334,
-                                70.5493885381972
-                            ],
-                            [
-                                -159.95301903659185,
-                                70.5493885381972
-                            ],
-                            [
-                                -159.92606957807547,
-                                70.54420672598609
-                            ]
-                        ]
-                    ]
-                ]
-            },
-            "links": [
-                {
-                    "rel": "self",
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-stac/ept/AK_NorthSlope_B8_2018.json"
-                },
-                {
-                    "rel": "parent",
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-stac/ept/catalog.json"
-                }
-            ],
-            "assets": {
-                "ept.json": {
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-public/AK_NorthSlope_B8_2018/ept.json",
-                    "title": "entwine",
-                    "description": "The ept.json for accessing data"
-                }
-            },
-            "bbox": [
-                -160.22251362176127,
-                70.54420672598609,
-                -159.73293179203827,
-                70.69136950308412
-            ],
-            "stac_extensions": [
-                "https://stac-extensions.github.io/pointcloud/v1.0.0/schema.json",
-                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
-            ]
-        },
-        {
-            "type": "Feature",
-            "stac_version": "1.0.0",
-            "id": "AK_NorthSlope_B9_2018",
-            "properties": {
-                "description": "A USGS Lidar pointcloud in Entwine/EPT format",
-                "pc:count": 338421753,
-                "pc:type": "lidar",
-                "pc:encoding": "ept",
-                "pc:schemas": [
-                    {
-                        "name": "X",
-                        "offset": -16890959,
-                        "scale": 0.01,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Y",
-                        "offset": 10489320,
-                        "scale": 0.01,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Z",
-                        "offset": 1122,
-                        "scale": 0.01,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Intensity",
-                        "size": 2,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ReturnNumber",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "NumberOfReturns",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ScanDirectionFlag",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "EdgeOfFlightLine",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "Classification",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ScanAngleRank",
-                        "size": 4,
-                        "type": "floating"
-                    },
-                    {
-                        "name": "UserData",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "PointSourceId",
-                        "size": 2,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "GpsTime",
-                        "size": 8,
-                        "type": "floating"
-                    },
-                    {
-                        "name": "ScanChannel",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ClassFlags",
-                        "size": 1,
-                        "type": "unsigned"
-                    }
-                ],
-                "proj:epsg": 3857,
-                "proj:projjson": {
-                    "$schema": "https://proj.org/schemas/v0.5/projjson.schema.json",
-                    "type": "ProjectedCRS",
-                    "name": "WGS 84 / Pseudo-Mercator",
-                    "base_crs": {
-                        "name": "WGS 84",
-                        "datum_ensemble": {
-                            "name": "World Geodetic System 1984 ensemble",
-                            "members": [
-                                {
-                                    "name": "World Geodetic System 1984 (Transit)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1166
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G730)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1152
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G873)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1153
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1150)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1154
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1674)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1155
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1762)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1156
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G2139)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1309
-                                    }
-                                }
-                            ],
-                            "ellipsoid": {
-                                "name": "WGS 84",
-                                "semi_major_axis": 6378137,
-                                "inverse_flattening": 298.257223563
-                            },
-                            "accuracy": "2.0",
-                            "id": {
-                                "authority": "EPSG",
-                                "code": 6326
-                            }
-                        },
-                        "coordinate_system": {
-                            "subtype": "ellipsoidal",
-                            "axis": [
-                                {
-                                    "name": "Geodetic latitude",
-                                    "abbreviation": "Lat",
-                                    "direction": "north",
-                                    "unit": "degree"
-                                },
-                                {
-                                    "name": "Geodetic longitude",
-                                    "abbreviation": "Lon",
-                                    "direction": "east",
-                                    "unit": "degree"
-                                }
-                            ]
-                        },
-                        "id": {
-                            "authority": "EPSG",
-                            "code": 4326
-                        }
-                    },
-                    "conversion": {
-                        "name": "Popular Visualisation Pseudo-Mercator",
-                        "method": {
-                            "name": "Popular Visualisation Pseudo Mercator",
-                            "id": {
-                                "authority": "EPSG",
-                                "code": 1024
-                            }
-                        },
-                        "parameters": [
-                            {
-                                "name": "Latitude of natural origin",
-                                "value": 0,
-                                "unit": "degree",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8801
-                                }
-                            },
-                            {
-                                "name": "Longitude of natural origin",
-                                "value": 0,
-                                "unit": "degree",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8802
-                                }
-                            },
-                            {
-                                "name": "False easting",
-                                "value": 0,
-                                "unit": "metre",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8806
-                                }
-                            },
-                            {
-                                "name": "False northing",
-                                "value": 0,
-                                "unit": "metre",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8807
-                                }
-                            }
-                        ]
-                    },
-                    "coordinate_system": {
-                        "subtype": "Cartesian",
-                        "axis": [
-                            {
-                                "name": "Easting",
-                                "abbreviation": "X",
-                                "direction": "east",
-                                "unit": "metre"
-                            },
-                            {
-                                "name": "Northing",
-                                "abbreviation": "Y",
-                                "direction": "north",
-                                "unit": "metre"
-                            }
-                        ]
-                    },
-                    "scope": "Web mapping and visualisation.",
-                    "area": "World between 85.06°S and 85.06°N.",
-                    "bbox": {
-                        "south_latitude": -85.06,
-                        "west_longitude": -180,
-                        "north_latitude": 85.06,
-                        "east_longitude": 180
-                    },
-                    "id": {
-                        "authority": "EPSG",
-                        "code": 3857
-                    }
-                },
-                "datetime": "2023-01-11T17:08:49.109881Z"
-            },
-            "geometry": {
-                "type": "MultiPolygon",
-                "coordinates": [
-                    [
-                        [
-                            [
-                                -151.75397991507128,
-                                68.1172807525132
-                            ],
-                            [
-                                -151.70008099803758,
-                                68.1172807525132
-                            ],
-                            [
-                                -151.68211469235968,
-                                68.1230790877876
-                            ],
-                            [
-                                -151.6866062687785,
-                                68.16652005356767
-                            ],
-                            [
-                                -151.77643779716888,
-                                68.16652005356767
-                            ],
-                            [
-                                -151.79440410284676,
-                                68.16073266843804
-                            ],
-                            [
-                                -151.79440410284676,
-                                68.12597770752195
-                            ],
-                            [
-                                -151.75397991507128,
-                                68.1172807525132
-                            ]
-                        ]
-                    ]
-                ]
-            },
-            "links": [
-                {
-                    "rel": "self",
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-stac/ept/AK_NorthSlope_B9_2018.json"
-                },
-                {
-                    "rel": "parent",
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-stac/ept/catalog.json"
-                }
-            ],
-            "assets": {
-                "ept.json": {
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-public/AK_NorthSlope_B9_2018/ept.json",
-                    "title": "entwine",
-                    "description": "The ept.json for accessing data"
-                }
-            },
-            "bbox": [
-                -151.79440410284676,
-                68.1172807525132,
-                -151.68211469235968,
-                68.16652005356767
-            ],
-            "stac_extensions": [
-                "https://stac-extensions.github.io/pointcloud/v1.0.0/schema.json",
-                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
-            ]
-        },
-        {
-            "type": "Feature",
-            "stac_version": "1.0.0",
-            "id": "AK_ValdezB_2007",
-            "properties": {
-                "description": "A USGS Lidar pointcloud in Entwine/EPT format",
-                "pc:count": 1068352809,
-                "pc:type": "lidar",
-                "pc:encoding": "ept",
-                "pc:schemas": [
-                    {
-                        "name": "X",
-                        "offset": -16283493,
-                        "scale": 0.01,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Y",
-                        "offset": 8648220,
-                        "scale": 0.01,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Z",
-                        "offset": 870,
+                        "offset": 60,
                         "scale": 0.01,
                         "size": 4,
                         "type": "signed"
@@ -15875,7 +7908,7 @@
                         "code": 3857
                     }
                 },
-                "datetime": "2023-01-11T17:08:49.111480Z"
+                "datetime": "2023-01-11T17:08:49.715050Z"
             },
             "geometry": {
                 "type": "MultiPolygon",
@@ -15883,240 +7916,1604 @@
                     [
                         [
                             [
-                                -146.0009300634949,
-                                61.027998332559285
+                                -91.45468657328482,
+                                40.365672614315415
                             ],
                             [
-                                -145.9964384870752,
-                                61.03930127296665
+                                -91.43672026760692,
+                                40.377526596960685
                             ],
                             [
-                                -145.9335564172021,
-                                61.03930127296665
+                                -91.37383819773471,
+                                40.377526596960685
                             ],
                             [
-                                -145.90660695868573,
-                                61.031766426944635
+                                -91.37383819773471,
+                                40.4012283065072
                             ],
                             [
-                                -145.902115382266,
-                                61.06565913905538
+                                -91.35587189205592,
+                                40.413076033128284
                             ],
                             [
-                                -145.92906484078333,
-                                61.06565913905538
+                                -91.37383819773471,
+                                40.436765229368746
                             ],
                             [
-                                -145.9470311464612,
-                                61.07318593201593
+                                -91.35587189205592,
+                                40.460446082014876
                             ],
                             [
-                                -146.0233879455925,
-                                61.06942275914876
+                                -91.35587189205592,
+                                40.50778275210959
                             ],
                             [
-                                -146.1042363211426,
-                                61.091995089249856
+                                -91.39629607983143,
+                                40.56099659696569
                             ],
                             [
-                                -146.1087278975623,
-                                61.10327521923803
+                                -91.36036346847561,
+                                40.572816156092046
                             ],
                             [
-                                -146.1491520853378,
-                                61.11455132718084
+                                -91.35587189205592,
+                                40.602355920948824
                             ],
                             [
-                                -146.1491520853378,
-                                61.129579882980444
+                                -91.33341400995923,
+                                40.59644901181115
                             ],
                             [
-                                -146.1311857796599,
-                                61.137091480920795
+                                -91.28849824576403,
+                                40.62007351659428
                             ],
                             [
-                                -146.1356773560787,
-                                61.14835552871373
+                                -91.26604036366643,
+                                40.614168173357015
                             ],
                             [
-                                -146.1177110504008,
-                                61.15586266159526
+                                -91.23459932873034,
+                                40.63188263705207
                             ],
                             [
-                                -146.1356773560787,
-                                61.16336800897104
+                                -91.18519198811634,
+                                40.62597833783145
                             ],
                             [
-                                -146.1850846966936,
-                                61.1596155584529
+                                -91.11781834182355,
+                                40.65549461343777
                             ],
                             [
-                                -146.2030510023715,
-                                61.14460129261579
+                                -91.09985203614654,
+                                40.67909823623855
                             ],
                             [
-                                -146.25245834298548,
-                                61.14835552871373
+                                -91.10434361256533,
+                                40.74396511722541
                             ],
                             [
-                                -146.27042464866338,
-                                61.140846610030486
+                                -91.08637730688746,
+                                40.75575230575744
                             ],
                             [
-                                -146.33330671853648,
-                                61.140846610030486
+                                -91.09086888330714,
+                                40.78521113524266
                             ],
                             [
-                                -146.35127302421438,
-                                61.15586266159526
+                                -91.07290257762924,
+                                40.796991009963286
                             ],
                             [
-                                -146.37373090631107,
-                                61.1596155584529
+                                -91.09086888330714,
+                                40.80876879473667
                             ],
                             [
-                                -146.39169721198897,
-                                61.14460129261579
+                                -91.06391942478984,
+                                40.820544489436024
                             ],
                             [
-                                -146.41415509408657,
-                                61.14835552871373
+                                -91.03247838985374,
+                                40.87350924753605
                             ],
                             [
-                                -146.44110455260386,
-                                61.140846610030486
+                                -90.99654577849795,
+                                40.885273444578516
                             ],
                             [
-                                -146.44110455260386,
-                                61.12582341407588
+                                -90.99205420207825,
+                                40.90291581968646
                             ],
                             [
-                                -146.4006803648284,
-                                61.11455132718084
+                                -90.95612159072245,
+                                40.91467478927396
                             ],
                             [
-                                -146.32432356569706,
-                                61.11830913621303
+                                -90.93815528504456,
+                                40.93818645473099
                             ],
                             [
-                                -146.28389937792159,
-                                61.10703436873033
+                                -90.94264686146425,
+                                41.02628068455085
                             ],
                             [
-                                -146.28389937792159,
-                                61.091995089249856
+                                -90.92468055578635,
+                                41.03801769047208
                             ],
                             [
-                                -146.42762982334568,
-                                61.09951562285183
+                                -90.94264686146425,
+                                41.06148542478046
                             ],
                             [
-                                -146.47254558754,
-                                61.08447276762896
+                                -90.93815528504456,
+                                41.1142572196588
                             ],
                             [
-                                -146.49949504605726,
-                                61.091995089249856
+                                -90.96959631998155,
+                                41.131838398902694
                             ],
                             [
-                                -146.61627603296316,
-                                61.091995089249856
+                                -90.96510474356185,
+                                41.14941486796468
                             ],
                             [
-                                -146.64771706789926,
-                                61.080710936219106
+                                -90.98307104923975,
+                                41.172842832420734
                             ],
                             [
-                                -146.62975076222136,
-                                61.06565913905538
+                                -91.00552893133735,
+                                41.166986626452925
                             ],
                             [
-                                -146.60280130370495,
-                                61.07318593201593
+                                -91.04595311911194,
+                                41.184553673977675
                             ],
                             [
-                                -146.57585184518769,
-                                61.06565913905538
+                                -91.05044469553165,
+                                41.213821616658315
                             ],
                             [
-                                -146.53991923383185,
-                                61.06565913905538
+                                -91.07290257762924,
+                                41.20796907517501
                             ],
                             [
-                                -146.52195292815398,
-                                61.07318593201593
+                                -91.07739415404895,
+                                41.23722654690084
                             ],
                             [
-                                -146.4950034696376,
-                                61.06565913905538
+                                -91.10434361256533,
+                                41.24892587040928
                             ],
                             [
-                                -146.46805401112027,
-                                61.07318593201593
+                                -91.08637730688746,
+                                41.260623099358604
                             ],
                             [
-                                -146.43212139976447,
-                                61.07318593201593
+                                -91.08637730688746,
+                                41.2840112731305
                             ],
                             [
-                                -146.40517194124808,
-                                61.06565913905538
+                                -91.05942784837104,
+                                41.295702217729286
                             ],
                             [
-                                -146.37822248273076,
-                                61.07318593201593
+                                -91.06391942478984,
+                                41.35996496181095
                             ],
                             [
-                                -146.34678144779468,
-                                61.06189507169881
+                                -91.04595311911194,
+                                41.37164228689233
                             ],
                             [
-                                -146.28389937792159,
-                                61.06189507169881
+                                -91.05044469553165,
+                                41.38915434500287
                             ],
                             [
-                                -146.27940780150186,
-                                61.07318593201593
+                                -91.03247838985374,
+                                41.41249642015934
                             ],
                             [
-                                -146.25245834298548,
-                                61.06565913905538
+                                -90.99654577849795,
+                                41.41249642015934
                             ],
                             [
-                                -146.2165257316297,
-                                61.07318593201593
+                                -90.97857947282004,
+                                41.42416431364152
                             ],
                             [
-                                -146.21203415520998,
-                                61.06189507169881
+                                -90.95163001430365,
+                                41.41249642015934
                             ],
                             [
-                                -146.1716099674345,
-                                61.05060018568114
+                                -90.91569740294786,
+                                41.41249642015934
                             ],
                             [
-                                -146.1491520853378,
-                                61.05436559504863
+                                -90.83035745097716,
+                                41.453324876206956
                             ],
                             [
-                                -146.1042363211426,
-                                61.03930127296665
+                                -90.80340799246076,
+                                41.44166222344304
                             ],
                             [
-                                -146.0548289805286,
-                                61.043068024677034
+                                -90.78095011036316,
+                                41.44749381187754
                             ],
                             [
-                                -146.0503374041089,
-                                61.031766426944635
+                                -90.76298380468528,
+                                41.43583011091659
                             ],
                             [
-                                -146.0278795220113,
-                                61.03553407373478
+                                -90.72705119332946,
+                                41.43583011091659
                             ],
                             [
-                                -146.0009300634949,
-                                61.027998332559285
+                                -90.69561015839338,
+                                41.453324876206956
+                            ],
+                            [
+                                -90.64620281777847,
+                                41.44749381187754
+                            ],
+                            [
+                                -90.64171124135876,
+                                41.46498543249706
+                            ],
+                            [
+                                -90.59230390074478,
+                                41.48247233581198
+                            ],
+                            [
+                                -90.58781232432509,
+                                41.499954521466115
+                            ],
+                            [
+                                -90.54738813655048,
+                                41.51743198910507
+                            ],
+                            [
+                                -90.52043867803319,
+                                41.50578086825384
+                            ],
+                            [
+                                -90.48450606667738,
+                                41.50578086825384
+                            ],
+                            [
+                                -90.46653976099948,
+                                41.51743198910507
+                            ],
+                            [
+                                -90.44408187890188,
+                                41.51160669080449
+                            ],
+                            [
+                                -90.41264084396579,
+                                41.552372768929196
+                            ],
+                            [
+                                -90.33179246841478,
+                                41.58729467248613
+                            ],
+                            [
+                                -90.3362840448345,
+                                41.66289402762578
+                            ],
+                            [
+                                -90.30484300989839,
+                                41.6803274437035
+                            ],
+                            [
+                                -90.30933458631718,
+                                41.73259936119018
+                            ],
+                            [
+                                -90.29136828064021,
+                                41.75581768208532
+                            ],
+                            [
+                                -90.2105199050892,
+                                41.79062941985086
+                            ],
+                            [
+                                -90.1880620229916,
+                                41.78482877561177
+                            ],
+                            [
+                                -90.1700957173137,
+                                41.79642953923999
+                            ],
+                            [
+                                -90.17458729373341,
+                                41.83701567816235
+                            ],
+                            [
+                                -90.15662098805551,
+                                41.8486069935272
+                            ],
+                            [
+                                -90.1611125644752,
+                                41.877576094786704
+                            ],
+                            [
+                                -90.1431462587973,
+                                41.889160060184366
+                            ],
+                            [
+                                -90.1476378352161,
+                                41.975972850445295
+                            ],
+                            [
+                                -90.12967152953821,
+                                41.98753896122283
+                            ],
+                            [
+                                -90.12967152953821,
+                                42.01066487976691
+                            ],
+                            [
+                                -90.1476378352161,
+                                42.02222468735519
+                            ],
+                            [
+                                -90.12967152953821,
+                                42.03378239370266
+                            ],
+                            [
+                                -90.1611125644752,
+                                42.05111501320434
+                            ],
+                            [
+                                -90.1611125644752,
+                                42.085766067053044
+                            ],
+                            [
+                                -90.1431462587973,
+                                42.097312215007946
+                            ],
+                            [
+                                -90.1476378352161,
+                                42.12616838929671
+                            ],
+                            [
+                                -90.17458729373341,
+                                42.13770718054795
+                            ],
+                            [
+                                -90.197045175831,
+                                42.13193804768047
+                            ],
+                            [
+                                -90.2015367522498,
+                                42.16077845664367
+                            ],
+                            [
+                                -90.32280931557628,
+                                42.2126580810474
+                            ],
+                            [
+                                -90.34526719767388,
+                                42.20689578084909
+                            ],
+                            [
+                                -90.3632335033518,
+                                42.229941827623726
+                            ],
+                            [
+                                -90.3991661147076,
+                                42.24146169688976
+                            ],
+                            [
+                                -90.4171324203855,
+                                42.26449512677002
+                            ],
+                            [
+                                -90.4171324203855,
+                                42.31053674965392
+                            ],
+                            [
+                                -90.3991661147076,
+                                42.32204189722364
+                            ],
+                            [
+                                -90.4171324203855,
+                                42.34504588202476
+                            ],
+                            [
+                                -90.43959030248219,
+                                42.35079556351369
+                            ],
+                            [
+                                -90.45755660816009,
+                                42.38528260811851
+                            ],
+                            [
+                                -90.54738813655048,
+                                42.41975071807578
+                            ],
+                            [
+                                -90.56535444222837,
+                                42.454199891314055
+                            ],
+                            [
+                                -90.60128705358417,
+                                42.454199891314055
+                            ],
+                            [
+                                -90.64620281777847,
+                                42.4771554853969
+                            ],
+                            [
+                                -90.62823651210057,
+                                42.500102661653436
+                            ],
+                            [
+                                -90.62823651210057,
+                                42.54597175832272
+                            ],
+                            [
+                                -90.65967754703756,
+                                42.58607959129946
+                            ],
+                            [
+                                -90.68662700555396,
+                                42.59753423570098
+                            ],
+                            [
+                                -90.68213542913428,
+                                42.61471225499596
+                            ],
+                            [
+                                -90.70010173481216,
+                                42.6261616362182
+                            ],
+                            [
+                                -90.70010173481216,
+                                42.6490540824091
+                            ],
+                            [
+                                -90.72255961690976,
+                                42.64333176041481
+                            ],
+                            [
+                                -90.75400065184587,
+                                42.66049714723862
+                            ],
+                            [
+                                -90.81688272171895,
+                                42.66049714723862
+                            ],
+                            [
+                                -90.83484902739687,
+                                42.67193810646553
+                            ],
+                            [
+                                -90.85730690949447,
+                                42.66621789005675
+                            ],
+                            [
+                                -90.91569740294786,
+                                42.69481370783698
+                            ],
+                            [
+                                -90.93815528504456,
+                                42.689095597150775
+                            ],
+                            [
+                                -90.97857947282004,
+                                42.70624834984527
+                            ],
+                            [
+                                -90.99654577849795,
+                                42.729111316168876
+                            ],
+                            [
+                                -91.01900366059554,
+                                42.723396364320564
+                            ],
+                            [
+                                -91.02349523701524,
+                                42.740539640350015
+                            ],
+                            [
+                                -91.05044469553165,
+                                42.75196585845518
+                            ],
+                            [
+                                -91.04595311911194,
+                                42.76910123657567
+                            ],
+                            [
+                                -91.07739415404895,
+                                42.797649668796765
+                            ],
+                            [
+                                -91.07290257762924,
+                                42.871813977770415
+                            ],
+                            [
+                                -91.09985203614654,
+                                42.883215971329356
+                            ],
+                            [
+                                -91.10434361256533,
+                                42.90031501125056
+                            ],
+                            [
+                                -91.12680149466293,
+                                42.90601363774883
+                            ],
+                            [
+                                -91.12680149466293,
+                                42.92880287615943
+                            ],
+                            [
+                                -91.14476780034084,
+                                42.94019433470866
+                            ],
+                            [
+                                -91.14027622392113,
+                                42.99142982090181
+                            ],
+                            [
+                                -91.17171725885814,
+                                43.031250139436096
+                            ],
+                            [
+                                -91.17171725885814,
+                                43.12217105425529
+                            ],
+                            [
+                                -91.14476780034084,
+                                43.13352668271199
+                            ],
+                            [
+                                -91.14027622392113,
+                                43.16190653053014
+                            ],
+                            [
+                                -91.11332676540474,
+                                43.19594495439486
+                            ],
+                            [
+                                -91.09086888330714,
+                                43.20161618017877
+                            ],
+                            [
+                                -91.08637730688746,
+                                43.21862669478103
+                            ],
+                            [
+                                -91.06391942478984,
+                                43.22429581204357
+                            ],
+                            [
+                                -91.04595311911194,
+                                43.2582994453152
+                            ],
+                            [
+                                -91.07739415404895,
+                                43.28662130884562
+                            ],
+                            [
+                                -91.07739415404895,
+                                43.30926930981076
+                            ],
+                            [
+                                -91.19866671737454,
+                                43.3601964677716
+                            ],
+                            [
+                                -91.19866671737454,
+                                43.38281705076763
+                            ],
+                            [
+                                -91.18070041169665,
+                                43.394124178371975
+                            ],
+                            [
+                                -91.19866671737454,
+                                43.405429196651255
+                            ],
+                            [
+                                -91.19417514095484,
+                                43.43368251374765
+                            ],
+                            [
+                                -91.22561617589184,
+                                43.45062817559183
+                            ],
+                            [
+                                -91.20764987021394,
+                                43.47321500791762
+                            ],
+                            [
+                                -91.21214144663274,
+                                43.51272165895486
+                            ],
+                            [
+                                -91.62536647722531,
+                                43.51272165895486
+                            ],
+                            [
+                                -91.64333278290322,
+                                43.501436681537506
+                            ],
+                            [
+                                -91.6702822414196,
+                                43.51272165895486
+                            ],
+                            [
+                                -91.92181052091108,
+                                43.51272165895486
+                            ],
+                            [
+                                -91.939776826589,
+                                43.501436681537506
+                            ],
+                            [
+                                -91.9667262851054,
+                                43.51272165895486
+                            ],
+                            [
+                                -92.32605239866426,
+                                43.51272165895486
+                            ],
+                            [
+                                -92.34401870434218,
+                                43.501436681537506
+                            ],
+                            [
+                                -92.37096816285856,
+                                43.51272165895486
+                            ],
+                            [
+                                -92.43385023273166,
+                                43.51272165895486
+                            ],
+                            [
+                                -92.45181653840956,
+                                43.501436681537506
+                            ],
+                            [
+                                -94.56285745556491,
+                                43.501436681537506
+                            ],
+                            [
+                                -94.58082376124281,
+                                43.51272165895486
+                            ],
+                            [
+                                -95.26354337700387,
+                                43.51272165895486
+                            ],
+                            [
+                                -95.28150968268176,
+                                43.501436681537506
+                            ],
+                            [
+                                -95.31744229403756,
+                                43.501436681537506
+                            ],
+                            [
+                                -95.32193387045727,
+                                43.518363356492316
+                            ],
+                            [
+                                -95.35786648181306,
+                                43.518363356492316
+                            ],
+                            [
+                                -95.36235805823186,
+                                43.501436681537506
+                            ],
+                            [
+                                -96.61101630284718,
+                                43.501436681537506
+                            ],
+                            [
+                                -96.59754157358898,
+                                43.46192264655436
+                            ],
+                            [
+                                -96.61550787926687,
+                                43.43933159507489
+                            ],
+                            [
+                                -96.53016792729709,
+                                43.37716269598316
+                            ],
+                            [
+                                -96.54813423297499,
+                                43.36585240447922
+                            ],
+                            [
+                                -96.53016792729709,
+                                43.35454000376812
+                            ],
+                            [
+                                -96.54813423297499,
+                                43.34322549389746
+                            ],
+                            [
+                                -96.53465950371678,
+                                43.30360810041603
+                            ],
+                            [
+                                -96.55711738581348,
+                                43.297946363786096
+                            ],
+                            [
+                                -96.58406684433078,
+                                43.30926930981076
+                            ],
+                            [
+                                -96.60203315000868,
+                                43.297946363786096
+                            ],
+                            [
+                                -96.58406684433078,
+                                43.28662130884562
+                            ],
+                            [
+                                -96.59754157358898,
+                                43.26962977232676
+                            ],
+                            [
+                                -96.55711738581348,
+                                43.25263349102871
+                            ],
+                            [
+                                -96.58855842075049,
+                                43.2356324651225
+                            ],
+                            [
+                                -96.57059211507259,
+                                43.21295705037832
+                            ],
+                            [
+                                -96.54364265655529,
+                                43.22429581204357
+                            ],
+                            [
+                                -96.53016792729709,
+                                43.207286878842076
+                            ],
+                            [
+                                -96.50321846877978,
+                                43.21862669478103
+                            ],
+                            [
+                                -96.4807605866822,
+                                43.21295705037832
+                            ],
+                            [
+                                -96.4807605866822,
+                                43.15623161508772
+                            ],
+                            [
+                                -96.4493195517461,
+                                43.11649244948364
+                            ],
+                            [
+                                -96.4807605866822,
+                                43.088091520467195
+                            ],
+                            [
+                                -96.46728585742399,
+                                43.07104463918079
+                            ],
+                            [
+                                -96.53465950371678,
+                                43.042622631184216
+                            ],
+                            [
+                                -96.50321846877978,
+                                43.0028096891946
+                            ],
+                            [
+                                -96.53465950371678,
+                                42.98573909645691
+                            ],
+                            [
+                                -96.51669319803888,
+                                42.95158368607303
+                            ],
+                            [
+                                -96.54813423297499,
+                                42.92310635670942
+                            ],
+                            [
+                                -96.55711738581348,
+                                42.854707037170385
+                            ],
+                            [
+                                -96.58406684433078,
+                                42.84329977668745
+                            ],
+                            [
+                                -96.60203315000868,
+                                42.82047893580643
+                            ],
+                            [
+                                -96.59754157358898,
+                                42.80335777547073
+                            ],
+                            [
+                                -96.62449103210628,
+                                42.79194103552196
+                            ],
+                            [
+                                -96.64245733778417,
+                                42.76910123657567
+                            ],
+                            [
+                                -96.63796576136447,
+                                42.740539640350015
+                            ],
+                            [
+                                -96.65593206704239,
+                                42.729111316168876
+                            ],
+                            [
+                                -96.63796576136447,
+                                42.71768088597832
+                            ],
+                            [
+                                -96.63796576136447,
+                                42.69481370783698
+                            ],
+                            [
+                                -96.58855842075049,
+                                42.677657796456536
+                            ],
+                            [
+                                -96.58406684433078,
+                                42.66049714723862
+                            ],
+                            [
+                                -96.53016792729709,
+                                42.63760891204582
+                            ],
+                            [
+                                -96.54813423297499,
+                                42.61471225499596
+                            ],
+                            [
+                                -96.50321846877978,
+                                42.591807176648146
+                            ],
+                            [
+                                -96.50771004519949,
+                                42.551703027492664
+                            ],
+                            [
+                                -96.48974373952159,
+                                42.528774793503544
+                            ],
+                            [
+                                -96.50771004519949,
+                                42.505838140362606
+                            ],
+                            [
+                                -96.4762690102634,
+                                42.500102661653436
+                            ],
+                            [
+                                -96.48974373952159,
+                                42.48289306865552
+                            ],
+                            [
+                                -96.44033639890759,
+                                42.48863012579063
+                            ],
+                            [
+                                -96.42237009322969,
+                                42.4771554853969
+                            ],
+                            [
+                                -96.3954206347124,
+                                42.4771554853969
+                            ],
+                            [
+                                -96.39991221113208,
+                                42.4599395789734
+                            ],
+                            [
+                                -96.3819459054542,
+                                42.44845967757801
+                            ],
+                            [
+                                -96.39991221113208,
+                                42.42549356205426
+                            ],
+                            [
+                                -96.4268616696494,
+                                42.414007348077206
+                            ],
+                            [
+                                -96.4268616696494,
+                                42.34504588202476
+                            ],
+                            [
+                                -96.4088953639706,
+                                42.32204189722364
+                            ],
+                            [
+                                -96.38643748187388,
+                                42.31628958636133
+                            ],
+                            [
+                                -96.38643748187388,
+                                42.293275084561
+                            ],
+                            [
+                                -96.36847117619601,
+                                42.27025216987827
+                            ],
+                            [
+                                -96.34152171767869,
+                                42.25873755790685
+                            ],
+                            [
+                                -96.34601329409841,
+                                42.24146169688976
+                            ],
+                            [
+                                -96.37296275261478,
+                                42.229941827623726
+                            ],
+                            [
+                                -96.37296275261478,
+                                42.20689578084909
+                            ],
+                            [
+                                -96.35499644693691,
+                                42.19536960350524
+                            ],
+                            [
+                                -96.3594880233566,
+                                42.166544961771166
+                            ],
+                            [
+                                -96.3280469884205,
+                                42.12616838929671
+                            ],
+                            [
+                                -96.27414807138679,
+                                42.1030845008127
+                            ],
+                            [
+                                -96.29211437706469,
+                                42.09153940375116
+                            ],
+                            [
+                                -96.29211437706469,
+                                42.05689150232248
+                            ],
+                            [
+                                -96.27414807138679,
+                                42.03378239370266
+                            ],
+                            [
+                                -96.2471986128695,
+                                42.02222468735519
+                            ],
+                            [
+                                -96.2471986128695,
+                                41.98753896122283
+                            ],
+                            [
+                                -96.19779127225551,
+                                41.99332122875197
+                            ],
+                            [
+                                -96.1932996958358,
+                                41.96440463878358
+                            ],
+                            [
+                                -96.15736708448,
+                                41.96440463878358
+                            ],
+                            [
+                                -96.1528755080603,
+                                41.92389935480818
+                            ],
+                            [
+                                -96.1708418137382,
+                                41.912321690287314
+                            ],
+                            [
+                                -96.1708418137382,
+                                41.889160060184366
+                            ],
+                            [
+                                -96.1528755080603,
+                                41.877576094786704
+                            ],
+                            [
+                                -96.15736708448,
+                                41.860196209018255
+                            ],
+                            [
+                                -96.11694289670451,
+                                41.84281159832309
+                            ],
+                            [
+                                -96.11245132028571,
+                                41.81382674818773
+                            ],
+                            [
+                                -96.07202713251021,
+                                41.79642953923999
+                            ],
+                            [
+                                -96.11694289670451,
+                                41.75001388899806
+                            ],
+                            [
+                                -96.11694289670451,
+                                41.726793469112664
+                            ],
+                            [
+                                -96.09897659102661,
+                                41.715180110818295
+                            ],
+                            [
+                                -96.13041762596362,
+                                41.697756138212135
+                            ],
+                            [
+                                -96.13041762596362,
+                                41.67451682961322
+                            ],
+                            [
+                                -96.09897659102661,
+                                41.645455890314246
+                            ],
+                            [
+                                -96.13041762596362,
+                                41.62801303210619
+                            ],
+                            [
+                                -96.13041762596362,
+                                41.60474854479802
+                            ],
+                            [
+                                -96.09897659102661,
+                                41.57565613550168
+                            ],
+                            [
+                                -96.10346816744632,
+                                41.534904738376376
+                            ],
+                            [
+                                -96.07202713251021,
+                                41.50578086825384
+                            ],
+                            [
+                                -96.03609452115442,
+                                41.50578086825384
+                            ],
+                            [
+                                -96.01812821547652,
+                                41.47081492443125
+                            ],
+                            [
+                                -95.9642292984428,
+                                41.44749381187754
+                            ],
+                            [
+                                -95.93727983992551,
+                                41.459155416417836
+                            ],
+                            [
+                                -95.92380511066732,
+                                41.453324876206956
+                            ],
+                            [
+                                -95.94177141634523,
+                                41.44166222344304
+                            ],
+                            [
+                                -95.93727983992551,
+                                41.41249642015934
+                            ],
+                            [
+                                -95.95524614560343,
+                                41.40082643057721
+                            ],
+                            [
+                                -95.93727983992551,
+                                41.37748016354434
+                            ],
+                            [
+                                -95.96872087486163,
+                                41.35996496181095
+                            ],
+                            [
+                                -95.9642292984428,
+                                41.33076248104183
+                            ],
+                            [
+                                -95.92380511066732,
+                                41.31323470645516
+                            ],
+                            [
+                                -95.94177141634523,
+                                41.28985700729874
+                            ],
+                            [
+                                -95.92380511066732,
+                                41.26647092833842
+                            ],
+                            [
+                                -95.92380511066732,
+                                41.219673634586805
+                            ],
+                            [
+                                -95.94177141634523,
+                                41.19626242160059
+                            ],
+                            [
+                                -95.92380511066732,
+                                41.172842832420734
+                            ],
+                            [
+                                -95.90134722856972,
+                                41.17869851493382
+                            ],
+                            [
+                                -95.88338092289183,
+                                41.166986626452925
+                            ],
+                            [
+                                -95.90134722856972,
+                                41.155272644210434
+                            ],
+                            [
+                                -95.86990619363362,
+                                41.1142572196588
+                            ],
+                            [
+                                -95.86990619363362,
+                                41.07908073220125
+                            ],
+                            [
+                                -95.88787249931153,
+                                41.06735105045115
+                            ],
+                            [
+                                -95.88787249931153,
+                                41.043885408763316
+                            ],
+                            [
+                                -95.86990619363362,
+                                41.020411396950735
+                            ],
+                            [
+                                -95.88787249931153,
+                                41.00867125254621
+                            ],
+                            [
+                                -95.86990619363362,
+                                40.98518468734098
+                            ],
+                            [
+                                -95.84295673511633,
+                                40.97343826678151
+                            ],
+                            [
+                                -95.84744831153603,
+                                40.920553489876006
+                            ],
+                            [
+                                -95.81600727659993,
+                                40.89115475902408
+                            ],
+                            [
+                                -95.86092304079423,
+                                40.86762636497023
+                            ],
+                            [
+                                -95.86092304079423,
+                                40.84408960810724
+                            ],
+                            [
+                                -95.84295673511633,
+                                40.832318093934916
+                            ],
+                            [
+                                -95.86092304079423,
+                                40.80876879473667
+                            ],
+                            [
+                                -95.84295673511633,
+                                40.78521113524266
+                            ],
+                            [
+                                -95.88338092289183,
+                                40.76753740478898
+                            ],
+                            [
+                                -95.88338092289183,
+                                40.74396511722541
+                            ],
+                            [
+                                -95.90134722856972,
+                                40.72038447217417
+                            ],
+                            [
+                                -95.86092304079423,
+                                40.70269350440533
+                            ],
+                            [
+                                -95.85643146437452,
+                                40.67319811374446
+                            ],
+                            [
+                                -95.78007466524413,
+                                40.64368966937722
+                            ],
+                            [
+                                -95.78007466524413,
+                                40.62007351659428
+                            ],
+                            [
+                                -95.76210835956624,
+                                40.60826230813637
+                            ],
+                            [
+                                -95.76210835956624,
+                                40.572816156092046
+                            ],
+                            [
+                                -95.71270101895134,
+                                40.578725152863676
+                            ],
+                            [
+                                -95.68575156043494,
+                                40.56690663745382
+                            ],
+                            [
+                                -95.66778525475705,
+                                40.578725152863676
+                            ],
+                            [
+                                -95.60490318488394,
+                                40.578725152863676
+                            ],
+                            [
+                                -95.58693687920605,
+                                40.56690663745382
+                            ],
+                            [
+                                -95.49710535081654,
+                                40.56690663745382
+                            ],
+                            [
+                                -95.47015589230016,
+                                40.578725152863676
+                            ],
+                            [
+                                -95.44320643378285,
+                                40.56690663745382
+                            ],
+                            [
+                                -95.41625697526555,
+                                40.578725152863676
+                            ],
+                            [
+                                -95.39829066958767,
+                                40.56690663745382
+                            ],
+                            [
+                                -95.36235805823186,
+                                40.56690663745382
+                            ],
+                            [
+                                -95.34439175255396,
+                                40.578725152863676
+                            ],
+                            [
+                                -95.30845914119817,
+                                40.578725152863676
+                            ],
+                            [
+                                -95.29049283552027,
+                                40.56690663745382
+                            ],
+                            [
+                                -95.10633820232157,
+                                40.572816156092046
+                            ],
+                            [
+                                -95.08837189664368,
+                                40.56099659696569
+                            ],
+                            [
+                                -95.05243928528789,
+                                40.56099659696569
+                            ],
+                            [
+                                -95.03447297960999,
+                                40.572816156092046
+                            ],
+                            [
+                                -95.00752352109359,
+                                40.56099659696569
+                            ],
+                            [
+                                -94.8907425341868,
+                                40.572816156092046
+                            ],
+                            [
+                                -94.8727762285089,
+                                40.56099659696569
+                            ],
+                            [
+                                -94.76946997086121,
+                                40.56690663745382
+                            ],
+                            [
+                                -94.7515036651833,
+                                40.55508603464455
+                            ],
+                            [
+                                -94.724554206666,
+                                40.56690663745382
+                            ],
+                            [
+                                -94.6616721367938,
+                                40.56690663745382
+                            ],
+                            [
+                                -94.643705831115,
+                                40.55508603464455
+                            ],
+                            [
+                                -94.61675637259862,
+                                40.56690663745382
+                            ],
+                            [
+                                -94.5538743027255,
+                                40.56690663745382
+                            ],
+                            [
+                                -94.53590799704762,
+                                40.55508603464455
+                            ],
+                            [
+                                -94.49997538569183,
+                                40.55508603464455
+                            ],
+                            [
+                                -94.48200908001392,
+                                40.56690663745382
+                            ],
+                            [
+                                -94.36522809310803,
+                                40.55508603464455
+                            ],
+                            [
+                                -94.33827863459074,
+                                40.56690663745382
+                            ],
+                            [
+                                -94.32031232891282,
+                                40.55508603464455
+                            ],
+                            [
+                                -94.28437971755703,
+                                40.55508603464455
+                            ],
+                            [
+                                -94.26641341187913,
+                                40.56690663745382
+                            ],
+                            [
+                                -94.02835986164676,
+                                40.56099659696569
+                            ],
+                            [
+                                -94.01039355596885,
+                                40.572816156092046
+                            ],
+                            [
+                                -93.98344409745246,
+                                40.56099659696569
+                            ],
+                            [
+                                -93.83971365202835,
+                                40.56099659696569
+                            ],
+                            [
+                                -93.82174734635046,
+                                40.572816156092046
+                            ],
+                            [
+                                -93.75886527647826,
+                                40.572816156092046
+                            ],
+                            [
+                                -93.73191581796097,
+                                40.56099659696569
+                            ],
+                            [
+                                -93.67352532450758,
+                                40.578725152863676
+                            ],
+                            [
+                                -93.64657586599118,
+                                40.56690663745382
+                            ],
+                            [
+                                -93.58369379611808,
+                                40.56690663745382
+                            ],
+                            [
+                                -93.5657274904402,
+                                40.578725152863676
+                            ],
+                            [
+                                -93.53877803192377,
+                                40.56690663745382
+                            ],
+                            [
+                                -93.23335083539861,
+                                40.56690663745382
+                            ],
+                            [
+                                -93.2064013768822,
+                                40.578725152863676
+                            ],
+                            [
+                                -93.1794519183649,
+                                40.56690663745382
+                            ],
+                            [
+                                -93.16148561268702,
+                                40.578725152863676
+                            ],
+                            [
+                                -92.95038152097192,
+                                40.572816156092046
+                            ],
+                            [
+                                -92.93241521529403,
+                                40.58463362775185
+                            ],
+                            [
+                                -92.50571545544325,
+                                40.578725152863676
+                            ],
+                            [
+                                -92.48774914976535,
+                                40.590541580739895
+                            ],
+                            [
+                                -92.39791762137585,
+                                40.590541580739895
+                            ],
+                            [
+                                -92.37096816285856,
+                                40.578725152863676
+                            ],
+                            [
+                                -92.33952712792245,
+                                40.59644901181115
+                            ],
+                            [
+                                -92.31257766940516,
+                                40.58463362775185
+                            ],
+                            [
+                                -92.27664505804935,
+                                40.58463362775185
+                            ],
+                            [
+                                -92.25867875237145,
+                                40.59644901181115
+                            ],
+                            [
+                                -92.23172929385507,
+                                40.58463362775185
+                            ],
+                            [
+                                -92.14189776546557,
+                                40.58463362775185
+                            ],
+                            [
+                                -92.11494830694828,
+                                40.59644901181115
+                            ],
+                            [
+                                -92.08799884843188,
+                                40.58463362775185
+                            ],
+                            [
+                                -92.07003254275398,
+                                40.59644901181115
+                            ],
+                            [
+                                -91.91282736807167,
+                                40.590541580739895
+                            ],
+                            [
+                                -91.85443687461829,
+                                40.60826230813637
+                            ],
+                            [
+                                -91.82748741610189,
+                                40.59644901181115
+                            ],
+                            [
+                                -91.8005379575846,
+                                40.60826230813637
+                            ],
+                            [
+                                -91.73765588771239,
+                                40.60826230813637
+                            ],
+                            [
+                                -91.71968958203449,
+                                40.58463362775185
+                            ],
+                            [
+                                -91.6927401235172,
+                                40.572816156092046
+                            ],
+                            [
+                                -91.6927401235172,
+                                40.54917495050712
+                            ],
+                            [
+                                -91.65680751216141,
+                                40.54917495050712
+                            ],
+                            [
+                                -91.65231593574171,
+                                40.53143856736625
+                            ],
+                            [
+                                -91.62985805364501,
+                                40.53735121685109
+                            ],
+                            [
+                                -91.62985805364501,
+                                40.50186749405108
+                            ],
+                            [
+                                -91.6029085951277,
+                                40.490035412959934
+                            ],
+                            [
+                                -91.58494228944981,
+                                40.45452665112581
+                            ],
+                            [
+                                -91.54900967809402,
+                                40.45452665112581
+                            ],
+                            [
+                                -91.53104337241611,
+                                40.43084371247727
+                            ],
+                            [
+                                -91.53104337241611,
+                                40.39530366113244
+                            ],
+                            [
+                                -91.50858549031851,
+                                40.4012283065072
+                            ],
+                            [
+                                -91.49061918464062,
+                                40.377526596960685
+                            ],
+                            [
+                                -91.45468657328482,
+                                40.365672614315415
                             ]
                         ]
                     ]
@@ -16125,7 +9522,7 @@
             "links": [
                 {
                     "rel": "self",
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-stac/ept/AK_ValdezB_2007.json"
+                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-stac/ept/IA_FullState.json"
                 },
                 {
                     "rel": "parent",
@@ -16134,16 +9531,16 @@
             ],
             "assets": {
                 "ept.json": {
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-public/AK_ValdezB_2007/ept.json",
+                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-public/IA_FullState/ept.json",
                     "title": "entwine",
                     "description": "The ept.json for accessing data"
                 }
             },
             "bbox": [
-                -146.64771706789926,
-                61.027998332559285,
-                -145.902115382266,
-                61.16336800897104
+                -96.65593206704239,
+                40.365672614315415,
+                -90.12967152953821,
+                43.518363356492316
             ],
             "stac_extensions": [
                 "https://stac-extensions.github.io/pointcloud/v1.0.0/schema.json",
@@ -16153,2602 +9550,30 @@
         {
             "type": "Feature",
             "stac_version": "1.0.0",
-            "id": "AK_Valdez_2007",
+            "id": "IA_Eastern_1_2019",
             "properties": {
                 "description": "A USGS Lidar pointcloud in Entwine/EPT format",
-                "pc:count": 798336818,
+                "pc:count": 154630110433,
                 "pc:type": "lidar",
                 "pc:encoding": "ept",
                 "pc:schemas": [
                     {
                         "name": "X",
-                        "offset": -16283584,
+                        "offset": -10180500,
                         "scale": 0.01,
                         "size": 4,
                         "type": "signed"
                     },
                     {
                         "name": "Y",
-                        "offset": 8636419,
+                        "offset": 5067635,
                         "scale": 0.01,
                         "size": 4,
                         "type": "signed"
                     },
                     {
                         "name": "Z",
-                        "offset": 870,
-                        "scale": 0.01,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Intensity",
-                        "size": 2,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ReturnNumber",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "NumberOfReturns",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ScanDirectionFlag",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "EdgeOfFlightLine",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "Classification",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ScanAngleRank",
-                        "size": 4,
-                        "type": "floating"
-                    },
-                    {
-                        "name": "UserData",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "PointSourceId",
-                        "size": 2,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "GpsTime",
-                        "size": 8,
-                        "type": "floating"
-                    },
-                    {
-                        "name": "OriginId",
-                        "size": 4,
-                        "type": "unsigned"
-                    }
-                ],
-                "proj:epsg": 3857,
-                "proj:projjson": {
-                    "$schema": "https://proj.org/schemas/v0.5/projjson.schema.json",
-                    "type": "ProjectedCRS",
-                    "name": "WGS 84 / Pseudo-Mercator",
-                    "base_crs": {
-                        "name": "WGS 84",
-                        "datum_ensemble": {
-                            "name": "World Geodetic System 1984 ensemble",
-                            "members": [
-                                {
-                                    "name": "World Geodetic System 1984 (Transit)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1166
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G730)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1152
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G873)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1153
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1150)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1154
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1674)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1155
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1762)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1156
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G2139)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1309
-                                    }
-                                }
-                            ],
-                            "ellipsoid": {
-                                "name": "WGS 84",
-                                "semi_major_axis": 6378137,
-                                "inverse_flattening": 298.257223563
-                            },
-                            "accuracy": "2.0",
-                            "id": {
-                                "authority": "EPSG",
-                                "code": 6326
-                            }
-                        },
-                        "coordinate_system": {
-                            "subtype": "ellipsoidal",
-                            "axis": [
-                                {
-                                    "name": "Geodetic latitude",
-                                    "abbreviation": "Lat",
-                                    "direction": "north",
-                                    "unit": "degree"
-                                },
-                                {
-                                    "name": "Geodetic longitude",
-                                    "abbreviation": "Lon",
-                                    "direction": "east",
-                                    "unit": "degree"
-                                }
-                            ]
-                        },
-                        "id": {
-                            "authority": "EPSG",
-                            "code": 4326
-                        }
-                    },
-                    "conversion": {
-                        "name": "Popular Visualisation Pseudo-Mercator",
-                        "method": {
-                            "name": "Popular Visualisation Pseudo Mercator",
-                            "id": {
-                                "authority": "EPSG",
-                                "code": 1024
-                            }
-                        },
-                        "parameters": [
-                            {
-                                "name": "Latitude of natural origin",
-                                "value": 0,
-                                "unit": "degree",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8801
-                                }
-                            },
-                            {
-                                "name": "Longitude of natural origin",
-                                "value": 0,
-                                "unit": "degree",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8802
-                                }
-                            },
-                            {
-                                "name": "False easting",
-                                "value": 0,
-                                "unit": "metre",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8806
-                                }
-                            },
-                            {
-                                "name": "False northing",
-                                "value": 0,
-                                "unit": "metre",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8807
-                                }
-                            }
-                        ]
-                    },
-                    "coordinate_system": {
-                        "subtype": "Cartesian",
-                        "axis": [
-                            {
-                                "name": "Easting",
-                                "abbreviation": "X",
-                                "direction": "east",
-                                "unit": "metre"
-                            },
-                            {
-                                "name": "Northing",
-                                "abbreviation": "Y",
-                                "direction": "north",
-                                "unit": "metre"
-                            }
-                        ]
-                    },
-                    "scope": "Web mapping and visualisation.",
-                    "area": "World between 85.06°S and 85.06°N.",
-                    "bbox": {
-                        "south_latitude": -85.06,
-                        "west_longitude": -180,
-                        "north_latitude": 85.06,
-                        "east_longitude": 180
-                    },
-                    "id": {
-                        "authority": "EPSG",
-                        "code": 3857
-                    }
-                },
-                "datetime": "2023-01-11T17:08:49.113251Z"
-            },
-            "geometry": {
-                "type": "MultiPolygon",
-                "coordinates": [
-                    [
-                        [
-                            [
-                                -146.0331623344506,
-                                61.00511956323127
-                            ],
-                            [
-                                -146.0062128759333,
-                                61.00511956323127
-                            ],
-                            [
-                                -145.98824657025543,
-                                61.01266073881787
-                            ],
-                            [
-                                -145.96578868815868,
-                                61.008890374934026
-                            ],
-                            [
-                                -145.9478223824799,
-                                61.01643065491962
-                            ],
-                            [
-                                -145.91188977112503,
-                                61.008890374934026
-                            ],
-                            [
-                                -145.91188977112503,
-                                61.04657386800306
-                            ],
-                            [
-                                -145.9343476532217,
-                                61.05033975572528
-                            ],
-                            [
-                                -145.96129711173901,
-                                61.0428075328306
-                            ],
-                            [
-                                -146.0196876051924,
-                                61.05410519603424
-                            ],
-                            [
-                                -146.0690949458064,
-                                61.05033975572528
-                            ],
-                            [
-                                -146.0870612514843,
-                                61.0729256876706
-                            ],
-                            [
-                                -146.1140107100007,
-                                61.080450753723554
-                            ],
-                            [
-                                -146.13646859209828,
-                                61.076688444274545
-                            ],
-                            [
-                                -146.1544348977762,
-                                61.084212616054444
-                            ],
-                            [
-                                -146.271215884683,
-                                61.084212616054444
-                            ],
-                            [
-                                -146.3026569196191,
-                                61.0653988328501
-                            ],
-                            [
-                                -146.3430811073946,
-                                61.076688444274545
-                            ],
-                            [
-                                -146.4059631772677,
-                                61.076688444274545
-                            ],
-                            [
-                                -146.43740421220377,
-                                61.0653988328501
-                            ],
-                            [
-                                -146.45986209430137,
-                                61.06916248387473
-                            ],
-                            [
-                                -146.4778283999793,
-                                61.061634734559746
-                            ],
-                            [
-                                -146.5047778584957,
-                                61.06916248387473
-                            ],
-                            [
-                                -146.581134657627,
-                                61.0653988328501
-                            ],
-                            [
-                                -146.60808411614425,
-                                61.0729256876706
-                            ],
-                            [
-                                -146.65299988033857,
-                                61.057870188966724
-                            ],
-                            [
-                                -146.63503357466067,
-                                61.0428075328306
-                            ],
-                            [
-                                -146.60808411614425,
-                                61.05033975572528
-                            ],
-                            [
-                                -146.581134657627,
-                                61.0428075328306
-                            ],
-                            [
-                                -146.54520204627116,
-                                61.0428075328306
-                            ],
-                            [
-                                -146.51825258775477,
-                                61.05033975572528
-                            ],
-                            [
-                                -146.4778283999793,
-                                61.03904075017109
-                            ],
-                            [
-                                -146.47333682355958,
-                                61.05033975572528
-                            ],
-                            [
-                                -146.44638736504228,
-                                61.0428075328306
-                            ],
-                            [
-                                -146.41045475368648,
-                                61.05033975572528
-                            ],
-                            [
-                                -146.3924884480086,
-                                61.0428075328306
-                            ],
-                            [
-                                -146.3700305659119,
-                                61.04657386800306
-                            ],
-                            [
-                                -146.33858953097487,
-                                61.03527351998759
-                            ],
-                            [
-                                -146.3116400724585,
-                                61.0428075328306
-                            ],
-                            [
-                                -146.2891821903609,
-                                61.03904075017109
-                            ],
-                            [
-                                -146.27570746110268,
-                                61.05033975572528
-                            ],
-                            [
-                                -146.25774115542478,
-                                61.0428075328306
-                            ],
-                            [
-                                -146.23528327332718,
-                                61.04657386800306
-                            ],
-                            [
-                                -146.1768927798738,
-                                61.027737716901115
-                            ],
-                            [
-                                -146.1544348977762,
-                                61.0315058422432
-                            ],
-                            [
-                                -146.1095191335819,
-                                61.01643065491962
-                            ],
-                            [
-                                -146.060111792967,
-                                61.0202001232762
-                            ],
-                            [
-                                -146.0331623344506,
-                                61.00511956323127
-                            ]
-                        ]
-                    ]
-                ]
-            },
-            "links": [
-                {
-                    "rel": "self",
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-stac/ept/AK_Valdez_2007.json"
-                },
-                {
-                    "rel": "parent",
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-stac/ept/catalog.json"
-                }
-            ],
-            "assets": {
-                "ept.json": {
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-public/AK_Valdez_2007/ept.json",
-                    "title": "entwine",
-                    "description": "The ept.json for accessing data"
-                }
-            },
-            "bbox": [
-                -146.65299988033857,
-                61.00511956323127,
-                -145.91188977112503,
-                61.084212616054444
-            ],
-            "stac_extensions": [
-                "https://stac-extensions.github.io/pointcloud/v1.0.0/schema.json",
-                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
-            ]
-        },
-        {
-            "type": "Feature",
-            "stac_version": "1.0.0",
-            "id": "AK_YukonFlats_2009",
-            "properties": {
-                "description": "A USGS Lidar pointcloud in Entwine/EPT format",
-                "pc:count": 968643215,
-                "pc:type": "lidar",
-                "pc:encoding": "ept",
-                "pc:schemas": [
-                    {
-                        "name": "X",
-                        "offset": -16240042,
-                        "scale": 0.01,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Y",
-                        "offset": 9925543,
-                        "scale": 0.01,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Z",
-                        "offset": 292,
-                        "scale": 0.01,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Intensity",
-                        "size": 2,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ReturnNumber",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "NumberOfReturns",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ScanDirectionFlag",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "EdgeOfFlightLine",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "Classification",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ScanAngleRank",
-                        "size": 4,
-                        "type": "floating"
-                    },
-                    {
-                        "name": "UserData",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "PointSourceId",
-                        "size": 2,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "GpsTime",
-                        "size": 8,
-                        "type": "floating"
-                    },
-                    {
-                        "name": "OriginId",
-                        "size": 4,
-                        "type": "unsigned"
-                    }
-                ],
-                "proj:epsg": 3857,
-                "proj:projjson": {
-                    "$schema": "https://proj.org/schemas/v0.5/projjson.schema.json",
-                    "type": "ProjectedCRS",
-                    "name": "WGS 84 / Pseudo-Mercator",
-                    "base_crs": {
-                        "name": "WGS 84",
-                        "datum_ensemble": {
-                            "name": "World Geodetic System 1984 ensemble",
-                            "members": [
-                                {
-                                    "name": "World Geodetic System 1984 (Transit)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1166
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G730)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1152
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G873)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1153
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1150)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1154
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1674)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1155
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1762)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1156
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G2139)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1309
-                                    }
-                                }
-                            ],
-                            "ellipsoid": {
-                                "name": "WGS 84",
-                                "semi_major_axis": 6378137,
-                                "inverse_flattening": 298.257223563
-                            },
-                            "accuracy": "2.0",
-                            "id": {
-                                "authority": "EPSG",
-                                "code": 6326
-                            }
-                        },
-                        "coordinate_system": {
-                            "subtype": "ellipsoidal",
-                            "axis": [
-                                {
-                                    "name": "Geodetic latitude",
-                                    "abbreviation": "Lat",
-                                    "direction": "north",
-                                    "unit": "degree"
-                                },
-                                {
-                                    "name": "Geodetic longitude",
-                                    "abbreviation": "Lon",
-                                    "direction": "east",
-                                    "unit": "degree"
-                                }
-                            ]
-                        },
-                        "id": {
-                            "authority": "EPSG",
-                            "code": 4326
-                        }
-                    },
-                    "conversion": {
-                        "name": "Popular Visualisation Pseudo-Mercator",
-                        "method": {
-                            "name": "Popular Visualisation Pseudo Mercator",
-                            "id": {
-                                "authority": "EPSG",
-                                "code": 1024
-                            }
-                        },
-                        "parameters": [
-                            {
-                                "name": "Latitude of natural origin",
-                                "value": 0,
-                                "unit": "degree",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8801
-                                }
-                            },
-                            {
-                                "name": "Longitude of natural origin",
-                                "value": 0,
-                                "unit": "degree",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8802
-                                }
-                            },
-                            {
-                                "name": "False easting",
-                                "value": 0,
-                                "unit": "metre",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8806
-                                }
-                            },
-                            {
-                                "name": "False northing",
-                                "value": 0,
-                                "unit": "metre",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8807
-                                }
-                            }
-                        ]
-                    },
-                    "coordinate_system": {
-                        "subtype": "Cartesian",
-                        "axis": [
-                            {
-                                "name": "Easting",
-                                "abbreviation": "X",
-                                "direction": "east",
-                                "unit": "metre"
-                            },
-                            {
-                                "name": "Northing",
-                                "abbreviation": "Y",
-                                "direction": "north",
-                                "unit": "metre"
-                            }
-                        ]
-                    },
-                    "scope": "Web mapping and visualisation.",
-                    "area": "World between 85.06°S and 85.06°N.",
-                    "bbox": {
-                        "south_latitude": -85.06,
-                        "west_longitude": -180,
-                        "north_latitude": 85.06,
-                        "east_longitude": 180
-                    },
-                    "id": {
-                        "authority": "EPSG",
-                        "code": 3857
-                    }
-                },
-                "datetime": "2023-01-11T17:08:49.115365Z"
-            },
-            "geometry": {
-                "type": "MultiPolygon",
-                "coordinates": [
-                    [
-                        [
-                            [
-                                -146.47121706889828,
-                                65.75018454528008
-                            ],
-                            [
-                                -146.4397760339622,
-                                65.77254140577831
-                            ],
-                            [
-                                -146.3903686933482,
-                                65.78849873225971
-                            ],
-                            [
-                                -146.37240238767032,
-                                65.80763448621865
-                            ],
-                            [
-                                -146.3229950470554,
-                                65.82357008872722
-                            ],
-                            [
-                                -146.30502874137753,
-                                65.84267978808853
-                            ],
-                            [
-                                -146.2825708592808,
-                                65.84586335723246
-                            ],
-                            [
-                                -146.2646045536029,
-                                65.86495649115074
-                            ],
-                            [
-                                -146.21519721298802,
-                                65.88085659628139
-                            ],
-                            [
-                                -146.21070563656923,
-                                65.89674685225212
-                            ],
-                            [
-                                -146.1747730252134,
-                                65.90310019796864
-                            ],
-                            [
-                                -146.1702814487937,
-                                65.9126272639424
-                            ],
-                            [
-                                -146.14782356669613,
-                                65.91580216539622
-                            ],
-                            [
-                                -146.1298572610182,
-                                65.93484331120824
-                            ],
-                            [
-                                -146.08044992040422,
-                                65.95070011653388
-                            ],
-                            [
-                                -146.06248361472632,
-                                65.96971531080301
-                            ],
-                            [
-                                -146.01307627411143,
-                                65.98555050165128
-                            ],
-                            [
-                                -145.99510996843352,
-                                66.00453977271751
-                            ],
-                            [
-                                -145.94570262781954,
-                                66.02035337270486
-                            ],
-                            [
-                                -145.90078686362435,
-                                66.05195115889708
-                            ],
-                            [
-                                -145.87832898152763,
-                                66.05510878165059
-                            ],
-                            [
-                                -145.86036267584973,
-                                66.0740462913295
-                            ],
-                            [
-                                -145.83790479375216,
-                                66.0772011721666
-                            ],
-                            [
-                                -145.83341321733243,
-                                66.08666346555681
-                            ],
-                            [
-                                -145.78400587671845,
-                                66.1024261264787
-                            ],
-                            [
-                                -145.77951430029876,
-                                66.11817900655197
-                            ],
-                            [
-                                -145.75705641820116,
-                                66.12132840929416
-                            ],
-                            [
-                                -145.75256484178144,
-                                66.13077427167829
-                            ],
-                            [
-                                -145.70315750116745,
-                                66.14650955851914
-                            ],
-                            [
-                                -145.68519119548955,
-                                66.16537901046999
-                            ],
-                            [
-                                -145.63578385487557,
-                                66.18109281593834
-                            ],
-                            [
-                                -145.61781754919767,
-                                66.19993650441012
-                            ],
-                            [
-                                -145.59535966710007,
-                                66.20307575384372
-                            ],
-                            [
-                                -145.59086809068037,
-                                66.21249116239099
-                            ],
-                            [
-                                -145.54146075006636,
-                                66.22817571313234
-                            ],
-                            [
-                                -145.52349444438846,
-                                66.24698431525057
-                            ],
-                            [
-                                -145.47408710377445,
-                                66.26264744043014
-                            ],
-                            [
-                                -145.45612079809655,
-                                66.28143034604048
-                            ],
-                            [
-                                -145.40671345748166,
-                                66.29707206926845
-                            ],
-                            [
-                                -145.40222188106287,
-                                66.30645243712254
-                            ],
-                            [
-                                -145.37976399896527,
-                                66.30957844896093
-                            ],
-                            [
-                                -145.36179769328737,
-                                66.3283263595366
-                            ],
-                            [
-                                -145.33933981118975,
-                                66.33144965158759
-                            ],
-                            [
-                                -145.33484823477008,
-                                66.3408171975869
-                            ],
-                            [
-                                -145.2854408941561,
-                                66.35642200941433
-                            ],
-                            [
-                                -145.26747458847817,
-                                66.37513497763335
-                            ],
-                            [
-                                -145.24501670638057,
-                                66.37825244800672
-                            ],
-                            [
-                                -145.2405251299609,
-                                66.38760253248473
-                            ],
-                            [
-                                -145.1911177893469,
-                                66.40317825348191
-                            ],
-                            [
-                                -145.173151483669,
-                                66.42185633201741
-                            ],
-                            [
-                                -145.12374414305498,
-                                66.43741074763476
-                            ],
-                            [
-                                -145.11925256663528,
-                                66.44673875199166
-                            ],
-                            [
-                                -145.09679468453768,
-                                66.44984731284254
-                            ],
-                            [
-                                -145.07882837885978,
-                                66.4684905543623
-                            ],
-                            [
-                                -145.05637049676218,
-                                66.47159640771557
-                            ],
-                            [
-                                -145.0518789203434,
-                                66.48091164815528
-                            ],
-                            [
-                                -145.0249294618261,
-                                66.48711987582146
-                            ],
-                            [
-                                -145.0294210382458,
-                                66.49642931916145
-                            ],
-                            [
-                                -145.0653536496016,
-                                66.50263368306999
-                            ],
-                            [
-                                -145.0698452260213,
-                                66.5119373322353
-                            ],
-                            [
-                                -145.11925256663528,
-                                66.52123750630054
-                            ],
-                            [
-                                -145.12374414305498,
-                                66.53053420631804
-                            ],
-                            [
-                                -145.1866262129272,
-                                66.5429244040879
-                            ],
-                            [
-                                -145.1911177893469,
-                                66.5522130020904
-                            ],
-                            [
-                                -145.2405251299609,
-                                66.56149812955557
-                            ],
-                            [
-                                -145.24501670638057,
-                                66.57077978753603
-                            ],
-                            [
-                                -145.3078987762537,
-                                66.58314993635429
-                            ],
-                            [
-                                -145.32586508193157,
-                                66.59551392156831
-                            ],
-                            [
-                                -145.36179769328737,
-                                66.58933269925589
-                            ],
-                            [
-                                -145.37976399896527,
-                                66.57077978753603
-                            ],
-                            [
-                                -145.42917133957926,
-                                66.55530843014203
-                            ],
-                            [
-                                -145.43366291599898,
-                                66.54602098910233
-                            ],
-                            [
-                                -145.45612079809655,
-                                66.5429244040879
-                            ],
-                            [
-                                -145.47408710377445,
-                                66.52433679225938
-                            ],
-                            [
-                                -145.52349444438846,
-                                66.50883650202101
-                            ],
-                            [
-                                -145.54146075006636,
-                                66.49022340998376
-                            ],
-                            [
-                                -145.59086809068037,
-                                66.47470187443948
-                            ],
-                            [
-                                -145.60883439635825,
-                                66.4560632738761
-                            ],
-                            [
-                                -145.63129227845585,
-                                66.45295548679101
-                            ],
-                            [
-                                -145.63578385487557,
-                                66.44362980419952
-                            ],
-                            [
-                                -145.65824173697317,
-                                66.44052046942687
-                            ],
-                            [
-                                -145.67620804265104,
-                                66.42807925975178
-                            ],
-                            [
-                                -145.73909011252326,
-                                66.44052046942687
-                            ],
-                            [
-                                -145.74358168894292,
-                                66.44984731284254
-                            ],
-                            [
-                                -145.80646375881605,
-                                66.46227768761176
-                            ],
-                            [
-                                -145.81095533523484,
-                                66.47159640771557
-                            ],
-                            [
-                                -145.88731213436614,
-                                66.48711987582146
-                            ],
-                            [
-                                -145.91426159288343,
-                                66.48091164815528
-                            ],
-                            [
-                                -145.95917735707772,
-                                66.44984731284254
-                            ],
-                            [
-                                -145.98163523917532,
-                                66.44673875199166
-                            ],
-                            [
-                                -145.99960154485325,
-                                66.42807925975178
-                            ],
-                            [
-                                -146.04900888546723,
-                                66.41251903591709
-                            ],
-                            [
-                                -146.06697519114513,
-                                66.39383398365847
-                            ],
-                            [
-                                -146.10290780250094,
-                                66.38760253248473
-                            ],
-                            [
-                                -146.1433319902764,
-                                66.3969491278189
-                            ],
-                            [
-                                -146.14782356669613,
-                                66.40629223506254
-                            ],
-                            [
-                                -146.22418036582744,
-                                66.42185633201741
-                            ],
-                            [
-                                -146.2286719422471,
-                                66.43119014283627
-                            ],
-                            [
-                                -146.2780792828611,
-                                66.44052046942687
-                            ],
-                            [
-                                -146.2825708592808,
-                                66.44984731284254
-                            ],
-                            [
-                                -146.30502874137753,
-                                66.44673875199166
-                            ],
-                            [
-                                -146.30952031779722,
-                                66.4560632738761
-                            ],
-                            [
-                                -146.3589276584121,
-                                66.46538431434071
-                            ],
-                            [
-                                -146.3634192348309,
-                                66.47470187443948
-                            ],
-                            [
-                                -146.3993518461867,
-                                66.48091164815528
-                            ],
-                            [
-                                -146.4173181518646,
-                                66.4684905543623
-                            ],
-                            [
-                                -146.4397760339622,
-                                66.46538431434071
-                            ],
-                            [
-                                -146.4442676103819,
-                                66.4560632738761
-                            ],
-                            [
-                                -146.4667254924795,
-                                66.45295548679101
-                            ],
-                            [
-                                -146.4846917981574,
-                                66.43430063878422
-                            ],
-                            [
-                                -146.50714968025412,
-                                66.43119014283627
-                            ],
-                            [
-                                -146.51164125667378,
-                                66.42185633201741
-                            ],
-                            [
-                                -146.53409913877138,
-                                66.41874428728951
-                            ],
-                            [
-                                -146.5520654444493,
-                                66.40006388441368
-                            ],
-                            [
-                                -146.57452332654688,
-                                66.3969491278189
-                            ],
-                            [
-                                -146.59248963222478,
-                                66.38448622539343
-                            ],
-                            [
-                                -146.57452332654688,
-                                66.37201711942123
-                            ],
-                            [
-                                -146.4981665274156,
-                                66.35642200941433
-                            ],
-                            [
-                                -146.49367495099588,
-                                66.3470602868485
-                            ],
-                            [
-                                -146.4442676103819,
-                                66.33769507057373
-                            ],
-                            [
-                                -146.4397760339622,
-                                66.3283263595366
-                            ],
-                            [
-                                -146.4173181518646,
-                                66.33144965158759
-                            ],
-                            [
-                                -146.41282657544582,
-                                66.32207861012355
-                            ],
-                            [
-                                -146.34994450557272,
-                                66.30957844896093
-                            ],
-                            [
-                                -146.345452929153,
-                                66.30019924731532
-                            ],
-                            [
-                                -146.29155401211932,
-                                66.28768820208646
-                            ],
-                            [
-                                -146.33646977631452,
-                                66.25638335836189
-                            ],
-                            [
-                                -146.3858771169285,
-                                66.24071633938178
-                            ],
-                            [
-                                -146.40384342260643,
-                                66.22190306212723
-                            ],
-                            [
-                                -146.4532507632204,
-                                66.20621461329242
-                            ],
-                            [
-                                -146.47121706889828,
-                                66.1873756060453
-                            ],
-                            [
-                                -146.5206244095132,
-                                66.17166570374408
-                            ],
-                            [
-                                -146.5385907151911,
-                                66.15280093816976
-                            ],
-                            [
-                                -146.5610485972878,
-                                66.14965544366869
-                            ],
-                            [
-                                -146.57901490296658,
-                                66.13077427167829
-                            ],
-                            [
-                                -146.605964361483,
-                                66.12447742103656
-                            ],
-                            [
-                                -146.6014727850633,
-                                66.11502921277102
-                            ],
-                            [
-                                -146.51164125667378,
-                                66.096122236085
-                            ],
-                            [
-                                -146.50714968025412,
-                                66.08666346555681
-                            ],
-                            [
-                                -146.4442676103819,
-                                66.0740462913295
-                            ],
-                            [
-                                -146.4397760339622,
-                                66.06457929915061
-                            ],
-                            [
-                                -146.3768939640891,
-                                66.05195115889708
-                            ],
-                            [
-                                -146.3589276584121,
-                                66.03931674890788
-                            ],
-                            [
-                                -146.3858771169285,
-                                66.0329971919817
-                            ],
-                            [
-                                -146.3903686933482,
-                                66.02351491579975
-                            ],
-                            [
-                                -146.41282657544582,
-                                66.02035337270486
-                            ],
-                            [
-                                -146.4307928811237,
-                                66.00137587554417
-                            ],
-                            [
-                                -146.48020022173768,
-                                65.98555050165128
-                            ],
-                            [
-                                -146.4846917981574,
-                                65.97605056548923
-                            ],
-                            [
-                                -146.50714968025412,
-                                65.97288313456332
-                            ],
-                            [
-                                -146.525115985932,
-                                65.95387029812004
-                            ],
-                            [
-                                -146.5475738680296,
-                                65.95070011653388
-                            ],
-                            [
-                                -146.5520654444493,
-                                65.94118721297359
-                            ],
-                            [
-                                -146.6014727850633,
-                                65.92532450869174
-                            ],
-                            [
-                                -146.6194390907412,
-                                65.90627628026769
-                            ],
-                            [
-                                -146.6688464313561,
-                                65.89039193145072
-                            ],
-                            [
-                                -146.67333800777487,
-                                65.88085659628139
-                            ],
-                            [
-                                -146.69579588987247,
-                                65.87767736334419
-                            ],
-                            [
-                                -146.7137621955504,
-                                65.85859369024068
-                            ],
-                            [
-                                -146.736220077648,
-                                65.85541169844566
-                            ],
-                            [
-                                -146.7541863833259,
-                                65.84267978808853
-                            ],
-                            [
-                                -146.72723692480858,
-                                65.83631146645713
-                            ],
-                            [
-                                -146.7227453483898,
-                                65.82675602506566
-                            ],
-                            [
-                                -146.6598632785167,
-                                65.81400991154148
-                            ],
-                            [
-                                -146.655371702097,
-                                65.8044461812804
-                            ],
-                            [
-                                -146.59248963222478,
-                                65.79168901210458
-                            ],
-                            [
-                                -146.58799805580512,
-                                65.78211698723568
-                            ],
-                            [
-                                -146.525115985932,
-                                65.76934875475735
-                            ],
-                            [
-                                -146.5206244095132,
-                                65.75976842954255
-                            ],
-                            [
-                                -146.47121706889828,
-                                65.75018454528008
-                            ]
-                        ]
-                    ]
-                ]
-            },
-            "links": [
-                {
-                    "rel": "self",
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-stac/ept/AK_YukonFlats_2009.json"
-                },
-                {
-                    "rel": "parent",
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-stac/ept/catalog.json"
-                }
-            ],
-            "assets": {
-                "ept.json": {
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-public/AK_YukonFlats_2009/ept.json",
-                    "title": "entwine",
-                    "description": "The ept.json for accessing data"
-                }
-            },
-            "bbox": [
-                -146.7541863833259,
-                65.75018454528008,
-                -145.0249294618261,
-                66.59551392156831
-            ],
-            "stac_extensions": [
-                "https://stac-extensions.github.io/pointcloud/v1.0.0/schema.json",
-                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
-            ]
-        },
-        {
-            "type": "Feature",
-            "stac_version": "1.0.0",
-            "id": "AL_17Co_1_2020",
-            "properties": {
-                "description": "A USGS Lidar pointcloud in Entwine/EPT format",
-                "pc:count": 184424043388,
-                "pc:type": "lidar",
-                "pc:encoding": "ept",
-                "pc:schemas": [
-                    {
-                        "name": "X",
-                        "offset": -9668484,
-                        "scale": 0.001,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Y",
-                        "offset": 4080225,
-                        "scale": 0.001,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Z",
-                        "offset": 357,
-                        "scale": 0.001,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Intensity",
-                        "size": 2,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ReturnNumber",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "NumberOfReturns",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ScanDirectionFlag",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "EdgeOfFlightLine",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "Classification",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ScanAngleRank",
-                        "size": 4,
-                        "type": "floating"
-                    },
-                    {
-                        "name": "UserData",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "PointSourceId",
-                        "size": 2,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "GpsTime",
-                        "size": 8,
-                        "type": "floating"
-                    },
-                    {
-                        "name": "ScanChannel",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ClassFlags",
-                        "size": 1,
-                        "type": "unsigned"
-                    }
-                ],
-                "proj:epsg": 3857,
-                "proj:projjson": {
-                    "$schema": "https://proj.org/schemas/v0.5/projjson.schema.json",
-                    "type": "ProjectedCRS",
-                    "name": "WGS 84 / Pseudo-Mercator",
-                    "base_crs": {
-                        "name": "WGS 84",
-                        "datum_ensemble": {
-                            "name": "World Geodetic System 1984 ensemble",
-                            "members": [
-                                {
-                                    "name": "World Geodetic System 1984 (Transit)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1166
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G730)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1152
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G873)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1153
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1150)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1154
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1674)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1155
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1762)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1156
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G2139)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1309
-                                    }
-                                }
-                            ],
-                            "ellipsoid": {
-                                "name": "WGS 84",
-                                "semi_major_axis": 6378137,
-                                "inverse_flattening": 298.257223563
-                            },
-                            "accuracy": "2.0",
-                            "id": {
-                                "authority": "EPSG",
-                                "code": 6326
-                            }
-                        },
-                        "coordinate_system": {
-                            "subtype": "ellipsoidal",
-                            "axis": [
-                                {
-                                    "name": "Geodetic latitude",
-                                    "abbreviation": "Lat",
-                                    "direction": "north",
-                                    "unit": "degree"
-                                },
-                                {
-                                    "name": "Geodetic longitude",
-                                    "abbreviation": "Lon",
-                                    "direction": "east",
-                                    "unit": "degree"
-                                }
-                            ]
-                        },
-                        "id": {
-                            "authority": "EPSG",
-                            "code": 4326
-                        }
-                    },
-                    "conversion": {
-                        "name": "Popular Visualisation Pseudo-Mercator",
-                        "method": {
-                            "name": "Popular Visualisation Pseudo Mercator",
-                            "id": {
-                                "authority": "EPSG",
-                                "code": 1024
-                            }
-                        },
-                        "parameters": [
-                            {
-                                "name": "Latitude of natural origin",
-                                "value": 0,
-                                "unit": "degree",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8801
-                                }
-                            },
-                            {
-                                "name": "Longitude of natural origin",
-                                "value": 0,
-                                "unit": "degree",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8802
-                                }
-                            },
-                            {
-                                "name": "False easting",
-                                "value": 0,
-                                "unit": "metre",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8806
-                                }
-                            },
-                            {
-                                "name": "False northing",
-                                "value": 0,
-                                "unit": "metre",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8807
-                                }
-                            }
-                        ]
-                    },
-                    "coordinate_system": {
-                        "subtype": "Cartesian",
-                        "axis": [
-                            {
-                                "name": "Easting",
-                                "abbreviation": "X",
-                                "direction": "east",
-                                "unit": "metre"
-                            },
-                            {
-                                "name": "Northing",
-                                "abbreviation": "Y",
-                                "direction": "north",
-                                "unit": "metre"
-                            }
-                        ]
-                    },
-                    "scope": "Web mapping and visualisation.",
-                    "area": "World between 85.06°S and 85.06°N.",
-                    "bbox": {
-                        "south_latitude": -85.06,
-                        "west_longitude": -180,
-                        "north_latitude": 85.06,
-                        "east_longitude": 180
-                    },
-                    "id": {
-                        "authority": "EPSG",
-                        "code": 3857
-                    }
-                },
-                "datetime": "2023-01-11T17:08:49.118107Z"
-            },
-            "geometry": {
-                "type": "MultiPolygon",
-                "coordinates": [
-                    [
-                        [
-                            [
-                                -86.14173312910766,
-                                33.72056032907575
-                            ],
-                            [
-                                -86.12376682342978,
-                                33.7335008595267
-                            ],
-                            [
-                                -86.06986790639597,
-                                33.7335008595267
-                            ],
-                            [
-                                -86.06986790639597,
-                                33.87571782441767
-                            ],
-                            [
-                                -86.08783421207387,
-                                33.88863491450404
-                            ],
-                            [
-                                -86.08334263565445,
-                                33.92091908266848
-                            ],
-                            [
-                                -86.13724155268815,
-                                33.92091908266848
-                            ],
-                            [
-                                -86.15520785836613,
-                                33.94673761269474
-                            ],
-                            [
-                                -86.15071628194661,
-                                33.9660963723694
-                            ],
-                            [
-                                -86.1686825876245,
-                                33.97899976488847
-                            ],
-                            [
-                                -86.1686825876245,
-                                34.00480067488521
-                            ],
-                            [
-                                -86.19114046972193,
-                                33.998351181877666
-                            ],
-                            [
-                                -86.21808992823878,
-                                34.01124967815733
-                            ],
-                            [
-                                -86.24503938675572,
-                                33.998351181877666
-                            ],
-                            [
-                                -86.27198884527256,
-                                34.01124967815733
-                            ],
-                            [
-                                -86.31241303304789,
-                                33.99190119917936
-                            ],
-                            [
-                                -86.31690460946731,
-                                34.049933410857
-                            ],
-                            [
-                                -86.29893830378941,
-                                34.06282406852613
-                            ],
-                            [
-                                -86.30342988020894,
-                                34.08215637890747
-                            ],
-                            [
-                                -86.27648042169209,
-                                34.09504213456402
-                            ],
-                            [
-                                -86.27198884527256,
-                                34.114367090269226
-                            ],
-                            [
-                                -86.23605623391668,
-                                34.114367090269226
-                            ],
-                            [
-                                -86.21808992823878,
-                                34.15300375731146
-                            ],
-                            [
-                                -86.18215731688299,
-                                34.140126830836614
-                            ],
-                            [
-                                -86.17766574046345,
-                                34.159441484442894
-                            ],
-                            [
-                                -86.13724155268815,
-                                34.17875172088724
-                            ],
-                            [
-                                -86.08783421207387,
-                                34.17231546627465
-                            ],
-                            [
-                                -86.08334263565445,
-                                34.19162275728718
-                            ],
-                            [
-                                -85.91266273171424,
-                                34.19162275728718
-                            ],
-                            [
-                                -85.89469642603623,
-                                34.17875172088724
-                            ],
-                            [
-                                -85.85876381468044,
-                                34.17875172088724
-                            ],
-                            [
-                                -85.8318143561635,
-                                34.19162275728718
-                            ],
-                            [
-                                -85.82732277974408,
-                                34.223791754766225
-                            ],
-                            [
-                                -85.79139016838828,
-                                34.223791754766225
-                            ],
-                            [
-                                -85.78689859196876,
-                                34.24308725880845
-                            ],
-                            [
-                                -85.76444070987132,
-                                34.23665591543307
-                            ],
-                            [
-                                -85.73299967493496,
-                                34.281664998908404
-                            ],
-                            [
-                                -85.71054179283755,
-                                34.27523660436496
-                            ],
-                            [
-                                -85.70605021641812,
-                                34.29452031308045
-                            ],
-                            [
-                                -85.6835923343207,
-                                34.300947232622626
-                            ],
-                            [
-                                -85.65215129938434,
-                                34.345921897898506
-                            ],
-                            [
-                                -85.61621868802854,
-                                34.345921897898506
-                            ],
-                            [
-                                -85.61621868802854,
-                                34.371610882354716
-                            ],
-                            [
-                                -85.59825238235064,
-                                34.39729199117268
-                            ],
-                            [
-                                -85.56231977099475,
-                                34.4101295913597
-                            ],
-                            [
-                                -85.56231977099475,
-                                34.46146028931501
-                            ],
-                            [
-                                -85.53537031247792,
-                                34.47428803639999
-                            ],
-                            [
-                                -85.53087873605838,
-                                34.493525960092136
-                            ],
-                            [
-                                -85.50842085396106,
-                                34.48711381184275
-                            ],
-                            [
-                                -85.49045454828307,
-                                34.512759446443866
-                            ],
-                            [
-                                -85.49045454828307,
-                                34.55121310255457
-                            ],
-                            [
-                                -85.50842085396106,
-                                34.56402704102908
-                            ],
-                            [
-                                -85.50392927754154,
-                                34.62166533094129
-                            ],
-                            [
-                                -85.52189558321943,
-                                34.634468408205684
-                            ],
-                            [
-                                -85.5174040068,
-                                34.692057799878334
-                            ],
-                            [
-                                -85.53537031247792,
-                                34.70485000581655
-                            ],
-                            [
-                                -85.53087873605838,
-                                34.762390453894376
-                            ],
-                            [
-                                -85.56231977099475,
-                                34.7687813635968
-                            ],
-                            [
-                                -85.56231977099475,
-                                34.807116428841844
-                            ],
-                            [
-                                -85.54435346531685,
-                                34.819890823710594
-                            ],
-                            [
-                                -85.54435346531685,
-                                34.84543367116028
-                            ],
-                            [
-                                -85.57579450025322,
-                                34.85181814480735
-                            ],
-                            [
-                                -85.57130292383371,
-                                34.92201465168199
-                            ],
-                            [
-                                -85.58926922951169,
-                                34.93477120891677
-                            ],
-                            [
-                                -85.58926922951169,
-                                34.99852423485128
-                            ],
-                            [
-                                -86.32588776230635,
-                                34.99852423485128
-                            ],
-                            [
-                                -86.33037933872578,
-                                34.966653923111544
-                            ],
-                            [
-                                -86.31241303304789,
-                                34.953902325445824
-                            ],
-                            [
-                                -86.34385406798425,
-                                34.9475257825665
-                            ],
-                            [
-                                -86.33936249156473,
-                                34.91563562932148
-                            ],
-                            [
-                                -86.3708035265011,
-                                34.8709685933783
-                            ],
-                            [
-                                -86.35283722082319,
-                                34.84543367116028
-                            ],
-                            [
-                                -86.35283722082319,
-                                34.75599904939833
-                            ],
-                            [
-                                -86.3708035265011,
-                                34.743214756190746
-                            ],
-                            [
-                                -86.3708035265011,
-                                34.615263051468176
-                            ],
-                            [
-                                -86.33936249156473,
-                                34.59605325018711
-                            ],
-                            [
-                                -86.33936249156473,
-                                34.53198849431168
-                            ],
-                            [
-                                -86.39326140859852,
-                                34.53198849431168
-                            ],
-                            [
-                                -86.42470244353488,
-                                34.49993761530374
-                            ],
-                            [
-                                -86.48758451340754,
-                                34.49993761530374
-                            ],
-                            [
-                                -86.51902554834389,
-                                34.544805393168964
-                            ],
-                            [
-                                -86.54597500686084,
-                                34.544805393168964
-                            ],
-                            [
-                                -86.54148343044132,
-                                34.576839005493895
-                            ],
-                            [
-                                -86.5594497361192,
-                                34.602457011049204
-                            ],
-                            [
-                                -86.62233180599196,
-                                34.602457011049204
-                            ],
-                            [
-                                -86.64029811166986,
-                                34.576839005493895
-                            ],
-                            [
-                                -86.66724757018679,
-                                34.602457011049204
-                            ],
-                            [
-                                -86.73012964005945,
-                                34.602457011049204
-                            ],
-                            [
-                                -86.73462121647894,
-                                34.58324424736749
-                            ],
-                            [
-                                -86.77504540425427,
-                                34.56402704102908
-                            ],
-                            [
-                                -86.80199486277111,
-                                34.576839005493895
-                            ],
-                            [
-                                -86.85140220338539,
-                                34.57043327003377
-                            ],
-                            [
-                                -86.8558937798049,
-                                34.58964899561259
-                            ],
-                            [
-                                -86.87835166190233,
-                                34.58324424736749
-                            ],
-                            [
-                                -86.99962422522827,
-                                34.64086920591329
-                            ],
-                            [
-                                -87.00411580164771,
-                                34.660068634837
-                            ],
-                            [
-                                -87.03106526016465,
-                                34.67286578353644
-                            ],
-                            [
-                                -87.06699787152044,
-                                34.660068634837
-                            ],
-                            [
-                                -87.08496417719833,
-                                34.6984541500374
-                            ],
-                            [
-                                -87.11191363571528,
-                                34.711245367174186
-                            ],
-                            [
-                                -87.11191363571528,
-                                34.73682186756158
-                            ],
-                            [
-                                -87.13886309423212,
-                                34.74960715015007
-                            ],
-                            [
-                                -87.16132097632955,
-                                34.743214756190746
-                            ],
-                            [
-                                -87.16581255274899,
-                                34.762390453894376
-                            ],
-                            [
-                                -87.20623674052428,
-                                34.78156169845633
-                            ],
-                            [
-                                -87.23318619904123,
-                                34.78156169845633
-                            ],
-                            [
-                                -87.1882704348464,
-                                34.807116428841844
-                            ],
-                            [
-                                -87.1882704348464,
-                                34.99852423485128
-                            ],
-                            [
-                                -87.23318619904123,
-                                35.024011551093125
-                            ],
-                            [
-                                -87.56556285408273,
-                                35.024011551093125
-                            ],
-                            [
-                                -87.58352915976062,
-                                35.011268885731944
-                            ],
-                            [
-                                -87.6194617711164,
-                                35.011268885731944
-                            ],
-                            [
-                                -87.63742807679432,
-                                35.024011551093125
-                            ],
-                            [
-                                -87.6733606881502,
-                                35.024011551093125
-                            ],
-                            [
-                                -87.6913269938281,
-                                35.011268885731944
-                            ],
-                            [
-                                -88.13150148293717,
-                                35.011268885731944
-                            ],
-                            [
-                                -88.16294251787343,
-                                35.03038213910358
-                            ],
-                            [
-                                -88.19887512922932,
-                                35.03038213910358
-                            ],
-                            [
-                                -88.21684143490722,
-                                35.00489680846151
-                            ],
-                            [
-                                -88.21684143490722,
-                                34.966653923111544
-                            ],
-                            [
-                                -88.1764172471319,
-                                34.9475257825665
-                            ],
-                            [
-                                -88.1719256707124,
-                                34.90287609731669
-                            ],
-                            [
-                                -88.10455202442023,
-                                34.8709685933783
-                            ],
-                            [
-                                -88.10904360083974,
-                                34.85181814480735
-                            ],
-                            [
-                                -88.13599305935661,
-                                34.83904870218613
-                            ],
-                            [
-                                -88.13150148293717,
-                                34.730428484304056
-                            ],
-                            [
-                                -88.14946778861507,
-                                34.717640234068966
-                            ],
-                            [
-                                -88.14497621219553,
-                                34.64726950961558
-                            ],
-                            [
-                                -88.16294251787343,
-                                34.634468408205684
-                            ],
-                            [
-                                -88.158450941454,
-                                34.56402704102908
-                            ],
-                            [
-                                -88.00124576677216,
-                                34.57043327003377
-                            ],
-                            [
-                                -87.9698047318359,
-                                34.55121310255457
-                            ],
-                            [
-                                -87.82607428641252,
-                                34.55121310255457
-                            ],
-                            [
-                                -87.80810798073452,
-                                34.56402704102908
-                            ],
-                            [
-                                -87.55657970124368,
-                                34.56402704102908
-                            ],
-                            [
-                                -87.55208812482425,
-                                34.28809290182797
-                            ],
-                            [
-                                -87.47573132569313,
-                                34.29452031308045
-                            ],
-                            [
-                                -87.45776502001515,
-                                34.281664998908404
-                            ],
-                            [
-                                -87.36793349162555,
-                                34.281664998908404
-                            ],
-                            [
-                                -87.34098403310873,
-                                34.29452031308045
-                            ],
-                            [
-                                -87.31403457459187,
-                                34.281664998908404
-                            ],
-                            [
-                                -87.29606826891388,
-                                34.29452031308045
-                            ],
-                            [
-                                -87.20623674052428,
-                                34.29452031308045
-                            ],
-                            [
-                                -87.1882704348464,
-                                34.281664998908404
-                            ],
-                            [
-                                -87.09843890645682,
-                                34.281664998908404
-                            ],
-                            [
-                                -87.0804726007789,
-                                34.30737366041113
-                            ],
-                            [
-                                -87.05352314226197,
-                                34.29452031308045
-                            ],
-                            [
-                                -87.01759053090618,
-                                34.29452031308045
-                            ],
-                            [
-                                -86.99962422522827,
-                                34.30737366041113
-                            ],
-                            [
-                                -86.97267476671134,
-                                34.29452031308045
-                            ],
-                            [
-                                -86.92326742609706,
-                                34.300947232622626
-                            ],
-                            [
-                                -86.89182639116072,
-                                34.281664998908404
-                            ],
-                            [
-                                -86.82894432128806,
-                                34.281664998908404
-                            ],
-                            [
-                                -86.81097801561017,
-                                34.29452031308045
-                            ],
-                            [
-                                -86.78402855709324,
-                                34.281664998908404
-                            ],
-                            [
-                                -86.75707909857637,
-                                34.29452031308045
-                            ],
-                            [
-                                -86.69419702870364,
-                                34.29452031308045
-                            ],
-                            [
-                                -86.67623072302572,
-                                34.281664998908404
-                            ],
-                            [
-                                -86.53250027760238,
-                                34.281664998908404
-                            ],
-                            [
-                                -86.51453397192446,
-                                34.29452031308045
-                            ],
-                            [
-                                -86.49207608982705,
-                                34.28809290182797
-                            ],
-                            [
-                                -86.49207608982705,
-                                34.27523660436496
-                            ],
-                            [
-                                -86.52800870118294,
-                                34.27523660436496
-                            ],
-                            [
-                                -86.57292446537767,
-                                34.21092562916793
-                            ],
-                            [
-                                -86.57292446537767,
-                                34.18518748457272
-                            ],
-                            [
-                                -86.6088570767335,
-                                34.17231546627465
-                            ],
-                            [
-                                -86.62682338241147,
-                                34.13368763158101
-                            ],
-                            [
-                                -86.65377284092833,
-                                34.12080776125333
-                            ],
-                            [
-                                -86.67623072302572,
-                                34.127247941705306
-                            ],
-                            [
-                                -86.68072229944516,
-                                34.10792592879693
-                            ],
-                            [
-                                -86.71665491080105,
-                                34.09504213456402
-                            ],
-                            [
-                                -86.71665491080105,
-                                34.05637898473689
-                            ],
-                            [
-                                -86.73462121647894,
-                                34.030593749116576
-                            ],
-                            [
-                                -86.75707909857637,
-                                34.03704079300249
-                            ],
-                            [
-                                -86.76157067499581,
-                                34.00480067488521
-                            ],
-                            [
-                                -86.78402855709324,
-                                34.01124967815733
-                            ],
-                            [
-                                -86.78852013351273,
-                                33.97899976488847
-                            ],
-                            [
-                                -86.8154695920296,
-                                33.9660963723694
-                            ],
-                            [
-                                -86.837927474127,
-                                33.972548313385104
-                            ],
-                            [
-                                -86.89182639116072,
-                                33.94673761269474
-                            ],
-                            [
-                                -86.90979269683868,
-                                33.92091908266848
-                            ],
-                            [
-                                -86.9457253081945,
-                                33.92091908266848
-                            ],
-                            [
-                                -86.9457253081945,
-                                33.89509272617572
-                            ],
-                            [
-                                -86.96369161387238,
-                                33.88217661390303
-                            ],
-                            [
-                                -86.9861494959698,
-                                33.88863491450404
-                            ],
-                            [
-                                -86.97267476671134,
-                                33.869258546092965
-                            ],
-                            [
-                                -86.99064107238934,
-                                33.85633852310623
-                            ],
-                            [
-                                -86.97267476671134,
-                                33.843416545303974
-                            ],
-                            [
-                                -86.97716634313088,
-                                33.82402991411265
-                            ],
-                            [
-                                -86.95920003745296,
-                                33.79817423404856
-                            ],
-                            [
-                                -86.89631796758022,
-                                33.79817423404856
-                            ],
-                            [
-                                -86.89182639116072,
-                                33.81756672669983
-                            ],
-                            [
-                                -86.86487693264385,
-                                33.8304926130478
-                            ],
-                            [
-                                -86.77504540425427,
-                                33.8304926130478
-                            ],
-                            [
-                                -86.72114648722048,
-                                33.80463888662241
-                            ],
-                            [
-                                -86.71665491080105,
-                                33.785243464057785
-                            ],
-                            [
-                                -86.62233180599196,
-                                33.739970393014225
-                            ],
-                            [
-                                -86.57292446537767,
-                                33.74643943861561
-                            ],
-                            [
-                                -86.54148343044132,
-                                33.72703083819859
-                            ],
-                            [
-                                -86.1686825876245,
-                                33.7335008595267
-                            ],
-                            [
-                                -86.14173312910766,
-                                33.72056032907575
-                            ]
-                        ]
-                    ]
-                ]
-            },
-            "links": [
-                {
-                    "rel": "self",
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-stac/ept/AL_17Co_1_2020.json"
-                },
-                {
-                    "rel": "parent",
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-stac/ept/catalog.json"
-                }
-            ],
-            "assets": {
-                "ept.json": {
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-public/AL_17Co_1_2020/ept.json",
-                    "title": "entwine",
-                    "description": "The ept.json for accessing data"
-                }
-            },
-            "bbox": [
-                -88.21684143490722,
-                33.72056032907575,
-                -85.49045454828307,
-                35.03038213910358
-            ],
-            "stac_extensions": [
-                "https://stac-extensions.github.io/pointcloud/v1.0.0/schema.json",
-                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
-            ]
-        },
-        {
-            "type": "Feature",
-            "stac_version": "1.0.0",
-            "id": "AL_17Co_2_2020",
-            "properties": {
-                "description": "A USGS Lidar pointcloud in Entwine/EPT format",
-                "pc:count": 140903876863,
-                "pc:type": "lidar",
-                "pc:encoding": "ept",
-                "pc:schemas": [
-                    {
-                        "name": "X",
-                        "offset": -9652899,
-                        "scale": 0.01,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Y",
-                        "offset": 3883490,
-                        "scale": 0.01,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Z",
-                        "offset": 1046,
+                        "offset": 927,
                         "scale": 0.01,
                         "size": 4,
                         "type": "signed"
@@ -18985,7 +9810,7 @@
                         "code": 3857
                     }
                 },
-                "datetime": "2023-01-11T17:08:49.122126Z"
+                "datetime": "2023-01-11T17:08:49.707963Z"
             },
             "geometry": {
                 "type": "MultiPolygon",
@@ -18993,992 +9818,588 @@
                     [
                         [
                             [
-                                -87.60521567695491,
-                                31.805748533517725
+                                -91.46904955662949,
+                                40.35042007267842
                             ],
                             [
-                                -87.4165694673368,
-                                31.805748533517725
+                                -91.45108325095158,
+                                40.362276737609896
                             ],
                             [
-                                -87.39860316165881,
-                                31.81897048045086
+                                -91.42413379243429,
+                                40.35042007267842
                             ],
                             [
-                                -87.37165370314197,
-                                31.805748533517725
+                                -91.36125172256207,
+                                40.35042007267842
                             ],
                             [
-                                -87.33572109178618,
-                                31.805748533517725
+                                -91.3432854168842,
+                                40.37413131752104
                             ],
                             [
-                                -87.31775478610818,
-                                31.81897048045086
+                                -91.3432854168842,
+                                40.421528784153416
                             ],
                             [
-                                -87.29080532759134,
-                                31.805748533517725
+                                -91.36125172256207,
+                                40.44521500370676
                             ],
                             [
-                                -87.17402434068491,
-                                31.805748533517725
+                                -91.3298106876251,
+                                40.46297419268916
                             ],
                             [
-                                -87.15605803500691,
-                                31.81897048045086
+                                -91.3298106876251,
+                                40.522137585875626
                             ],
                             [
-                                -87.12910857649007,
-                                31.805748533517725
+                                -91.36125172256207,
+                                40.55169971895978
                             ],
                             [
-                                -86.90452975551607,
-                                31.805748533517725
+                                -91.35676014614239,
+                                40.56943073726656
                             ],
                             [
-                                -86.88656344983818,
-                                31.81897048045086
+                                -91.33430226404478,
+                                40.56352091966555
                             ],
                             [
-                                -86.88656344983818,
-                                31.951085766776423
+                                -91.3298106876251,
+                                40.59306478893255
                             ],
                             [
-                                -86.85961399132131,
-                                31.93788276867059
+                                -91.30735280552841,
+                                40.5871570588602
                             ],
                             [
-                                -86.82368137996544,
-                                31.93788276867059
+                                -91.27591177059139,
+                                40.604878683288604
                             ],
                             [
-                                -86.80571507428752,
-                                31.951085766776423
+                                -91.25345388849469,
+                                40.59897199708087
                             ],
                             [
-                                -86.76978246293173,
-                                31.951085766776423
+                                -91.248962312075,
+                                40.61669048981539
                             ],
                             [
-                                -86.75181615725383,
-                                31.93788276867059
+                                -91.1726055129437,
+                                40.610784847538966
                             ],
                             [
-                                -86.7248666987369,
-                                31.951085766776423
+                                -91.1052318666518,
+                                40.640307838850205
                             ],
                             [
-                                -86.69791724022004,
-                                31.93788276867059
+                                -91.1052318666518,
+                                40.66391683497797
                             ],
                             [
-                                -86.63503517034732,
-                                31.93788276867059
+                                -91.0872655609739,
+                                40.675718200372444
                             ],
                             [
-                                -86.61706886466942,
-                                31.951085766776423
+                                -91.0917571373927,
+                                40.71700653050509
                             ],
                             [
-                                -86.59011940615257,
-                                31.93788276867059
+                                -91.04684137319842,
+                                40.77594546501981
                             ],
                             [
-                                -86.56316994763563,
-                                31.951085766776423
+                                -91.05133294961722,
+                                40.80539534215669
                             ],
                             [
-                                -86.52723733627984,
-                                31.951085766776423
+                                -91.03336664394021,
+                                40.828945838791824
                             ],
                             [
-                                -86.50927103060192,
-                                31.93788276867059
+                                -91.00641718542292,
+                                40.84071795173686
                             ],
                             [
-                                -86.3924900436954,
-                                31.93788276867059
+                                -91.00641718542292,
+                                40.864255906252886
                             ],
                             [
-                                -86.3924900436954,
-                                32.01707229004267
+                                -90.95700984480891,
+                                40.88190388419478
                             ],
                             [
-                                -86.37452373801752,
-                                32.043453606655696
+                                -90.95251826838923,
+                                40.899547157716505
                             ],
                             [
-                                -86.31164166814477,
-                                32.043453606655696
+                                -90.92556880987193,
+                                40.899547157716505
                             ],
                             [
-                                -86.31164166814477,
-                                31.951085766776423
+                                -90.93006038629163,
+                                40.975946970617485
                             ],
                             [
-                                -86.29367536246687,
-                                31.93788276867059
+                                -90.91209408061371,
+                                40.987692944441
                             ],
                             [
-                                -86.17689437556035,
-                                31.93788276867059
+                                -90.91209408061371,
+                                41.02291831368823
                             ],
                             [
-                                -86.15892806988245,
-                                31.964286867635003
+                                -90.93006038629163,
+                                41.0346559189617
                             ],
                             [
-                                -86.13197861136562,
-                                31.951085766776423
+                                -90.92556880987193,
+                                41.11089934476664
                             ],
                             [
-                                -86.06909654149287,
-                                31.951085766776423
+                                -90.9435351155498,
+                                41.12262125386949
                             ],
                             [
-                                -86.05113023581497,
-                                31.964286867635003
+                                -90.92556880987193,
+                                41.14605879199077
                             ],
                             [
-                                -86.01519762445909,
-                                31.964286867635003
+                                -90.95251826838923,
+                                41.15777442077674
                             ],
                             [
-                                -85.98824816594224,
-                                31.951085766776423
+                                -90.95700984480891,
+                                41.18705433267942
                             ],
                             [
-                                -85.98824816594224,
-                                32.069827322333694
+                                -91.00641718542292,
+                                41.181199397220766
                             ],
                             [
-                                -85.97028186026435,
-                                32.08301132876033
+                                -91.01090876184261,
+                                41.19876263311362
                             ],
                             [
-                                -85.98824816594224,
-                                32.10937363666943
+                                -91.04684137319842,
+                                41.2104688394749
                             ],
                             [
-                                -85.97028186026435,
-                                32.1225519373056
+                                -91.05133294961722,
+                                41.23972519306169
                             ],
                             [
-                                -85.98824816594224,
-                                32.13572833516602
+                                -91.07828240813451,
+                                41.2514240692722
                             ],
                             [
-                                -85.97028186026435,
-                                32.14890282982868
+                                -91.03336664394021,
+                                41.30988702933561
                             ],
                             [
-                                -85.98824816594224,
-                                32.17524610787492
+                                -91.03785822035901,
+                                41.35077993698478
                             ],
                             [
-                                -85.97028186026435,
-                                32.18841489041677
+                                -91.01989191468111,
+                                41.36245891015557
                             ],
                             [
-                                -85.97477343668385,
-                                32.247650832894664
+                                -91.01989191468111,
+                                41.397483255418
                             ],
                             [
-                                -85.95680713100586,
-                                32.26080913340264
+                                -90.99743403258351,
+                                41.391647174437814
                             ],
                             [
-                                -85.9073997903916,
-                                32.25423022152051
+                                -90.9704845740671,
+                                41.4033188124078
                             ],
                             [
-                                -85.88943348471369,
-                                32.28054300806442
+                                -90.95251826838923,
+                                41.391647174437814
                             ],
                             [
-                                -85.94333240174748,
-                                32.30684816337105
+                                -90.88963619851613,
+                                41.391647174437814
                             ],
                             [
-                                -85.94333240174748,
-                                32.34629158047895
+                                -90.88514462209642,
+                                41.409153845393774
                             ],
                             [
-                                -85.97028186026435,
-                                32.34629158047895
+                                -90.81777097580452,
+                                41.43832114979632
                             ],
                             [
-                                -85.97028186026435,
-                                32.372577643140374
+                                -90.72793944741503,
+                                41.43832114979632
                             ],
                             [
-                                -85.98824816594224,
-                                32.38571780860546
+                                -90.70997314173714,
+                                41.42665580019445
                             ],
                             [
-                                -85.98375658952281,
-                                32.40542447330867
+                                -90.67404053038133,
+                                41.42665580019445
                             ],
                             [
-                                -86.01070604803964,
-                                32.41855986017946
+                                -90.65607422470343,
+                                41.44998440306123
                             ],
                             [
-                                -86.01519762445909,
-                                32.438259355058406
+                                -90.62014161334764,
+                                41.44998440306123
                             ],
                             [
-                                -86.0915544235903,
-                                32.43169333489099
+                                -90.61565003692795,
+                                41.467475352094205
                             ],
                             [
-                                -86.12299545852666,
-                                32.45138996075934
+                                -90.59319215483035,
+                                41.46164555988282
                             ],
                             [
-                                -86.14545334062409,
-                                32.44482489703164
+                                -90.58870057841155,
+                                41.47913336405187
                             ],
                             [
-                                -86.16341964630196,
-                                32.47108228195621
+                                -90.54827639063605,
+                                41.496616450627954
                             ],
                             [
-                                -86.19935225765778,
-                                32.47108228195621
+                                -90.47191959150474,
+                                41.49078927930154
                             ],
                             [
-                                -86.20384383407729,
-                                32.50389324758694
+                                -90.44047855656864,
+                                41.508269220618494
                             ],
                             [
-                                -86.23079329259413,
-                                32.51701428325091
+                                -90.41802067447105,
+                                41.50244309773794
                             ],
                             [
-                                -86.26672590395003,
-                                32.51701428325091
+                                -90.41802067447105,
+                                41.52574444375234
                             ],
                             [
-                                -86.29816693888631,
-                                32.49733201166951
+                                -90.40005436879315,
+                                41.54903740126067
                             ],
                             [
-                                -86.32062482098372,
-                                32.50389324758694
+                                -90.36412175743736,
+                                41.54903740126067
                             ],
                             [
-                                -86.32062482098372,
-                                32.46451865327294
+                                -90.31920599324215,
+                                41.57232196943448
                             ],
                             [
-                                -86.33859112666173,
-                                32.45138996075934
+                                -90.31920599324215,
+                                41.64212532975173
                             ],
                             [
-                                -86.37452373801752,
-                                32.45138996075934
+                                -90.37759648669555,
+                                41.65956436860173
                             ],
                             [
-                                -86.43291423147072,
-                                32.41855986017946
+                                -90.61565003692795,
+                                41.65375188020951
                             ],
                             [
-                                -86.46884684282662,
-                                32.41855986017946
+                                -90.62014161334764,
+                                41.671187771650565
                             ],
                             [
-                                -86.51376260702136,
-                                32.352863812481445
+                                -91.1142150194903,
+                                41.671187771650565
                             ],
                             [
-                                -86.52723733627984,
-                                32.35943556696031
+                                -91.13218132516819,
+                                41.68280907630225
                             ],
                             [
-                                -86.52723733627984,
-                                32.38571780860546
+                                -91.1815886657822,
+                                41.67699868628229
                             ],
                             [
-                                -86.59011940615257,
-                                32.38571780860546
+                                -91.19955497146009,
+                                41.68861894169819
                             ],
                             [
-                                -86.59011940615257,
-                                32.41199240573826
+                                -91.23548758281589,
+                                41.68861894169819
                             ],
                             [
-                                -86.60808571183046,
-                                32.4251268365809
+                                -91.23997915923559,
+                                41.89163362280483
                             ],
                             [
-                                -86.64401832318626,
-                                32.4251268365809
+                                -91.22201285355769,
+                                41.903215039478496
                             ],
                             [
-                                -86.67096778170311,
-                                32.41199240573826
+                                -91.23997915923559,
+                                41.91479435584008
                             ],
                             [
-                                -86.67545935812262,
-                                32.379147964738166
+                                -91.23548758281589,
+                                41.95530542182369
                             ],
                             [
-                                -86.68893408738111,
-                                32.38571780860546
+                                -91.2669286177529,
+                                41.97265942976103
                             ],
                             [
-                                -86.68893408738111,
-                                32.4251268365809
+                                -91.2669286177529,
+                                42.03047198223968
                             ],
                             [
-                                -86.7248666987369,
-                                32.4251268365809
+                                -91.23548758281589,
+                                42.04780550463138
                             ],
                             [
-                                -86.75630773367327,
-                                32.40542447330867
+                                -91.23997915923559,
+                                42.34175173093878
                             ],
                             [
-                                -86.80571507428752,
-                                32.41199240573826
+                                -91.22201285355769,
+                                42.35325117057596
                             ],
                             [
-                                -86.81020665070706,
-                                32.36600684386391
+                                -91.23997915923559,
+                                42.36474850657978
                             ],
                             [
-                                -86.79224034502906,
-                                32.352863812481445
+                                -91.76100202389557,
+                                42.36474850657978
                             ],
                             [
-                                -86.80571507428752,
-                                32.34629158047895
+                                -91.77896832957347,
+                                42.3762437388722
                             ],
                             [
-                                -86.83266453280437,
-                                32.35943556696031
+                                -92.56948577940192,
+                                42.3762437388722
                             ],
                             [
-                                -86.87308872057979,
-                                32.33971887100473
+                                -92.58745208507982,
+                                42.36474850657978
                             ],
                             [
-                                -86.87308872057979,
-                                32.300272590155075
+                                -92.58296050866011,
+                                42.27846721400978
                             ],
                             [
-                                -86.84613926206285,
-                                32.300272590155075
+                                -92.38533114620321,
+                                42.27846721400978
                             ],
                             [
-                                -86.89105502625767,
-                                32.27396552672666
+                                -92.35389011126712,
+                                42.261196758375505
                             ],
                             [
-                                -86.87758029699921,
-                                32.227909807076585
+                                -92.33143222916952,
+                                42.26695410268278
                             ],
                             [
-                                -86.90003817909664,
-                                32.234490625620445
+                                -92.31346592349163,
+                                42.255438888319105
                             ],
                             [
-                                -86.91800448477453,
-                                32.22132851199806
+                                -92.31346592349163,
+                                42.04780550463138
                             ],
                             [
-                                -86.91800448477453,
-                                32.06323460618769
+                                -92.33143222916952,
+                                42.03625034837753
                             ],
                             [
-                                -87.15605803500691,
-                                32.056641414824036
+                                -92.32694065274983,
+                                41.85687677183646
                             ],
                             [
-                                -87.16054961142645,
-                                32.089602618935
+                                -92.26405858287762,
+                                41.85687677183646
                             ],
                             [
-                                -87.2099569520407,
-                                32.10937363666943
+                                -92.24609227719883,
+                                41.845286954841285
                             ],
                             [
-                                -87.21444852846022,
-                                32.129140374109205
+                                -92.06193764400014,
+                                41.85108212582557
                             ],
                             [
-                                -87.23690641055757,
-                                32.13572833516602
+                                -92.04397133832225,
+                                41.8394912588952
                             ],
                             [
-                                -87.24139798697706,
-                                32.168661002404775
+                                -91.88676616364086,
+                                41.845286954841285
                             ],
                             [
-                                -87.26385586907449,
-                                32.16207542087201
+                                -91.85532512870476,
+                                41.82789829216495
                             ],
                             [
-                                -87.26834744549392,
-                                32.18183073722971
+                                -91.85532512870476,
+                                41.76990196482876
                             ],
                             [
-                                -87.31775478610818,
-                                32.20158176807741
+                                -91.87329143438266,
+                                41.75829640129217
                             ],
                             [
-                                -87.32224636252772,
-                                32.22132851199806
+                                -91.85532512870476,
+                                41.74668873862338
                             ],
                             [
-                                -87.35817897388351,
-                                32.22132851199806
+                                -91.85532512870476,
+                                41.56068073406594
                             ],
                             [
-                                -87.3761452795615,
-                                32.26080913340264
+                                -91.87329143438266,
+                                41.54903740126067
                             ],
                             [
-                                -87.39860316165881,
-                                32.25423022152051
+                                -91.86879985796296,
+                                41.51991989363872
                             ],
                             [
-                                -87.42555262017576,
-                                32.26738756848872
+                                -91.96761453919186,
+                                41.51991989363872
                             ],
                             [
-                                -87.43004419659519,
-                                32.287120012449726
+                                -91.96312296277215,
+                                41.374135787690555
                             ],
                             [
-                                -87.4525020786926,
-                                32.28054300806442
+                                -91.98108926845005,
+                                41.35077993698478
                             ],
                             [
-                                -87.45699365511204,
-                                32.326572019848115
+                                -91.96312296277215,
+                                41.33909886828744
                             ],
                             [
-                                -87.50640099572638,
-                                32.31999787826951
+                                -91.98108926845005,
+                                41.32741570417314
                             ],
                             [
-                                -87.51089257214582,
-                                32.48420810391921
+                                -91.98108926845005,
+                                41.163631450050396
                             ],
                             [
-                                -87.70852193460298,
-                                32.48420810391921
+                                -91.96312296277215,
+                                41.15191686808542
                             ],
                             [
-                                -87.71301351102241,
-                                32.543250608465414
+                                -91.91371562215724,
+                                41.15777442077674
                             ],
                             [
-                                -87.78937031015361,
-                                32.53669224555345
+                                -91.89574931648026,
+                                41.14605879199077
                             ],
                             [
-                                -87.79386188657305,
-                                32.55636589720012
+                                -91.73405256537828,
+                                41.14605879199077
                             ],
                             [
-                                -87.85674395644577,
-                                32.55636589720012
+                                -91.73405256537828,
+                                40.97007319925979
                             ],
                             [
-                                -87.88818499138213,
-                                32.53669224555345
+                                -91.75201887105615,
+                                40.95832408772824
                             ],
                             [
-                                -87.91064287347957,
-                                32.543250608465414
+                                -91.75201887105615,
+                                40.81717163555637
                             ],
                             [
-                                -87.93759233199641,
-                                32.530133403679784
+                                -91.72057783612007,
+                                40.7995064116847
                             ],
                             [
-                                -87.94208390841585,
-                                32.51045400479775
+                                -91.73854414179796,
+                                40.78772698327588
                             ],
                             [
-                                -87.96454179051325,
-                                32.50389324758694
+                                -91.73854414179796,
+                                40.5871570588602
                             ],
                             [
-                                -87.96903336693279,
-                                32.47108228195621
+                                -91.72057783612007,
+                                40.57534003301047
                             ],
                             [
-                                -88.01844070754704,
-                                32.47764543218865
+                                -91.72506941253977,
+                                40.53396400439389
                             ],
                             [
-                                -88.02293228396647,
-                                32.45795454619027
+                                -91.70710310686185,
+                                40.522137585875626
                             ],
                             [
-                                -88.04988174248341,
-                                32.44482489703164
+                                -91.65769576624696,
+                                40.52805105600427
                             ],
                             [
-                                -88.0633564717418,
-                                32.372577643140374
+                                -91.65320418982817,
+                                40.48664580953704
                             ],
                             [
-                                -88.02293228396647,
-                                32.352863812481445
+                                -91.63074630773058,
+                                40.49256240974245
                             ],
                             [
-                                -88.01844070754704,
-                                32.33314568411045
+                                -91.62625473131087,
+                                40.47481104428403
                             ],
                             [
-                                -87.99149124903012,
-                                32.31999787826951
+                                -91.59930527279447,
+                                40.46297419268916
                             ],
                             [
-                                -88.03640701322495,
-                                32.29369653983068
+                                -91.59930527279447,
+                                40.43929423102417
                             ],
                             [
-                                -88.03191543680552,
-                                32.168661002404775
+                                -91.57684739069687,
+                                40.44521500370676
                             ],
                             [
-                                -88.0633564717418,
-                                32.14890282982868
+                                -91.55888108501897,
+                                40.43337293685958
                             ],
                             [
-                                -88.05886489532237,
-                                32.10278377294248
+                                -91.55888108501897,
+                                40.38598381227112
                             ],
                             [
-                                -88.07683120100027,
-                                32.07641956320885
+                                -91.53642320292138,
+                                40.391909277666926
                             ],
                             [
-                                -88.12623854161453,
-                                32.08301132876033
+                                -91.53193162650167,
+                                40.37413131752104
                             ],
                             [
-                                -88.14420484729243,
-                                32.056641414824036
+                                -91.50947374440408,
+                                40.38005782555003
                             ],
                             [
-                                -88.14420484729243,
-                                32.003878782448965
+                                -91.50498216798529,
+                                40.362276737609896
                             ],
                             [
-                                -88.07233962458083,
-                                31.964286867635003
-                            ],
-                            [
-                                -87.98250809619115,
-                                31.964286867635003
-                            ],
-                            [
-                                -87.96454179051325,
-                                31.97748607081821
-                            ],
-                            [
-                                -87.93759233199641,
-                                31.964286867635003
-                            ],
-                            [
-                                -87.91064287347957,
-                                31.97748607081821
-                            ],
-                            [
-                                -87.88369341496264,
-                                31.964286867635003
-                            ],
-                            [
-                                -87.85674395644577,
-                                31.97748607081821
-                            ],
-                            [
-                                -87.82979449792893,
-                                31.964286867635003
-                            ],
-                            [
-                                -87.79386188657305,
-                                31.964286867635003
-                            ],
-                            [
-                                -87.76691242805619,
-                                31.97748607081821
-                            ],
-                            [
-                                -87.73996296953926,
-                                31.964286867635003
-                            ],
-                            [
-                                -87.72199666386136,
-                                31.97748607081821
-                            ],
-                            [
-                                -87.68606405250556,
-                                31.97748607081821
-                            ],
-                            [
-                                -87.66809774682766,
-                                31.951085766776423
-                            ],
-                            [
-                                -87.68606405250556,
-                                31.93788276867059
-                            ],
-                            [
-                                -87.68606405250556,
-                                31.87183933444711
-                            ],
-                            [
-                                -87.66809774682766,
-                                31.858624961872934
-                            ],
-                            [
-                                -87.63216513547178,
-                                31.858624961872934
-                            ],
-                            [
-                                -87.63216513547178,
-                                31.81897048045086
-                            ],
-                            [
-                                -87.60521567695491,
-                                31.805748533517725
-                            ]
-                        ]
-                    ],
-                    [
-                        [
-                            [
-                                -86.5002878777629,
-                                33.079401661402805
-                            ],
-                            [
-                                -86.31164166814477,
-                                33.079401661402805
-                            ],
-                            [
-                                -86.30715009172525,
-                                33.09895551460539
-                            ],
-                            [
-                                -86.02867235371755,
-                                33.09895551460539
-                            ],
-                            [
-                                -86.02418077729811,
-                                33.079401661402805
-                            ],
-                            [
-                                -85.96129870742539,
-                                33.079401661402805
-                            ],
-                            [
-                                -85.95680713100586,
-                                33.09895551460539
-                            ],
-                            [
-                                -85.63790520522284,
-                                33.092438046711315
-                            ],
-                            [
-                                -85.63790520522284,
-                                33.17061575707457
-                            ],
-                            [
-                                -85.61993889954495,
-                                33.18363860494382
-                            ],
-                            [
-                                -85.63790520522284,
-                                33.19665951734876
-                            ],
-                            [
-                                -85.61993889954495,
-                                33.20967849390468
-                            ],
-                            [
-                                -85.61993889954495,
-                                33.482629143949616
-                            ],
-                            [
-                                -85.34146116153715,
-                                33.482629143949616
-                            ],
-                            [
-                                -85.33696958511774,
-                                33.46316106149896
-                            ],
-                            [
-                                -85.30103697376184,
-                                33.46316106149896
-                            ],
-                            [
-                                -85.28307066808395,
-                                33.476140269119675
-                            ],
-                            [
-                                -85.28307066808395,
-                                33.515066226422505
-                            ],
-                            [
-                                -85.30103697376184,
-                                33.528037655756975
-                            ],
-                            [
-                                -85.29654539734241,
-                                33.59934573120545
-                            ],
-                            [
-                                -85.31451170302032,
-                                33.61230450810546
-                            ],
-                            [
-                                -85.31002012660088,
-                                33.657644884964334
-                            ],
-                            [
-                                -85.32798643227878,
-                                33.670594893318004
-                            ],
-                            [
-                                -85.32349485585925,
-                                33.74178508068116
-                            ],
-                            [
-                                -85.34146116153715,
-                                33.754722410207876
-                            ],
-                            [
-                                -85.33696958511774,
-                                33.81291623229639
-                            ],
-                            [
-                                -85.3684106200541,
-                                33.81937977113556
-                            ],
-                            [
-                                -85.3504443143761,
-                                33.832305383433244
-                            ],
-                            [
-                                -85.3504443143761,
-                                33.896904125548915
-                            ],
-                            [
-                                -85.38188534931247,
-                                33.90336131107534
-                            ],
-                            [
-                                -85.37739377289303,
-                                33.96145396898459
-                            ],
-                            [
-                                -85.39536007857095,
-                                33.98726020467195
-                            ],
-                            [
-                                -85.41781796066836,
-                                33.98080938005986
-                            ],
-                            [
-                                -85.42230953708778,
-                                33.96145396898459
-                            ],
-                            [
-                                -85.43578426634626,
-                                33.98080938005986
-                            ],
-                            [
-                                -85.45824214844369,
-                                33.974358065878114
-                            ],
-                            [
-                                -85.44925899560472,
-                                34.00016038500906
-                            ],
-                            [
-                                -85.5390905239943,
-                                34.00016038500906
-                            ],
-                            [
-                                -85.57053155893068,
-                                33.96790626217152
-                            ],
-                            [
-                                -85.66036308732026,
-                                33.96790626217152
-                            ],
-                            [
-                                -85.6648546637397,
-                                33.98726020467195
-                            ],
-                            [
-                                -85.75468619212928,
-                                33.98726020467195
-                            ],
-                            [
-                                -85.78612722706565,
-                                33.955001186362175
-                            ],
-                            [
-                                -85.8355345676799,
-                                33.974358065878114
-                            ],
-                            [
-                                -85.86697560261628,
-                                33.955001186362175
-                            ],
-                            [
-                                -85.90290821397217,
-                                33.955001186362175
-                            ],
-                            [
-                                -85.92087451965006,
-                                33.92918516241168
-                            ],
-                            [
-                                -85.97028186026435,
-                                33.93563990232887
-                            ],
-                            [
-                                -85.98824816594224,
-                                33.90981800756983
-                            ],
-                            [
-                                -86.01070604803964,
-                                33.90336131107534
-                            ],
-                            [
-                                -86.01519762445909,
-                                33.8839882875799
-                            ],
-                            [
-                                -86.0780796943318,
-                                33.8839882875799
-                            ],
-                            [
-                                -86.09604600000979,
-                                33.87107049402297
-                            ],
-                            [
-                                -86.09604600000979,
-                                33.74178508068116
-                            ],
-                            [
-                                -86.56316994763563,
-                                33.74178508068116
-                            ],
-                            [
-                                -86.56316994763563,
-                                33.72884579955837
-                            ],
-                            [
-                                -86.53622048911879,
-                                33.715904567205186
-                            ],
-                            [
-                                -86.53622048911879,
-                                33.664120132815626
-                            ],
-                            [
-                                -86.56766152405513,
-                                33.64469292739909
-                            ],
-                            [
-                                -86.56766152405513,
-                                33.5539746775368
-                            ],
-                            [
-                                -86.54969521837717,
-                                33.541007139585986
-                            ],
-                            [
-                                -86.52723733627984,
-                                33.54749115181942
-                            ],
-                            [
-                                -86.5227457598603,
-                                33.528037655756975
-                            ],
-                            [
-                                -86.5002878777629,
-                                33.53452264088292
-                            ],
-                            [
-                                -86.49579630134346,
-                                33.48911753273008
-                            ],
-                            [
-                                -86.40596477295388,
-                                33.48911753273008
-                            ],
-                            [
-                                -86.40596477295388,
-                                33.372252207416054
-                            ],
-                            [
-                                -86.37901531443694,
-                                33.372252207416054
-                            ],
-                            [
-                                -86.36104900875903,
-                                33.359257461248276
-                            ],
-                            [
-                                -86.3924900436954,
-                                33.339761703453306
-                            ],
-                            [
-                                -86.3924900436954,
-                                33.30075709380186
-                            ],
-                            [
-                                -86.44189738430968,
-                                33.29425462870256
-                            ],
-                            [
-                                -86.44638896072918,
-                                33.26173503395938
-                            ],
-                            [
-                                -86.48681314850451,
-                                33.255229661495434
-                            ],
-                            [
-                                -86.48681314850451,
-                                33.216187256119106
-                            ],
-                            [
-                                -86.51376260702136,
-                                33.216187256119106
-                            ],
-                            [
-                                -86.51376260702136,
-                                33.16410360746123
-                            ],
-                            [
-                                -86.49579630134346,
-                                33.1510778571179
-                            ],
-                            [
-                                -86.49579630134346,
-                                33.11198900063082
-                            ],
-                            [
-                                -86.51376260702136,
-                                33.08592009562756
-                            ],
-                            [
-                                -86.5002878777629,
-                                33.079401661402805
+                                -91.46904955662949,
+                                40.35042007267842
                             ]
                         ]
                     ]
@@ -19987,7 +10408,7 @@
             "links": [
                 {
                     "rel": "self",
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-stac/ept/AL_17Co_2_2020.json"
+                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-stac/ept/IA_Eastern_1_2019.json"
                 },
                 {
                     "rel": "parent",
@@ -19996,1661 +10417,16 @@
             ],
             "assets": {
                 "ept.json": {
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-public/AL_17Co_2_2020/ept.json",
+                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-public/IA_Eastern_1_2019/ept.json",
                     "title": "entwine",
                     "description": "The ept.json for accessing data"
                 }
             },
             "bbox": [
-                -88.14420484729243,
-                31.805748533517725,
-                -85.28307066808395,
-                34.00016038500906
-            ],
-            "stac_extensions": [
-                "https://stac-extensions.github.io/pointcloud/v1.0.0/schema.json",
-                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
-            ]
-        },
-        {
-            "type": "Feature",
-            "stac_version": "1.0.0",
-            "id": "AL_25Co_TL_2017",
-            "properties": {
-                "description": "A USGS Lidar pointcloud in Entwine/EPT format",
-                "pc:count": 25358618,
-                "pc:type": "lidar",
-                "pc:encoding": "ept",
-                "pc:schemas": [
-                    {
-                        "name": "X",
-                        "offset": -9661119,
-                        "scale": 0.001,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Y",
-                        "offset": 3756614,
-                        "scale": 0.001,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Z",
-                        "offset": 330,
-                        "scale": 0.001,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Intensity",
-                        "size": 2,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ReturnNumber",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "NumberOfReturns",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ScanDirectionFlag",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "EdgeOfFlightLine",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "Classification",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ScanAngleRank",
-                        "size": 4,
-                        "type": "floating"
-                    },
-                    {
-                        "name": "UserData",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "PointSourceId",
-                        "size": 2,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "GpsTime",
-                        "size": 8,
-                        "type": "floating"
-                    },
-                    {
-                        "name": "ScanChannel",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ClassFlags",
-                        "size": 1,
-                        "type": "unsigned"
-                    }
-                ],
-                "proj:epsg": 3857,
-                "proj:projjson": {
-                    "$schema": "https://proj.org/schemas/v0.5/projjson.schema.json",
-                    "type": "ProjectedCRS",
-                    "name": "WGS 84 / Pseudo-Mercator",
-                    "base_crs": {
-                        "name": "WGS 84",
-                        "datum_ensemble": {
-                            "name": "World Geodetic System 1984 ensemble",
-                            "members": [
-                                {
-                                    "name": "World Geodetic System 1984 (Transit)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1166
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G730)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1152
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G873)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1153
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1150)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1154
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1674)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1155
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1762)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1156
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G2139)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1309
-                                    }
-                                }
-                            ],
-                            "ellipsoid": {
-                                "name": "WGS 84",
-                                "semi_major_axis": 6378137,
-                                "inverse_flattening": 298.257223563
-                            },
-                            "accuracy": "2.0",
-                            "id": {
-                                "authority": "EPSG",
-                                "code": 6326
-                            }
-                        },
-                        "coordinate_system": {
-                            "subtype": "ellipsoidal",
-                            "axis": [
-                                {
-                                    "name": "Geodetic latitude",
-                                    "abbreviation": "Lat",
-                                    "direction": "north",
-                                    "unit": "degree"
-                                },
-                                {
-                                    "name": "Geodetic longitude",
-                                    "abbreviation": "Lon",
-                                    "direction": "east",
-                                    "unit": "degree"
-                                }
-                            ]
-                        },
-                        "id": {
-                            "authority": "EPSG",
-                            "code": 4326
-                        }
-                    },
-                    "conversion": {
-                        "name": "Popular Visualisation Pseudo-Mercator",
-                        "method": {
-                            "name": "Popular Visualisation Pseudo Mercator",
-                            "id": {
-                                "authority": "EPSG",
-                                "code": 1024
-                            }
-                        },
-                        "parameters": [
-                            {
-                                "name": "Latitude of natural origin",
-                                "value": 0,
-                                "unit": "degree",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8801
-                                }
-                            },
-                            {
-                                "name": "Longitude of natural origin",
-                                "value": 0,
-                                "unit": "degree",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8802
-                                }
-                            },
-                            {
-                                "name": "False easting",
-                                "value": 0,
-                                "unit": "metre",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8806
-                                }
-                            },
-                            {
-                                "name": "False northing",
-                                "value": 0,
-                                "unit": "metre",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8807
-                                }
-                            }
-                        ]
-                    },
-                    "coordinate_system": {
-                        "subtype": "Cartesian",
-                        "axis": [
-                            {
-                                "name": "Easting",
-                                "abbreviation": "X",
-                                "direction": "east",
-                                "unit": "metre"
-                            },
-                            {
-                                "name": "Northing",
-                                "abbreviation": "Y",
-                                "direction": "north",
-                                "unit": "metre"
-                            }
-                        ]
-                    },
-                    "scope": "Web mapping and visualisation.",
-                    "area": "World between 85.06°S and 85.06°N.",
-                    "bbox": {
-                        "south_latitude": -85.06,
-                        "west_longitude": -180,
-                        "north_latitude": 85.06,
-                        "east_longitude": 180
-                    },
-                    "id": {
-                        "authority": "EPSG",
-                        "code": 3857
-                    }
-                },
-                "datetime": "2023-01-11T17:08:49.124767Z"
-            },
-            "geometry": {
-                "type": "MultiPolygon",
-                "coordinates": [
-                    [
-                        [
-                            [
-                                -87.43559691694178,
-                                31.354896749348864
-                            ],
-                            [
-                                -87.41763061126379,
-                                31.368182821276704
-                            ],
-                            [
-                                -87.44458006978071,
-                                31.381467015258686
-                            ],
-                            [
-                                -87.46254637545864,
-                                31.368182821276704
-                            ],
-                            [
-                                -87.43559691694178,
-                                31.354896749348864
-                            ]
-                        ]
-                    ],
-                    [
-                        [
-                            [
-                                -86.12854817887317,
-                                32.418379545798366
-                            ],
-                            [
-                                -86.12854817887317,
-                                32.4446446351634
-                            ],
-                            [
-                                -86.15100606097057,
-                                32.45120971202285
-                            ],
-                            [
-                                -86.15100606097057,
-                                32.42494653532583
-                            ],
-                            [
-                                -86.12854817887317,
-                                32.418379545798366
-                            ]
-                        ]
-                    ],
-                    [
-                        [
-                            [
-                                -86.20939655442379,
-                                32.51027387431023
-                            ],
-                            [
-                                -86.19592182516533,
-                                32.52995331263387
-                            ],
-                            [
-                                -86.2318544365212,
-                                32.54307054372084
-                            ],
-                            [
-                                -86.2318544365212,
-                                32.516834165909195
-                            ],
-                            [
-                                -86.20939655442379,
-                                32.51027387431023
-                            ]
-                        ]
-                    ]
-                ]
-            },
-            "links": [
-                {
-                    "rel": "self",
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-stac/ept/AL_25Co_TL_2017.json"
-                },
-                {
-                    "rel": "parent",
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-stac/ept/catalog.json"
-                }
-            ],
-            "assets": {
-                "ept.json": {
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-public/AL_25Co_TL_2017/ept.json",
-                    "title": "entwine",
-                    "description": "The ept.json for accessing data"
-                }
-            },
-            "bbox": [
-                -87.46254637545864,
-                31.354896749348864,
-                -86.12854817887317,
-                32.54307054372084
-            ],
-            "stac_extensions": [
-                "https://stac-extensions.github.io/pointcloud/v1.0.0/schema.json",
-                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
-            ]
-        },
-        {
-            "type": "Feature",
-            "stac_version": "1.0.0",
-            "id": "AL_BaldwinCo-East_2011",
-            "properties": {
-                "description": "A USGS Lidar pointcloud in Entwine/EPT format",
-                "pc:count": 1761346914,
-                "pc:type": "lidar",
-                "pc:encoding": "ept",
-                "pc:schemas": [
-                    {
-                        "name": "X",
-                        "offset": -9740753,
-                        "scale": 0.01,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Y",
-                        "offset": 3570834,
-                        "scale": 0.01,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Z",
-                        "offset": 677,
-                        "scale": 0.01,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Intensity",
-                        "size": 2,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ReturnNumber",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "NumberOfReturns",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ScanDirectionFlag",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "EdgeOfFlightLine",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "Classification",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ScanAngleRank",
-                        "size": 4,
-                        "type": "floating"
-                    },
-                    {
-                        "name": "UserData",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "PointSourceId",
-                        "size": 2,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "GpsTime",
-                        "size": 8,
-                        "type": "floating"
-                    },
-                    {
-                        "name": "OriginId",
-                        "size": 4,
-                        "type": "unsigned"
-                    }
-                ],
-                "proj:epsg": 3857,
-                "proj:projjson": {
-                    "$schema": "https://proj.org/schemas/v0.5/projjson.schema.json",
-                    "type": "ProjectedCRS",
-                    "name": "WGS 84 / Pseudo-Mercator",
-                    "base_crs": {
-                        "name": "WGS 84",
-                        "datum_ensemble": {
-                            "name": "World Geodetic System 1984 ensemble",
-                            "members": [
-                                {
-                                    "name": "World Geodetic System 1984 (Transit)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1166
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G730)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1152
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G873)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1153
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1150)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1154
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1674)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1155
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1762)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1156
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G2139)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1309
-                                    }
-                                }
-                            ],
-                            "ellipsoid": {
-                                "name": "WGS 84",
-                                "semi_major_axis": 6378137,
-                                "inverse_flattening": 298.257223563
-                            },
-                            "accuracy": "2.0",
-                            "id": {
-                                "authority": "EPSG",
-                                "code": 6326
-                            }
-                        },
-                        "coordinate_system": {
-                            "subtype": "ellipsoidal",
-                            "axis": [
-                                {
-                                    "name": "Geodetic latitude",
-                                    "abbreviation": "Lat",
-                                    "direction": "north",
-                                    "unit": "degree"
-                                },
-                                {
-                                    "name": "Geodetic longitude",
-                                    "abbreviation": "Lon",
-                                    "direction": "east",
-                                    "unit": "degree"
-                                }
-                            ]
-                        },
-                        "id": {
-                            "authority": "EPSG",
-                            "code": 4326
-                        }
-                    },
-                    "conversion": {
-                        "name": "Popular Visualisation Pseudo-Mercator",
-                        "method": {
-                            "name": "Popular Visualisation Pseudo Mercator",
-                            "id": {
-                                "authority": "EPSG",
-                                "code": 1024
-                            }
-                        },
-                        "parameters": [
-                            {
-                                "name": "Latitude of natural origin",
-                                "value": 0,
-                                "unit": "degree",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8801
-                                }
-                            },
-                            {
-                                "name": "Longitude of natural origin",
-                                "value": 0,
-                                "unit": "degree",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8802
-                                }
-                            },
-                            {
-                                "name": "False easting",
-                                "value": 0,
-                                "unit": "metre",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8806
-                                }
-                            },
-                            {
-                                "name": "False northing",
-                                "value": 0,
-                                "unit": "metre",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8807
-                                }
-                            }
-                        ]
-                    },
-                    "coordinate_system": {
-                        "subtype": "Cartesian",
-                        "axis": [
-                            {
-                                "name": "Easting",
-                                "abbreviation": "X",
-                                "direction": "east",
-                                "unit": "metre"
-                            },
-                            {
-                                "name": "Northing",
-                                "abbreviation": "Y",
-                                "direction": "north",
-                                "unit": "metre"
-                            }
-                        ]
-                    },
-                    "scope": "Web mapping and visualisation.",
-                    "area": "World between 85.06°S and 85.06°N.",
-                    "bbox": {
-                        "south_latitude": -85.06,
-                        "west_longitude": -180,
-                        "north_latitude": 85.06,
-                        "east_longitude": 180
-                    },
-                    "id": {
-                        "authority": "EPSG",
-                        "code": 3857
-                    }
-                },
-                "datetime": "2023-01-11T17:08:49.125963Z"
-            },
-            "geometry": {
-                "type": "MultiPolygon",
-                "coordinates": [
-                    [
-                        [
-                            [
-                                -87.62323534262887,
-                                30.2817355393626
-                            ],
-                            [
-                                -87.53789539065883,
-                                30.31532056933837
-                            ],
-                            [
-                                -87.48848805004455,
-                                30.30860448365945
-                            ],
-                            [
-                                -87.48399647362503,
-                                30.328751359796698
-                            ],
-                            [
-                                -87.43458913301077,
-                                30.322036194737738
-                            ],
-                            [
-                                -87.4031480980744,
-                                30.38245610074131
-                            ],
-                            [
-                                -87.38069021597698,
-                                30.38916712001022
-                            ],
-                            [
-                                -87.34924918104062,
-                                30.436131345030812
-                            ],
-                            [
-                                -87.35374075746014,
-                                30.4696633802158
-                            ],
-                            [
-                                -87.37619863955756,
-                                30.47636840248764
-                            ],
-                            [
-                                -87.38069021597698,
-                                30.49648069869216
-                            ],
-                            [
-                                -87.40763967449392,
-                                30.50988658671964
-                            ],
-                            [
-                                -87.40763967449392,
-                                30.550093160210277
-                            ],
-                            [
-                                -87.36272391029908,
-                                30.603676028975137
-                            ],
-                            [
-                                -87.37619863955756,
-                                30.67730409809879
-                            ],
-                            [
-                                -87.39416494523545,
-                                30.70406404008885
-                            ],
-                            [
-                                -87.50196277930293,
-                                30.7575616601965
-                            ],
-                            [
-                                -87.54238696707826,
-                                30.737503532712577
-                            ],
-                            [
-                                -87.53789539065883,
-                                30.583585923027897
-                            ],
-                            [
-                                -87.55586169633672,
-                                30.5701902055388
-                            ],
-                            [
-                                -87.55137011991721,
-                                30.429423553649585
-                            ],
-                            [
-                                -87.57831957843413,
-                                30.429423553649585
-                            ],
-                            [
-                                -87.60976061337051,
-                                30.409297411900774
-                            ],
-                            [
-                                -87.6636595304042,
-                                30.409297411900774
-                            ],
-                            [
-                                -87.6636595304042,
-                                30.30188793776165
-                            ],
-                            [
-                                -87.62323534262887,
-                                30.2817355393626
-                            ]
-                        ]
-                    ]
-                ]
-            },
-            "links": [
-                {
-                    "rel": "self",
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-stac/ept/AL_BaldwinCo-East_2011.json"
-                },
-                {
-                    "rel": "parent",
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-stac/ept/catalog.json"
-                }
-            ],
-            "assets": {
-                "ept.json": {
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-public/AL_BaldwinCo-East_2011/ept.json",
-                    "title": "entwine",
-                    "description": "The ept.json for accessing data"
-                }
-            },
-            "bbox": [
-                -87.6636595304042,
-                30.2817355393626,
-                -87.34924918104062,
-                30.7575616601965
-            ],
-            "stac_extensions": [
-                "https://stac-extensions.github.io/pointcloud/v1.0.0/schema.json",
-                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
-            ]
-        },
-        {
-            "type": "Feature",
-            "stac_version": "1.0.0",
-            "id": "AL_BaldwinCo-West_2011",
-            "properties": {
-                "description": "A USGS Lidar pointcloud in Entwine/EPT format",
-                "pc:count": 583915920,
-                "pc:type": "lidar",
-                "pc:encoding": "ept",
-                "pc:schemas": [
-                    {
-                        "name": "X",
-                        "offset": -9791574,
-                        "scale": 0.01,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Y",
-                        "offset": 3600301,
-                        "scale": 0.01,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Z",
-                        "offset": 421,
-                        "scale": 0.01,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Intensity",
-                        "size": 2,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ReturnNumber",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "NumberOfReturns",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ScanDirectionFlag",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "EdgeOfFlightLine",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "Classification",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ScanAngleRank",
-                        "size": 4,
-                        "type": "floating"
-                    },
-                    {
-                        "name": "UserData",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "PointSourceId",
-                        "size": 2,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "GpsTime",
-                        "size": 8,
-                        "type": "floating"
-                    },
-                    {
-                        "name": "OriginId",
-                        "size": 4,
-                        "type": "unsigned"
-                    }
-                ],
-                "proj:epsg": 3857,
-                "proj:projjson": {
-                    "$schema": "https://proj.org/schemas/v0.5/projjson.schema.json",
-                    "type": "ProjectedCRS",
-                    "name": "WGS 84 / Pseudo-Mercator",
-                    "base_crs": {
-                        "name": "WGS 84",
-                        "datum_ensemble": {
-                            "name": "World Geodetic System 1984 ensemble",
-                            "members": [
-                                {
-                                    "name": "World Geodetic System 1984 (Transit)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1166
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G730)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1152
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G873)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1153
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1150)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1154
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1674)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1155
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1762)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1156
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G2139)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1309
-                                    }
-                                }
-                            ],
-                            "ellipsoid": {
-                                "name": "WGS 84",
-                                "semi_major_axis": 6378137,
-                                "inverse_flattening": 298.257223563
-                            },
-                            "accuracy": "2.0",
-                            "id": {
-                                "authority": "EPSG",
-                                "code": 6326
-                            }
-                        },
-                        "coordinate_system": {
-                            "subtype": "ellipsoidal",
-                            "axis": [
-                                {
-                                    "name": "Geodetic latitude",
-                                    "abbreviation": "Lat",
-                                    "direction": "north",
-                                    "unit": "degree"
-                                },
-                                {
-                                    "name": "Geodetic longitude",
-                                    "abbreviation": "Lon",
-                                    "direction": "east",
-                                    "unit": "degree"
-                                }
-                            ]
-                        },
-                        "id": {
-                            "authority": "EPSG",
-                            "code": 4326
-                        }
-                    },
-                    "conversion": {
-                        "name": "Popular Visualisation Pseudo-Mercator",
-                        "method": {
-                            "name": "Popular Visualisation Pseudo Mercator",
-                            "id": {
-                                "authority": "EPSG",
-                                "code": 1024
-                            }
-                        },
-                        "parameters": [
-                            {
-                                "name": "Latitude of natural origin",
-                                "value": 0,
-                                "unit": "degree",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8801
-                                }
-                            },
-                            {
-                                "name": "Longitude of natural origin",
-                                "value": 0,
-                                "unit": "degree",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8802
-                                }
-                            },
-                            {
-                                "name": "False easting",
-                                "value": 0,
-                                "unit": "metre",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8806
-                                }
-                            },
-                            {
-                                "name": "False northing",
-                                "value": 0,
-                                "unit": "metre",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8807
-                                }
-                            }
-                        ]
-                    },
-                    "coordinate_system": {
-                        "subtype": "Cartesian",
-                        "axis": [
-                            {
-                                "name": "Easting",
-                                "abbreviation": "X",
-                                "direction": "east",
-                                "unit": "metre"
-                            },
-                            {
-                                "name": "Northing",
-                                "abbreviation": "Y",
-                                "direction": "north",
-                                "unit": "metre"
-                            }
-                        ]
-                    },
-                    "scope": "Web mapping and visualisation.",
-                    "area": "World between 85.06°S and 85.06°N.",
-                    "bbox": {
-                        "south_latitude": -85.06,
-                        "west_longitude": -180,
-                        "north_latitude": 85.06,
-                        "east_longitude": 180
-                    },
-                    "id": {
-                        "authority": "EPSG",
-                        "code": 3857
-                    }
-                },
-                "datetime": "2023-01-11T17:08:49.127318Z"
-            },
-            "geometry": {
-                "type": "MultiPolygon",
-                "coordinates": [
-                    [
-                        [
-                            [
-                                -87.99325185728185,
-                                30.616520549506
-                            ],
-                            [
-                                -87.97528555160396,
-                                30.62990986292517
-                            ],
-                            [
-                                -87.89443717605332,
-                                30.62990986292517
-                            ],
-                            [
-                                -87.89892875247274,
-                                30.67675786924697
-                            ],
-                            [
-                                -87.88096244679485,
-                                30.69013884319944
-                            ],
-                            [
-                                -87.88545402321436,
-                                30.81716553509689
-                            ],
-                            [
-                                -87.86748771753639,
-                                30.830527013129686
-                            ],
-                            [
-                                -87.8719792939559,
-                                30.877277539982167
-                            ],
-                            [
-                                -87.96181082234547,
-                                30.877277539982167
-                            ],
-                            [
-                                -87.98876028086234,
-                                30.863922572080476
-                            ],
-                            [
-                                -88.00672658654032,
-                                30.823846506515693
-                            ],
-                            [
-                                -88.06062550357402,
-                                30.79711983259629
-                            ],
-                            [
-                                -88.06062550357402,
-                                30.743644189120925
-                            ],
-                            [
-                                -88.03367604505716,
-                                30.730270636067708
-                            ],
-                            [
-                                -88.01570973937926,
-                                30.70351796263528
-                            ],
-                            [
-                                -88.0202013157987,
-                                30.62990986292517
-                            ],
-                            [
-                                -87.99325185728185,
-                                30.616520549506
-                            ]
-                        ]
-                    ]
-                ]
-            },
-            "links": [
-                {
-                    "rel": "self",
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-stac/ept/AL_BaldwinCo-West_2011.json"
-                },
-                {
-                    "rel": "parent",
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-stac/ept/catalog.json"
-                }
-            ],
-            "assets": {
-                "ept.json": {
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-public/AL_BaldwinCo-West_2011/ept.json",
-                    "title": "entwine",
-                    "description": "The ept.json for accessing data"
-                }
-            },
-            "bbox": [
-                -88.06062550357402,
-                30.616520549506,
-                -87.86748771753639,
-                30.877277539982167
-            ],
-            "stac_extensions": [
-                "https://stac-extensions.github.io/pointcloud/v1.0.0/schema.json",
-                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
-            ]
-        },
-        {
-            "type": "Feature",
-            "stac_version": "1.0.0",
-            "id": "AL_BlountCo_2010",
-            "properties": {
-                "description": "A USGS Lidar pointcloud in Entwine/EPT format",
-                "pc:count": 6784747694,
-                "pc:type": "lidar",
-                "pc:encoding": "ept",
-                "pc:schemas": [
-                    {
-                        "name": "X",
-                        "offset": -9643871,
-                        "scale": 0.01,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Y",
-                        "offset": 4030537,
-                        "scale": 0.01,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Z",
-                        "offset": 313,
-                        "scale": 0.01,
-                        "size": 4,
-                        "type": "signed"
-                    },
-                    {
-                        "name": "Intensity",
-                        "size": 2,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ReturnNumber",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "NumberOfReturns",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ScanDirectionFlag",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "EdgeOfFlightLine",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "Classification",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "ScanAngleRank",
-                        "size": 4,
-                        "type": "floating"
-                    },
-                    {
-                        "name": "UserData",
-                        "size": 1,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "PointSourceId",
-                        "size": 2,
-                        "type": "unsigned"
-                    },
-                    {
-                        "name": "GpsTime",
-                        "size": 8,
-                        "type": "floating"
-                    },
-                    {
-                        "name": "OriginId",
-                        "size": 4,
-                        "type": "unsigned"
-                    }
-                ],
-                "proj:epsg": 3857,
-                "proj:projjson": {
-                    "$schema": "https://proj.org/schemas/v0.5/projjson.schema.json",
-                    "type": "ProjectedCRS",
-                    "name": "WGS 84 / Pseudo-Mercator",
-                    "base_crs": {
-                        "name": "WGS 84",
-                        "datum_ensemble": {
-                            "name": "World Geodetic System 1984 ensemble",
-                            "members": [
-                                {
-                                    "name": "World Geodetic System 1984 (Transit)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1166
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G730)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1152
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G873)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1153
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1150)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1154
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1674)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1155
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G1762)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1156
-                                    }
-                                },
-                                {
-                                    "name": "World Geodetic System 1984 (G2139)",
-                                    "id": {
-                                        "authority": "EPSG",
-                                        "code": 1309
-                                    }
-                                }
-                            ],
-                            "ellipsoid": {
-                                "name": "WGS 84",
-                                "semi_major_axis": 6378137,
-                                "inverse_flattening": 298.257223563
-                            },
-                            "accuracy": "2.0",
-                            "id": {
-                                "authority": "EPSG",
-                                "code": 6326
-                            }
-                        },
-                        "coordinate_system": {
-                            "subtype": "ellipsoidal",
-                            "axis": [
-                                {
-                                    "name": "Geodetic latitude",
-                                    "abbreviation": "Lat",
-                                    "direction": "north",
-                                    "unit": "degree"
-                                },
-                                {
-                                    "name": "Geodetic longitude",
-                                    "abbreviation": "Lon",
-                                    "direction": "east",
-                                    "unit": "degree"
-                                }
-                            ]
-                        },
-                        "id": {
-                            "authority": "EPSG",
-                            "code": 4326
-                        }
-                    },
-                    "conversion": {
-                        "name": "Popular Visualisation Pseudo-Mercator",
-                        "method": {
-                            "name": "Popular Visualisation Pseudo Mercator",
-                            "id": {
-                                "authority": "EPSG",
-                                "code": 1024
-                            }
-                        },
-                        "parameters": [
-                            {
-                                "name": "Latitude of natural origin",
-                                "value": 0,
-                                "unit": "degree",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8801
-                                }
-                            },
-                            {
-                                "name": "Longitude of natural origin",
-                                "value": 0,
-                                "unit": "degree",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8802
-                                }
-                            },
-                            {
-                                "name": "False easting",
-                                "value": 0,
-                                "unit": "metre",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8806
-                                }
-                            },
-                            {
-                                "name": "False northing",
-                                "value": 0,
-                                "unit": "metre",
-                                "id": {
-                                    "authority": "EPSG",
-                                    "code": 8807
-                                }
-                            }
-                        ]
-                    },
-                    "coordinate_system": {
-                        "subtype": "Cartesian",
-                        "axis": [
-                            {
-                                "name": "Easting",
-                                "abbreviation": "X",
-                                "direction": "east",
-                                "unit": "metre"
-                            },
-                            {
-                                "name": "Northing",
-                                "abbreviation": "Y",
-                                "direction": "north",
-                                "unit": "metre"
-                            }
-                        ]
-                    },
-                    "scope": "Web mapping and visualisation.",
-                    "area": "World between 85.06°S and 85.06°N.",
-                    "bbox": {
-                        "south_latitude": -85.06,
-                        "west_longitude": -180,
-                        "north_latitude": 85.06,
-                        "east_longitude": 180
-                    },
-                    "id": {
-                        "authority": "EPSG",
-                        "code": 3857
-                    }
-                },
-                "datetime": "2023-01-11T17:08:49.128575Z"
-            },
-            "geometry": {
-                "type": "MultiPolygon",
-                "coordinates": [
-                    [
-                        [
-                            [
-                                -86.63088998412591,
-                                33.746479749036695
-                            ],
-                            [
-                                -86.61292367844793,
-                                33.75941637031644
-                            ],
-                            [
-                                -86.57699106709212,
-                                33.746479749036695
-                            ],
-                            [
-                                -86.55902476141422,
-                                33.75941637031644
-                            ],
-                            [
-                                -86.55902476141422,
-                                33.7852837562305
-                            ],
-                            [
-                                -86.53656687931681,
-                                33.778817641946524
-                            ],
-                            [
-                                -86.50512584438043,
-                                33.798214520136185
-                            ],
-                            [
-                                -86.48266796228302,
-                                33.79174938230882
-                            ],
-                            [
-                                -86.45122692734665,
-                                33.811143330855906
-                            ],
-                            [
-                                -86.42876904524931,
-                                33.804679169667
-                            ],
-                            [
-                                -86.388344857474,
-                                33.82407018802663
-                            ],
-                            [
-                                -86.38385328105448,
-                                33.843456810084895
-                            ],
-                            [
-                                -86.33444594044022,
-                                33.86283903461933
-                            ],
-                            [
-                                -86.33444594044022,
-                                33.90159028623923
-                            ],
-                            [
-                                -86.30300490550384,
-                                33.920959310891455
-                            ],
-                            [
-                                -86.33444594044022,
-                                33.96613657924832
-                            ],
-                            [
-                                -86.31647963476233,
-                                33.97903996566658
-                            ],
-                            [
-                                -86.32097121118176,
-                                34.062864229622
-                            ],
-                            [
-                                -86.2940217526649,
-                                34.075752920642415
-                            ],
-                            [
-                                -86.28953017624546,
-                                34.10796606850599
-                            ],
-                            [
-                                -86.31647963476233,
-                                34.12084789484949
-                            ],
-                            [
-                                -86.33444594044022,
-                                34.1594815996935
-                            ],
-                            [
-                                -86.35690382253763,
-                                34.16591883297068
-                            ],
-                            [
-                                -86.37487012821553,
-                                34.20453192346365
-                            ],
-                            [
-                                -86.42427746882979,
-                                34.2366959939633
-                            ],
-                            [
-                                -86.42876904524931,
-                                34.26884778145957
-                            ],
-                            [
-                                -86.53207530289727,
-                                34.2624184068615
-                            ],
-                            [
-                                -86.60394052560896,
-                                34.13372775906311
-                            ],
-                            [
-                                -86.63987313696485,
-                                34.13372775906311
-                            ],
-                            [
-                                -86.67131417190122,
-                                34.10152441964559
-                            ],
-                            [
-                                -86.69377205399854,
-                                34.10796606850599
-                            ],
-                            [
-                                -86.7207215125155,
-                                34.09508228038496
-                            ],
-                            [
-                                -86.7207215125155,
-                                34.04352751718811
-                            ],
-                            [
-                                -86.74767097103233,
-                                34.030633925480416
-                            ],
-                            [
-                                -86.75216254745176,
-                                34.01128986367855
-                            ],
-                            [
-                                -86.77462042954919,
-                                34.00484086345837
-                            ],
-                            [
-                                -86.7791120059687,
-                                33.985490924562
-                            ],
-                            [
-                                -86.83301092300249,
-                                33.95968415181489
-                            ],
-                            [
-                                -86.85546880509982,
-                                33.96613657924832
-                            ],
-                            [
-                                -86.85996038151934,
-                                33.94677782872278
-                            ],
-                            [
-                                -86.89589299287515,
-                                33.94677782872278
-                            ],
-                            [
-                                -86.90038456929464,
-                                33.92741467419311
-                            ],
-                            [
-                                -86.94080875706997,
-                                33.908047116869554
-                            ],
-                            [
-                                -86.94080875706997,
-                                33.88221686040999
-                            ],
-                            [
-                                -86.9812329448453,
-                                33.86283903461933
-                            ],
-                            [
-                                -86.9812329448453,
-                                33.83699509128556
-                            ],
-                            [
-                                -86.9632666391674,
-                                33.811143330855906
-                            ],
-                            [
-                                -86.93631718065045,
-                                33.798214520136185
-                            ],
-                            [
-                                -86.86894353435828,
-                                33.83053288391776
-                            ],
-                            [
-                                -86.7791120059687,
-                                33.83053288391776
-                            ],
-                            [
-                                -86.65783944264275,
-                                33.772351039502546
-                            ],
-                            [
-                                -86.65334786622323,
-                                33.75294830366543
-                            ],
-                            [
-                                -86.63088998412591,
-                                33.746479749036695
-                            ]
-                        ]
-                    ]
-                ]
-            },
-            "links": [
-                {
-                    "rel": "self",
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-stac/ept/AL_BlountCo_2010.json"
-                },
-                {
-                    "rel": "parent",
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-stac/ept/catalog.json"
-                }
-            ],
-            "assets": {
-                "ept.json": {
-                    "href": "https://s3-us-west-2.amazonaws.com/usgs-lidar-public/AL_BlountCo_2010/ept.json",
-                    "title": "entwine",
-                    "description": "The ept.json for accessing data"
-                }
-            },
-            "bbox": [
-                -86.9812329448453,
-                33.746479749036695,
-                -86.28953017624546,
-                34.26884778145957
+                -92.58745208507982,
+                40.35042007267842,
+                -90.31920599324215,
+                42.3762437388722
             ],
             "stac_extensions": [
                 "https://stac-extensions.github.io/pointcloud/v1.0.0/schema.json",

--- a/test/unit/io/StacReaderTest.cpp
+++ b/test/unit/io/StacReaderTest.cpp
@@ -56,7 +56,7 @@ TEST(StacReaderTest, item_collection_test)
 
     options.add("filename", Support::datapath("stac/test_item_collection.json"));
     options.add("asset_names", "ept.json");
-    options.add("item_ids", "AK_NorthSlope_\\w{0,}");
+    options.add("item_ids", "AK_GlacierBay_\\w{0,}");
 
     StageFactory f;
     Stage& reader = *f.createStage("readers.stac");
@@ -68,22 +68,11 @@ TEST(StacReaderTest, item_collection_test)
     EXPECT_TRUE(jsonMetadata.contains("stac_ids"));
     std::vector<std::string> idList = jsonMetadata["stac_ids"].get<std::vector<std::string>>();
 
-    EXPECT_TRUE(std::find(idList.begin(), idList.end(), "AK_NorthSlope_B1_2018") != idList.end());
-    EXPECT_TRUE(std::find(idList.begin(), idList.end(), "AK_NorthSlope_B2_2018") != idList.end());
-    EXPECT_TRUE(std::find(idList.begin(), idList.end(), "AK_NorthSlope_B3_2018") != idList.end());
-    EXPECT_TRUE(std::find(idList.begin(), idList.end(), "AK_NorthSlope_B4_2018") != idList.end());
-    EXPECT_TRUE(std::find(idList.begin(), idList.end(), "AK_NorthSlope_B5_2018") != idList.end());
-    EXPECT_TRUE(std::find(idList.begin(), idList.end(), "AK_NorthSlope_B6_2018") != idList.end());
-    EXPECT_TRUE(std::find(idList.begin(), idList.end(), "AK_NorthSlope_B7_2018") != idList.end());
-    EXPECT_TRUE(std::find(idList.begin(), idList.end(), "AK_NorthSlope_B8_2018") != idList.end());
-    EXPECT_TRUE(std::find(idList.begin(), idList.end(), "AK_NorthSlope_B9_2018") != idList.end());
-    EXPECT_TRUE(std::find(idList.begin(), idList.end(), "AK_NorthSlope_B10_2018") != idList.end());
-    EXPECT_TRUE(std::find(idList.begin(), idList.end(), "AK_NorthSlope_B11_2018") != idList.end());
-    EXPECT_TRUE(std::find(idList.begin(), idList.end(), "AK_NorthSlope_B12_2018") != idList.end());
-    EXPECT_TRUE(std::find(idList.begin(), idList.end(), "AK_NorthSlope_B13_2018") != idList.end());
-    EXPECT_TRUE(std::find(idList.begin(), idList.end(), "AK_NorthSlope_B14_2018") != idList.end());
+    EXPECT_TRUE(std::find(idList.begin(), idList.end(), "AK_GlacierBay_B3_2019") != idList.end());
+    EXPECT_TRUE(std::find(idList.begin(), idList.end(), "AK_GlacierBay_4_2019") != idList.end());
+    EXPECT_EQ(idList.size(), 2);
 
-    EXPECT_EQ(qi.m_pointCount, 9050847242);
+    EXPECT_EQ(qi.m_pointCount, 33904747117);
 }
 
 TEST(StacReaderTest, remote_item_test)
@@ -263,7 +252,7 @@ TEST(StacReaderTest, bounds_prune_accept_test)
     Options options;
     std::string bounds = "([-10190065.06156413, -10189065.06156413], [5109498.61041016, 5110498.61041016]) / EPSG:3857";
 
-    options.add("filename", "https://usgs-lidar-stac.s3-us-west-2.amazonaws.com/ept/item_collection.json");
+    options.add("filename", Support::datapath("stac/test_item_collection.json"));
     options.add("asset_names", "ept.json");
     options.add("bounds", bounds);
 

--- a/test/unit/io/StacReaderTest.cpp
+++ b/test/unit/io/StacReaderTest.cpp
@@ -261,9 +261,9 @@ TEST(StacReaderTest, date_prune_reject_test)
 TEST(StacReaderTest, bounds_prune_accept_test)
 {
     Options options;
-    std::string bounds = "([-79.0,-74.0],[38.0,39.0])";
+    std::string bounds = "([-10190065.06156413, -10189065.06156413], [5109498.61041016, 5110498.61041016]) / EPSG:3857";
 
-    options.add("filename", Support::datapath("stac/MD_GoldenBeach_2012.json"));
+    options.add("filename", "https://usgs-lidar-stac.s3-us-west-2.amazonaws.com/ept/item_collection.json");
     options.add("asset_names", "ept.json");
     options.add("bounds", bounds);
 
@@ -276,8 +276,10 @@ TEST(StacReaderTest, bounds_prune_accept_test)
     NL::json jsonMetadata = NL::json::parse(Utils::toJSON(qi.m_metadata));
     EXPECT_TRUE(jsonMetadata.contains("stac_ids"));
     std::vector<std::string> idList = jsonMetadata["stac_ids"].get<std::vector<std::string>>();
-    EXPECT_TRUE(std::find(idList.begin(), idList.end(), "MD_GoldenBeach_2012") != idList.end());
-    EXPECT_EQ(qi.m_pointCount, 4860658);
+    EXPECT_TRUE(std::find(idList.begin(), idList.end(), "IA_Eastern_1_2019") != idList.end());
+    EXPECT_TRUE(std::find(idList.begin(), idList.end(), "IA_FullState") != idList.end());
+    EXPECT_EQ(idList.size(), 2);
+    EXPECT_EQ(qi.m_pointCount, 322323007151);
 
 }
 
@@ -293,7 +295,6 @@ TEST(StacReaderTest, bounds_prune_reject_test)
     StageFactory f;
     Stage& reader = *f.createStage("readers.stac");
     reader.setOptions(options);
-
     EXPECT_THROW(QuickInfo qi = reader.preview(), pdal_error);
 }
 


### PR DESCRIPTION
If SRS is passed with bounds to args, reproject to 4326 for comparisons with geometry from STAC item. Adjusted test to reflect changes.