### PR TITLE
Dont open readers.nitf stream multiple times if already open

### DIFF
--- a/plugins/nitf/io/NitfReader.hpp
+++ b/plugins/nitf/io/NitfReader.hpp
@@ -151,9 +151,8 @@ public:
 protected:
     virtual void createStream()
     {
-        if (m_streamIf)
-            std::cerr << "Attempt to create stream twice!\n";
-        m_streamIf.reset(new NitfStreamIf(m_filename, m_offset));
+        if (!m_streamIf)
+            m_streamIf.reset(new NitfStreamIf(m_filename, m_offset));
     }
 
 private:


### PR DESCRIPTION
This is a consequence of #3846 that was not addressed in the previous release.