### PR TITLE
Add workshop instructions for offline/USB install + small fixes

### DIFF
--- a/doc/workshop/agenda.rst
+++ b/doc/workshop/agenda.rst
@@ -23,28 +23,57 @@ After the basic set up the workshop is divided into three 45 to 90 min sections 
 Materials
 --------------------------------------------------------------------------------
 
-Slides
+USB Drive
 ................................................................................
 
-* `Slides <https://pdal.s3.amazonaws.com/workshop/slides.zip>`__
-
-Workshop Materials
-................................................................................
-
-These materials are available as a PDF and an HTML website.
-
-* `PDF download <https://pdal.s3.amazonaws.com/workshop/PDAL-workshop.pdf>`__
-* `HTML <https://pdal.s3.amazonaws.com/workshop/PDAL-workshop-html.zip>`__
-
-USB Example Data Drive
-................................................................................
-
-A companion USB drive containing workshop example data is required
-to follow along with these examples.
+A companion USB drive containing everything needed to do the workshop without
+internet connectivity
 
 .. image:: ./images/agenda-usb-drive.jpg
+    :width: 400
 
 .. note::
 
     A drive image is available for download at
     https://pdal.s3.amazonaws.com/workshop/PDAL-Workshop-complete.zip
+
+
+Included in the USB driver are
+
+* Installers for QGIS_ and mambaforge_.
+* Conda environments for macOS (x86_64 and arm64) and Windows platforms with needed dependencies
+* Copy of PDAL documentation
+* Collection of cool-lidar_ datasets
+
+Offline Installation Instructions
+.................................
+
+
+#. From the installer directory, install both QGIS_ and mambaforge_
+#. Once mambaforge_ is installed, open a terminal and navigate to the location of your USB drive
+#. Uncompress the environment, activate it, and use the ``conda-unpack`` command
+
+  * macOS Users 
+
+     .. code-block:: bash
+
+        $ mkdir -p "$HOME/mambaforge/envs/pdal-workshop"
+        $ tar -xzf conda_environments/pdal-workshop_osx-arm64.tar.gz -C "$HOME/mambaforge/envs/pdal-workshop"
+        $ source "$HOME/mambaforge/envs/pdal-workshop/bin/activate"
+        (pdal-workshop) $ conda-unpack
+
+  * Windows Users 
+
+     .. code-block:: doscon
+      
+        > mkdir "%userprofile%\mambaforge\envs\pdal-workshop"
+        > tar -xvf ./conda_environments/pdal-workshop-win64.zip -C "%userprofile%\mambaforge\envs\pdal-workshop"
+        > call "%userprofile%\mambaforge\envs\pdal-workshop\scripts\activate"
+        (pdal-workshop) > conda-unpack 
+
+#. Success
+
+
+.. _QGIS: https://www.qgis.org/en/site/
+.. _mambaforge: https://github.com/conda-forge/miniforge#mambaforge
+.. _cool-lidar: https://github.com/hobuinc/cool-lidar

--- a/doc/workshop/agenda.rst
+++ b/doc/workshop/agenda.rst
@@ -40,40 +40,13 @@ internet connectivity
 
 Included in the USB driver are
 
-* Installers for QGIS_ and mambaforge_.
+* Installers for QGIS_, CloudCompare_, and mambaforge_.
 * Conda environments for macOS (x86_64 and arm64) and Windows platforms with needed dependencies
 * Copy of PDAL documentation
+* Data needed for examples
 * Collection of cool-lidar_ datasets
-
-Offline Installation Instructions
-.................................
-
-
-#. From the installer directory, install both QGIS_ and mambaforge_
-#. Once mambaforge_ is installed, open a terminal and navigate to the location of your USB drive
-#. Uncompress the environment, activate it, and use the ``conda-unpack`` command
-
-  * macOS Users 
-
-     .. code-block:: bash
-
-        $ mkdir -p "$HOME/mambaforge/envs/pdal-workshop"
-        $ tar -xzf conda_environments/pdal-workshop_osx-arm64.tar.gz -C "$HOME/mambaforge/envs/pdal-workshop"
-        $ source "$HOME/mambaforge/envs/pdal-workshop/bin/activate"
-        (pdal-workshop) $ conda-unpack
-
-  * Windows Users 
-
-     .. code-block:: doscon
-      
-        > mkdir "%userprofile%\mambaforge\envs\pdal-workshop"
-        > tar -xvf ./conda_environments/pdal-workshop-win64.zip -C "%userprofile%\mambaforge\envs\pdal-workshop"
-        > call "%userprofile%\mambaforge\envs\pdal-workshop\scripts\activate"
-        (pdal-workshop) > conda-unpack 
-
-#. Success
-
 
 .. _QGIS: https://www.qgis.org/en/site/
 .. _mambaforge: https://github.com/conda-forge/miniforge#mambaforge
 .. _cool-lidar: https://github.com/hobuinc/cool-lidar
+.. _CloudCompare: https://www.danielgm.net/cc/

--- a/doc/workshop/conda.rst
+++ b/doc/workshop/conda.rst
@@ -38,6 +38,13 @@ so much, and provides it for Windows, Linux, and macOS.
     previous edition of the workshop was provided using Docker, but it was
     found to be a bit too difficult to follow.
 
+.. note::
+
+    PDAL does not have a python wheel package and thus is distributed via ``conda-forge`` conda 
+    channel. If you would like to know more about the limitations that prevent PDAL from being 
+    distributed as a pip package, you can read about it at the 
+    `pypackaging-native website`_
+
 Installing Conda
 --------------------------------------------------------------------------------
 
@@ -45,20 +52,39 @@ Installing Conda
    home directory (something like ``C:\Users\hobu\PDAL``) or the equivalent for your OS.
    We will refer to this location for the rest of the workshop materials.
 
+2. Download and install the mambaforge_ installer for your platform
 
-2. Download the Conda installer for your OS setup. https://docs.conda.io/en/latest/miniconda.html
+3. After installing mambaforge create your workshop by running
 
+   .. code-block:: doscon
 
-3. After installing Conda, create an environment for PDAL with::
-
-    conda create --name pdalworkshop
-
-
-4. Then *activate* the new environment::
-
-    conda activate pdalworkshop
+      > conda create -c conda-forge -n pdal-workshop 
 
 
-5. Install PDAL, Entwine, and GDAL, and install it from **conda-forge**::
+4. Then *activate* the new environment
+    
+   .. code-block:: doscon
 
-    conda install -c conda-forge pdal python-pdal gdal entwine matplotlib
+      > conda activate pdal-workshop
+
+
+5. Install PDAL, Entwine, and GDAL, and install it from **conda-forge**
+
+   .. code-block:: doscon
+    
+      (pdal-workshop) > mamba install -c conda-forge python-pdal gdal entwine matplotlib
+
+
+Alternatively use the following ``environment.yml`` file to create your environment
+
+  .. literalinclude:: environment.yml
+    :language: yaml
+
+
+  .. note:: 
+
+    The ``conda-pack`` package is used for packaging the pdal-workshop conda environment to go
+    to the USB image, and is not needed otherwise
+
+.. _mambaforge: https://github.com/conda-forge/miniforge#mambaforge
+.. _pypackaging-native website: https://pypackaging-native.github.io/key-issues/native-dependencies/geospatial_stack/

--- a/doc/workshop/conda.rst
+++ b/doc/workshop/conda.rst
@@ -45,7 +45,33 @@ so much, and provides it for Windows, Linux, and macOS.
     distributed as a pip package, you can read about it at the 
     `pypackaging-native website`_
 
-Installing Conda
+
+Installing Conda Environment (Workshop USB)
+--------------------------------------------------------------------------------
+
+#. From the installer directory, install both QGIS_, CloudCompare_, and mambaforge_
+#. Once mambaforge_ is installed, open a terminal and navigate to the location of your USB drive
+#. Uncompress the environment, activate it, and use the ``conda-unpack`` command
+  
+  * macOS Users 
+
+     .. code-block:: bash
+
+        $ mkdir -p "$HOME/mambaforge/envs/pdal-workshop"
+        $ tar -xzf conda_environments/pdal-workshop_osx-arm64.tar.gz -C "$HOME/mambaforge/envs/pdal-workshop"
+        $ source "$HOME/mambaforge/envs/pdal-workshop/bin/activate"
+        (pdal-workshop) $ conda-unpack
+  * Windows Users 
+
+     .. code-block:: doscon
+      
+        > mkdir "%userprofile%\mambaforge\envs\pdal-workshop"
+        > tar -xvf ./conda_environments/pdal-workshop-win64.zip -C "%userprofile%\mambaforge\envs\pdal-workshop"
+        > call "%userprofile%\mambaforge\envs\pdal-workshop\scripts\activate"
+        (pdal-workshop) > conda-unpack 
+
+
+Installing Conda 
 --------------------------------------------------------------------------------
 
 1. Copy the entire contents of your workshop USB key to a ``PDAL`` directory in your
@@ -88,3 +114,6 @@ Alternatively use the following ``environment.yml`` file to create your environm
 
 .. _mambaforge: https://github.com/conda-forge/miniforge#mambaforge
 .. _pypackaging-native website: https://pypackaging-native.github.io/key-issues/native-dependencies/geospatial_stack/
+.. _QGIS: https://www.qgis.org/en/site/
+.. _cool-lidar: https://github.com/hobuinc/cool-lidar
+.. _CloudCompare: https://www.danielgm.net/cc/

--- a/doc/workshop/environment.yml
+++ b/doc/workshop/environment.yml
@@ -1,0 +1,11 @@
+name: pdal-workshop
+channels:
+  - conda-forge
+dependencies:
+  - python=3.11
+  - pdal=2.5.6
+  - python-pdal
+  - gdal
+  - untwine
+  - geopandas
+  - conda-pack

--- a/doc/workshop/generation/batch_processing/batch-processing.rst
+++ b/doc/workshop/generation/batch_processing/batch-processing.rst
@@ -111,7 +111,7 @@ using the substitutions syntax to do this.
 
  .. code-block:: console
 
-  PS ./exercises/batch> Get-ChildItem  ./exercises/batch/source/*.laz | ^
+  PS ./exercises/batch> Get-ChildItem  ./exercises/batch_processing/source/*.laz | ^
   foreach {pdal pipeline ./exercises/batch/batch_srs_gdal.json ^
   --readers.las.filename=./source/$($_.BaseName).laz ^
   --writers.gdal.filename=./dtm/$($_.BaseName).tif ^

--- a/doc/workshop/generation/batch_processing/batch-processing.rst
+++ b/doc/workshop/generation/batch_processing/batch-processing.rst
@@ -39,9 +39,9 @@ To compress a series of LAS files in one directory into compressed LAZ files in 
 directory, the `PowerShell` syntax would be:
 
 
-.. code-block:: console
+.. code-block:: powershell
 
-  Get-ChildItem .\DIR1\*.las | foreach {pdal translate -i .\DIR1\$($_.BaseName).las ^
+  PS ./exercises/batch> Get-ChildItem .\DIR1\*.las | foreach {pdal translate -i .\DIR1\$($_.BaseName).las ^
   -o .\DIR2\$($_.BaseName).laz}
 
 Note the use of the `$($_.BaseName)` syntax for the files passed. This option on the `$($_)` shortcut for
@@ -56,9 +56,9 @@ time. There is a free download of the `xargs` program that provides parallel exe
 at http://www.pirosa.co.uk/demo/wxargs/ppx2.exe. A clone of this program can be found at https://github.com/ghuls/ppx2.
 For this tool, the file names are passed with using the `{}` syntax.
 
-.. code-block:: console
+.. code-block:: powershell
 
-  Get-ChildItem .\dir1\ | Select-Object -ExpandProperty BaseName ^
+  PS ./exercises/batch> Get-ChildItem .\dir1\ | Select-Object -ExpandProperty BaseName ^
   | .\ppx2.exe -P 3 pdal translate -i ".\dir1\{}.las" -o ".\dir2\{}.laz"
 
 
@@ -109,10 +109,10 @@ You might have spotted that this pipeline doesn't have any input or output file 
 output spatial reference. We will be adding those at the command line, not within the actual pipeline and
 using the substitutions syntax to do this.
 
- .. code-block:: console
+ .. code-block:: powershell
 
   PS ./exercises/batch> Get-ChildItem  ./exercises/batch_processing/source/*.laz | ^
-  foreach {pdal pipeline ./exercises/batch/batch_srs_gdal.json ^
+  foreach {pdal pipeline ./exercises/batch_processing/batch_srs_gdal.json ^
   --readers.las.filename=./source/$($_.BaseName).laz ^
   --writers.gdal.filename=./dtm/$($_.BaseName).tif ^
   --filters.reprojection.in_srs=epsg:3794 ^

--- a/doc/workshop/introduction/metadata.rst
+++ b/doc/workshop/introduction/metadata.rst
@@ -97,10 +97,12 @@ gives us that, but it also gives us a bunch of other stuff we don't need
 at the moment. Let's focus on extracting what we want using the
 ``jq`` command.
 
-If you do not have `jq`_ installed into your Conda environment and are not on Windows, 
-run the following command in your `Conda Shell`: ``conda install -c conda-forge jq``.
-Windows users should use `this link <https://github.com/jqlang/jq/releases/download/jq-1.6/jq-win64.exe>`_
-to install `jq`_
+.. note::
+
+    If you do not have `jq`_ installed into your Conda environment and are not on Windows, 
+    run the following command in your `Conda Shell`: ``conda install -c conda-forge jq``.
+    Windows users should use `this link <https://github.com/jqlang/jq/releases/download/jq-1.7/jq-win64.exe>`_
+    to install `jq`_
 
 .. code-block:: console
 
@@ -116,6 +118,7 @@ to install `jq`_
 
 
 Output:
+
 .. code-block:: console
         
     false


### PR DESCRIPTION
Modify the workshop instructions page to include instructions on how to utilize the installers that will be available on the USB drives provided.

Also included some other updates. 