### PR TITLE
Add dependabot.yml for checking gh-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+	- package-ecosystem: "github-actions"
+	  directory: "/"
+	  schedule:
+	  	interval: daily


### PR DESCRIPTION
When dependabot is enabled, this configuration will check the github actions configs and see if the versioned actions are up-to-date.  If not a pull request will automatically be generated and it will be apparent if an upgrade to an action will cause a failure or not.

This addresses the issue where a configuration gets significantly out of date and multiple issues pile up, making updating the CI pipeline jobs a far bigger task.