### PR TITLE
Allows mixing user set and auto-generate domains for the TileDB writer

### DIFF
--- a/plugins/tiledb/io/TileDBWriter.hpp
+++ b/plugins/tiledb/io/TileDBWriter.hpp
@@ -77,7 +77,6 @@ private:
     bool flushCache(size_t size);
 
     struct Args;
-    bool isValidDomain(TileDBWriter::Args& args);
     std::unique_ptr<TileDBWriter::Args> m_args;
 
     size_t m_current_idx;


### PR DESCRIPTION
This updates the TileDB writer to use the user set domains when the domain is only set for some of the dimensions.

For example, if the user sets valid values for `x_domain_st` and `x_domain_end`, this will use the user set domain for the `X` dimension and the default domain (either from stats or max domain) for the remaining dimensions.

This also fixes a check that all required data is set to include data needed when using time as a dimension.