### PR TITLE
Set default chunk_size to be larger than capacity

### DIFF
--- a/doc/stages/writers.tiledb.rst
+++ b/doc/stages/writers.tiledb.rst
@@ -39,7 +39,7 @@ config_file
   `TileDB`_ configuration file. [Optional]
 
 data_tile_capacity
-  Number of points per tile. Not used when `append=true`. [Optional]
+  Number of points per tile. Not used when `append=true`. [Default: 100,000]
 
 x_tile_size
   Tile size (x). Floating point value used for determining on-disk data order. Not used when `append=true`. [Optional]
@@ -87,13 +87,13 @@ combine_bit_fields
   Store all sub-byte fields together in an attribute named `BitFields`. Not used when `append=true`. [Default: true]
 
 chunk_size
-  Point cache size for chunked writes. [Optional]
+  Point cache size for chunked writes. [Default: 1,000,000]
 
 append
   Instead of creating a new array, append to an existing array that has the dimensions stored as a TileDB dimension or TileDB attribute. [Default: false]
 
 stats
-  Dump query stats to stdout. [Optional]
+  Dump query stats to stdout. [Default: false]
 
 filters
   JSON array or object of compression filters for either dimenions or attributes of the form {dimension/attribute name : {"compression": name, compression_options: value, ...}}.  Not used when `append=true`. [Optional]

--- a/plugins/tiledb/io/TileDBWriter.cpp
+++ b/plugins/tiledb/io/TileDBWriter.cpp
@@ -153,7 +153,7 @@ void TileDBWriter::addArgs(ProgramArgs& args)
                      "Add offset to use fo default x float-scale filter",
                      m_args->m_offset[2], 0.0);
     args.add("chunk_size", "Point cache size for chunked writes",
-             m_args->m_cache_size, size_t(10000));
+             m_args->m_cache_size, size_t(1000000));
     args.add("stats", "Dump TileDB query stats to stdout", m_args->m_stats,
              false);
     args.add("filter_profile", "Filter profile to use for compression filters",


### PR DESCRIPTION
A small chunk_size will lead to many, small fragments in TileDB which will hurt read performance. This change increases the default chunk size to fit 10 tiles using the default capacity.