### PR TITLE
Correct metadata point counts for remote-las-file optimization

### DIFF
--- a/kernels/private/PointlessLas.hpp
+++ b/kernels/private/PointlessLas.hpp
@@ -42,9 +42,17 @@
 namespace pdal
 {
 
+struct PointlessLas
+{
+    uint64_t pointCount;
+    std::unique_ptr<arbiter::LocalHandle> handle;
+};
+
 // Uses arbiter to make range requests to fetch the LAS header and VLRs of a remote LAS file.
 // Returns a LocalHandle to a temporary file that has the same LAS header / VLRs as the remote
 // file (except for changed byte-offsets where necessary) but doesn't contain any points.
-std::unique_ptr<arbiter::LocalHandle> getPointlessLasFile(const std::string& filename);
+// Since the points are removed from the result, and the header values for point count are
+// zeroed to make the file correct, we return the point count alongside the pointless file.
+PointlessLas getPointlessLasFile(const std::string& filename);
 
 } // namespace pdal


### PR DESCRIPTION
`pdal info` with `--metadata` and `--summary` flags was (correctly) emitting point counts of zero after #4249, which set the header point count values to 0 to keep our zero-point LAS file valid.  This PR returns the point count separately while it creates the zero-point LAS file so we can correct this value in our metadata.  This is all a little messy but with the special zero-point LAS file stuff it seems to be the only way to do it.