### PR TITLE
 Fixing seg fault referencing bounding box array entry. 

### DIFF
--- a/kernels/private/stac/StacInfo.hpp
+++ b/kernels/private/stac/StacInfo.hpp
@@ -124,8 +124,6 @@ inline bool stacProjection(MetadataNode& root, MetadataNode& statsMeta,
         props.add(projJson.clone("proj:projjson"));
         props.add(projWkt2.clone("proj:wkt2"));
     }
-    else
-        return false;
 
     return false;
 }

--- a/kernels/private/stac/StacInfo.hpp
+++ b/kernels/private/stac/StacInfo.hpp
@@ -38,9 +38,23 @@
 namespace pdal
 {
 
+class StacKey
+{
+public:
+    StacKey(std::string key):
+        m_key(key)
+        {};
+    ~StacKey(){};
+
+    inline bool operator()(const MetadataNode& n) {return n.name() == m_key;};
+private:
+    std::string m_key;
+};
+
 inline MetadataNode getChild(MetadataNode& m, std::string key)
 {
-    MetadataNode n = m.findChild(key);
+    StacKey sk(key);
+    MetadataNode n = m.findChild(sk);
     if (n.empty())
         throw std::out_of_range(key);
     else
@@ -102,7 +116,7 @@ inline void addBox(MetadataNode& n, MetadataNode& box, std::string name)
     n.addWithType(name, getChild(box, "maxz").value(), "double", "");
 }
 
-inline bool stacProjection(MetadataNode& root, MetadataNode& statsMeta,
+inline void stacProjection(MetadataNode& root, MetadataNode& statsMeta,
     MetadataNode& readerMeta, MetadataNode& stac)
 {
     MetadataNode props = getChild(stac, "properties");
@@ -131,8 +145,6 @@ inline bool stacProjection(MetadataNode& root, MetadataNode& statsMeta,
         props.add(projJson.clone("proj:projjson"));
         props.add(projWkt2.clone("proj:wkt2"));
     }
-
-    return false;
 }
 
 inline void addStacMetadata(MetadataNode& root, MetadataNode& statsMeta,

--- a/kernels/private/stac/StacInfo.hpp
+++ b/kernels/private/stac/StacInfo.hpp
@@ -153,12 +153,8 @@ inline void addStacMetadata(MetadataNode& root, MetadataNode& statsMeta,
         properties.add("datetime", datetime);
     }
 
-
-    // TODO add from metadata?
     stac.add("type", "Feature");
     stac.add("stac_version", "1.0.0");
-
-    //stac_extensions - pointcloud and projection extensions
 
     //links
     MetadataNode self = stac.addList("links");
@@ -171,7 +167,6 @@ inline void addStacMetadata(MetadataNode& root, MetadataNode& statsMeta,
     data.add("href", absPath);
     data.add("title", "Pointcloud data");
     assets.add(data.clone("data"));
-    auto&& enc = readerMeta.findChild("global_encoding");
 
     stac.add("stac_extensions", "https://stac-extensions.github.io/pointcloud/v1.0.0/schema.json");
     stacPointcloud(root, statsMeta, infoMeta, properties, pcType);

--- a/test/unit/apps/InfoTest.cpp
+++ b/test/unit/apps/InfoTest.cpp
@@ -211,3 +211,36 @@ std::string r = R"foo(
 )foo";
     test("--all", r);
 }
+
+TEST(Info, stac)
+{
+std::string r = R"foo(
+    "properties":
+    {
+      "datetime": "2015-09-10T00:00:00Z",
+      "pc:count": 110000,
+      "pc:encoding": ".las",
+)foo";
+    test("--stac", r);
+
+
+//anything other than message and status is a success
+std::string validation = R"foo(
+  "stac":
+  {
+    "message": "Failed to create STAC Feature with missing key. 'EPSG:4326'",
+    "status": "error"
+  }
+)foo";
+
+    std::string cmd;
+
+    std::string output;
+    cmd = appName() + " " + "--stac" + " " +
+        Support::datapath("las/sample_c.las") + " 2>&1";
+
+    EXPECT_EQ(Utils::run_shell_command(cmd, output), 0);
+    EXPECT_NE(output.find(validation), std::string::npos)
+        << "Found: '" << output << "'" << std::endl
+        << "expected: '" << validation<<"'" << std::endl;
+}


### PR DESCRIPTION
STAC metadata creation was referencing a `MetadataNode` by array index, which fails the assumption when the source file doesn't have a CRS. Move to referencing by child name and failing to an error message in the `stac` key of the info dump if key `EPSG:4326` doesn't exist in key `stats.bbox`.

STAC users expect the geometry to represent the data in 4326, so the `stac` key will now carry a message if the STAC information fails to be made in this way.