### PR TITLE
Additional example for filter.assign

### DIFF
--- a/doc/stages/filters.assign.rst
+++ b/doc/stages/filters.assign.rst
@@ -56,24 +56,36 @@ evaluate to `true` for the ``ValueExpression`` to be applied.
 Example 1
 =========
 
-.. code-block::
+.. code-block:: json
 
-    "value" : "Red = Red / 256"
+  [
+      "input.las",
+      {
+          "type":"filters.assign",
+          "value" : "Red = Red / 256"
+      },
+      "output.laz"
+  ]
 
 This scales the ``Red`` value by 1/256. If the input values are in the range 0 - 65535, the output
 value will be in the range 0 - 255.
 
-
 Example 2
 =========
 
-.. code-block::
+.. code-block:: json
 
-    "value" :
-    [
-        "Classification = 2 WHERE HeightAboveGround < 5",
-        "Classification = 1 WHERE HeightAboveGround >= 5"
-    ]
+  [
+      "input.las",
+      {
+          "type":"filters.assign",
+          "value": [
+              "Classification = 2 WHERE HeightAboveGround < 5",
+              "Classification = 1 WHERE HeightAboveGround >= 5"
+          ]
+      },
+      "output.laz"
+  ]
 
 This sets the classification of points to either ``Ground`` or ``Unassigned`` depending on the
 value of the ``HeightAboveGround`` dimension.
@@ -81,13 +93,19 @@ value of the ``HeightAboveGround`` dimension.
 Example 3
 =========
 
-.. code-block::
+.. code-block:: json
 
-    "value" :
-    [
-        "X = 1",
-        "X = 2 WHERE X > 10"
-    ]
+  [
+      "input.las",
+      {
+          "type":"filters.assign",
+          "value": [
+              "X = 1",
+              "X = 2 WHERE X > 10"
+          ]
+      },
+      "output.laz"
+  ]
 
 This sets the value of ``X`` for all points to 1. The second statement is essentially ignored
 since the first statement sets the ``X`` value of all points to 1 and therefore no points

--- a/doc/stages/filters.assign.rst
+++ b/doc/stages/filters.assign.rst
@@ -79,6 +79,28 @@ Example 2
       "input.las",
       {
           "type": "filters.assign",
+          "value" : [
+              "Red = Red * 256",
+              "Green = Green * 256",
+              "Blue = Blue * 256"
+          ]
+      },
+      "output.laz"
+  ]
+
+This scales the values of Red, Green and Blue by 256. If the input values are in the range 0 - 255, the output
+value will be in the range 0 - 65535. This can be handy when creating a :ref:`COPC <writers.copc>` file which
+(as defined in LAS 1.4) needs color values scaled in that range.
+
+Example 3
+=========
+
+.. code-block:: json
+
+  [
+      "input.las",
+      {
+          "type": "filters.assign",
           "value": [
               "Classification = 2 WHERE HeightAboveGround < 5",
               "Classification = 1 WHERE HeightAboveGround >= 5"
@@ -90,7 +112,7 @@ Example 2
 This sets the classification of points to either ``Ground`` or ``Unassigned`` depending on the
 value of the ``HeightAboveGround`` dimension.
 
-Example 3
+Example 4
 =========
 
 .. code-block:: json

--- a/doc/stages/filters.assign.rst
+++ b/doc/stages/filters.assign.rst
@@ -61,7 +61,7 @@ Example 1
   [
       "input.las",
       {
-          "type":"filters.assign",
+          "type": "filters.assign",
           "value" : "Red = Red / 256"
       },
       "output.laz"
@@ -78,7 +78,7 @@ Example 2
   [
       "input.las",
       {
-          "type":"filters.assign",
+          "type": "filters.assign",
           "value": [
               "Classification = 2 WHERE HeightAboveGround < 5",
               "Classification = 1 WHERE HeightAboveGround >= 5"
@@ -98,7 +98,7 @@ Example 3
   [
       "input.las",
       {
-          "type":"filters.assign",
+          "type": "filters.assign",
           "value": [
               "X = 1",
               "X = 2 WHERE X > 10"


### PR DESCRIPTION
An additional example for filter.assign to scale RGB values for COPC creation (via @hobu's help on making a working COPC at https://norden.social/@hobu@fosstodon.org/110612109780980924)

I did not test to conversion to HTML and hope I got RST's funky syntax right.

Not sure if renumbering the examples is good, people might have linked to specific anchors. Using longer section titles might look bad in the sidebar though so I did not touch that.

I also made the existing examples use full pipeline definitions just like other pages in the documentation do. This would have saved me some wondering about how to defined a filter.