### PR TITLE
Fix convention error with `xmlErrorPtr` caused by `libxml2` API change

### DIFF
--- a/pdal/XMLSchema.cpp
+++ b/pdal/XMLSchema.cpp
@@ -73,7 +73,11 @@ namespace pdal
 {
 
 void SchemaStructuredErrorHandler
+#if LIBXML_VERSION >= 21200
+(void * /*userData*/, const xmlError *error)
+#else
 (void * /*userData*/, xmlErrorPtr error)
+#endif
 {
     std::ostringstream oss;
 
@@ -98,14 +102,22 @@ void SchemaStructuredErrorHandler
 }
 
 void SchemaParserStructuredErrorHandler
+#if LIBXML_VERSION >= 21200
+(void * /*userData*/, const xmlError *error)
+#else
 (void * /*userData*/, xmlErrorPtr error)
+#endif
 {
     std::cerr << "Schema parsing error: '" << error->message << "' " <<
         "on line " << error->line << std::endl;
 }
 
 void SchemaValidationStructuredErrorHandler
+#if LIBXML_VERSION >= 21200
+(void * /*userData*/, const xmlError *error)
+#else
 (void * /*userData*/, xmlErrorPtr error)
+#endif
 {
     std::cerr << "Schema validation error: '" << error->message << "' " <<
         "on line " << error->line << std::endl;


### PR DESCRIPTION
Starting with `libxml2 2.12.0`, the API has changed the const-ness of the `xmlError` pointers, which results in a build error due to a mismatched type on `const xmlError *` and `xmlErrorPtr`.
This commit papers over the difference by using preprocessor conditionals.

Related libxml2 commit and issue:
- https://gitlab.gnome.org/GNOME/libxml2/-/commit/45470611b047db78106dcb2fdbd4164163c15ab7
- https://gitlab.gnome.org/GNOME/libxml2/-/commit/61034116d0a3c8b295c6137956adc3ae55720711

Fix #4255