### PR TITLE
Fix readers.stac doing head requests before necessary

### DIFF
--- a/io/private/stac/Item.cpp
+++ b/io/private/stac/Item.cpp
@@ -186,6 +186,11 @@ std::string Item::extractDriverFromItem(const NL::json& asset) const
                 return ct.second;
     }
 
+    // Try to guess from the path
+    std::string driver = m_factory.inferReaderDriver(dataUrl);
+    if (driver.size())
+        return driver;
+
     if (!FileUtils::fileExists(dataUrl))
     {
         // Use this to test if dataUrl is a valid endpoint
@@ -207,11 +212,6 @@ std::string Item::extractDriverFromItem(const NL::json& asset) const
                 ". " + e.what());
         }
     }
-
-    // Try to guess from the path
-    std::string driver = m_factory.inferReaderDriver(dataUrl);
-    if (driver.size())
-        return driver;
 
     return output;
 }


### PR DESCRIPTION
STAC Item class was doing a HEAD request before exhausting all other options when determining what PDAL driver to use, which was causing a massive slowdown, especially in particularly large `FeatureCollections`. 

Fixed by moving `m_factory.inferReaderDriver(dataUrl);` to before the head request.