### PR TITLE
Remove unwanted include in georeference filter

### DIFF
--- a/filters/private/georeference/LocalCartesian.cpp
+++ b/filters/private/georeference/LocalCartesian.cpp
@@ -36,11 +36,6 @@
 #include <ogr_spatialref.h>
 #include <ostream>
 
-#if PROJ_AT_LEAST_VERSION(9, 3, 0)
-#include "proj/util.hpp" // for nn_dynamic_pointer_cast
-#else
-#endif
-
 namespace pdal
 {
 namespace georeference


### PR DESCRIPTION
As @xiaodong2077 pointed out in #4109, removing extra include that are not used.