### PR TITLE
LasHeader copyable

### DIFF
--- a/io/LasHeader.cpp
+++ b/io/LasHeader.cpp
@@ -55,6 +55,9 @@ std::string GetDefaultSoftwareId()
 
 struct LasHeader::Private
 {
+    Private()
+    {}
+
     Private(las::Header& h, las::Srs& srs, las::VlrList& vlrs) : h(h), srs(srs), vlrs(vlrs)
     {}
 
@@ -62,15 +65,18 @@ struct LasHeader::Private
         interfaceVlrs(src.interfaceVlrs)
     {}
 
-    las::Header& h;
-    las::Srs& srs;
-    las::VlrList& vlrs;
+    las::Header h;
+    las::Srs srs;
+    las::VlrList vlrs;
 
     VlrList interfaceVlrs;
 };
 
 LasHeader::LasHeader(las::Header& h, las::Srs& srs, las::VlrList& vlrs) :
     d(std::make_unique<Private>(h, srs, vlrs))
+{}
+
+LasHeader::LasHeader() : d(std::make_unique<Private>())
 {}
 
 LasHeader::LasHeader(const LasHeader& src) : d(std::make_unique<Private>(*(src.d)))
@@ -93,6 +99,21 @@ LasHeader& LasHeader::operator=(LasHeader&& src)
 
 LasHeader::~LasHeader()
 {}
+
+las::Header& LasHeader::getHeader()
+{
+    return d->h;
+}
+
+las::Srs& LasHeader::getSrs()
+{
+    return d->srs;
+}
+
+las::VlrList& LasHeader::getVlrs()
+{
+    return d->vlrs;
+}
 
 std::string LasHeader::getSystemIdentifier() const
 {

--- a/io/LasHeader.hpp
+++ b/io/LasHeader.hpp
@@ -300,6 +300,13 @@ private:
 
     static void get(ILeStream& in, Uuid& uuid);
     static void put(OLeStream& in, Uuid uuid);
+
+    friend LasReader;
+
+    LasHeader();
+    las::Header& getHeader();
+    las::Srs& getSrs();
+    las::VlrList& getVlrs();
 };
 
 } // namespace pdal

--- a/io/LasReader.cpp
+++ b/io/LasReader.cpp
@@ -82,17 +82,20 @@ struct LasReader::Options
 struct LasReader::Private
 {
     Options opts;
-    las::Header header;
     LasHeader apiHeader;
     LazPerfVlrDecompressor *decompressor;
     std::vector<char> decompressorBuf;
     point_count_t index;
     las::VlrList ignoreVlrs;
-    las::VlrList vlrs;
-    las::Srs srs;
+    las::Header& header;
+    las::VlrList& vlrs;
+    las::Srs& srs;
     std::vector<las::ExtraDim> extraDims;
 
-    Private() : apiHeader(header, srs, vlrs), decompressor(nullptr), index(0)
+    Private() : apiHeader(), decompressor(nullptr), index(0)
+    , header(apiHeader.getHeader())
+    , vlrs(apiHeader.getVlrs())
+    , srs(apiHeader.getSrs())
     {}
 };
 

--- a/test/unit/io/LasReaderTest.cpp
+++ b/test/unit/io/LasReaderTest.cpp
@@ -160,6 +160,56 @@ TEST(LasReaderTest, header)
     EXPECT_EQ(h.pointCountByReturn(4), 0);
 }
 
+TEST(LasReaderTest, copied_header)
+{
+    auto getHeader = [](const std::string& path){
+        PointTable table;
+        Options ops;
+        ops.add("filename", path);
+
+        LasReader reader;
+        reader.setOptions(ops);
+
+        reader.prepare(table);
+        return reader.header();
+    };
+
+    LasHeader h = getHeader(Support::datapath("las/simple.las"));
+
+    EXPECT_EQ(h.softwareId(), "TerraScan");
+
+    // Remaining checks
+    EXPECT_EQ(h.fileSignature(), "LASF");
+    EXPECT_EQ(h.fileSourceId(), 0);
+    EXPECT_TRUE(h.projectId().isNull());
+    EXPECT_EQ(h.versionMajor(), 1);
+    EXPECT_EQ(h.versionMinor(), 2);
+    EXPECT_EQ(h.creationDOY(), 0);
+    EXPECT_EQ(h.creationYear(), 0);
+    EXPECT_EQ(h.vlrOffset(), 227);
+    EXPECT_EQ(h.pointFormat(), 3);
+    EXPECT_EQ(h.pointCount(), 1065u);
+    EXPECT_DOUBLE_EQ(h.scaleX(), .01);
+    EXPECT_DOUBLE_EQ(h.scaleY(), .01);
+    EXPECT_DOUBLE_EQ(h.scaleZ(), .01);
+    EXPECT_DOUBLE_EQ(h.offsetX(), 0);
+    EXPECT_DOUBLE_EQ(h.offsetY(), 0);
+    EXPECT_DOUBLE_EQ(h.offsetZ(), 0);
+    EXPECT_DOUBLE_EQ(h.maxX(), 638982.55);
+    EXPECT_DOUBLE_EQ(h.maxY(), 853535.43);
+    EXPECT_DOUBLE_EQ(h.maxZ(), 586.38);
+    EXPECT_DOUBLE_EQ(h.minX(), 635619.85);
+    EXPECT_DOUBLE_EQ(h.minY(), 848899.70);
+    EXPECT_DOUBLE_EQ(h.minZ(), 406.59);
+    EXPECT_EQ(h.compressed(), false);
+    EXPECT_EQ(h.pointCountByReturn(0), 925u);
+    EXPECT_EQ(h.pointCountByReturn(1), 114);
+    EXPECT_EQ(h.pointCountByReturn(2), 21);
+    EXPECT_EQ(h.pointCountByReturn(3), 5);
+    EXPECT_EQ(h.pointCountByReturn(4), 0);
+
+}
+
 TEST(LasReaderTest, vlr)
 {
     Options ops1;


### PR DESCRIPTION
This PR fixes the issue described in #4008

The changes in the code try to be minimal.

The idea is to move the ownership of `las::Header`, `las::Srs`, `las::VlrList` from `LasReader` to `LasHeader`. Because `LasReader` will always have the internal instance of `LasHeader`, the references are never pointing to invalid data.