### PR TITLE
add filters.stats.commonsrs to allow user to override the default 'co…

### DIFF
--- a/filters/StatsFilter.cpp
+++ b/filters/StatsFilter.cpp
@@ -211,6 +211,7 @@ void StatsFilter::addArgs(ProgramArgs& args)
         m_global);
     args.add("count", "Dimensions whose values should be counted", m_counts);
     args.add("advanced", "Calculate skewness and kurtosis", m_advanced);
+    args.add("commonsrs", "Common SRS to use for normalizing bounding boxes", m_commonSrs, "EPSG:4326");
 }
 
 
@@ -321,11 +322,11 @@ void StatsFilter::extractMetadata(PointTableRef table)
         if (!ref.empty())
         {
             p.setSpatialReference(ref);
-            if (p.transform("EPSG:4326"))
+            if (p.transform(m_commonSrs))
             {
                 BOX3D ddbox = p.bounds();
                 MetadataNode epsg_4326_box = Utils::toMetadata(ddbox);
-                MetadataNode dddbox = box_metadata.add("EPSG:4326");
+                MetadataNode dddbox = box_metadata.add(m_commonSrs);
                 dddbox.add(epsg_4326_box);
 
                 MetadataNode ddboundary = dddbox.addWithType("boundary",

--- a/filters/StatsFilter.hpp
+++ b/filters/StatsFilter.hpp
@@ -238,6 +238,7 @@ private:
     StringList m_enums;
     StringList m_counts;
     StringList m_global;
+    std::string m_commonSrs;
     bool m_advanced;
     std::map<Dimension::Id, stats::Summary> m_stats;
 };


### PR DESCRIPTION
…mmon' srs when writing box metadata