### PR TITLE
Allow pdal to link with CURL target

### DIFF
--- a/vendor/arbiter/CMakeLists.txt
+++ b/vendor/arbiter/CMakeLists.txt
@@ -12,9 +12,17 @@ target_include_directories(${PDAL_ARBITER_LIB_NAME}
     PRIVATE
         ${NLOHMANN_INCLUDE_DIR}
 )
+
+if (NOT TARGET CURL::libcurl)
+    add_library(CURL::libcurl UNKNOWN IMPORTED)
+    set_target_properties(CURL::libcurl
+        PROPERTIES
+            IMPORTED_LOCATION "${CURL_LIBRARIES}")
+endif ()
+
 target_link_libraries(${PDAL_ARBITER_LIB_NAME}
     PRIVATE
-        ${CURL_LIBRARIES}
+        CURL::libcurl
 )
 target_compile_definitions(${PDAL_ARBITER_LIB_NAME}
     PRIVATE


### PR DESCRIPTION
Hello,

When I'm building pdal with curl 7.88, pdal is unable to link with curl. 
This MR tries to fix that, by allowing CURL::libcurl to be link instead of CURL_LIBRARIES (with a fallback if the target doesn't exist).