### PR TITLE
Remove redundant header include in EsriReader.hpp

### DIFF
--- a/plugins/i3s/io/EsriReader.hpp
+++ b/plugins/i3s/io/EsriReader.hpp
@@ -45,7 +45,6 @@
 
 #include <pdal/Reader.hpp>
 #include <pdal/Streamable.hpp>
-#include <pdal/Streamable.hpp>
 #include <pdal/util/Bounds.hpp>
 
 #include "EsriUtil.hpp"


### PR DESCRIPTION
Hi,
`pdal/Streamable.hpp` is included twice in `plugins/i3s/io/EsriReader.hpp`. This MR removes the second redundant include.