### PR TITLE
Fix building with MinGW

### DIFF
--- a/apps/pdal.cpp
+++ b/apps/pdal.cpp
@@ -301,7 +301,7 @@ namespace
     LogPtr logPtr(Log::makeLog("PDAL", "stderr"));
 }
 
-#ifdef _WIN32
+#ifdef PDAL_WIN32_STL
 int wmain( int argc, wchar_t *argv[ ], wchar_t *envp[ ] )
 #else
 int main(int argc, char *argv[])

--- a/pdal/DynamicLibrary.cpp
+++ b/pdal/DynamicLibrary.cpp
@@ -87,7 +87,11 @@ DynamicLibrary *DynamicLibrary::load(const std::string &name,
     void *handle = NULL;
 
 #ifdef _WIN32
+#ifdef PDAL_WIN32_STL
     handle = ::LoadLibraryW(FileUtils::toNative(name).c_str());
+#else
+    handle = ::LoadLibraryA(FileUtils::toNative(name).c_str());
+#endif
     if (handle == NULL)
     {
         DWORD errorCode = ::GetLastError();

--- a/pdal/PDALUtils.cpp
+++ b/pdal/PDALUtils.cpp
@@ -469,8 +469,13 @@ std::string dllDir()
         GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
         (LPCSTR)&dllDir, &hm))
     {
+#ifdef PDAL_WIN32_STL
         wchar_t path[MAX_PATH];
         DWORD cnt = GetModuleFileNameW(hm, path, sizeof(path));
+#else
+        char path[MAX_PATH];
+        DWORD cnt = GetModuleFileNameA(hm, path, sizeof(path));
+#endif
         if (cnt > 0 && cnt < MAX_PATH)
             s = FileUtils::fromNative(path);
     }

--- a/pdal/util/pdal_util_export.hpp
+++ b/pdal/util/pdal_util_export.hpp
@@ -42,7 +42,11 @@
 #   define PDAL_DLL   __declspec(dllexport)
 #   define PDAL_LOCAL
 #   define PDAL_DLL_UNIX
+#ifdef __GNUC__
+#   define PDAL_DLL_DEPRECATED __attribute__((deprecated)) PDAL_DLL
+#else
 #   define PDAL_DLL_DEPRECATED   __declspec(deprecated, dllexport)
+#endif
 #else
 #   define PDAL_DLL     __attribute__ ((visibility("default")))
 #   define PDAL_LOCAL   __attribute__((visibility("hidden")))


### PR DESCRIPTION
PDAL 2.5.0 doesn't build with MinGW compilers. This is mainly because of the missing/incomplete filesystem API in the C++ standard libraries on that platform.

The proposed changes add the work-around of using ANSI Windows API functions in more places.

Additionally, it fixes an issue with the deprecated attribute for GNU compatible compilers on Windows.

See also this downstream PR for the binary package of PDAL in MSYS2: https://github.com/msys2/MINGW-packages/pull/15234