### PR TITLE
Always read COPC file VLRs and add to metadata

### DIFF
--- a/cmake/standalone.cmake
+++ b/cmake/standalone.cmake
@@ -2,6 +2,10 @@ set(ROOT_DIR "${CMAKE_SOURCE_DIR}/../..")
 
 get_filename_component(ROOT_DIR "${ROOT_DIR}" ABSOLUTE)
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 include(${ROOT_DIR}/cmake/common.cmake )
 include(${ROOT_DIR}/cmake/libraries.cmake )
 include(FeatureSummary)

--- a/io/CopcReader.cpp
+++ b/io/CopcReader.cpp
@@ -173,7 +173,7 @@ void CopcReader::addArgs(ProgramArgs& args)
     args.add("ogr", "OGR filter geometries", m_args->ogr);
     args.add("fix_dims", "Make invalid dimension names valid by changing invalid "
         "characters to '_'", m_args->fixNames, true);
-    args.add("vlr", "Read LAS VLRs and add to metadata.", m_args->doVlrs);
+    args.add("vlr", "Read LAS VLRs and add to metadata.", m_args->doVlrs, true);
     args.add("keep_alive", "Number of chunks to keep alive in memory when working",
             m_args->keepAliveChunkCount, 10);
     args.add("srs_consume_preference", "Preference order to read SRS VLRs",

--- a/io/CopcWriter.cpp
+++ b/io/CopcWriter.cpp
@@ -214,11 +214,12 @@ void CopcWriter::handleForwardVlrs(MetadataNode& forwards)
         if (userIdNode.valid() && recordIdNode.valid())
         {
 
+            const MetadataNode& descriptionNode = n.findChild("description");
             const std::vector<uint8_t>& data = Utils::base64_decode(n.findChild("data").value());
             const char *d = (const char *)data.data();
             std::vector<char> buf(d, d + data.size());
             las::Evlr e(userIdNode.value(), (uint16_t)std::stoi(recordIdNode.value()),
-                n.description(), std::move(buf));
+                descriptionNode.value(), std::move(buf));
             b->vlrs.push_back(e);
         }
     }


### PR DESCRIPTION
I don't know why this is an option, or why it defaults to `false`, but the behavior is both not aligned with `readers.las` and easy to stub your toe on.