### PR TITLE
Improve detection of libunwind on macOS

### DIFF
--- a/cmake/modules/FindLibunwind.cmake
+++ b/cmake/modules/FindLibunwind.cmake
@@ -2,14 +2,21 @@
 # ~~~~~~~~~
 # CMake module to search for LIBUNWIND
 #
- 
-find_library(LIBUNWIND_LIBRARY unwind)
+
 find_path(LIBUNWIND_INCLUDE_DIR libunwind.h)
 
-find_package_handle_standard_args(LIBUNWIND REQUIRED_VARS
-    LIBUNWIND_LIBRARY LIBUNWIND_INCLUDE_DIR)
+if(NOT APPLE)
+  find_library(LIBUNWIND_LIBRARY unwind)
+  find_package_handle_standard_args(
+    LIBUNWIND REQUIRED_VARS LIBUNWIND_LIBRARY LIBUNWIND_INCLUDE_DIR)
+else()
+  find_package_handle_standard_args(LIBUNWIND
+                                    REQUIRED_VARS LIBUNWIND_INCLUDE_DIR)
+endif()
 
-if (LIBUNWIND_FOUND)
-  set(LIBUNWIND_LIBRARIES ${LIBUNWIND_LIBRARY})
+if(LIBUNWIND_FOUND)
+  if(LIBUNWIND_LIBRARY)
+    set(LIBUNWIND_LIBRARIES ${LIBUNWIND_LIBRARY})
+  endif()
   set(LIBUNWIND_INCLUDE_DIRS ${LIBUNWIND_INCLUDE_DIR})
 endif()


### PR DESCRIPTION
`libunwind` is part of the system since Mac OS X 10.6 (2009), it is sufficient to find only the include file 'libunwind.h'.

This follows the logic implemented in 'FindLibexecinfo.cmake'.

The CI build log shows the present faulty behaviour:

```
2023-09-28T18:14:17.0335100Z -- Could NOT find LIBUNWIND (missing: LIBUNWIND_LIBRARY) 

...

2023-09-28T18:14:17.0727280Z -- The following OPTIONAL packages have not been found:
2023-09-28T18:14:17.0727680Z 
2023-09-28T18:14:17.0727940Z  * Libunwind

```