### PR TITLE
Refactor TileDB writer

### DIFF
--- a/plugins/tiledb/io/TileDBWriter.hpp
+++ b/plugins/tiledb/io/TileDBWriter.hpp
@@ -84,10 +84,6 @@ private:
     std::unique_ptr<tiledb::Context> m_ctx;
     std::unique_ptr<tiledb::Array> m_array;
     std::vector<DimBuffer> m_buffers;
-    std::vector<double> m_xs;
-    std::vector<double> m_ys;
-    std::vector<double> m_zs;
-    std::vector<double> m_tms;
     bool m_use_time;
     bool m_time_first;
 

--- a/plugins/tiledb/io/TileDBWriter.hpp
+++ b/plugins/tiledb/io/TileDBWriter.hpp
@@ -84,8 +84,6 @@ private:
     std::unique_ptr<tiledb::Context> m_ctx;
     std::unique_ptr<tiledb::Array> m_array;
     std::vector<DimBuffer> m_buffers;
-    bool m_use_time;
-    bool m_time_first;
 
     TileDBWriter(const TileDBWriter&) = delete;
     TileDBWriter& operator=(const TileDBWriter&) = delete;

--- a/plugins/tiledb/io/TileDBWriter.hpp
+++ b/plugins/tiledb/io/TileDBWriter.hpp
@@ -82,9 +82,8 @@ private:
     size_t m_current_idx;
 
     std::unique_ptr<tiledb::Context> m_ctx;
-    std::unique_ptr<tiledb::ArraySchema> m_schema;
     std::unique_ptr<tiledb::Array> m_array;
-    std::vector<DimBuffer> m_attrs;
+    std::vector<DimBuffer> m_buffers;
     std::vector<double> m_xs;
     std::vector<double> m_ys;
     std::vector<double> m_zs;

--- a/plugins/tiledb/io/TileDBWriter.hpp
+++ b/plugins/tiledb/io/TileDBWriter.hpp
@@ -53,12 +53,18 @@ public:
         std::string m_name;
         Dimension::Id m_id;
         Dimension::Type m_type;
+        size_t m_dim_size;
         std::vector<uint8_t> m_buffer;
 
         DimBuffer(const std::string& name, Dimension::Id id,
-                  Dimension::Type type)
-            : m_name(name), m_id(id), m_type(type)
+                  Dimension::Type type, size_t dimSize)
+            : m_name(name), m_id(id), m_type(type), m_dim_size(dimSize)
         {
+        }
+
+        inline void resizeBuffer(size_t nelements)
+        {
+            m_buffer.resize(m_dim_size * nelements);
         }
     };
 

--- a/plugins/tiledb/test/TileDBWriterTimeDimTest.cpp
+++ b/plugins/tiledb/test/TileDBWriterTimeDimTest.cpp
@@ -415,7 +415,6 @@ TEST_F(TileDBWriterTimeDimTest, append_write_with_time)
     reader_options.add("xyz_mode", "ramp");
     reader_options.add("bounds", rdr_bounds);
     reader_options.add("density", 2.0);
-    reader_options.add("use_time", false);
 
     XYZTimeFauxReader reader;
     reader.setOptions(reader_options);


### PR DESCRIPTION
* Clean-up and isolate code for creating a new TileDB array.
* Inline helper function that is only used once.
* Remove duplicate buffer data for TileDB dimensions.
* Remove unneeded private variables from TileDBWriter class,
* Move all member variables for user provided data to Args struct.