### PR TITLE
new filter : calculate 2d/3d  relative distance and height to target pointcloud

### DIFF
--- a/filters/DisAndHeightToTarget.cpp
+++ b/filters/DisAndHeightToTarget.cpp
@@ -1,0 +1,90 @@
+#include "DisAndHeightToTarget.hpp"
+
+namespace pdal
+{
+
+    static PluginInfo const s_info{
+        "filters.disandheighttotarget",
+        "cal 2D or 3D distance and height to target pointcloud ,first input pointcloud as target pointcloud ",
+        "http://pdal.io/stages/filters.disandheighttotarget.html"};
+
+    CREATE_SHARED_STAGE(DisAndHeightToTarget, s_info)
+
+    std::string DisAndHeightToTarget::getName() const
+    {
+        return s_info.name;
+    }
+
+    void DisAndHeightToTarget::addArgs(ProgramArgs &args)
+    {
+        args.add("height_dimension", "height to target pointView dimension name ", m_heightToTargetDimName, "HeightToTarget");
+        args.add("distance_dimension", "distance  to target pointView dimension name", m_disToTargetDimName, "DistanceToTarget");
+        args.add("is3D", "2/3D distance  ", m_is3D, true);
+    }
+
+    void DisAndHeightToTarget::addDimensions(PointLayoutPtr layout)
+    {
+        m_heightToTargetDim = layout->registerOrAssignDim(m_heightToTargetDimName, Dimension::Type::Double);
+        m_disToTargetDim = layout->registerOrAssignDim(m_disToTargetDimName, Dimension::Type::Double);
+    }
+
+    void DisAndHeightToTarget::prepared(PointTableRef table)
+    {
+        PointLayoutPtr layout(table.layout());
+
+        if (layout->findDim("X") == Dimension::Id::Unknown ||
+            layout->findDim("Y") == Dimension::Id::Unknown ||
+            layout->findDim("Z") == Dimension::Id::Unknown)
+            throwError("Dimension X Y Z does not all exist.");
+    }
+
+    PointViewSet DisAndHeightToTarget::run(PointViewPtr view)
+    {
+        
+         PointViewSet viewSet;
+        if (!this->m_target)     
+        {
+            log()->get(LogLevel::Debug2) << "Adding target points\n";
+            this->m_target = view;
+        }
+      
+        else
+        {
+
+            KD3Index &kd_fixed3D = this->m_target->build3dIndex();
+            KD2Index &kd_fixed2D = this->m_target->build2dIndex();
+
+            for (pdal::PointId i = 0; i < view->size(); ++i)
+            {
+                PointRef point(*view, i);
+                PointIdList indices(1);
+                std::vector<double> sqr_dists(1);
+                if (m_is3D)
+                    kd_fixed3D.knnSearch(point, 1, &indices, &sqr_dists);
+                else
+                    kd_fixed2D.knnSearch(point, 1, &indices, &sqr_dists);
+
+                double height_to_target =point.getFieldAs<double>(Dimension::Id::Z)- this->m_target->getFieldAs<double>(Dimension::Id::Z, indices[0]) ;
+                double distance_to_target = std::sqrt(sqr_dists[0]);
+               
+                point.setField(m_heightToTargetDim, height_to_target);
+                point.setField(m_disToTargetDim, distance_to_target);
+            }
+            viewSet.insert(view);
+            this->m_complete = true;
+        }
+
+     
+        return viewSet;
+    }
+
+    void DisAndHeightToTarget::done(PointTableRef _)
+    {
+        if (!this->m_complete)
+        {
+            throw pdal_error(
+                "filters.disandheighttotarget  must have two point view inputs, no less");
+        }
+    }
+
+} // namespace pdal

--- a/filters/DisAndHeightToTarget.hpp
+++ b/filters/DisAndHeightToTarget.hpp
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <pdal/Filter.hpp>
+#include <pdal/KDIndex.hpp>
+
+namespace pdal
+{
+
+    class PDAL_DLL DisAndHeightToTarget : public Filter
+    {
+    public:
+        DisAndHeightToTarget() : Filter() ,m_target(nullptr) ,m_complete(false)
+        {}
+        std::string getName() const;
+
+    private:
+        virtual void addArgs(ProgramArgs &args);
+        virtual void addDimensions(PointLayoutPtr layout);
+        virtual void prepared(PointTableRef table);
+        virtual PointViewSet run(PointViewPtr view);
+        virtual void done(PointTableRef _);
+
+        DisAndHeightToTarget &operator=(const DisAndHeightToTarget &); // not implemented
+        DisAndHeightToTarget(const DisAndHeightToTarget &);            // not implemented
+
+    private:
+
+        std::string m_heightToTargetDimName; //height to target pointView dimension name
+        std::string m_disToTargetDimName; //distance  to target pointView dimension name
+        bool m_is3D;          //2D or 3D defalut true
+
+        Dimension::Id m_heightToTargetDim;   //height to target pointView dimension ID
+        Dimension::Id m_disToTargetDim;   //distance  to target pointView dimension ID
+
+        bool m_complete;        //judge input pointview size >=2
+        PointViewPtr m_target; //reference target pointView
+
+      
+       
+
+
+
+    };
+
+} // namespace pdal


### PR DESCRIPTION
- using one point cloud as a reference, calculate the relative elevation and distance values of another point cloud
- As shown below, it is rendered according to the relative elevation dimension.
The red point is the reference point cloud (the ins trajectory point), and the other is the point cloud rendered according to the relative elevation.
![image](https://github.com/PDAL/PDAL/assets/96613044/de788fe3-65d3-42f0-aed6-fe4a952c1dfc)
