### PR TITLE
Update ground.rst

### DIFF
--- a/doc/workshop/manipulation/ground/ground.rst
+++ b/doc/workshop/manipulation/ground/ground.rst
@@ -80,7 +80,7 @@ technique we learned about in :ref:`workshop-denoising`.
         ./exercises/analysis/ground/CSite1_orig-utm.laz \
         -o ./exercises/analysis/ground/ground.copc.laz \
         smrf expression \
-        --filters.expression.expression="Classification == 2"\
+        --filters.expression.expression="Classification == 2" \
         -v 4
 
     .. code-block:: doscon
@@ -90,7 +90,7 @@ technique we learned about in :ref:`workshop-denoising`.
         ./exercises/analysis/ground/CSite1_orig-utm.laz ^
         -o ./exercises/analysis/ground/ground.copc.laz ^
         smrf expression ^
-        --filters.expression.expression="Classification == 2"^
+        --filters.expression.expression="Classification == 2" ^
         -v 4
 
 2. Now we will instead use the :ref:`translate_command` command to stack the


### PR DESCRIPTION
Missing spaces before shell newline indicator results in error

```
PDAL: Couldn't create filter stage of type 'filters.4'.
You probably have a version of PDAL that didn't come with a plugin
you're trying to load.  Please see the FAQ at https://pdal.io/faq.html
```