### PR TITLE
PointView::stableSort stopgap fix

### DIFF
--- a/pdal/PointView.hpp
+++ b/pdal/PointView.hpp
@@ -307,7 +307,15 @@ public:
     template <typename Compare>
     void stableSort(Compare compare)
     {
-        auto order = m_index;
+        clearTemps();
+
+        // This vector of ascending IDs represents our current normal order.
+        std::vector<std::size_t> order;
+        order.reserve(size());
+        for (std::size_t i = 0; i < size(); ++i)
+            order.push_back(i);
+
+        // Sort these IDs into the proper order based on the comparator.
         std::stable_sort(
             order.begin(),
             order.end(),
@@ -315,7 +323,13 @@ public:
             {
                 return compare(PointRef(*this, a), PointRef(*this, b));
             });
-        m_index = order;
+
+        // Now, overwrite our ordering index with the result of the sort.  Use
+        // a temporary copy of the index to avoid hammering over things as we
+        // are copying.
+        const auto old = m_index;
+        for (std::size_t i = 0; i < size(); ++i)
+            m_index[i] = old[order[i]];
     }
 
 protected:


### PR DESCRIPTION
#4058 was not quite correct - it treated PointView offsets into the PointTable as PointId values rather than properly referring to its index.  This was noticeable when a PointView was sorted which was a subset of the full PointTable (since it would index out of bounds due to treating table offsets as view offsets) data so a unit test for this case has been added.