### PR TITLE
Filters.stac

### DIFF
--- a/filters/StacFilter.cpp
+++ b/filters/StacFilter.cpp
@@ -116,7 +116,10 @@ void StacFilter::extractMetadata(PointTableRef table)
 
     //Base STAC object
     MetadataNode properties = m_metadata.add("properties");
+    properties.add("datetime", "2022-11-15T16:06:02.616469Z");
     MetadataNode id = m_metadata.add("id", stem);
+    m_metadata.add("type", "Feature");
+    m_metadata.add("stac_version", "1.0.0");
 
     //extensions - pointcloud and projection extensions
     m_metadata.add("extensions", "https://stac-extensions.github.io/pointcloud/v1.0.0/schema.json");
@@ -125,7 +128,7 @@ void StacFilter::extractMetadata(PointTableRef table)
     //links - empty because this is defaulting to stdout.
     MetadataNode self = m_metadata.addList("links");
     self.add("rel", "derived_from");
-    self.add("target", m_inputFile);
+    self.add("href", m_inputFile);
 
     //assets - add source file to data asset
     MetadataNode assets = m_metadata.add("assets");
@@ -153,6 +156,12 @@ void StacFilter::extractMetadata(PointTableRef table)
     properties.add("pc:count", count);
     properties.add("pc:type", "lidar");
     properties.add("pc:encoding", fileExt);
+    auto dims = table.layout()->toMetadata().children();
+    // MetadataNode schemas = properties.addList("pc:schemas");
+    for (auto& c: dims)
+        properties.add(c.clone("pc:schemas"));
+    // schemas.add(dims.findChild("dimensions"));
+    // properties.add("pc:schemas", dims);
 
     // If we have X, Y, & Z dims, output bboxes
     auto xs = m_stats.find(Dimension::Id::X);

--- a/filters/StacFilter.cpp
+++ b/filters/StacFilter.cpp
@@ -1,0 +1,211 @@
+/******************************************************************************
+* Copyright (c) 2023, Kyle Mann (kyle@hobu.com)
+*
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following
+* conditions are met:
+*
+*     * Redistributions of source code must retain the above copyright
+*       notice, this list of conditions and the following disclaimer.
+*     * Redistributions in binary form must reproduce the above copyright
+*       notice, this list of conditions and the following disclaimer in
+*       the documentation and/or other materials provided
+*       with the distribution.
+*     * Neither the name of Hobu, Inc. or Flaxen Geo Consulting nor the
+*       names of its contributors may be used to endorse or promote
+*       products derived from this software without specific prior
+*       written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+* FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+* COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+* BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+* OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+* AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+* OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+* OF SUCH DAMAGE.
+****************************************************************************/
+
+#include "StacFilter.hpp"
+#include "StatsFilter.hpp"
+#include <pdal/Polygon.hpp>
+#include <pdal/util/FileUtils.hpp>
+
+
+namespace pdal
+{
+
+using namespace stats;
+
+static PluginInfo const s_info = PluginInfo(
+    "filters.stac",
+    "Collect information on lidar data and form STAC compatible GeoJSON Feature.",
+    "http://pdal.io/stages/filters.stac.html" );
+
+StacFilter::StacFilter() {};
+StacFilter::~StacFilter() {};
+
+CREATE_STATIC_STAGE(StacFilter, s_info);
+
+std::string StacFilter::getName() const {
+    return s_info.name;
+}
+
+void StacFilter::addArgs(ProgramArgs& args)
+{
+    args.add("input_file", "Input file.",  m_inputFile);
+}
+
+void StacFilter::filter(PointView& view)
+{
+    PointRef point(view, 0);
+    for (PointId idx = 0; idx < view.size(); ++idx)
+    {
+        point.setPointId(idx);
+        processOne(point);
+    }
+}
+
+bool StacFilter::processOne(PointRef& point)
+{
+    for (auto p = m_stats.begin(); p != m_stats.end(); ++p)
+    {
+        Dimension::Id d = p->first;
+        Summary& c = p->second;
+        c.insert(point.getFieldAs<double>(d));
+    }
+    return true;
+}
+
+void StacFilter::prepared(PointTableRef table)
+{
+    PointLayoutPtr layout(table.layout());
+
+    for (auto& id : layout->dims())
+    {
+        m_stats.insert(std::make_pair(id,
+            Summary(layout->dimName(id), Summary::NoEnum, true)));
+    }
+}
+
+void StacFilter::done(PointTableRef table)
+{
+    extractMetadata(table);
+}
+
+void addBox(MetadataNode& n, std::string name, const BOX3D& box)
+{
+    n.add(name, box.minx);
+    n.add(name, box.miny);
+    n.add(name, box.minz);
+    n.add(name, box.maxx);
+    n.add(name, box.maxy);
+    n.add(name, box.maxz);
+}
+
+void StacFilter::extractMetadata(PointTableRef table)
+{
+    std::string stem = FileUtils::stem(m_inputFile);
+    std::string fileExt = FileUtils::extension(m_inputFile);
+
+    //Base STAC object
+    MetadataNode properties = m_metadata.add("properties");
+    MetadataNode id = m_metadata.add("id", stem);
+
+    //extensions - pointcloud and projection extensions
+    m_metadata.add("extensions", "https://stac-extensions.github.io/pointcloud/v1.0.0/schema.json");
+    m_metadata.add("extensions", "https://stac-extensions.github.io/projection/v1.1.0/schema.json");
+
+    //links - empty because this is defaulting to stdout.
+    MetadataNode self = m_metadata.addList("links");
+    self.add("rel", "derived_from");
+    self.add("target", m_inputFile);
+
+    //assets - add source file to data asset
+    MetadataNode assets = m_metadata.add("assets");
+    MetadataNode data;
+    data.add("href", m_inputFile);
+    data.add("title", "Lidar data");
+    assets.add(data.clone("data"));
+
+    uint32_t position(0);
+    point_count_t count = 0;
+    bool bNoPoints(true);
+    for (auto di = m_stats.begin(); di != m_stats.end(); ++di)
+    {
+        Summary& s = di->second;
+
+        bNoPoints = (bool)s.count();
+        count = s.count();
+
+        // MetadataNode pcStats = properties.addList("pc:statistics");
+        // pcStats.add("position", position++);
+        // s.extractMetadata(pcStats);
+    }
+
+    //POINTCLOUD EXTENSIONS
+    properties.add("pc:count", count);
+    properties.add("pc:type", "lidar");
+    properties.add("pc:encoding", fileExt);
+
+    // If we have X, Y, & Z dims, output bboxes
+    auto xs = m_stats.find(Dimension::Id::X);
+    auto ys = m_stats.find(Dimension::Id::Y);
+    auto zs = m_stats.find(Dimension::Id::Z);
+    if (xs != m_stats.end() &&
+        ys != m_stats.end() &&
+        zs != m_stats.end() &&
+        bNoPoints)
+    {
+        BOX3D box(xs->second.minimum(), ys->second.minimum(),
+            zs->second.minimum(), xs->second.maximum(), ys->second.maximum(),
+            zs->second.maximum());
+        Polygon p(box);
+        addBox(properties, "proj:bbox", box);
+
+        // MetadataNode bbox = Utils::toMetadata(box);
+        // MetadataNode metadata = box_metadata.add("native");
+
+        MetadataNode projgeom = properties.addWithType("proj:geometry",
+            p.json(), "json", "GeoJSON boundary");
+        // MetadataNode bbox = metadata.add(mbox);
+        SpatialReference ref = table.anySpatialReference();
+
+        // if we don't get an SRS from the PointTableRef,
+        // we won't add another metadata node
+        if (!ref.empty())
+        {
+            p.setSpatialReference(ref);
+            properties.add("proj:wkt2", ref.getWKT2());
+            // properties.addWithType("proj:projjson", ref.getPROJJSON(), "json",
+            //     "PROJ JSON");
+
+            if (p.transform("EPSG:4326"))
+            {
+                BOX3D ddbox = p.bounds();
+                // MetadataNode epsg_4326_box = Utils::toMetadata(ddbox);
+                m_metadata.addWithType("geometry", p.json(), "json", "GeoJSON boundary");
+                addBox(m_metadata, "bbox", ddbox);
+            }
+        }
+        else {
+            SpatialReference r("EPSG:4326");
+            properties.add("proj:epsg", 4326);
+            properties.add("proj:wkt2", r.getWKT2());
+            m_metadata.addWithType("geometry", p.json(), "json", "GeoJSON boundary");
+            addBox(m_metadata, "bbox", box);
+            // properties.addWithType("proj:projjson", r.getPROJJSON(), "json",
+            //     "PROJ JSON");
+
+        }
+    }
+
+}
+
+}//pdal

--- a/filters/StacFilter.cpp
+++ b/filters/StacFilter.cpp
@@ -137,10 +137,11 @@ void StacFilter::extractMetadata(PointTableRef table)
     data.add("title", "Lidar data");
     assets.add(data.clone("data"));
 
-    //Add dimension statistics
+    //pointcloud extension
     uint32_t position(0);
     point_count_t count = 0;
     bool bNoPoints(true);
+    //Add dimension statistics
     for (auto di = m_stats.begin(); di != m_stats.end(); ++di)
     {
         Summary& s = di->second;
@@ -152,8 +153,6 @@ void StacFilter::extractMetadata(PointTableRef table)
         pcStats.add("position", position++);
         s.extractMetadata(pcStats);
     }
-
-    //pointcloud extension
     properties.add("pc:count", count);
     properties.add("pc:type", "lidar");
     properties.add("pc:encoding", fileExt);

--- a/filters/StacFilter.hpp
+++ b/filters/StacFilter.hpp
@@ -51,7 +51,6 @@ public:
     std::string getName() const;
 
 private:
-    // virtual void addArgs(ProgramArgs& args);
     virtual void addArgs(ProgramArgs& args);
     virtual bool processOne(PointRef& point);
     virtual void prepared(PointTableRef table);

--- a/filters/StacFilter.hpp
+++ b/filters/StacFilter.hpp
@@ -35,14 +35,11 @@
 #pragma once
 
 #include "StatsFilter.hpp"
-#include <pdal/Filter.hpp>
-#include <pdal/Streamable.hpp>
-#include <pdal/util/ProgramArgs.hpp>
 
 namespace pdal
 {
 
-class PDAL_DLL StacFilter : public Filter, public Streamable
+class PDAL_DLL StacFilter : public StatsFilter
 {
 public:
     StacFilter();
@@ -51,16 +48,17 @@ public:
     std::string getName() const;
 
 private:
-    virtual void addArgs(ProgramArgs& args);
-    virtual bool processOne(PointRef& point);
-    virtual void prepared(PointTableRef table);
-    virtual void done(PointTableRef table);
-    virtual void filter(PointView& view);
+    void addArgs(ProgramArgs& args);
+    void prepared(PointTableRef table);
     void extractMetadata(PointTableRef table);
 
-    std::map<Dimension::Id, stats::Summary> m_stats;
-    std::string m_inputFile;
+    void pointcloud(MetadataNode& n, PointTableRef& table);
+    void projection(MetadataNode& n, PointTableRef& table);
 
+    std::map<Dimension::Id, stats::Summary> m_stats;
+    std::string m_filename;
+    std::string m_defaultSrs;
+    std::string m_pcType;
 
 };
 

--- a/filters/StacFilter.hpp
+++ b/filters/StacFilter.hpp
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (c) 2013, Howard Butler (hobu.inc@gmail.com)
+* Copyright (c) 2023, Kyle Mann (kyle@hobu.com)
 *
 * All rights reserved.
 *
@@ -34,65 +34,35 @@
 
 #pragma once
 
-#include <pdal/Kernel.hpp>
-#include <pdal/PipelineManager.hpp>
-#include <pdal/PointView.hpp>
-#include <pdal/Stage.hpp>
-#include <pdal/util/FileUtils.hpp>
-
-#ifdef __clang__
-#pragma GCC diagnostic ignored "-Wtautological-constant-out-of-range-compare"
-#endif
+#include "StatsFilter.hpp"
+#include <pdal/Filter.hpp>
+#include <pdal/Streamable.hpp>
+#include <pdal/util/ProgramArgs.hpp>
 
 namespace pdal
 {
 
-class PDAL_DLL InfoKernel : public Kernel
+class PDAL_DLL StacFilter : public Filter, public Streamable
 {
 public:
+    StacFilter();
+    ~StacFilter();
+
     std::string getName() const;
-    int execute(); // overrride
-
-    InfoKernel();
-    void setup(const std::string& filename);
-    MetadataNode run(const std::string& filename);
-
-    inline bool showAll() { return m_showAll; }
-    inline void doShowAll(bool value) { m_showAll = value; }
-    inline void doComputeSummary(bool value) { m_showSummary = value; }
-    inline void doComputeBoundary(bool value) { m_boundary = value; }
 
 private:
-    void addSwitches(ProgramArgs& args);
-    void validateSwitches(ProgramArgs& args);
-    void makeReader(const std::string& filename);
-    void makePipeline();
-    void dump(MetadataNode& root);
-    MetadataNode dumpSummary(const QuickInfo& qi);
+    // virtual void addArgs(ProgramArgs& args);
+    virtual void addArgs(ProgramArgs& args);
+    virtual bool processOne(PointRef& point);
+    virtual void prepared(PointTableRef table);
+    virtual void done(PointTableRef table);
+    virtual void filter(PointView& view);
+    void extractMetadata(PointTableRef table);
 
+    std::map<Dimension::Id, stats::Summary> m_stats;
     std::string m_inputFile;
-    bool m_showStats;
-    bool m_showSchema;
-    bool m_showAll;
-    bool m_showMetadata;
-    bool m_boundary;
-    bool m_stac;
-    std::string m_pointIndexes;
-    std::string m_dimensions;
-    std::string m_enumerate;
-    std::string m_queryPoint;
-    std::string m_pipelineFile;
-    bool m_showSummary;
-    bool m_needPoints;
-    bool m_usestdin;
 
-    Stage *m_statsStage;
-    Stage *m_hexbinStage;
-    Stage *m_infoStage;
-    Stage *m_reader;
-    Stage *m_stacStage;
 
-    MetadataNode m_tree;
 };
 
-} // namespace pdal
+}

--- a/filters/StatsFilter.hpp
+++ b/filters/StatsFilter.hpp
@@ -232,7 +232,7 @@ private:
     virtual void prepared(PointTableRef table);
     virtual void done(PointTableRef table);
     virtual void filter(PointView& view);
-    void extractMetadata(PointTableRef table);
+    virtual void extractMetadata(PointTableRef table);
 
     StringList m_dimNames;
     StringList m_enums;


### PR DESCRIPTION
Addresses #4027.

Adds `filters.stac`. A metadata filter that organizes data and outputs it to fit [STAC Feature specifications](https://github.com/radiantearth/stac-spec/blob/master/item-spec/item-spec.md). 

Notes and considerations: https://gist.github.com/kylemann16/51fa4d3963a011b63f846346528ce888