### PR TITLE
Arbiter updates for S3 endpoints.json handling

### DIFF
--- a/vendor/arbiter/arbiter.hpp
+++ b/vendor/arbiter/arbiter.hpp
@@ -1,7 +1,7 @@
 /// Arbiter amalgamated header (https://github.com/connormanning/arbiter).
 /// It is intended to be used with #include "arbiter.hpp"
 
-// Git SHA: e22de9894155621a3b2ec122ea560f942d87394e
+// Git SHA: f7d78bb7b37e2e66671a642bd1076894f45c68a5
 
 // //////////////////////////////////////////////////////////////////////
 // Beginning of content of file: LICENSE


### PR DESCRIPTION
The default DNS suffix was incorrectly used when endpoints.json lacked an explicit hostname, now the `region.service.suffix` should be built using the correct default suffix for a given region if its partition configuration is found.