### PR TITLE
Handle 0 points in filters.greedyprojection

### DIFF
--- a/filters/GreedyProjection.cpp
+++ b/filters/GreedyProjection.cpp
@@ -130,6 +130,11 @@ void GreedyProjection::filter(PointView& view)
     nf.setLog(log());
     nf.doFilter(view);
 
+    // no points in the view, nothing we
+    // can do
+    if (!view.size())
+        return;
+
     KD3Index& tree = view.build3dIndex();
 
     view_ = &view;


### PR DESCRIPTION
Addresses `filters.greedyprojection` segfault described in #4019 