### PR TITLE
Add WKTv2 VLRs to COPC

### DIFF
--- a/doc/stages/readers.copc.rst
+++ b/doc/stages/readers.copc.rst
@@ -130,3 +130,6 @@ keep_alive
 fix_dims
   Make invalid dimension names valid by converting disallowed characters to '_'. Only
   applies to names specified in an extra-bytes VLR. [Default: true]
+
+srs_consume_preference
+  Preference order to read SRS VLRs. [Default: 'wkt1, wkt2, projjson']

--- a/doc/stages/writers.copc.rst
+++ b/doc/stages/writers.copc.rst
@@ -156,6 +156,9 @@ vlrs
 threads
     Number of threads to use when writing [Default: 10]
 
+enhanced_srs_vlrs
+  Write WKT2 and PROJJSON as VLR [Default: false]
+
 .. include:: writer_opts.rst
 
 .. _COPC format: https://copc.io/

--- a/io/CopcReader.cpp
+++ b/io/CopcReader.cpp
@@ -103,6 +103,8 @@ public:
     NL::json ogr;
 
     int keepAliveChunkCount = 10;
+
+    std::string srsConsumePreference;
 };
 
 struct CopcReader::Private
@@ -174,6 +176,8 @@ void CopcReader::addArgs(ProgramArgs& args)
     args.add("vlr", "Read LAS VLRs and add to metadata.", m_args->doVlrs);
     args.add("keep_alive", "Number of chunks to keep alive in memory when working",
             m_args->keepAliveChunkCount, 10);
+    args.add("srs_consume_preference", "Preference order to read SRS VLRs",
+        m_args->srsConsumePreference, "wkt1, geotiff, wkt2, projjson");
 
 }
 

--- a/io/CopcReader.cpp
+++ b/io/CopcReader.cpp
@@ -177,7 +177,7 @@ void CopcReader::addArgs(ProgramArgs& args)
     args.add("keep_alive", "Number of chunks to keep alive in memory when working",
             m_args->keepAliveChunkCount, 10);
     args.add("srs_consume_preference", "Preference order to read SRS VLRs",
-        m_args->srsConsumePreference, "wkt1, geotiff, wkt2, projjson");
+        m_args->srsConsumePreference, "wkt1, wkt2, projjson");
 
 }
 
@@ -341,9 +341,58 @@ void CopcReader::fetchHeader()
 
 las::Vlr CopcReader::fetchSrsVlr(const las::VlrCatalog& catalog)
 {
-    las::Vlr vlr(las::TransformUserId, las::WktRecordId);
-    vlr.dataVec = catalog.fetchWithDescription(las::TransformUserId, las::WktRecordId,
-        vlr.description);
+    std::string srsConsumePreference = m_args->srsConsumePreference;
+    if (srsConsumePreference.empty())
+        srsConsumePreference = "wkt1, wkt2, projjson";
+
+    auto prefs = Utils::split2(srsConsumePreference, [](char c) { return c == ','; });
+    std::transform(prefs.cbegin(), prefs.cend(), prefs.begin(),
+                   [](std::string s)
+                   { Utils::trim(s); return Utils::tolower(s); });
+
+    auto makeVlr = [&catalog] (const std::string userId, uint16_t recordId) {
+        las::Vlr vlr(userId, recordId);
+        vlr.dataVec = catalog.fetchWithDescription(userId, recordId, vlr.description);
+        return vlr;
+    };
+
+    las::Vlr vlr;
+    for (const std::string& pref : prefs)
+    {
+        if (pref == "wkt2")
+        {
+            vlr = makeVlr(las::TransformUserId, las::LASFWkt2recordId);
+            if (!vlr.empty())
+            {
+                log()->get(LogLevel::Debug) << "Using WKT2 VLR" << std::endl;
+                break;
+            }
+        }
+        else if (pref == "projjson")
+        {
+            vlr = makeVlr(las::PdalUserId, las::PdalProjJsonRecordId);
+            if (!vlr.empty())
+            {
+                log()->get(LogLevel::Debug) << "Using PROJJSON VLR" << std::endl;
+                break;
+            }
+        }
+        else if (pref == "wkt1")
+        {
+            vlr = makeVlr(las::TransformUserId, las::WktRecordId);
+            if (!vlr.empty())
+            {
+                log()->get(LogLevel::Debug) << "Using WKT1 VLR" << std::endl;
+                break;
+            }
+        }
+        else
+        {
+            log()->get(LogLevel::Warning) << "Unknown value [" << pref <<
+                "] in srs consume preference." << std::endl;
+        }
+    }
+
     if (!vlr.empty())
         setSpatialReference(std::string(vlr.data(), vlr.data() + vlr.dataSize()));
     return vlr;

--- a/io/CopcWriter.cpp
+++ b/io/CopcWriter.cpp
@@ -378,6 +378,20 @@ void CopcWriter::write(const PointViewPtr v)
     else
        b->srs = v->spatialReference();
 
+    if (b->opts.enhancedSrsVlrs) {
+        auto addVlr = [&](const std::string& userId, uint16_t recordId, const std::string& desc, const std::string& str)
+        {
+            if (!str.empty()) {
+                std::vector<char> strBytes(str.begin(), str.end());
+                strBytes.resize(strBytes.size() + 1, 0);
+                las::Evlr v(userId, recordId, desc, std::move(strBytes));
+                b->vlrs.push_back(v);
+            }
+        };
+        addVlr(las::TransformUserId, las::LASFWkt2recordId, "PDAL WKT2 Record", b->srs.getWKT2());
+        addVlr(las::PdalUserId, las::PdalProjJsonRecordId, "PDAL PROJJSON Record", b->srs.getPROJJSON());
+    }
+
     // Set the input string into scaling.
     b->scaling.m_xXform.m_scale.set(b->opts.scaleX.val());
     b->scaling.m_yXform.m_scale.set(b->opts.scaleY.val());

--- a/io/CopcWriter.cpp
+++ b/io/CopcWriter.cpp
@@ -121,6 +121,8 @@ void CopcWriter::addArgs(ProgramArgs& args)
     args.add("fixed_seed", "Fix the random seed", b->opts.fixedSeed).setHidden();
     args.add("a_srs", "Spatial reference to use to write output", b->opts.aSrs);
     args.add("threads", "", b->opts.threadCount).setHidden();
+    args.add("enhanced_srs_vlrs", "Write WKT2 and PROJJSON as VLR?", b->opts.enhancedSrsVlrs,
+        decltype(b->opts.enhancedSrsVlrs)(false));
 }
 
 void CopcWriter::fillForwardList()

--- a/io/private/copcwriter/Common.hpp
+++ b/io/private/copcwriter/Common.hpp
@@ -109,6 +109,7 @@ struct Options
     bool fixedSeed;
     pdal::SpatialReference aSrs;
     int threadCount = 10;
+    bool enhancedSrsVlrs = false;
 };
 
 struct BaseInfo

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -161,6 +161,13 @@ PDAL_ADD_TEST(pdal_io_copc_reader_test
     INCLUDES
         ${NLOHMANN_INCLUDE_DIR}
 )
+PDAL_ADD_TEST(pdal_io_copc_writer_test
+    FILES
+        io/CopcWriterTest.cpp
+    INCLUDES
+        ${GDAL_INCLUDE_DIR}
+        ${NLOHMANN_INCLUDE_DIR}
+)
 PDAL_ADD_TEST(pdal_io_faux_test FILES io/FauxReaderTest.cpp)
 PDAL_ADD_TEST(pdal_io_gdal_reader_test
     FILES

--- a/test/unit/io/CopcWriterTest.cpp
+++ b/test/unit/io/CopcWriterTest.cpp
@@ -1,0 +1,146 @@
+/******************************************************************************
+ * Copyright (c) 2021, Hobu Inc. (info@hobu.co)
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of Hobu, Inc. or Flaxen Geo Consulting nor the
+ *       names of its contributors may be used to endorse or promote
+ *       products derived from this software without specific prior
+ *       written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ ****************************************************************************/
+
+#include <algorithm>
+
+#include <pdal/pdal_test_main.hpp>
+
+#include <io/CopcReader.hpp>
+#include <io/CopcWriter.hpp>
+#include <io/LasReader.hpp>
+
+#include <pdal/PDALUtils.hpp>
+
+#include "Support.hpp"
+
+namespace pdal
+{
+
+namespace
+{
+    std::string wkt2DerivedProjected =
+        "DERIVEDPROJCRS[\"Custom Site Calibrated CRS\",\n"
+        "    BASEPROJCRS[\"NAD83(2011) / Mississippi East (ftUS)\",\n"
+        "        BASEGEOGCRS[\"NAD83(2011)\",\n"
+        "            DATUM[\"NAD83 (National Spatial Reference System "
+        "2011)\",\n"
+        "                ELLIPSOID[\"GRS 1980\",6378137,298.257222101,\n"
+        "                    LENGTHUNIT[\"metre\",1]]],\n"
+        "            PRIMEM[\"Greenwich\",0,\n"
+        "                ANGLEUNIT[\"degree\",0.0174532925199433]]],\n"
+        "        CONVERSION[\"SPCS83 Mississippi East zone (US Survey "
+        "feet)\",\n"
+        "            METHOD[\"Transverse Mercator\",\n"
+        "                ID[\"EPSG\",9807]],\n"
+        "            PARAMETER[\"Latitude of natural origin\",29.5,\n"
+        "                ANGLEUNIT[\"degree\",0.0174532925199433],\n"
+        "                ID[\"EPSG\",8801]],\n"
+        "            PARAMETER[\"Longitude of natural "
+        "origin\",-88.8333333333333,\n"
+        "                ANGLEUNIT[\"degree\",0.0174532925199433],\n"
+        "                ID[\"EPSG\",8802]],\n"
+        "            PARAMETER[\"Scale factor at natural origin\",0.99995,\n"
+        "                SCALEUNIT[\"unity\",1],\n"
+        "                ID[\"EPSG\",8805]],\n"
+        "            PARAMETER[\"False easting\",984250,\n"
+        "                LENGTHUNIT[\"US survey foot\",0.304800609601219],\n"
+        "                ID[\"EPSG\",8806]],\n"
+        "            PARAMETER[\"False northing\",0,\n"
+        "                LENGTHUNIT[\"US survey foot\",0.304800609601219],\n"
+        "                ID[\"EPSG\",8807]]]],\n"
+        "    DERIVINGCONVERSION[\"Affine transformation as PROJ-based\",\n"
+        "        METHOD[\"PROJ-based operation method: "
+        "+proj=pipeline +step +proj=unitconvert +xy_in=m +xy_out=us-ft "
+        "+step +proj=affine +xoff=20 "
+        "+step +proj=unitconvert +xy_in=us-ft +xy_out=m\"]],\n"
+        "    CS[Cartesian,2],\n"
+        "        AXIS[\"northing (Y)\",north,\n"
+        "            LENGTHUNIT[\"US survey foot\",0.304800609601219]],\n"
+        "        AXIS[\"easting (X)\",east,\n"
+        "            LENGTHUNIT[\"US survey foot\",0.304800609601219]],\n"
+        "    REMARK[\"EPSG:6507 with 20 feet offset and axis inversion\"]]";
+}
+
+TEST(CopcWriterTest, srsWkt2)
+{
+    const auto filename = Support::temppath("srsWkt2.copc.las");
+    {
+        Options readerOps;
+        readerOps.add("filename", Support::datapath("las/utm15.las"));
+
+        LasReader reader;
+        reader.setOptions(readerOps);
+
+        Options writerOps;
+        writerOps.add("filename", filename);
+        writerOps.add("a_srs", wkt2DerivedProjected);
+        writerOps.add("enhanced_srs_vlrs", true);
+        CopcWriter writer;
+        writer.setInput(reader);
+        writer.setOptions(writerOps);
+
+        PointTable table;
+        writer.prepare(table);
+        writer.execute(table);
+    }
+
+    {
+        Options options;
+        options.add("filename", filename);
+
+        CopcReader creader;
+        creader.setOptions(options);
+
+        const QuickInfo qi(creader.preview());
+        std::string srs = qi.m_srs.getWKT();
+
+        EXPECT_TRUE(Utils::startsWith(srs, "DERIVEDPROJCRS[\"Custom Site Calibrated CRS\""));
+    }
+
+    {
+        Options options;
+        options.add("filename", filename);
+        options.add("srs_consume_preference", "projjson, wkt2");
+
+        CopcReader creader;
+        creader.setOptions(options);
+
+        const QuickInfo qi(creader.preview());
+        std::string srs = qi.m_srs.getPROJJSON();
+
+        EXPECT_TRUE(Utils::startsWith(srs, "{\n  \"type\": \"DerivedProjectedCRS\","));
+    }
+}
+
+} // namespace pdal


### PR DESCRIPTION
Continuation of #3998 , same behaviour in COPC as in LAS/LAZ

It writes WKT2 and PROJJSON vlrs when set with `enhanced_srs_vlrs` in CopcWriter
Reads the SpatialReference from the vlr defined in the option `srs_consume_preference`, which defaults to `wkt1, wkt2, projjson`.