### PR TITLE
change the option name of e57 to follow check rules

### DIFF
--- a/doc/stages/writers.e57.rst
+++ b/doc/stages/writers.e57.rst
@@ -40,7 +40,7 @@ Example
       {
           "type":"writers.e57",
           "filename":"outputfile.e57",
-            "doublePrecision":false
+            "double_precision":false
       }
   ]
 
@@ -51,7 +51,7 @@ Options
 _`filename`
   E57 file to write [Required]
 
-doublePrecision
+double_precision
   Use double precision for storage (false by default).
 
 .. include:: writer_opts.rst

--- a/plugins/e57/io/E57Writer.cpp
+++ b/plugins/e57/io/E57Writer.cpp
@@ -146,7 +146,7 @@ std::string E57Writer::getName() const
 void E57Writer::addArgs(ProgramArgs& args)
 {
     args.add("filename", "Output filename", m_filename).setPositional();
-    args.add("doublePrecision",
+    args.add("double_precision",
              "Double precision for storage (false by default)", m_doublePrecision);
     args.add("extra_dims", "Extra dimensions to write to E57 data",
              m_extraDimsSpec);


### PR DESCRIPTION
fix this error:
```
PDAL: Invalid option name 'doublePrecision'.  Options must consist of only lowercase letters, numbers and '_'.

pdal: ../pdal/Options.cpp:83: void pdal::Options::add(const pdal::Option&): Assertion `Option::nameValid(option.getName(), true)' failed.
Aborted (core dumped)
```

