### PR TITLE
Create updated filter profiles for TileDB writer

### DIFF
--- a/doc/stages/writers.tiledb.rst
+++ b/doc/stages/writers.tiledb.rst
@@ -123,122 +123,173 @@ timestamp
 TileDB provides default filter profiles. The filters can be over-written by the `filters` option. If a TileDB attribute is not set by the filter profile or the `filter` option, the compression filter set by the compression option is used.
 
 Filters set by the `balanced` (default) filter profile (the delta filter is skipped if using TileDB version less than 2.16.0):
-.. code-block:: json
 
-  {
-      "X":{
-        {"compression": "float-scale", "scale_float_factor": scale_x, "scale_float_offset": offset_x, "scale_float_bytewidth": 4},
-        {"compression": "delta", "reinterpret_data": "INT32"},
-        {"compression": "bit-shuffle"},
-        {"compression": "zstd", "compression_level": 7}
-      },
-      "Y":{
-        {"compression": "float-scale", "scale_float_factor": scale_y, "scale_float_offset": offset_y, "scale_float_bytewidth": 4},
-        {"compression": "delta", "reinterpret_data": "INT32"},
-        {"compression": "bit-shuffle"},
-        {"compression": "zstd", "compression_level": 7}
-      },
-      "Z":{
-        {"compression": "float-scale", "scale_float_factor": scale_z, "scale_float_offset": offset_z, "scale_float_bytewidth": 4},
-        {"compression": "delta", "reinterpret_data": "INT32"},
-        {"compression": "bit-shuffle"},
-        {"compression": "zstd", "compression_level": 7}
-      },
-      "Intensity":{
-        {"compression": "delta"},
-        {"compression": "zstd", "compression_level": 5},
-      },
-      "BitFields":{"compression": "zstd", "compression_level": 5},
-      "ReturnNumber": {"compression": "zstd", "compression_level": 5},
-      "NumberOfReturns": {"compression": "zstd", "compression_level": 5},
-      "ScanDirectionFlag": {"compression": "zstd", "compression_level": 5},
-      "EdgeOfFlightLine": {"compression": "zstd", "compression_level": 5},
-      "Classification": {"compression": "zstd", "compression_level": 5},
-      "ScanAngleRank": {"compression": "zstd", "compression_level": 5},
-      "UserData": {"compression": "zstd", "compression_level": 5},
-      "PointSourceId": {"compression": "zstd", "compression_level": 5},
-      "Red": {
-        {"compression": "delta"},
-        {"compression": "bit-width-reduction-filter"}
-        {"compression": "zstd", "compression_level": 7},
-      },
-      "Green": {
-        {"compression": "delta"},
-        {"compression": "bit-width-reduction-filter"}
-        {"compression": "zstd", "compression_level": 7},
-      },
-      "Blue": {
-        {"compression": "delta"},
-        {"compression": "bit-width-reduction-filter"}
-        {"compression": "zstd", "compression_level": 7},
-      },
-      "GpsTime": {
-        {"compression": "typed-view", "typed_view_output_datatype": int64},
-        {"compression": "delta", "reinterpret_data": "INT64"},
-        {"compression": "bit-width-reduction-filter"},
-        {"compression": "zstd", "compression_level": 7},
-      }
-  }
+* X
+
+  1. Float-scale filter (factor=`scale_x`, offset=`offset_x`, scale_float_bytewidth=4)
+  2. Delta filter (reinterpret_datatype=`INT32`)
+  3. Bit shuffle filter
+  4. Zstd filter (level=7)
+
+* Y
+
+  1. Float-scale filter (factor=`scale_y`, offset=`offset_y`, scale_float_bytewidth=4)
+  2. Delta filter (reinterpret_datatype=`INT32`)
+  3. Bit shuffle filter
+  4. Zstd filter (level=7)
+
+* Z
+
+  1. Float-scale filter (factor=`scale_z`, offset=`offset_z`, scale_float_bytewidth=4)
+  2. Delta filter (reinterpret_datatype=`INT32`)
+  3. Bit shuffle filter
+  4. Zstd filter (level=7)
+
+* GPSTime
+
+  1. Delta filter (reinterpret_datatype="INT64")
+  2. Bit width reduction filter
+  3. Zstd filter (level=7)
+
+* Intensity
+
+  1. Delta filter
+  2. Zstd filter (level=5)
+
+* BitFields
+
+  1. Zstd filter (level=5)
+
+* ReturnNumber
+
+  1. Zstd filter (level=5)
+
+* NumberOfReturns
+
+  1. Zstd filter (level=5)
+
+* ScanDirectionFlag
+
+  1. Zstd filter (level=5)
+
+* EdgeOfFlightLine
+
+  1. Zstd filter (level=5)
+
+* Classification
+
+  1. Zstd filter (level=5)
+
+* UserData
+
+  1. Zstd filter (level=5)
+
+* PointSourceId
+
+  1. Zstd filter (level=5)
+
+* Red
+
+  1. Delta filter
+  2. Bit width reduction filter
+  3. Zstd filter (level=7)
+
+* Green
+
+  1. Delta filter
+  2. Bit width reduction filter
+  3. Zstd filter (level=7)
+
+* Blue
+
+  1. Delta filter
+  2. Bit width reduction filter
+  3. Zstd filter (level=7)
 
 Filters set by the `aggressive` filter profile (the delta filter is skipped if using TileDB version less than 2.16.0):
-.. code-block:: json
 
-  {
-      "X":{
-        {"compression": "float-scale", "scale_float_factor": scale_x, "scale_float_offset": offset_x, "scale_float_bytewidth": 4},
-        {"compression": "delta", "reinterpret_data": "INT32"},
-        {"compression": "bit-width-reduction"},
-        {"compression": "bzip2", "compression_level": 9}
-      },
-      "Y":{
-        {"compression": "float-scale", "scale_float_factor": scale_y, "scale_float_offset": offset_y, "scale_float_bytewidth": 4},
-        {"compression": "delta", "reinterpret_data": "INT32"},
-        {"compression": "bit-shuffle"},
-        {"compression": "bzip2", "compression_level": 9}
-      },
-      "Z":{
-        {"compression": "float-scale", "scale_float_factor": scale_z, "scale_float_offset": offset_z, "scale_float_bytewidth": 4},
-        {"compression": "delta", "reinterpret_data": "INT32"},
-        {"compression": "bit-width-reduction"},
-        {"compression": "bzip2", "compression_level": 9}
-      },
-      "Intensity":{
-        {"compression": "delta"},
-        {"compression": "bit-width-reduction"},
-        {"compression": "bzip2", "compression_level": 5},
-      },
-      "BitFields":{"compression": "bzip2", "compression_level": 9},
-      "ReturnNumber": {"compression": "bzip2", "compression_level": 9},
-      "NumberOfReturns": {"compression": "bzip2", "compression_level": 9},
-      "ScanDirectionFlag": {"compression": "bzip2", "compression_level": 9},
-      "EdgeOfFlightLine": {"compression": "bzip2", "compression_level": 9},
-      "Classification": {"compression": "bzip2", "compression_level": 9},
-      "ScanAngleRank": {"compression": "bzip2", "compression_level": 9},
-      "UserData": {"compression": "gzip", "compression_level": 9},
-      "PointSourceId": {"compression": "zstd", "compression_level": 9},
-      "Red": {
-        {"compression": "delta"},
-        {"compression": "bit-width-reduction"}
-        {"compression": "bzip2", "compression_level": 9},
-      },
-      "Green": {
-        {"compression": "delta"},
-        {"compression": "bit-width-reduction"}
-        {"compression": "bzip2", "compression_level": 9},
-      },
-      "Blue": {
-        {"compression": "delta"},
-        {"compression": "bit-width-reduction"}
-        {"compression": "bzip2", "compression_level": 9},
-      },
-      "GpsTime": {
-        {"compression": "typed-view", "typed_view_output_datatype": int64},
-        {"compression": "delta", "reinterpret_data": "INT64"},
-        {"compression": "bit-width-reduction"},
-        {"compression": "bzip2", "compression_level": 9},
-      }
-  }
+* X
 
+  1. Float-scale filter (factor=`scale_x`, offset=`offset_x`, scale_float_bytewidth=4)
+  2. Delta filter (reinterpret_datatype=`INT32`)
+  3. Bit width reduction filter
+  4. BZIP2 filter (level=5)
+
+* Y
+
+  1. Float-scale filter (factor=`scale_y`, offset=`offset_y`, scale_float_bytewidth=4)
+  2. Delta filter (reinterpret_datatype=`INT32`)
+  3. Bit width reduction filter
+  4. BZIP2 filter (level=5)
+
+* Z
+
+  1. Float-scale filter (factor=`scale_z`, offset=`offset_z`, scale_float_bytewidth=4)
+  2. Delta filter (reinterpret_datatype=`INT32`)
+  3. Bit width reduction filter
+  4. BZIP2 filter (level=5)
+
+* GPSTime
+
+  1. Delta filter (reinterpret_datatype="INT64")
+  2. Bit width reduction filter
+  3. BZIP2 filter (level=9)
+
+* Intensity
+
+  1. Delta filter
+  2. Bit width reduction
+  3. BZIP2 filter (level=5)
+
+* BitFields
+
+  1. BZIP2 filter (level=9)
+
+* ReturnNumber
+
+  1. BZIP2 filter (level=9)
+
+* NumberOfReturns
+
+  1. BZIP2 filter (level=9)
+
+* ScanDirectionFlag
+
+  1. BZIP2 filter (level=9)
+
+* EdgeOfFlightLine
+
+  1. BZIP2 filter (level=9)
+
+* Classification
+
+  1. BZIP2 filter (level=9)
+
+* UserData
+
+  1. BZIP2 filter (level=9)
+
+* PointSourceId
+
+  1. BZIP2 filter (level=9)
+
+* Red
+
+  1. Delta filter
+  2. Bit width reduction filter
+  3. BZIP2 filter (level=9)
+
+* Green
+
+  1. Delta filter
+  2. Bit width reduction filter
+  3. BZIP2 filter (level=9)
+
+* Blue
+
+  1. Delta filter
+  2. Bit width reduction filter
+  3. BZIP2 filter (level=9)
 
 
 The filter profile `none` does not set any default filters.

--- a/doc/stages/writers.tiledb.rst
+++ b/doc/stages/writers.tiledb.rst
@@ -78,55 +78,169 @@ time_domain_end
   Domain maximum for GpsTime. Not used when `append=true`. [Optional]
 
 use_time_dim
-  Use GpsTime coordinate data as an array dimension instead of an array attribute. Not used when `append=true`. [Optional]
+  Use GpsTime coordinate data as an array dimension instead of an array attribute. Not used when `append=true`. [Default: false]
 
 time_first
-  Put the GpsTime dimension first instead of last. Only used when `use_time_dim=true`. Not used when `append=true`. Default is `false`. [Optional]
+  Put the GpsTime dimension first instead of last. Only used when `use_time_dim=true`. Not used when `append=true`. [Default: false]
 
 chunk_size
   Point cache size for chunked writes. [Optional]
 
-compression
-  The default TileDB compression filter to use. Only used if the dimension or attribute name is not included in `filters`. Not used when `append=true`. Default is None. [Optional]
-
-compression_level
-  The TileDB compression level to use for the default compression. Option is ignored if set to `-1`. Not used when `append=true`. Default is `-1`. [Optional]
-
 append
-  Instead of creating a new array, append to an existing array that has the dimensions stored as a TileDB dimension or TileDB attribute. Default is `false`.  [Optional]
+  Instead of creating a new array, append to an existing array that has the dimensions stored as a TileDB dimension or TileDB attribute. [Default: false]
 
 stats
   Dump query stats to stdout. [Optional]
 
 filters
-  JSON array or object of compression filters for either `dims` or `attributes` of the form {dim/attributename : {"compression": name, compression_options: value, ...}}.  Not used when `append=true`. [Optional]
+  JSON array or object of compression filters for either dimenions or attributes of the form {dimension/attribute name : {"compression": name, compression_options: value, ...}}.  Not used when `append=true`. [Optional]
+
+filter_profile
+  Profile of compression filters to use for dimensions and attributes not provided in `filters`. Options include `balanced`, `aggressive`, and `none`. Not used when `append=true`. [Default: balanced]
+
+scale_x, scale_y, scale_z
+  Scale factor used for the float-scale filter for the X, Y, and Z dimensions, respectively, when using the `balanced` or `aggressive` filter profile. Not used when `append=true`. [Default: 0.01]
+
+  Note: written value = (nominal value - offset) / scale.
+
+offset_x, offset_y, offset_z
+  Offset used for the float-scale filter for the  X, Y and Z dimenisons, respectively, when using the `balanced` or `aggressive` filter profile. Not used when `append=true`. [Default: 0.0]
+
+  Note: written value = (nominal value - offset) / scale.
+
+compression
+  The default TileDB compression filter to use. Only used if the dimension or attribute name is not included in `filters`. Not used when `append=true`. [Default: none]
+
+compression_level
+  The TileDB compression level to use for the default compression. Option is ignored if set to `-1`. Not used when `append=true`. [Default: -1]
 
 timestamp
   Sets the TileDB timestamp for this write. [Optional]
 
 .. include:: writer_opts.rst
 
-By default TileDB will use the following set of compression filters for coordinates and attributes;
 
+TileDB provides default filter profiles. The filters can be over-written by the `filters` option. If a TileDB attribute is not set by the filter profile or the `filter` option, the compression filter set by the compression option is used.
+
+Filters set by the `balanced` (default) filter profile (the delta filter is skipped if using TileDB version less than 2.16.0):
 .. code-block:: json
 
   {
-      "X":{"compression": "zstd", "compression_level": 7},
-      "Y":{"compression": "zstd", "compression_level": 7},
-      "Z":{"compression": "zstd", "compression_level": 7},
-      "Intensity":{"compression": "bzip2", "compression_level": 5},
-      "ReturnNumber": {"compression": "zstd", "compression_level": 7},
-      "NumberOfReturns": {"compression": "zstd", "compression_level": 7},
-      "ScanDirectionFlag": {"compression": "bzip2", "compression_level": 5},
-      "EdgeOfFlightLine": {"compression": "bzip2", "compression_level": 5},
-      "Classification": {"compression": "gzip", "compression_level": 9},
-      "ScanAngleRank": {"compression": "bzip2", "compression_level": 5},
-      "UserData": {"compression": "gzip", "compression_level": 9},
-      "PointSourceId": {"compression": "bzip2"},
-      "Red": {"compression": "zstd", "compression_level": 7},
-      "Green": {{"compression": "zstd", "compression_level": 7},
-      "Blue": {{"compression": "zstd", "compression_level": 7},
-      "GpsTime": {"compression": "zstd", "compression_level": 7}
+      "X":{
+        {"compression": "float-scale", "scale_float_factor": scale_x, "scale_float_offset": offset_x, "scale_float_bytewidth": 4},
+        {"compression": "delta", "reinterpret_data": "INT32"},
+        {"compression": "bit-shuffle"},
+        {"compression": "zstd", "compression_level": 7}
+      },
+      "Y":{
+        {"compression": "float-scale", "scale_float_factor": scale_y, "scale_float_offset": offset_y, "scale_float_bytewidth": 4},
+        {"compression": "delta", "reinterpret_data": "INT32"},
+        {"compression": "bit-shuffle"},
+        {"compression": "zstd", "compression_level": 7}
+      },
+      "Z":{
+        {"compression": "float-scale", "scale_float_factor": scale_z, "scale_float_offset": offset_z, "scale_float_bytewidth": 4},
+        {"compression": "delta", "reinterpret_data": "INT32"},
+        {"compression": "bit-shuffle"},
+        {"compression": "zstd", "compression_level": 7}
+      },
+      "Intensity":{
+        {"compression": "delta"},
+        {"compression": "zstd", "compression_level": 5},
+      },
+      "BitFields":{"compression": "zstd", "compression_level": 5},
+      "ReturnNumber": {"compression": "zstd", "compression_level": 5},
+      "NumberOfReturns": {"compression": "zstd", "compression_level": 5},
+      "ScanDirectionFlag": {"compression": "zstd", "compression_level": 5},
+      "EdgeOfFlightLine": {"compression": "zstd", "compression_level": 5},
+      "Classification": {"compression": "zstd", "compression_level": 5},
+      "ScanAngleRank": {"compression": "zstd", "compression_level": 5},
+      "UserData": {"compression": "zstd", "compression_level": 5},
+      "PointSourceId": {"compression": "zstd", "compression_level": 5},
+      "Red": {
+        {"compression": "delta"},
+        {"compression": "bit-width-reduction-filter"}
+        {"compression": "zstd", "compression_level": 7},
+      },
+      "Green": {
+        {"compression": "delta"},
+        {"compression": "bit-width-reduction-filter"}
+        {"compression": "zstd", "compression_level": 7},
+      },
+      "Blue": {
+        {"compression": "delta"},
+        {"compression": "bit-width-reduction-filter"}
+        {"compression": "zstd", "compression_level": 7},
+      },
+      "GpsTime": {
+        {"compression": "typed-view", "typed_view_output_datatype": int64},
+        {"compression": "delta", "reinterpret_data": "INT64"},
+        {"compression": "bit-width-reduction-filter"},
+        {"compression": "zstd", "compression_level": 7},
+      }
   }
+
+Filters set by the `aggressive` filter profile (the delta filter is skipped if using TileDB version less than 2.16.0):
+.. code-block:: json
+
+  {
+      "X":{
+        {"compression": "float-scale", "scale_float_factor": scale_x, "scale_float_offset": offset_x, "scale_float_bytewidth": 4},
+        {"compression": "delta", "reinterpret_data": "INT32"},
+        {"compression": "bit-width-reduction"},
+        {"compression": "bzip2", "compression_level": 9}
+      },
+      "Y":{
+        {"compression": "float-scale", "scale_float_factor": scale_y, "scale_float_offset": offset_y, "scale_float_bytewidth": 4},
+        {"compression": "delta", "reinterpret_data": "INT32"},
+        {"compression": "bit-shuffle"},
+        {"compression": "bzip2", "compression_level": 9}
+      },
+      "Z":{
+        {"compression": "float-scale", "scale_float_factor": scale_z, "scale_float_offset": offset_z, "scale_float_bytewidth": 4},
+        {"compression": "delta", "reinterpret_data": "INT32"},
+        {"compression": "bit-width-reduction"},
+        {"compression": "bzip2", "compression_level": 9}
+      },
+      "Intensity":{
+        {"compression": "delta"},
+        {"compression": "bit-width-reduction"},
+        {"compression": "bzip2", "compression_level": 5},
+      },
+      "BitFields":{"compression": "bzip2", "compression_level": 9},
+      "ReturnNumber": {"compression": "bzip2", "compression_level": 9},
+      "NumberOfReturns": {"compression": "bzip2", "compression_level": 9},
+      "ScanDirectionFlag": {"compression": "bzip2", "compression_level": 9},
+      "EdgeOfFlightLine": {"compression": "bzip2", "compression_level": 9},
+      "Classification": {"compression": "bzip2", "compression_level": 9},
+      "ScanAngleRank": {"compression": "bzip2", "compression_level": 9},
+      "UserData": {"compression": "gzip", "compression_level": 9},
+      "PointSourceId": {"compression": "zstd", "compression_level": 9},
+      "Red": {
+        {"compression": "delta"},
+        {"compression": "bit-width-reduction"}
+        {"compression": "bzip2", "compression_level": 9},
+      },
+      "Green": {
+        {"compression": "delta"},
+        {"compression": "bit-width-reduction"}
+        {"compression": "bzip2", "compression_level": 9},
+      },
+      "Blue": {
+        {"compression": "delta"},
+        {"compression": "bit-width-reduction"}
+        {"compression": "bzip2", "compression_level": 9},
+      },
+      "GpsTime": {
+        {"compression": "typed-view", "typed_view_output_datatype": int64},
+        {"compression": "delta", "reinterpret_data": "INT64"},
+        {"compression": "bit-width-reduction"},
+        {"compression": "bzip2", "compression_level": 9},
+      }
+  }
+
+
+
+The filter profile `none` does not set any default filters.
 
 .. _TileDB: https://tiledb.io

--- a/plugins/tiledb/io/TileDBUtils.hpp
+++ b/plugins/tiledb/io/TileDBUtils.hpp
@@ -212,12 +212,18 @@ public:
      Constructor.
 
      \param userProvidedFilters JSON containing the user defined filters.
+     \param filterProfile Filter profile to use for filters not set by user.
+     \param scaleFactor x, y, and z scale factors for float-scale filter.
+     \param addOffset x, y, and z add offset for float-scale filter.
      \param defaultCompressor Filter to use for the default filter.
      \param defaultCompressionLevel Compression level to use for the default
             filter.
 
      */
     FilterFactory(const NL::json& userProvidedFilters,
+                  const std::string& filterProfile,
+                  const std::array<double, 3>& scaleFactor,
+                  const std::array<double, 3>& addOffset,
                   const std::string& defaultCompressor,
                   int32_t defaultCompressionLevel);
 
@@ -286,14 +292,25 @@ public:
       \param ctx TileDB context object.
       \param dimName name of the dimension to get the default filter list for.
      */
-    tiledb::FilterList
-    defaultProfileFilterList(const tiledb::Context& ctx,
-                             const std::string& dimName) const;
+    tiledb::FilterList defaultProfileFilterList(const tiledb::Context& ctx,
+                                                const std::string& dimName,
+                                                bool balanced) const;
 
 private:
+    enum class Profile : uint8_t
+    {
+        none,
+        balanced,
+        aggressive
+    };
+
     NL::json m_user_filters{};
     std::optional<tiledb_filter_type_t> m_default_filter_type{std::nullopt};
     std::optional<int32_t> m_default_compression_level{std::nullopt};
+
+    Profile m_filter_profile;
+    std::array<double, 3> m_scale_factor;
+    std::array<double, 3> m_add_offset;
 };
 
 class TileDBDimBuffer

--- a/plugins/tiledb/test/TileDBReaderTest.cpp
+++ b/plugins/tiledb/test/TileDBReaderTest.cpp
@@ -36,12 +36,13 @@
 #define NOMINMAX
 #endif
 
-#include <pdal/Filter.hpp>
-#include <pdal/pdal_test_main.hpp>
-#include <pdal/util/FileUtils.hpp>
+#include <nlohmann/json.hpp>
 
 #include <io/FauxReader.hpp>
+#include <pdal/Filter.hpp>
 #include <pdal/StageFactory.hpp>
+#include <pdal/pdal_test_main.hpp>
+#include <pdal/util/FileUtils.hpp>
 
 #include "Support.hpp"
 
@@ -72,6 +73,9 @@ protected:
         writer_options.add("x_tile_size", 1);
         writer_options.add("y_tile_size", 1);
         writer_options.add("z_tile_size", 1);
+        writer_options.add("scale_x", 1.0e-9);
+        writer_options.add("scale_y", 1.0e-9);
+        writer_options.add("scale_z", 1.0e-9);
 
         reader_options.add("mode", "ramp");
         reader_options.add("count", count);

--- a/plugins/tiledb/test/TileDBUtilsTest.cpp
+++ b/plugins/tiledb/test/TileDBUtilsTest.cpp
@@ -209,7 +209,8 @@ TEST(FilterFactory, dim_with_unset_default_filter)
 {
     NL::json jsonOptions({});
     tiledb::Context ctx{};
-    FilterFactory factory{jsonOptions, "", 0};
+    FilterFactory factory{jsonOptions,        "none", {{0.01, 0.01, 0.01}},
+                          {{1.0f, 1.0, 1.0}}, "",     0};
     auto filterList = factory.filterList(ctx, "Curvature");
     auto nfilters = filterList.nfilters();
     EXPECT_EQ(nfilters, 0);
@@ -219,7 +220,8 @@ TEST(FilterFactory, dim_with_set_default_filter)
 {
     NL::json jsonOptions({});
     tiledb::Context ctx{};
-    FilterFactory factory{jsonOptions, "zstd", 9};
+    FilterFactory factory{jsonOptions,       "none", {{0.01, 0.01, 0.01}},
+                          {{1.0, 1.0, 1.0}}, "zstd", 9};
     auto filterList = factory.filterList(ctx, "Curvature");
     auto nfilters = filterList.nfilters();
     EXPECT_EQ(nfilters, 1);
@@ -240,7 +242,8 @@ TEST(FilterFactory, user_set_scale_float)
                          {"scale_float_bytewidth", 2},
                          {"scale_float_factor", 2.0},
                          {"scale_float_offset", 100.0}}};
-    FilterFactory factory{jsonOptions, "zstd", 7};
+    FilterFactory factory{jsonOptions,       "balanced", {{0.01, 0.01, 0.01}},
+                          {{1.0, 1.0, 1.0}}, "zstd",     7};
 
     tiledb::Context ctx{};
     auto filterList = factory.filterList(ctx, "Z");
@@ -268,7 +271,8 @@ TEST(FilterFactory, user_set_two_filter_list)
     NL::json jsonOptions({});
     jsonOptions["X"] = {{{"compression", "bit-shuffle"}},
                         {{"compression", "gzip"}, {"compression_level", 9}}};
-    FilterFactory factory{jsonOptions, "zstd", 7};
+    FilterFactory factory{jsonOptions,       "balanced", {{0.01, 0.01, 0.01}},
+                          {{1.0, 1.0, 1.0}}, "zstd",     7};
 
     tiledb::Context ctx{};
     auto filterList = factory.filterList(ctx, "X");

--- a/plugins/tiledb/test/TileDBWriterTest.cpp
+++ b/plugins/tiledb/test/TileDBWriterTest.cpp
@@ -361,7 +361,11 @@ TEST_F(TileDBWriterTest, default_options)
 
     tiledb::FilterList fl =
         array.schema().domain().dimension("X").filter_list();
+#if TILEDB_VERSION_MAJOR == 2 && TILEDB_VERSION_MINOR < 16
     EXPECT_EQ(fl.nfilters(), 3U);
+#else
+    EXPECT_EQ(fl.nfilters(), 4U);
+#endif
 
     tiledb::Filter f1 = fl.filter(0);
     EXPECT_EQ(f1.filter_type(), TILEDB_FILTER_SCALE_FLOAT);

--- a/plugins/tiledb/test/TileDBWriterTest.cpp
+++ b/plugins/tiledb/test/TileDBWriterTest.cpp
@@ -221,6 +221,7 @@ TEST_F(TileDBWriterTest, write_simple_compression)
     options.add("array_name", pth);
     options.add("compression", "zstd");
     options.add("compression_level", 7);
+    options.add("filter_profile", "none");
 
     if (FileUtils::directoryExists(pth))
         FileUtils::deleteDirectory(pth);
@@ -360,13 +361,19 @@ TEST_F(TileDBWriterTest, default_options)
 
     tiledb::FilterList fl =
         array.schema().domain().dimension("X").filter_list();
-    EXPECT_EQ(fl.nfilters(), 1U);
+    EXPECT_EQ(fl.nfilters(), 3U);
 
     tiledb::Filter f1 = fl.filter(0);
-    EXPECT_EQ(f1.filter_type(), TILEDB_FILTER_ZSTD);
-    int32_t compressionLevel;
-    f1.get_option(TILEDB_COMPRESSION_LEVEL, &compressionLevel);
-    EXPECT_EQ(compressionLevel, 7);
+    EXPECT_EQ(f1.filter_type(), TILEDB_FILTER_SCALE_FLOAT);
+    uint64_t byteWidth;
+    f1.get_option<uint64_t>(TILEDB_SCALE_FLOAT_BYTEWIDTH, &byteWidth);
+    EXPECT_EQ(byteWidth, 4);
+    double scale;
+    f1.get_option<double>(TILEDB_SCALE_FLOAT_FACTOR, &scale);
+    EXPECT_NEAR(scale, 0.01, 1.0e-9);
+    double offset;
+    f1.get_option<double>(TILEDB_SCALE_FLOAT_OFFSET, &offset);
+    EXPECT_NEAR(offset, 0.0, 1.0e-9);
 
     tiledb::Attribute att = array.schema().attributes().begin()->second;
     tiledb::FilterList flAtts = att.filter_list();


### PR DESCRIPTION
* Add 3 possible filter profiles: none, balanced, and aggressive
* Add scale and offset input parameters for float-scale compression of X, Y, and Z
* Add delta filter (requires TileDB 2.16)