### PR TITLE
Specialization for projected bounds query in COPC/EPT readers

### DIFF
--- a/io/EptReader.cpp
+++ b/io/EptReader.cpp
@@ -683,32 +683,6 @@ bool EptReader::hasSpatialFilter() const
 // Determine if an EPT tile overlaps our query boundary
 bool EptReader::passesSpatialFilter(const BOX3D& tileBounds) const
 {
-    /*
-    // Reproject the tile bounds to the largest rect. solid that contains all the corners.
-    auto reproject = [](BOX3D src, SrsTransform& xform) -> BOX3D
-    {
-        if (!xform.valid())
-            return src;
-
-        BOX3D b;
-        auto reprogrow = [&b, &xform](double x, double y, double z)
-        {
-            xform.transform(x, y, z);
-            b.grow(x, y, z);
-        };
-
-        reprogrow(src.minx, src.miny, src.minz);
-        reprogrow(src.maxx, src.miny, src.minz);
-        reprogrow(src.minx, src.maxy, src.minz);
-        reprogrow(src.maxx, src.maxy, src.minz);
-        reprogrow(src.minx, src.miny, src.maxz);
-        reprogrow(src.maxx, src.miny, src.maxz);
-        reprogrow(src.minx, src.maxy, src.maxz);
-        reprogrow(src.maxx, src.maxy, src.maxz);
-        return b;
-    };
-    */
-
     auto boxOverlaps = [this, &tileBounds]() -> bool
     {
         if (!m_p->bounds.box.valid())

--- a/io/EptReader.cpp
+++ b/io/EptReader.cpp
@@ -261,15 +261,18 @@ void EptReader::initialize()
     // Create transformations from our source data to the bounds SRS.
     if (m_args->m_bounds.valid())
     {
+        const SpatialReference& boundsSrs = m_args->m_bounds.spatialReference();
         if (m_args->m_bounds.is2d())
         {
+            if (boundsSrs.isGeographic() && !getSpatialReference().isGeographic())
+                throwError("For lon/lat 'bounds', bounds must be 3D");
+
             m_p->bounds.box = BOX3D(m_args->m_bounds.to2d());
             m_p->bounds.box.minz = (std::numeric_limits<double>::lowest)();
             m_p->bounds.box.maxz = (std::numeric_limits<double>::max)();
         }
         else
             m_p->bounds.box = m_args->m_bounds.to3d();
-        const SpatialReference& boundsSrs = m_args->m_bounds.spatialReference();
         if (boundsSrs.valid() && m_p->info->srs().valid())
             m_p->bounds.xform = SrsTransform(m_p->info->srs(), boundsSrs);
     }


### PR DESCRIPTION
The COPC/EPT readers have an implicit assumption, when supplied with `bounds` which are a different SRS from the data, that accumulating the mins/maxes of the cubic node corners reprojected into the query SRS is accurate for determining overlapping nodes.  This is generally true for projected SRSes but can be incorrect for combinations of geographic/geocentric/projected systems.

This PR only corrects a single combination which was incorrect before: where the data is in BCBF but the bounds query is in geographic.  There may need to be specializations for other combinations in the future.  For now, these implementations are duplicated across the COPC/EPT readers, and another future enhancement would be to combine a lot of the common functionality between these readers.  It is not just the new code, there is a lot of duplicated code there so that's out of scope for this PR.

This code also needs a unit test - this could be simple since prior to this specialization, data about 45 degrees north or south of the equator would be missed for full-body global data in BCBF when queried in lon/lat.