### PR TITLE
Eliminate ambiguity in code readability #3997

### DIFF
--- a/cmake/gdal.cmake
+++ b/cmake/gdal.cmake
@@ -20,9 +20,9 @@ if (GDAL_FOUND)
     #
     # Older versions of FindGDAL.cmake don't properly set GDAL_VERSION
     #
-    if (GDAL_VERSION VERSION_LESS 3.0.0)
+    if (GDAL_VERSION VERSION_LESS 3.4.0)
         message(FATAL_ERROR
-            "Found GDAL version ${GDAL_VERSION}.  Version 3.0+ is required")
+            "Found GDAL version ${GDAL_VERSION}.  Version 3.4+ is required")
     endif()
     mark_as_advanced(CLEAR GDAL_INCLUDE_DIR)
     mark_as_advanced(CLEAR GDAL_LIBRARY)


### PR DESCRIPTION
#3997

Although error messages with GDAL3.0.4 are
```
CMake Error at /usr/share/cmake-3.16/Modules/FindPackageHandleStandardArgs.cmake:146 (message):
  Could NOT find GDAL: Found unsuitable version "3.0.4", but required is at
  least "3.4" (found /usr/lib/libgdal.so)
```

I think the comparation part should stay with the new version.

In fact, as the `find_package(GDAL 3.0 REQUIRED)` line will generate error messages, is it necessary to keep the comparation part `if...endif()`?