### PR TITLE
update plugin cmake macro to specify MSVC

### DIFF
--- a/cmake/macros.cmake
+++ b/cmake/macros.cmake
@@ -126,7 +126,7 @@ macro(PDAL_ADD_PLUGIN _name _type _shortname)
     set(multiValueArgs FILES LINK_WITH INCLUDES SYSTEM_INCLUDES)
     cmake_parse_arguments(PDAL_ADD_PLUGIN "${options}" "${oneValueArgs}"
         "${multiValueArgs}" ${ARGN})
-    if(WIN32)
+    if(MSVC)
         set(${_name} "libpdal_plugin_${_type}_${_shortname}")
     else()
         set(${_name} "pdal_plugin_${_type}_${_shortname}")


### PR DESCRIPTION
This PR modifies the plugin section of the `cmake/macros.cmake` file to further specify `MSVC` instead of `WIN32`. I was cross-compiling using mingw on a linux host, this would produce `liblibpdal_plugin_kernel_fauxplugin.dll` (note double `lib` prefix). With this PR, the dll is correctly named `libpdal_plugin_kernel_fauxplugin.dll`

FYI @xantares and @dg0yt since they have helped with many of the other merged `MinGW` patches.