### PR TITLE
Refactor internal TileDB plugin 

### DIFF
--- a/plugins/tiledb/io/TileDBReader.cpp
+++ b/plugins/tiledb/io/TileDBReader.cpp
@@ -214,7 +214,6 @@ void TileDBReader::addDimensions(PointLayoutPtr layout)
 
         di.m_offset = 0;
         di.m_span = 1;
-        di.m_dimCategory = DimCategory::Dimension;
         di.m_tileType = dim.type();
         di.m_type = getPdalType(di.m_tileType);
 
@@ -233,7 +232,6 @@ void TileDBReader::addDimensions(PointLayoutPtr layout)
         di.m_name = a.first;
         di.m_offset = 0;
         di.m_span = 1;
-        di.m_dimCategory = DimCategory::Attribute;
         di.m_tileType = a.second.type();
         di.m_type = getPdalType(di.m_tileType);
         if (di.m_type != pdal::Dimension::Type::None)
@@ -344,13 +342,6 @@ void TileDBReader::localReady()
 
     m_query.reset(new tiledb::Query(*m_ctx, *m_array));
     m_query->set_layout(TILEDB_UNORDERED);
-
-    // Build the buffer for the dimensions.
-    auto it = std::find_if(
-        m_dims.begin(), m_dims.end(),
-        [](DimInfo& di) { return di.m_dimCategory == DimCategory::Dimension; });
-
-    DimInfo& di = *it;
 
     for (DimInfo& di : m_dims)
     {

--- a/plugins/tiledb/io/TileDBReader.cpp
+++ b/plugins/tiledb/io/TileDBReader.cpp
@@ -125,7 +125,7 @@ void TileDBReader::initialize()
         if (m_args->m_stats)
             tiledb::Stats::enable();
 
-#if TILEDB_VERSION_MINOR < 15
+#if TILEDB_VERSION_MAJOR == 2 && TILEDB_VERSION_MINOR < 15
         m_array.reset(new tiledb::Array(*m_ctx, m_filename, TILEDB_READ));
         if (m_args->m_startTimeStamp != 0)
             m_array->set_open_timestamp_start(m_args->m_startTimeStamp);

--- a/plugins/tiledb/io/TileDBReader.hpp
+++ b/plugins/tiledb/io/TileDBReader.hpp
@@ -46,17 +46,11 @@
 namespace pdal
 {
 
+class TileDBDimBuffer;
+
 class PDAL_DLL TileDBReader : public Reader, public Streamable
 {
 public:
-    class DimBuffer
-    {
-    public:
-        virtual ~DimBuffer() = default;
-        virtual void setQuery(tiledb::Query* query, size_t count) = 0;
-        virtual void setFields(PointRef& point, size_t bufOffset) = 0;
-    };
-
     TileDBReader();
     ~TileDBReader();
 
@@ -83,7 +77,7 @@ private:
     point_count_t m_offset;
     point_count_t m_resultSize;
     bool m_complete;
-    std::vector<std::unique_ptr<DimBuffer>> m_dims;
+    std::vector<std::unique_ptr<TileDBDimBuffer>> m_dims;
 
     std::unique_ptr<tiledb::Context> m_ctx;
     std::unique_ptr<tiledb::Array> m_array;

--- a/plugins/tiledb/io/TileDBReader.hpp
+++ b/plugins/tiledb/io/TileDBReader.hpp
@@ -83,17 +83,19 @@ public:
 
     TileDBReader();
     ~TileDBReader();
-    std::string getName() const;
+
+    std::string getName() const override;
 
 private:
-    virtual void addArgs(ProgramArgs& args);
-    virtual void initialize();
-    virtual void addDimensions(PointLayoutPtr layout);
-    virtual void prepared(PointTableRef);
-    virtual void ready(PointTableRef);
-    virtual bool processOne(PointRef& point);
-    virtual point_count_t read(PointViewPtr view, point_count_t count);
-    virtual void done(PointTableRef table);
+    virtual void addArgs(ProgramArgs& args) override;
+    virtual void initialize() override;
+    virtual void addDimensions(PointLayoutPtr layout) override;
+    virtual void prepared(PointTableRef) override;
+    virtual void ready(PointTableRef) override;
+    virtual bool processOne(PointRef& point) override;
+    virtual point_count_t read(PointViewPtr view, point_count_t count) override;
+    virtual void done(PointTableRef table) override;
+
     void localReady();
     bool processPoint(PointRef& point);
 

--- a/plugins/tiledb/io/TileDBReader.hpp
+++ b/plugins/tiledb/io/TileDBReader.hpp
@@ -38,11 +38,9 @@
 #define NOMINMAX
 #endif
 
-#include <iostream>
-
-#include "TileDBUtils.hpp"
 #include <pdal/Reader.hpp>
 #include <pdal/Streamable.hpp>
+
 #include <tiledb/tiledb>
 
 namespace pdal
@@ -89,7 +87,8 @@ public:
         std::string m_name;
     };
 
-    TileDBReader() = default;
+    TileDBReader();
+    ~TileDBReader();
     std::string getName() const;
 
 private:
@@ -104,19 +103,14 @@ private:
     void localReady();
     bool processPoint(PointRef& point);
 
-    std::string m_cfgFileName;
-    point_count_t m_chunkSize;
+    struct Args;
+    std::unique_ptr<TileDBReader::Args> m_args;
+
     point_count_t m_offset;
     point_count_t m_resultSize;
-    uint64_t m_startTimeStamp;
-    uint64_t m_endTimeStamp;
-    bool m_strict;
     bool m_complete;
-    bool m_stats;
-    DomainBounds m_bbox;
     std::vector<std::unique_ptr<Buffer>> m_buffers;
     std::vector<DimInfo> m_dims;
-    bool m_has_time = false;
 
     std::unique_ptr<tiledb::Context> m_ctx;
     std::unique_ptr<tiledb::Array> m_array;
@@ -127,12 +121,6 @@ private:
 
     template <typename T> void setQueryBuffer(const DimInfo& di);
     void setQueryBuffer(const DimInfo& di);
-
-public:
-    bool hasTime()
-    {
-        return m_has_time;
-    };
 };
 
 } // namespace pdal

--- a/plugins/tiledb/io/TileDBReader.hpp
+++ b/plugins/tiledb/io/TileDBReader.hpp
@@ -69,22 +69,16 @@ public:
         }
     };
 
-    enum class DimCategory
-    {
-        Dimension,
-        Attribute
-    };
-
     struct DimInfo
     {
+        std::string m_name;
+        Dimension::Id m_id;
+        Dimension::Type m_type;
         Buffer* m_buffer;
-        DimCategory m_dimCategory;
+
         size_t m_span;
         size_t m_offset;
         tiledb_datatype_t m_tileType;
-        Dimension::Type m_type;
-        Dimension::Id m_id;
-        std::string m_name;
     };
 
     TileDBReader();

--- a/plugins/tiledb/io/TileDBWriter.cpp
+++ b/plugins/tiledb/io/TileDBWriter.cpp
@@ -363,7 +363,7 @@ void TileDBWriter::ready(pdal::BasePointTable& table)
     }
 
     // Open the array at the requested timestamp range.
-#if TILEDB_VERSION_MINOR < 15
+#if TILEDB_VERSION_MAJOR == 2 && TILEDB_VERSION_MINOR < 15
     if (m_args->m_timeStamp != UINT64_MAX)
         m_array.reset(new tiledb::Array(*m_ctx, m_args->m_arrayName,
                                         TILEDB_WRITE, m_args->m_timeStamp));

--- a/plugins/tiledb/io/TileDBWriter.hpp
+++ b/plugins/tiledb/io/TileDBWriter.hpp
@@ -37,6 +37,7 @@
 #ifndef NOMINMAX
 #define NOMINMAX
 #endif
+
 #include <pdal/Streamable.hpp>
 #include <pdal/Writer.hpp>
 

--- a/plugins/tiledb/io/TileDBWriter.hpp
+++ b/plugins/tiledb/io/TileDBWriter.hpp
@@ -46,29 +46,11 @@
 namespace pdal
 {
 
+class TileDBDimBuffer;
+
 class PDAL_DLL TileDBWriter : public Writer, public Streamable
 {
 public:
-    struct DimBuffer
-    {
-        std::string m_name;
-        Dimension::Id m_id;
-        Dimension::Type m_type;
-        size_t m_dim_size;
-        std::vector<uint8_t> m_buffer;
-
-        DimBuffer(const std::string& name, Dimension::Id id,
-                  Dimension::Type type, size_t dimSize)
-            : m_name(name), m_id(id), m_type(type), m_dim_size(dimSize)
-        {
-        }
-
-        inline void resizeBuffer(size_t nelements)
-        {
-            m_buffer.resize(m_dim_size * nelements);
-        }
-    };
-
     TileDBWriter();
     ~TileDBWriter();
     std::string getName() const;
@@ -81,7 +63,7 @@ private:
     virtual bool processOne(PointRef& point);
     virtual void done(PointTableRef table);
 
-    bool flushCache(size_t size);
+    bool flushCache();
 
     struct Args;
     std::unique_ptr<TileDBWriter::Args> m_args;
@@ -90,7 +72,7 @@ private:
 
     std::unique_ptr<tiledb::Context> m_ctx;
     std::unique_ptr<tiledb::Array> m_array;
-    std::vector<DimBuffer> m_buffers;
+    std::vector<std::unique_ptr<TileDBDimBuffer>> m_buffers;
 
     TileDBWriter(const TileDBWriter&) = delete;
     TileDBWriter& operator=(const TileDBWriter&) = delete;


### PR DESCRIPTION
* Add `Args` struct to `TileDBReader` class.
* Use `override` more consistently.
* Create templated class to manage TileDB buffers that can be used by both the `TileDBReader` and the `TileDBWriter`.