### PR TITLE
Include <cstdint> to fix GCC 13 compatibility

### DIFF
--- a/plugins/e57/libE57Format/include/E57Format.h
+++ b/plugins/e57/libE57Format/include/E57Format.h
@@ -31,6 +31,7 @@
 
 //! @file  E57Format.h header file for the E57 API
 
+#include <cstdint>
 #include <cfloat>
 #include <memory>
 #include <vector>


### PR DESCRIPTION
The reduced standard library header coupling in GCC 13 causes PDAL to fail compilation due to a missing `#include <cstdint>` in `E57Format.h`.