### PR TITLE
Point view sorting stopgap

### DIFF
--- a/filters/SkewnessBalancingFilter.cpp
+++ b/filters/SkewnessBalancingFilter.cpp
@@ -61,7 +61,7 @@ void SkewnessBalancingFilter::processGround(PointViewPtr view)
     auto cmp = [](const PointRef& p1, const PointRef& p2) {
         return p1.compare(Dimension::Id::Z, p2);
     };
-    std::sort(view->begin(), view->end(), cmp);
+    view->sort(cmp);
 
     auto setClass = [&view](PointId first, PointId last, int cl)
     {

--- a/filters/SkewnessBalancingFilter.cpp
+++ b/filters/SkewnessBalancingFilter.cpp
@@ -61,7 +61,7 @@ void SkewnessBalancingFilter::processGround(PointViewPtr view)
     auto cmp = [](const PointRef& p1, const PointRef& p2) {
         return p1.compare(Dimension::Id::Z, p2);
     };
-    view->sort(cmp);
+    view->stableSort(cmp);
 
     auto setClass = [&view](PointId first, PointId last, int cl)
     {

--- a/filters/SortFilter.cpp
+++ b/filters/SortFilter.cpp
@@ -71,7 +71,7 @@ void SortFilter::filter(PointView& view)
         return (m_order == SortOrder::ASC) ? result : !result;
     };
 
-    view.sort(cmp);
+    view.stableSort(cmp);
 }
 
 std::istream& operator >> (std::istream& in, SortOrder& order)

--- a/filters/SortFilter.cpp
+++ b/filters/SortFilter.cpp
@@ -71,7 +71,7 @@ void SortFilter::filter(PointView& view)
         return (m_order == SortOrder::ASC) ? result : !result;
     };
 
-    std::stable_sort(view.begin(), view.end(), cmp);
+    view.sort(cmp);
 }
 
 std::istream& operator >> (std::istream& in, SortOrder& order)

--- a/io/private/copcwriter/Processor.cpp
+++ b/io/private/copcwriter/Processor.cpp
@@ -178,11 +178,10 @@ void Processor::writeCompressed(VoxelKey k, PointViewPtr v)
     lazperf::writer::chunk_compressor compressor(b.pointFormatId, b.numExtraBytes);
 
     // Sort by GPS time - no-op if there's no GPS time.
-    std::sort(v->begin(), v->end(),
-        [](const PointRef& p1, const PointRef& p2)
-        {
-            return p1.compare(Dimension::Id::GpsTime, p2);
-        });
+    v->sort([](const PointRef& p1, const PointRef& p2)
+    {
+        return p1.compare(Dimension::Id::GpsTime, p2);
+    });
 
     for (PointId idx = 0; idx < v->size(); ++idx)
     {

--- a/io/private/copcwriter/Processor.cpp
+++ b/io/private/copcwriter/Processor.cpp
@@ -178,7 +178,7 @@ void Processor::writeCompressed(VoxelKey k, PointViewPtr v)
     lazperf::writer::chunk_compressor compressor(b.pointFormatId, b.numExtraBytes);
 
     // Sort by GPS time - no-op if there's no GPS time.
-    v->sort([](const PointRef& p1, const PointRef& p2)
+    v->stableSort([](const PointRef& p1, const PointRef& p2)
     {
         return p1.compare(Dimension::Id::GpsTime, p2);
     });

--- a/pdal/PointRef.hpp
+++ b/pdal/PointRef.hpp
@@ -45,61 +45,25 @@ namespace pdal
 class PDAL_DLL PointRef
 {
 public:
-    // This ctor is normally used by some std::algorithm that needs a temporary.
-    // See the copy ctor below for more info.
-    PointRef() : m_container(nullptr), m_layout(nullptr), m_idx(0), m_tmp(false)
-    {}
-
     PointRef(PointContainer& container, PointId idx = 0) :
         m_container(&container), m_layout(container.layout()), m_idx(idx),
         m_tmp(false)
     {}
 
-    // Normally a point ref shouldn't be copied. But a PointRef is the *value* type
-    // when using an algorithm on a PointView. Some algorithms create a temporary copy
-    // of data by invoking the copy ctor on the data, which in the case of a point
-    // view, means calling this function and having the new PointRef point to the
-    // same entry in the PointTable as the source. So we create a new entry in the
-    // PointView index that does this.
-    //
-    // In most of these sorting algorithms, the temporaries come and go all the time.
-    // Usually there's only one, but we don't know and don't control it.
-    // If we kept adding a new entry in the PointLayout index
-    // each time we needed a temporary, we'd expand the PointView index unnecessarily.
-    // So we track these temporary PointRefs separately (m_tmp) and when they go away,
-    // we stick their index on a stack to be reused (see the dtor). This is why we
-    // call getTemp() -- it *may* allow us to reuse an entry in the PointView index
-    // that was used for a previous temporary, rather than continuously expand the
-    // index, potentially causing allocations.
-    //
-    // I'm thinking there are better ways to deal with this.
-    //
-    PointRef(const PointRef& r) :
-        m_container(r.m_container), m_layout(r.m_layout), m_tmp(true)
-    {
-        m_idx = m_container->getTemp(r.m_idx);
-    }
+    // PointRefs are not default-constructible - they always reference a point.
+    PointRef() = delete;
+
+    // PointRefs are not copyable or assignable - reordering may be implemented
+    // at the container scope e.g. PointView::sort.
+    PointRef(const PointRef& r) = delete;
+    PointRef(PointRef&& r) = delete;
+    PointRef& operator=(PointRef&& r) = delete;
+    PointRef& operator=(PointRef& r) = delete;
 
     ~PointRef()
     {
         if (m_tmp)
             m_container->freeTemp(m_idx);
-    }
-
-    // This is typically used by an std::sorting algorithm to copy to a temporary. See
-    // the info on the copy ctor above for more info.
-    PointRef& operator=(const PointRef& r)
-    {
-        if (!m_container)
-        {
-            m_container = r.m_container;
-            m_layout = r.m_layout;
-            m_idx = m_container->getTemp(r.m_idx);
-            m_tmp = true;
-        }
-        else
-            m_container->setItem(m_idx, r.m_idx);
-        return *this;
     }
 
     /**

--- a/pdal/PointRef.hpp
+++ b/pdal/PointRef.hpp
@@ -45,28 +45,25 @@ namespace pdal
 class PDAL_DLL PointRef
 {
 public:
-    PointRef(PointContainer& container, PointId idx = 0) :
-        m_container(&container), m_layout(container.layout()), m_idx(idx),
-        m_tmp(false)
-    {}
-
-    ~PointRef()
-    {
-        if (m_tmp)
-            m_container->freeTemp(m_idx);
-    }
-
-    // TODO: These next three special methods (which are not really intended for
-    // downstream usage but rather for allowing std::sort and friends to work)
-    // are not necessarily working in all compilers and should be avoided for
-    // mutating operations like std::sort (use PointView::stableSort instead).  
-    // Read-only operations like std::accumulate should be fine.  For now, 
-    // PointView::stableSort is a stopgap since PDAL sorts PointViews internally
-    // in several places.
+    // TODO: These three special methods:
+    //   PointRef()
+    //   PointRef(const PointRef&)
+    //   operator=(const PointRef&)
+    // which are not really intended for downstream usage but rather for 
+    // allowing std::sort and friends to work, are not necessarily working in 
+    // all compilers and should be avoided for mutating operations like 
+    // std::sort (use PointView::stableSort instead).  Read-only operations like
+    // std::accumulate should be fine.  For now, PointView::stableSort is a 
+    // stopgap since PDAL sorts PointViews internally in several places.
 
     // This ctor is normally used by some std::algorithm that needs a temporary.
     // See the copy ctor below for more info.
     PointRef() : m_container(nullptr), m_layout(nullptr), m_idx(0), m_tmp(false)
+    {}
+
+    PointRef(PointContainer& container, PointId idx = 0) :
+        m_container(&container), m_layout(container.layout()), m_idx(idx),
+        m_tmp(false)
     {}
 
     // Normally a point ref shouldn't be copied. But a PointRef is the *value* type
@@ -92,6 +89,12 @@ public:
         m_container(r.m_container), m_layout(r.m_layout), m_tmp(true)
     {
         m_idx = m_container->getTemp(r.m_idx);
+    }
+
+    ~PointRef()
+    {
+        if (m_tmp)
+            m_container->freeTemp(m_idx);
     }
 
     // This is typically used by an std::sorting algorithm to copy to a temporary. See

--- a/pdal/PointView.hpp
+++ b/pdal/PointView.hpp
@@ -305,12 +305,12 @@ public:
     KD2Index& build2dIndex();
 
     template <typename Compare>
-    void sort(Compare compare)
+    void stableSort(Compare compare)
     {
         auto order = m_index;
         std::stable_sort(
-            order.begin(), 
-            order.end(), 
+            order.begin(),
+            order.end(),
             [this, &compare](const PointId a, const PointId b)
             {
                 return compare(PointRef(*this, a), PointRef(*this, b));

--- a/pdal/PointView.hpp
+++ b/pdal/PointView.hpp
@@ -304,6 +304,20 @@ public:
     KD3Index& build3dIndex();
     KD2Index& build2dIndex();
 
+    template <typename Compare>
+    void sort(Compare compare)
+    {
+        auto order = m_index;
+        std::stable_sort(
+            order.begin(), 
+            order.end(), 
+            [this, &compare](const PointId a, const PointId b)
+            {
+                return compare(PointRef(*this, a), PointRef(*this, b));
+            });
+        m_index = order;
+    }
+
 protected:
     PointTableRef m_pointTable;
     PointLayoutPtr m_layout;

--- a/scripts/ci/osx/setup.sh
+++ b/scripts/ci/osx/setup.sh
@@ -3,8 +3,6 @@
 echo "Configuring build type '$BUILD_TYPE'"
 mkdir build
 
-mamba install --yes libcxx=14
-
 if [ "$BUILD_TYPE" == "fixed" ]; then
     mamba install --yes --quiet gdal=3.5.3  python=3.11
 fi

--- a/test/unit/filters/SortFilterTest.cpp
+++ b/test/unit/filters/SortFilterTest.cpp
@@ -94,7 +94,7 @@ void doSort(point_count_t count, Dimension::Id dim,
 TEST(SortFilterTest, simple)
 {
     // note that this also tests default sort order ASC /**
-    for (point_count_t count = 3; count < 8; count++)
+    for (point_count_t count = 3; count < 30; count++)
         doSort(count, Dimension::Id::X);
 }
 

--- a/test/unit/io/CopcReaderTest.cpp
+++ b/test/unit/io/CopcReaderTest.cpp
@@ -427,8 +427,8 @@ TEST(CopcReaderTest, stream)
     {
         return (a.compare(Dimension::Id::GpsTime, b));
     };
-    normalView.sort(cmp);
-    streamView.sort(cmp);
+    normalView.stableSort(cmp);
+    streamView.stableSort(cmp);
 
     for (PointId i(0); i < normalView.size(); ++i)
         for (const auto& dim : normalTable.layout()->dims())

--- a/test/unit/io/CopcReaderTest.cpp
+++ b/test/unit/io/CopcReaderTest.cpp
@@ -427,8 +427,8 @@ TEST(CopcReaderTest, stream)
     {
         return (a.compare(Dimension::Id::GpsTime, b));
     };
-    std::sort(normalView.begin(), normalView.end(), cmp);
-    std::sort(streamView.begin(), streamView.end(), cmp);
+    normalView.sort(cmp);
+    streamView.sort(cmp);
 
     for (PointId i(0); i < normalView.size(); ++i)
         for (const auto& dim : normalTable.layout()->dims())

--- a/test/unit/io/EptReaderTest.cpp
+++ b/test/unit/io/EptReaderTest.cpp
@@ -629,9 +629,9 @@ void streamTest(const std::string src)
         if (a.compare(nodeIdDim, b)) return true;
         return !b.compare(nodeIdDim, a) && a.compare(pointIdDim, b);
     });
-    std::stable_sort(normalView.begin(), normalView.end(), sort);
 
-    std::stable_sort(streamView.begin(), streamView.end(), sort);
+    normalView.sort(sort);
+    streamView.sort(sort);
 
     for (PointId i(0); i < normalView.size(); ++i)
     {

--- a/test/unit/io/EptReaderTest.cpp
+++ b/test/unit/io/EptReaderTest.cpp
@@ -630,8 +630,8 @@ void streamTest(const std::string src)
         return !b.compare(nodeIdDim, a) && a.compare(pointIdDim, b);
     });
 
-    normalView.sort(sort);
-    streamView.sort(sort);
+    normalView.stableSort(sort);
+    streamView.stableSort(sort);
 
     for (PointId i(0); i < normalView.size(); ++i)
     {


### PR DESCRIPTION
`PointRef`, which is the iterator type for a `PointView`, has some special constructor/assignment operators which are not intended for direct downstream usage, but instead exist for `std::sort` and friends to work.  However on some compilers (e.g. clang libcxx15+ on M1 hardware) these are not currently working correctly.

This PR leaves the broken operators present, but switches internal PDAL PointView sorting to use a new method `PointView::sort`.  This is a stopgap until we can get these functions working properly with all compilers.  So currently, mutating algorithms like `std::sort` should not be used on a `PointView`, although read-only operations like `std::accumulate` should be fine to use.