### PR TITLE
add 'ogr' block to filters.geomdistance

### DIFF
--- a/doc/stages/filters.geomdistance.rst
+++ b/doc/stages/filters.geomdistance.rst
@@ -58,6 +58,9 @@ dimension
   The dimension to write the distance into
   bounds or polygon. [Default: distance]
 
+ogr
+  An `ogr` block (described in :ref:`readers.ept`)
+
 ring
   Use the outer ring of the polygon (so as to get distances to the exterior
   ring instead of all points inside the polygon having distance ``0``).


### PR DESCRIPTION
It's much simpler to use OGR to define the polygon to select than pasting in GeoJSON/WKT. This PR allows you to use the same `ogr` block that's in `readers.ept`. Note that it only selects the *first* polygon in the selection set. Use OGR SQL if you need to grab a specific polygon from the file.

```
    {
        "type": "filters.geomdistance",
        "ogr": {
            "datasource": "mygeometries.geojson"
            },
        "ring":"true"
    },

```