### PR TITLE
Write las header bounding box using the converted coordinates

### DIFF
--- a/io/LasWriter.cpp
+++ b/io/LasWriter.cpp
@@ -869,13 +869,13 @@ bool LasWriter::fillPointBuf(PointRef& point, LeInserter& ostream)
     double xOrig = point.getFieldAs<double>(Id::X);
     double yOrig = point.getFieldAs<double>(Id::Y);
     double zOrig = point.getFieldAs<double>(Id::Z);
-    double x = m_scaling.m_xXform.toScaled(xOrig);
-    double y = m_scaling.m_yXform.toScaled(yOrig);
-    double z = m_scaling.m_zXform.toScaled(zOrig);
+    int32_t x = converter(m_scaling.m_xXform.toScaled(xOrig), Id::X);
+    int32_t y = converter(m_scaling.m_yXform.toScaled(yOrig), Id::Y);
+    int32_t z = converter(m_scaling.m_zXform.toScaled(zOrig), Id::Z);
 
-    ostream << converter(x, Id::X);
-    ostream << converter(y, Id::Y);
-    ostream << converter(z, Id::Z);
+    ostream << x;
+    ostream << y;
+    ostream << z;
 
     ostream << point.getFieldAs<uint16_t>(Id::Intensity);
 
@@ -968,7 +968,10 @@ bool LasWriter::fillPointBuf(PointRef& point, LeInserter& ostream)
         Utils::insertDim(ostream, dim.m_dimType.m_type, e);
     }
 
-    d->summary.addPoint(xOrig, yOrig, zOrig, returnNumber);
+    double xConverted = m_scaling.m_xXform.fromScaled(x);
+    double yConverted = m_scaling.m_yXform.fromScaled(y);
+    double zConverted = m_scaling.m_zXform.fromScaled(z);
+    d->summary.addPoint(xConverted, yConverted, zConverted, returnNumber);
     return true;
 }
 


### PR DESCRIPTION
`LasWriter` computes the bounding box using the original coordinates and saves this bounding box in the LAS header. Since the coordinates data stored in LAS are quantized as 32bits int, the coordinate loaded back will be slight different and maybe outside the bounding box. Software such as PotreeConverter depends on the header bounding box, and will fail to process the laz file.

For example, this [pt_out_bbox.txt](https://github.com/PDAL/PDAL/files/11885928/pt_out_bbox.txt) just contains two points, translate to laz using this command:
`pdal translate --writers.las.scale_x=0.0001 --writers.las.scale_y=0.0001 --writers.las.scale_z=0.0001 pt_out_bbox.txt pt_out_bbox.laz`
Then run `lasinfo` on the `pt_out_bbox.laz` will output multiple warnings, including "WARNING: 2 points outside of header bounding box", see [lasinfo_output.txt](https://github.com/PDAL/PDAL/files/11885958/lasinfo_output.txt) for detail.

The header bounding box should be consistent with the coordinates stored in the output las file.

By the way, LAZ file created using the LASzip library does not have this problem. LASzip does write LAS header bounding box using the quantized min/max values, see https://github.com/LASzip/LASzip/blob/78b71a53147bb81e361dd39227121fd5dcb4d9eb/src/laszip_dll.cpp#L3276-L3311
