### PR TITLE
COPC/LAS: legacy return counts for LAS1.4/PDRF>=6

### DIFF
--- a/io/LasReader.cpp
+++ b/io/LasReader.cpp
@@ -139,6 +139,11 @@ const LasHeader& LasReader::header() const
     return d->apiHeader;
 }
 
+const las::Header& LasReader::lasHeader() const
+{
+    return d->header;
+}
+
 uint64_t LasReader::vlrData(const std::string& userId, uint16_t recordId, char const * & data)
 {
     const las::Vlr *vlr = las::findVlr(userId, recordId, d->vlrs);

--- a/io/LasReader.hpp
+++ b/io/LasReader.hpp
@@ -60,6 +60,8 @@ class LasHeader;
 
 class PDAL_DLL LasReader : public Reader, public Streamable
 {
+    friend class LasTester;
+
 protected:
     class LasStreamIf
     {
@@ -120,6 +122,8 @@ private:
     void loadPointV14(PointRef& point, char *buf, size_t bufsize);
     void loadExtraDims(LeExtractor& istream, PointRef& data);
     point_count_t readFileBlock(std::vector<char>& buf, point_count_t maxPoints);
+
+    const las::Header& lasHeader() const;
 
     struct Options;
     struct Private;

--- a/io/private/las/Header.cpp
+++ b/io/private/las/Header.cpp
@@ -148,8 +148,12 @@ void Header::setPointsByReturn(int returnNum, uint64_t pointCount)
 {
     ePointsByReturn[returnNum] = pointCount;
     if (returnNum < LegacyReturnCount)
-        legacyPointsByReturn[returnNum] =
-            (pointCount <= (std::numeric_limits<uint32_t>::max)()) ? (uint32_t)pointCount : 0;
+    {
+        bool condition = (pointCount <= (std::numeric_limits<uint32_t>::max)()) &&
+            !((versionMinor >= 4) && (pointFormat() >= 6) );
+
+        legacyPointsByReturn[returnNum] = condition ? (uint32_t)pointCount : 0;
+    }
 }
 
 } // namespace las

--- a/test/unit/io/LasWriterTest.cpp
+++ b/test/unit/io/LasWriterTest.cpp
@@ -2245,45 +2245,60 @@ TEST(LasWriterTest, issue2235)
     // Read
     Options readerOps;
     readerOps.add("filename", Support::datapath("las/4_1.las"));
+    const int returnsWithPoints = 4;
 
     LasReader reader;
     reader.setOptions(readerOps);
 
+    LasTester tester;
+
     // Write with point data record < 6
-    Options writerOps41;
-    writerOps41.add("filename", Support::temppath("out_4_1.las"));
-    writerOps41.add("minor_version", 4);
-    writerOps41.add("dataformat_id", 1);
+    {
+        Options writerOps41;
+        writerOps41.add("filename", Support::temppath("out_4_1.las"));
+        writerOps41.add("minor_version", 4);
+        writerOps41.add("dataformat_id", 1);
 
-    LasWriter writer41;
-    writer41.setInput(reader);
-    writer41.setOptions(writerOps41);
+        LasWriter writer41;
+        writer41.setInput(reader);
+        writer41.setOptions(writerOps41);
 
-    PointTable table41;
-    writer41.prepare(table41);
-    writer41.execute(table41);
+        PointTable table41;
+        writer41.prepare(table41);
+        writer41.execute(table41);
 
-    LasTester tester41;
-    const las::Header& h41 = tester41.header(writer41);
-    EXPECT_EQ(h41.legacyPointCount, (int32_t)h41.pointCount());
+        const las::Header& h41 = tester.header(writer41);
+        EXPECT_EQ(h41.legacyPointCount, (int32_t)h41.pointCount());
+
+        for (int i=0; i<h41.LegacyReturnCount; i++)
+            EXPECT_EQ(h41.legacyPointsByReturn[i], h41.ePointsByReturn[i]);
+    }
 
     // Write with point data record >= 6
-    Options writerOps46;
-    writerOps46.add("filename", Support::temppath("out_4_6.las"));
-    writerOps46.add("minor_version", 4);
-    writerOps46.add("dataformat_id", 6);
+    {
+        Options writerOps46;
+        writerOps46.add("filename", Support::temppath("out_4_6.las"));
+        writerOps46.add("minor_version", 4);
+        writerOps46.add("dataformat_id", 6);
 
-    LasWriter writer46;
-    writer46.setInput(reader);
-    writer46.setOptions(writerOps46);
+        LasWriter writer46;
+        writer46.setInput(reader);
+        writer46.setOptions(writerOps46);
 
-    PointTable table46;
-    writer46.prepare(table46);
-    writer46.execute(table46);
+        PointTable table46;
+        writer46.prepare(table46);
+        writer46.execute(table46);
 
-    LasTester tester46;
-    const las::Header& h46 = tester46.header(writer46);
+        const las::Header& h46 = tester.header(writer46);
 
-    EXPECT_EQ(h46.legacyPointCount, 0);
-    EXPECT_NE(h46.pointCount(), 0);
+        EXPECT_EQ(h46.legacyPointCount, 0);
+        EXPECT_NE(h46.pointCount(), 0);
+
+        for (int i=0; i<h46.LegacyReturnCount; i++)
+        {
+            EXPECT_EQ(h46.legacyPointsByReturn[i], 0);
+            if (i < returnsWithPoints)
+                EXPECT_NE(h46.ePointsByReturn[i], 0);
+        }
+    }
 }


### PR DESCRIPTION
Fixes #2235 

* The changes in #4133 only fixed the overall legacy point count, not the legacy point counts by return fields. Zero those too.
* COPC has a different writer altogether from LAS, and [all COPC files are LAS1.4 & PDRF>=6](https://github.com/copcio/copcio.github.io#implementation). Always zero both the legacy point count and legacy point counts by return fields.

Relevant LAS spec excerpts (v1.4 r15 §2.4):

> **Legacy Number of Point Records**
> This field contains the total number of point records within the file
> if the file is maintaining legacy compatibility, the number of points
> is no greater than UINT32_MAX, and the Point Data Record Format is
> less than 6. Otherwise, it must be set to zero.
>
> **Legacy Number of Points by Return**
> These fields contain an array of the total point records per return if
> the file is maintaining legacy compatibility, the number of points is
> no greater than UINT32_MAX, and the Point Data Record Format is less
> than 6. Otherwise, each member of the array must be set to zero.

Also silences warnings from lastools:

```
WARNING: point type is 6 but (legacy) number of point records in header is 198975 instead zero.
WARNING: point type is 6 but (legacy) number of points by return [1] in header is 99237 instead zero.
WARNING: point type is 6 but (legacy) number of points by return [2] in header is 58815 instead zero.
WARNING: point type is 6 but (legacy) number of points by return [3] in header is 31030 instead zero.
WARNING: point type is 6 but (legacy) number of points by return [4] in header is 9893 instead zero.
```