### PR TITLE
Fix S3 HEAD requests

### DIFF
--- a/vendor/arbiter/arbiter.hpp
+++ b/vendor/arbiter/arbiter.hpp
@@ -4089,7 +4089,7 @@ public:
             http::Query query = http::Query()) const;
 
     /* Perform an HTTP HEAD request. */
-    std::unique_ptr<std::size_t> tryGetSize(
+    virtual std::unique_ptr<std::size_t> tryGetSize(
             std::string path,
             http::Headers headers,
             http::Query query = http::Query()) const;
@@ -4279,7 +4279,9 @@ public:
 
     // Overrides.
     virtual std::unique_ptr<std::size_t> tryGetSize(
-            std::string path) const override;
+            std::string path,
+            http::Headers headers,
+            http::Query query = http::Query()) const override;
 
     /** Inherited from Drivers::Http. */
     virtual void put(


### PR DESCRIPTION
S3 HEAD requests were being incorrectly routed to the generic HTTP functionality rather than the S3-specific implementation.  This was always an issue (these requests occur as an optional optimization prior to a GET), but was only recently made very apparent when retry backoffs were increased.  Closes #3955.