### PR TITLE
Set while condition for LiTree to be larger than min points

### DIFF
--- a/filters/LiTreeFilter.cpp
+++ b/filters/LiTreeFilter.cpp
@@ -279,7 +279,7 @@ void LiTreeFilter::filter(PointView& view)
 
     // "...stop when Ui is empty."
     int64_t tree_id(1);
-    while (Ui.size() > 1)
+    while (Ui.size() > m_minSize)
     {
         // "We find the highest point t0 (global maximum) in Ui, which is assumed
         // to be the top of the tallest tree i in Ui."


### PR DESCRIPTION
Set exit condition so LiTree doesn't get stuck when number of points left are fewer than `min_points`. 

I explain the meat if the issue in [#4217](https://github.com/PDAL/PDAL/issues/4217), but basically LiTree never terminates, and needs some kind of exit condition. 

I submitted this without testing, will get to that soon. 