### PR TITLE
Fix LasReader to not fetch whole file when only metadata is requested

### DIFF
--- a/io/LasReader.cpp
+++ b/io/LasReader.cpp
@@ -113,14 +113,16 @@ public:
         setg(&*m_range.begin(), &*m_range.begin(), &*m_range.end());
     }
 
-    pos_type seekpos(pos_type sp, std::ios_base::openmode which) override
+    std::istream::pos_type seekpos(std::istream::pos_type sp,
+        std::ios_base::openmode which) override
     {
-        return seekoff(sp - pos_type(off_type(0)), std::ios_base::beg, which);
+        return seekoff(sp - std::istream::pos_type(std::istream::off_type(0)),
+            std::ios_base::beg, which);
     }
 
-    pos_type seekoff(off_type off,
-                     std::ios_base::seekdir dir,
-                     std::ios_base::openmode which = std::ios_base::in) override
+    std::istream::pos_type seekoff(std::istream::off_type off,
+        std::ios_base::seekdir dir,
+        std::ios_base::openmode which = std::ios_base::in) override
     {
         if (dir == std::ios_base::cur)
             gbump(off);


### PR DESCRIPTION
Fixes #4165

This does fix the issue (as written up by myself) but is not necessarily complete - I haven't written any tests, and the reviewer may have opinions about this issue that require further changes - eg there may be other scenarios where doing range requests is better than fetching the whole file, that can be tacked on.

I'm happy to do those things - to address any comments to get it up to PDAL's standard - I'm just starting the discussion here, I don't want to do too much more work until I hear "sounds like a plan" (as opposed to "not something we're interested in") from PDAL team.