### PR TITLE
Documentation Dependency Updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,10 @@
 version: 2
 updates:
-	- package-ecosystem: "github-actions"
-	  directory: "/"
-	  schedule:
-	  	interval: daily
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: daily
+  - package-ecosystem: "pip"
+    directory: "/doc"
+    schedule:
+      interval: daily

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,7 +8,7 @@ version: 2
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "3.10"
+    python: "3.11"
   jobs:
     pre_build:
       - doxygen ./doc/doxygen/doxygen.conf 1> /dev/null

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,6 +1,6 @@
-sphinx
+sphinx==7.2.5
 breathe==4.35.0
-sphinxcontrib-bibtex
+sphinxcontrib-bibtex==2.5.0
 sphinx-rtd-theme==1.3.0
-sphinxcontrib-spelling
-sphinx-notfound-page
+sphinxcontrib-spelling==8.0.0
+sphinx-notfound-page==1.0.0

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,6 +1,6 @@
-sphinx==6
-breathe
+sphinx
+breathe==4.35.0
 sphinxcontrib-bibtex
-sphinx_rtd_theme==1.2.2
+sphinx-rtd-theme==1.3.0
 sphinxcontrib-spelling
 sphinx-notfound-page


### PR DESCRIPTION
This PR fixes the case where TABs were placed in `dependabot.yaml`, also adds the `doc/requirements.txt` to the list of files dependabot checks for updates.