### PR TITLE
Add spherical coordinates support to e57 readers

### DIFF
--- a/pdal/Dimension.json
+++ b/pdal/Dimension.json
@@ -626,5 +626,20 @@
     "name": "Dimension",
     "type": "uint8",
     "description": "Dimension of the points. three types of dimensions are available (Linear : points form a linear feature. Planar : points form a planar surface. Complex : random group of points)."
+    },
+    {
+    "name": "SphericalRange",
+    "type": "double",
+    "description": "Range in context of spherical coordinates."
+    },
+    {
+    "name": "SphericalAzimuth",
+    "type": "double",
+    "description": "Azimuth in context of spherical coordinates."
+    },
+    {
+    "name": "SphericalElevation",
+    "type": "double",
+    "description": "Elevation in context of spherical coordinates."
     }
 ] }

--- a/plugins/e57/io/E57Reader.cpp
+++ b/plugins/e57/io/E57Reader.cpp
@@ -125,6 +125,15 @@ void E57Reader::addDimensions(PointLayoutPtr layout)
         }
     }
 
+    if (layout->hasDim(Dimension::Id::SphericalRange) &&
+        layout->hasDim(Dimension::Id::SphericalAzimuth) &&
+        layout->hasDim(Dimension::Id::SphericalElevation))
+    {
+        layout->registerDim(Dimension::Id::X);
+        layout->registerDim(Dimension::Id::Y);
+        layout->registerDim(Dimension::Id::Z);
+    }
+
     m_extraDims.reset(new e57plugin::ExtraDims());
     m_extraDims->parse(m_extraDimsSpec);
     auto i = m_extraDims->begin();
@@ -315,6 +324,18 @@ bool E57Reader::fillPoint(PointRef& point)
                 point.setField(dim->m_id, keyValue.second[m_currentIndex]);
             }
         }
+    }
+
+    if (point.hasDim(Dimension::Id::SphericalRange) &&
+        point.hasDim(Dimension::Id::SphericalAzimuth) &&
+        point.hasDim(Dimension::Id::SphericalElevation))
+    {
+        const double range = point.getFieldAs<double>(Dimension::Id::SphericalRange);
+        const double azimuth = point.getFieldAs<double>(Dimension::Id::SphericalAzimuth);
+        const double elevation = point.getFieldAs<double>(Dimension::Id::SphericalElevation);
+        point.setField(Dimension::Id::X, range * std::cos(elevation) * std::cos(azimuth));
+        point.setField(Dimension::Id::Y, range * std::cos(elevation) * std::sin(azimuth));
+        point.setField(Dimension::Id::Z, range * std::sin(elevation));
     }
 
     if (m_scan->hasPose())

--- a/plugins/e57/io/Utils.cpp
+++ b/plugins/e57/io/Utils.cpp
@@ -51,11 +51,11 @@ Dimension::Id e57ToPdal(const std::string &e57Dimension)
     else if (e57Dimension == "cartesianZ")
         return Dimension::Id::Z;
     else if (e57Dimension == "sphericalRange")
-        return Dimension::Id::X;
+        return Dimension::Id::SphericalRange;
     else if (e57Dimension == "sphericalAzimuth")
-        return Dimension::Id::Y;
+        return Dimension::Id::SphericalAzimuth;
     else if (e57Dimension == "sphericalElevation")
-        return Dimension::Id::Z;
+        return Dimension::Id::SphericalElevation;
     else if (e57Dimension == "nor:normalX")
         return Dimension::Id::NormalX;
     else if (e57Dimension == "nor:normalY")
@@ -115,6 +115,7 @@ std::string pdalToE57(Dimension::Id pdalDimension)
 std::vector<Dimension::Id> supportedPdalTypes()
 {
     return {Dimension::Id::X, Dimension::Id::Y, Dimension::Id::Z,
+            Dimension::Id::SphericalRange, Dimension::Id::SphericalAzimuth, Dimension::Id::SphericalElevation,
             Dimension::Id::NormalX, Dimension::Id::NormalY, Dimension::Id::NormalZ,
             Dimension::Id::Red, Dimension::Id::Green, Dimension::Id::Blue,
             Dimension::Id::Intensity, Dimension::Id::Omit, Dimension::Id::Classification
@@ -124,9 +125,10 @@ std::vector<Dimension::Id> supportedPdalTypes()
 std::vector<std::string> supportedE57Types()
 {
     return {"cartesianX",  "cartesianY", "cartesianZ",
+            "sphericalRange", "sphericalAzimuth", "sphericalElevation",
             "nor:normalX", "nor:normalY", "nor:normalZ",
             "colorRed", "colorGreen", "colorBlue", "intensity",
-            "cartesianInvalidState", "classification"};
+            "cartesianInvalidState", "sphericalInvalidState", "classification"};
 }
 
 std::vector<std::string> scalableE57Types()

--- a/plugins/e57/test/E57ReaderTest.cpp
+++ b/plugins/e57/test/E57ReaderTest.cpp
@@ -83,7 +83,8 @@ TEST(E57Reader, testHeader)
     {
         if (e57Dim.find("nor:normal") == e57Dim.npos &&
                 e57Dim.find("cartesianInvalidState") == e57Dim.npos &&
-                e57Dim.find("classification") == e57Dim.npos)
+                e57Dim.find("classification") == e57Dim.npos &&
+                e57Dim.find("spherical") == e57Dim.npos)
             ASSERT_TRUE(table.layout()->hasDim(pdal::e57plugin::e57ToPdal(e57Dim)));
     }
 }


### PR DESCRIPTION
Hi,

This MR would allow PDAL to read e57 files with spherical coordinates.

Related to https://github.com/PDAL/PDAL/issues/3382

Note: https://github.com/PDAL/PDAL/blob/master/CONTRIBUTING.md has broken links, (https://pdal.io/project/testing.html and https://pdal.io/project/conventions.html)