### PR TITLE
Fix az driver

### DIFF
--- a/vendor/arbiter/arbiter.hpp
+++ b/vendor/arbiter/arbiter.hpp
@@ -4530,7 +4530,9 @@ public:
 
     // Overrides.
     virtual std::unique_ptr<std::size_t> tryGetSize(
-            std::string path) const override;
+            std::string path,
+            http::Headers headers,
+            http::Query query = http::Query()) const override;
 
     /** Inherited from Drivers::Http. */
     virtual std::vector<char> put(


### PR DESCRIPTION
In `arbiter` `AZ` driver was missing `override` for `std::unique_ptr<std::size_t> tryGetSize(std::string path, http::Headers headers, http::Query query) const`.
`Protocol` was missing on init as well.

As a consequence, most `az://` requests were failing.
