### PR TITLE
Enhancements/fixes related to coordinate epochs

### DIFF
--- a/pdal/SpatialReference.cpp
+++ b/pdal/SpatialReference.cpp
@@ -237,6 +237,8 @@ void SpatialReference::set(std::string v)
         throw pdal_error(oss.str());
     }
 
+    m_epoch = srs.GetCoordinateEpoch();
+
     m_wkt = exportToWkt(&srs);
 }
 

--- a/pdal/SpatialReference.cpp
+++ b/pdal/SpatialReference.cpp
@@ -208,16 +208,26 @@ void SpatialReference::parse(const std::string& s, std::string::size_type& pos)
 
 void SpatialReference::set(std::string v)
 {
+    m_wkt.clear();
+    m_wkt2.clear();
     m_horizontalWkt.clear();
     if (v.empty())
     {
-        m_wkt.clear();
         return;
     }
 
-    if (isWKT(v))
+    if (isWKT2(v))
     {
         m_wkt = v;
+        m_wkt2 = v;
+        return;
+    }
+    else if (isWKT1(v))
+    {
+        m_wkt = v;
+        OGRScopedSpatialReference srs = ogrCreateSrs(m_wkt);
+        if (srs)
+            m_wkt2 = exportToWkt(srs.get(), {"FORMAT=WKT2_2018"});
         return;
     }
 
@@ -240,6 +250,8 @@ void SpatialReference::set(std::string v)
     m_epoch = srs.GetCoordinateEpoch();
 
     m_wkt = exportToWkt(&srs);
+
+    m_wkt2 = exportToWkt(&srs, {"FORMAT=WKT2_2018"});
 }
 
 
@@ -483,13 +495,9 @@ SpatialReference SpatialReference::wgs84FromZone(int zone)
 }
 
 
-bool SpatialReference::isWKT(const std::string& wkt)
+bool SpatialReference::isWKT2(const std::string& wkt)
 {
-    // List comes from GDAL.  WKT includes FITTED_CS, but this isn't
-    // included in GDAL list.  Not sure why.
-    StringList leaders { "PROJCS", "GEOGCS", "COMPD_CS", "GEOCCS",
-        "VERT_CS", "LOCAL_CS",
-    // New specification names.
+    StringList leaders {
         "GEODCRS", "GEODETICCRS",
         "PROJCRS", "PROJECTEDCRS",
         "VERTCRS", "VERITCALCRS",
@@ -505,6 +513,27 @@ bool SpatialReference::isWKT(const std::string& wkt)
         if (wkt.compare(0, s.size(), s) == 0)
             return true;
     return false;
+}
+
+
+bool SpatialReference::isWKT1(const std::string& wkt)
+{
+    // List comes from GDAL.  WKT includes FITTED_CS, but this isn't
+    // included in GDAL list.  Not sure why.
+    StringList leaders { "PROJCS", "GEOGCS", "COMPD_CS", "GEOCCS",
+        "VERT_CS", "LOCAL_CS"
+    };
+
+    for (const std::string& s : leaders)
+        if (wkt.compare(0, s.size(), s) == 0)
+            return true;
+    return false;
+}
+
+
+bool SpatialReference::isWKT(const std::string& wkt)
+{
+    return isWKT1(wkt) || isWKT2(wkt);
 }
 
 
@@ -535,9 +564,7 @@ std::string SpatialReference::getWKT1() const
 
 std::string SpatialReference::getWKT2() const
 {
-    std::string wkt = getWKT();
-    OGRScopedSpatialReference srs = ogrCreateSrs(wkt);
-    return exportToWkt(srs.get(), {"FORMAT=WKT2_2018"});
+    return m_wkt2;
 }
 
 int SpatialReference::getUTMZone() const

--- a/pdal/SpatialReference.cpp
+++ b/pdal/SpatialReference.cpp
@@ -499,9 +499,11 @@ bool SpatialReference::isWKT2(const std::string& wkt)
 {
     StringList leaders {
         "GEODCRS", "GEODETICCRS",
+        "GEOGCRS", "GEOGRAPHICCRS",
         "PROJCRS", "PROJECTEDCRS",
-        "VERTCRS", "VERITCALCRS",
+        "VERTCRS", "VERTICALCRS",
         "ENGCRS", "ENGINEERINGCRS",
+        "BOUNDCRS",
         "IMAGECRS",
         "PARAMETRICCRS",
         "TIMECRS",

--- a/pdal/SpatialReference.hpp
+++ b/pdal/SpatialReference.hpp
@@ -182,12 +182,15 @@ public:
 
 private:
     std::string m_wkt;
+    std::string m_wkt2;
     double m_epoch = 0.0f;
     mutable std::string m_horizontalWkt;
     friend PDAL_DLL std::ostream& operator<<(std::ostream& ostr,
         const SpatialReference& srs);
     friend PDAL_DLL std::istream& operator>>(std::istream& istr,
         SpatialReference& srs);
+    static bool isWKT1(const std::string& wkt);
+    static bool isWKT2(const std::string& wkt);
 };
 
 PDAL_DLL std::ostream& operator<<(std::ostream& ostr,

--- a/pdal/private/SrsTransform.cpp
+++ b/pdal/private/SrsTransform.cpp
@@ -97,9 +97,9 @@ SrsTransform::SrsTransform(const SpatialReference& src,
                            const SpatialReference& dst,
                            std::vector<int> dstOrder)
 {
-    OGRSpatialReference srcRef(src.getWKT().data());
+    OGRSpatialReference srcRef(src.getWKT2().data());
     srcRef.SetCoordinateEpoch(src.getEpoch());
-    OGRSpatialReference dstRef(dst.getWKT().data());
+    OGRSpatialReference dstRef(dst.getWKT2().data());
     dstRef.SetCoordinateEpoch(dst.getEpoch());
 
 // Starting with version 3, the axes (X, Y, Z or lon, lat, h or whatever)
@@ -119,9 +119,9 @@ SrsTransform::SrsTransform(const SpatialReference& src,
 
 void SrsTransform::set(const SpatialReference& src, const SpatialReference& dst)
 {
-    OGRSpatialReference osrSrc(src.getWKT().data());
+    OGRSpatialReference osrSrc(src.getWKT2().data());
     osrSrc.SetCoordinateEpoch(src.getEpoch());
-    OGRSpatialReference osrDst(dst.getWKT().data());
+    OGRSpatialReference osrDst(dst.getWKT2().data());
     osrDst.SetCoordinateEpoch(dst.getEpoch());
     set(osrSrc, osrDst);
 }

--- a/pdal/private/SrsTransform.cpp
+++ b/pdal/private/SrsTransform.cpp
@@ -98,7 +98,9 @@ SrsTransform::SrsTransform(const SpatialReference& src,
                            std::vector<int> dstOrder)
 {
     OGRSpatialReference srcRef(src.getWKT().data());
+    srcRef.SetCoordinateEpoch(src.getEpoch());
     OGRSpatialReference dstRef(dst.getWKT().data());
+    dstRef.SetCoordinateEpoch(dst.getEpoch());
 
 // Starting with version 3, the axes (X, Y, Z or lon, lat, h or whatever)
 // are mapped according to the WKT definition.  In particular, this means
@@ -117,7 +119,11 @@ SrsTransform::SrsTransform(const SpatialReference& src,
 
 void SrsTransform::set(const SpatialReference& src, const SpatialReference& dst)
 {
-    set(OGRSpatialReference(src.getWKT().data()), OGRSpatialReference(dst.getWKT().data()));
+    OGRSpatialReference osrSrc(src.getWKT().data());
+    osrSrc.SetCoordinateEpoch(src.getEpoch());
+    OGRSpatialReference osrDst(dst.getWKT().data());
+    osrDst.SetCoordinateEpoch(dst.getEpoch());
+    set(osrSrc, osrDst);
 }
 
 


### PR DESCRIPTION
Complements PR #4049, closes #3995 . To be fully effective, it requires https://github.com/OSGeo/PROJ/pull/3884 and https://github.com/OSGeo/gdal/pull/8340, but it can be applied independently as it doesn't use new API

-   SpatialReference::set(): store coordinate epoch from OGRSpatialReference built from SetFromUserInput()
    
    This is useful to get the epoch for a SpatialReference built from a
    string like 'urn:ogc:def:coordinateMetadata:AUTHORTIY::CODE code' (since
    https://github.com/OSGeo/gdal/pull/8340 and https://github.com/OSGeo/PROJ/pull/3884), which
    resolves to a CoordinateMetadata object with a CRS and potentially a
    coordinate epoch

-  SrsTransform: make sure to propagate coordinate epoch when rebuilding OGRSpatialReference objects

-  SpatialReference::set(): when building from SetFromUserInput(), get the WKT2 version
    
    This limits the loss of information, particularly for CRS like
    'urn:ogc:def:coordinateMetadata:NRCAN::NAD83_CSRS_1997_MTM7_HT2_1997'
    which include a GEOIDMODEL[] node, that would be lost otherwise


With that PR and above mentionned GDAL and PROJ PRs,
```
$ cat in.csv
X,Y,Z
268955,5540412,0

$ cat pipeline.json
[
    {
        "type":"readers.text",
        "filename":"in.csv"
    },
    {
        "type":"filters.reprojection",
        "in_srs":"urn:ogc:def:coordinateMetadata:NRCAN::NAD83_CSRS_1997_MTM7_HT2_1997",
        "out_srs":"urn:ogc:def:coordinateMetadata:NRCAN::NAD83_CSRS_2010_UTM19_CGVD2013_2010"
    },
    {
        "type":"writers.text",
        "filename":"outputfile.txt"
    }
]

$ PROJ_NETWORK=ON bin/pdal pipeline pipeline.json

$ cat outputfile.txt 
"X","Y","Z"
356670.104,5540546.584,-0.306
```

hence we get the same results as with gdaltransform and cs2cs with similar invokations
