### PR TITLE
prevent invalid conversion from const compile error

### DIFF
--- a/pdal/Geometry.cpp
+++ b/pdal/Geometry.cpp
@@ -153,7 +153,7 @@ Geometry& Geometry::operator=(const Geometry& input)
 
 bool Geometry::srsValid() const
 {
-    OGRSpatialReference *srs = m_geom->getSpatialReference();
+    OGRSpatialReference *srs = const_cast<OGRSpatialReference *>(m_geom->getSpatialReference());
     return srs && srs->GetRoot();
 }
 
@@ -172,7 +172,7 @@ Utils::StatusWithReason Geometry::transform(SpatialReference out)
         return StatusWithReason(-2,
             "Geometry::transform() failed.  NULL target SRS.");
 
-    OGRSpatialReference *inSrs = m_geom->getSpatialReference();
+    OGRSpatialReference *inSrs = const_cast<OGRSpatialReference *>(m_geom->getSpatialReference());
     SrsTransform transform(*inSrs, OGRSpatialReference(out.getWKT().data()));
     if (m_geom->transform(transform.get()) != OGRERR_NONE)
         return StatusWithReason(-1, "Geometry::transform() failed.");


### PR DESCRIPTION
Compiling PDAL was breaking with:
```
/home/jgr/dev/cpp/PDAL/pdal/Geometry.cpp: In member function ‘pdal::Utils::StatusWithReason pdal::Geometry::transform(pdal::SpatialReference)’:
/home/jgr/dev/cpp/PDAL/pdal/Geometry.cpp:175:61: error: invalid conversion from ‘const OGRSpatialReference*’ to ‘OGRSpatialReference*’ [-fpermissive]
  175 |     OGRSpatialReference *inSrs = m_geom->getSpatialReference();
      |                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
      |                                                             |
      |                                                             const OGRSpatialReference*
```

I'm running on Ubuntu, with:
```
gcc --version
gcc (Ubuntu 11.3.0-1ubuntu1~22.04) 11.3.0

gdalinfo --version
GDAL 3.7.0dev-7cd1a9bb31, released 2023/04/17 (debug build)
```

Tests were passed after this change.