### PR TITLE
harden pdal::Geometry constructors to protect against bad references 

### DIFF
--- a/pdal/Geometry.cpp
+++ b/pdal/Geometry.cpp
@@ -67,21 +67,35 @@ Geometry::Geometry(const std::string& wkt_or_json, SpatialReference ref)
 
 
 Geometry::Geometry(const Geometry& input) : m_geom(input.m_geom->clone())
-{}
+{
+    if (input.m_geom)
+        m_geom.reset(input.m_geom->clone());
+}
 
 
 Geometry::Geometry(Geometry&& input) : m_geom(std::move(input.m_geom))
 {}
 
 
-Geometry::Geometry(OGRGeometryH g) :
-    m_geom((reinterpret_cast<OGRGeometry *>(g))->clone())
-{}
-
-
-Geometry::Geometry(OGRGeometryH g, const SpatialReference& srs) :
-    m_geom((reinterpret_cast<OGRGeometry *>(g))->clone())
+Geometry::Geometry(OGRGeometryH g)
 {
+
+    OGRGeometry* geom(nullptr);
+    geom = reinterpret_cast<OGRGeometry *>(g);
+
+    if (geom)
+        m_geom.reset(geom->clone());
+}
+
+
+Geometry::Geometry(OGRGeometryH g, const SpatialReference& srs)
+{
+    OGRGeometry* geom(nullptr);
+    geom = reinterpret_cast<OGRGeometry *>(g);
+
+    if (geom)
+        m_geom.reset(geom->clone());
+
     setSpatialReference(srs);
 }
 


### PR DESCRIPTION
This hopefully addresses #4016 