### PR TITLE
Add streaming tutorial

### DIFF
--- a/doc/development/overview.rst
+++ b/doc/development/overview.rst
@@ -101,11 +101,12 @@ pipeline stages are executed.  Most functions receive a PointTableRef object,
 which refers to the active point table.  A PointTableRef can be stored
 or copied cheaply.
 
-A subclass of PointTable called StreamingPointTable exists to allow a pipeline
-to run without loading all points in memory.  A StreamingPointTable holds a
+A subclass of PointTable called FixedPointTable exists to allow a pipeline
+to run without loading all points in memory.  A FixedPointTable holds a
 fixed number of points.  Some filters can't operate in streaming mode and
 an attempt to run a pipeline with a stage that doesn't support streaming
-will raise an exception.
+will raise an exception. A custom implementation of this can be created
+by inheriting from a class called StreamPointTable.
 
 Point View
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/development/writing.rst
+++ b/doc/development/writing.rst
@@ -92,3 +92,11 @@ After the project is built, you can run it by typing:
 .. code-block:: bash
 
   $ ./tutorial
+
+Streaming
+-------------------------------------------------------------------------------
+
+Writing in streaming mode creates and writes the cloud one point at a time,
+and the implementation is somewhat different. An example is given in 
+``examples/writing-streamer``.
+

--- a/examples/writing-streamer/CMakeLists.txt
+++ b/examples/writing-streamer/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.6)
+project(StreamerTutorial)
+
+find_package(PDAL 2.0.0 REQUIRED CONFIG)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+add_executable(streamer_tutorial streamer_tutorial.cpp)
+
+target_link_libraries(streamer_tutorial PRIVATE ${PDAL_LIBRARIES})
+target_include_directories(streamer_tutorial PRIVATE
+    ${PDAL_INCLUDE_DIRS}
+    ${PDAL_INCLUDE_DIRS}/pdal)
+

--- a/examples/writing-streamer/streamer_tutorial.cpp
+++ b/examples/writing-streamer/streamer_tutorial.cpp
@@ -1,0 +1,131 @@
+#include <pdal/PointView.hpp>
+#include <pdal/PointTable.hpp>
+#include <pdal/Options.hpp>
+#include <pdal/StageFactory.hpp>
+#include <pdal/Streamable.hpp>
+#include <pdal/Reader.hpp>
+
+#include <vector>
+
+namespace pdal {
+    
+// A class to produce a point cloud point-by-point, rather than
+// having it all in memory at the same time. It will be streamed to
+// disk. See the GDALReader class for how to add more fields
+// and read from disk.
+class PDAL_DLL StreamedPointCloud : public Reader, public Streamable
+{
+public:
+    std::string getName() const;
+    StreamedPointCloud();
+    ~StreamedPointCloud();
+
+private:
+    virtual void initialize();
+    virtual void addDimensions(PointLayoutPtr layout);
+    virtual void ready(PointTableRef table);
+    virtual point_count_t read(PointViewPtr view, point_count_t num);
+    virtual void done(PointTableRef table);
+    virtual bool processOne(PointRef& point);
+    virtual void addArgs(ProgramArgs& args);
+
+    point_count_t m_count, m_size;
+};
+    
+std::string StreamedPointCloud::getName() const
+{
+    return "streamed_point_cloud";
+}
+
+StreamedPointCloud::StreamedPointCloud()
+    : m_count(0), m_size(0)
+{}
+
+StreamedPointCloud::~StreamedPointCloud()
+{
+}
+
+// Set the size of the cloud. Will ask for a point till the counter
+// reaches this size.
+void StreamedPointCloud::initialize()
+{
+    m_size = 5;
+}
+
+// Set the cloud dimensions. Only X, Y and Z are supported.
+void StreamedPointCloud::addDimensions(PointLayoutPtr layout)
+{
+    layout->registerDim(pdal::Dimension::Id::X);
+    layout->registerDim(pdal::Dimension::Id::Y);
+    layout->registerDim(pdal::Dimension::Id::Z);
+}
+
+void StreamedPointCloud::addArgs(ProgramArgs& args)
+{
+}
+
+void StreamedPointCloud::ready(PointTableRef table)
+{
+    m_count = 0;
+}
+
+// This function is used when a point cloud is formed fully in memory.
+// Not applicable here.
+point_count_t StreamedPointCloud::read(PointViewPtr view, point_count_t numPts)
+{
+    throw pdal_error("The read() function must not be called in streaming mode.");
+    return -1;
+}
+
+// Create one point at a time.
+bool StreamedPointCloud::processOne(PointRef& point)
+{
+    if (m_count == m_size)
+        return false; // done
+
+    double x = m_count * 0.1;
+    double y = m_count * 0.2;
+    double z = m_count * 0.3;
+    
+    point.setField(Dimension::Id::X, x);
+    point.setField(Dimension::Id::Y, y);
+    point.setField(Dimension::Id::Z, z);
+
+    m_count++;
+    return true;
+}
+
+void StreamedPointCloud::done(PointTableRef table)
+{
+}
+
+} // end namespace pdal
+
+int main(int argc, char* argv[])
+{
+    using namespace pdal;
+    
+    // A point cloud. Only one point at a time will be in memory
+    StreamedPointCloud gr;
+
+    // Will copy here each point and then stream it to disk    
+    FixedPointTable t(1);
+    gr.prepare(t);
+
+    // Set the output filename
+    Options write_options;
+    write_options.add("filename", "output.las");
+    
+    // StageFactory always "owns" stages it creates. They'll be destroyed with
+    // the factory.
+    StageFactory factory;
+    Stage *writer = factory.createStage("writers.las");
+
+    // Stream the point cloud to disk
+    writer->setInput(gr);
+    writer->setOptions(write_options);
+    writer->prepare(t);
+    writer->execute(t);
+ 
+    return 0;   
+}

--- a/examples/writing-streamer/streamer_tutorial.cpp
+++ b/examples/writing-streamer/streamer_tutorial.cpp
@@ -106,11 +106,11 @@ int main(int argc, char* argv[])
     using namespace pdal;
     
     // A point cloud. Only one point at a time will be in memory
-    StreamedPointCloud gr;
+    StreamedPointCloud stream_cloud;
 
     // Will copy here each point and then stream it to disk    
     FixedPointTable t(1);
-    gr.prepare(t);
+    stream_cloud.prepare(t);
 
     // Set the output filename
     Options write_options;
@@ -122,7 +122,7 @@ int main(int argc, char* argv[])
     Stage *writer = factory.createStage("writers.las");
 
     // Stream the point cloud to disk
-    writer->setInput(gr);
+    writer->setInput(stream_cloud);
     writer->setOptions(write_options);
     writer->prepare(t);
     writer->execute(t);

--- a/examples/writing-streamer/streamer_tutorial.cpp
+++ b/examples/writing-streamer/streamer_tutorial.cpp
@@ -49,10 +49,10 @@ StreamedPointCloud::~StreamedPointCloud()
 // reaches this size.
 void StreamedPointCloud::initialize()
 {
-    m_size = 5;
+    m_size = 500;
 }
 
-// Set the cloud dimensions. Only X, Y and Z are supported.
+// Set the cloud dimensions.
 void StreamedPointCloud::addDimensions(PointLayoutPtr layout)
 {
     layout->registerDim(pdal::Dimension::Id::X);
@@ -108,8 +108,12 @@ int main(int argc, char* argv[])
     // A point cloud. Only one point at a time will be in memory
     StreamedPointCloud stream_cloud;
 
-    // Will copy here each point and then stream it to disk    
-    FixedPointTable t(1);
+    // Will copy here each point and then stream it to disk.
+    // buf_size is the number of points that will be
+    // processed and kept in memory at the same time. 
+    // A somewhat bigger value may result in some efficiencies.
+    int buf_size = 5;
+    FixedPointTable t(buf_size);
     stream_cloud.prepare(t);
 
     // Set the output filename

--- a/examples/writing-streamer/streamer_tutorial.cpp
+++ b/examples/writing-streamer/streamer_tutorial.cpp
@@ -105,12 +105,11 @@ int main(int argc, char* argv[])
 {
     using namespace pdal;
     
-    // A point cloud. Only one point at a time will be in memory
+    // Streamed cloud structure
     StreamedPointCloud stream_cloud;
 
-    // Will copy here each point and then stream it to disk.
     // buf_size is the number of points that will be
-    // processed and kept in memory at the same time. 
+    // processed and kept in this table at the same time. 
     // A somewhat bigger value may result in some efficiencies.
     int buf_size = 5;
     FixedPointTable t(buf_size);

--- a/pdal/PointTable.hpp
+++ b/pdal/PointTable.hpp
@@ -274,6 +274,8 @@ private:
     std::vector<bool> m_skips;
 };
 
+// A concrete implementation of StreamPointTable that uses a fixed-size
+// buffer for point data.
 class PDAL_DLL FixedPointTable : public StreamPointTable
 {
 public:


### PR DESCRIPTION
This adds an example to PDAL for how to create and stream to disk a cloud point-by-point. I think this is an important use case since clouds are often too big to fit in memory.  The background on this is in https://github.com/PDAL/PDAL/issues/4234.

I also made a small documentation fix replacing the mention of StreamingPointTable with FixedPointTable, as the latter is the real workhorse for streaming unless the user needs some custom logic.

This was tested with PDAL 2.6.0 as fetched with conda.

Happy to hear any feedback and iterate. 