### PR TITLE
Fix edge cases in EPT origin query

### DIFF
--- a/io/EptReader.cpp
+++ b/io/EptReader.cpp
@@ -375,6 +375,14 @@ void EptReader::handleOriginQuery()
     try
     {
         BOX3D q(toBox3d(found.at("bounds")));
+        // Bloat the query bounds slightly (we'll choose one tick of the EPT's
+        // scale) to make sure we don't miss any points due to them being 
+        // precisely on the bounds edge.
+        q.grow(
+            (std::max)(
+                m_p->info->dims().at("X").m_xform.m_scale.m_val,
+                m_p->info->dims().at("Y").m_xform.m_scale.m_val
+            ));
 
         if (m_p->bounds.box.valid())
             m_p->bounds.box.clip(q);
@@ -507,6 +515,22 @@ void EptReader::ready(PointTableRef table)
     // origins and ordering for an EPT writer.
     m_nodeIdDim = table.layout()->findDim("EptNodeId");
     m_pointIdDim = table.layout()->findDim("EptPointId");
+
+    if (
+        m_queryOriginId != -1 && 
+        !table.layout()->hasDim(Dimension::Id::OriginId))
+    {
+        // In this case we can't compare the OriginId for each point since the
+        // EPT data does not have that attribute saved.  We will keep the 
+        // spatial query to limit the data to the extents of the requested
+        // origin, but if other origins overlap these extents, then their points
+        // will also be included.
+        m_queryOriginId = -1;
+
+        log()->get(LogLevel::Warning) << 
+            "An origin query was given but no OriginId dimension exists - " <<
+            "points from other origins may be included" << std::endl;
+    }
 
     m_p->hierarchy.reset(new ept::Hierarchy);
 
@@ -731,9 +755,11 @@ bool EptReader::processPoint(PointRef& dst, const ept::TileContents& tile)
     PointId pointId = m_pointId++;
 
     PointRef p(t, pointId);
-    int64_t originId = p.getFieldAs<int64_t>(Id::OriginId);
-    if (m_queryOriginId != -1 && originId != m_queryOriginId)
+    if (m_queryOriginId != -1 && 
+        p.getFieldAs<int64_t>(Id::OriginId)!= m_queryOriginId)
+    {
         return false;
+    }
 
     auto passesBoundsFilter = [this](double x, double y, double z)
     {


### PR DESCRIPTION
- Make sure to gather all points from an origin query by bloating its bounds by a bit - otherwise points precisely on the query bounds could be missed
- If the EPT dataset does *not* contain an OriginId dimension, don't try to compare OriginId values per-point: previously this check would always compare `0` with the query-origin-ID since the value does not exist, so all points would be discarded for origins besides the first one.  Instead, clear the query-origin-ID in that case but keep the spatial query.  This means we'll clip our query to the extents of the requested origin, however if other origins overlap it then their points will be included as well since we cannot distinguish them.  A warning is emitted if this occurs.