### PR TITLE
check if directory exists before listing it

### DIFF
--- a/pdal/PluginDirectory.cpp
+++ b/pdal/PluginDirectory.cpp
@@ -120,6 +120,11 @@ PluginDirectory::PluginDirectory()
 {
     for (const auto& dir : pluginSearchPaths())
     {
+        // Don't try to list the directory if it
+        // doesn't exist
+        if (!FileUtils::directoryExists(dir))
+            continue;
+
         StringList files = FileUtils::directoryList(dir);
         for (auto& file : files)
         {


### PR DESCRIPTION
This should address https://github.com/PDAL/python/issues/145 where `PDAL_DRIVER_PATH` is set to a bunk directory and it is trying to list it on Windows and throwing an error.