### PR TITLE
Fix classification mask for LAS V10 loader utility

### DIFF
--- a/io/private/las/Utils.cpp
+++ b/io/private/las/Utils.cpp
@@ -455,6 +455,7 @@ void LoaderDriver::init(int pdrf, const Scaling& scaling, const ExtraDims& dims)
 {
     switch (pdrf)
     {
+    /*
     case 0:
         m_loaders.push_back(PointLoaderPtr(new V10BaseLoader(scaling)));
         break;
@@ -471,6 +472,7 @@ void LoaderDriver::init(int pdrf, const Scaling& scaling, const ExtraDims& dims)
         m_loaders.push_back(PointLoaderPtr(new GpstimeLoader(20)));
         m_loaders.push_back(PointLoaderPtr(new ColorLoader(28)));
         break;
+    */
     case 6:
         m_loaders.push_back(PointLoaderPtr(new V14BaseLoader(scaling)));
         break;
@@ -483,6 +485,8 @@ void LoaderDriver::init(int pdrf, const Scaling& scaling, const ExtraDims& dims)
         m_loaders.push_back(PointLoaderPtr(new ColorLoader(30)));
         m_loaders.push_back(PointLoaderPtr(new NirLoader(36)));
         break;
+    default:
+        throw std::runtime_error("Only LAS 1.4 supported by this utility");
     }
     if (dims.size())
         m_loaders.push_back(PointLoaderPtr(new ExtraDimLoader(dims)));
@@ -530,7 +534,7 @@ void V10BaseLoader::load(PointRef& point, const char *buf, int bufsize)
     uint8_t scanDirFlag = (flags >> 6) & 0x01;
     uint8_t flight = (flags >> 7) & 0x01;
 
-    uint8_t classification = classificationWithFlags & 0x05;
+    uint8_t classification = classificationWithFlags & 0x1F;
     uint8_t synthetic = (classificationWithFlags >> 5) & 0x01;
     uint8_t keypoint = (classificationWithFlags >> 6) & 0x01;
     uint8_t withheld = (classificationWithFlags >> 7) & 0x01;


### PR DESCRIPTION
A private utility function had an incorrect mask for extracting legacy LAS data.  However, this function was unused (and untested): these utilities are only used by the COPC reader, whose data must be LAS 1.**4**.  To make that clear, I've removed the legacy PDRF loaders from the `init()` function in these utilities for now.

At some point, we should probably make the LasReader use these utilities as well, since currently they are duplicated with slight changes between `las/Utils` and the `io/LasReader`.  That's why I haven't deleted them entirely.  The equivalent line in the LasReader is written correctly [here](https://github.com/PDAL/PDAL/blob/300bc6613f535d5df79c9589ecf6f6bc79247220/io/LasReader.cpp#L616) and is also sufficiently tested.

Because these code paths were completely unused and also not public API, this change shouldn't necessitate a re-release and should not have produced any incorrect data from PDAL in the meantime.

Closes #4268.