### PR TITLE
Add cell_order and tile_order options to TileDB writer

### DIFF
--- a/doc/stages/writers.tiledb.rst
+++ b/doc/stages/writers.tiledb.rst
@@ -41,6 +41,12 @@ config_file
 data_tile_capacity
   Number of points per tile. Not used when `append=true`. [Default: 100,000]
 
+cell_order
+  The layout to use for TileDB cells. May be `auto`, `row-major`, `col-major`, or `hilbert`. Not used when `append=true`. [Default: auto]
+
+tile_order
+  The layout to use for TileDB tiles. May be `row-major` or `col-major`. Not used when `append=true`. [Default: row-major]
+
 x_tile_size
   Tile size (x). Floating point value used for determining on-disk data order. Not used when `append=true`. [Optional]
 
@@ -216,21 +222,21 @@ Filters set by the `aggressive` filter profile (the delta filter is skipped if u
   1. Float-scale filter (factor=`scale_x`, offset=`offset_x`, scale_float_bytewidth=4)
   2. Delta filter (reinterpret_datatype=`INT32`)
   3. Bit width reduction filter
-  4. BZIP2 filter (level=5)
+  4. BZIP2 filter (level=9)
 
 * Y
 
   1. Float-scale filter (factor=`scale_y`, offset=`offset_y`, scale_float_bytewidth=4)
   2. Delta filter (reinterpret_datatype=`INT32`)
   3. Bit width reduction filter
-  4. BZIP2 filter (level=5)
+  4. BZIP2 filter (level=9)
 
 * Z
 
   1. Float-scale filter (factor=`scale_z`, offset=`offset_z`, scale_float_bytewidth=4)
   2. Delta filter (reinterpret_datatype=`INT32`)
   3. Bit width reduction filter
-  4. BZIP2 filter (level=5)
+  4. BZIP2 filter (level=9)
 
 * GPSTime
 

--- a/plugins/tiledb/io/TileDBWriter.cpp
+++ b/plugins/tiledb/io/TileDBWriter.cpp
@@ -282,10 +282,12 @@ void TileDBWriter::ready(pdal::BasePointTable& table)
             ((m_args->m_x_tile_size > 0) && (m_args->m_y_tile_size > 0) &&
              (m_args->m_z_tile_size > 0) &&
              (!m_args->m_use_time || m_args->m_time_tile_size > 0));
-        bool anyTiles =
+        if (!hasValidTiles &&
             ((m_args->m_x_tile_size > 0) || (m_args->m_y_tile_size > 0) ||
              (m_args->m_z_tile_size > 0) ||
-             (!m_args->m_use_time || m_args->m_time_tile_size > 0));
+             (!m_args->m_use_time || m_args->m_time_tile_size > 0)))
+            std::cerr << "WARNING: Not all tile sizes are valid. Ignoring tile "
+                         "sizes.";
 
         // Create schema and set basic properties.
         tiledb::ArraySchema schema{*m_ctx, TILEDB_SPARSE};
@@ -309,9 +311,6 @@ void TileDBWriter::ready(pdal::BasePointTable& table)
             // are.
             if (!hasValidTiles)
             {
-                if (anyTiles)
-                    std::cerr << "WARNING: Not all tile sizes are valid. "
-                                 "Ignoring tile sizes.";
                 schema.set_cell_order(TILEDB_HILBERT);
             }
             else


### PR DESCRIPTION
* Let the user explicitly set cell_order and tile_order.
* Add  warning if using `auto` cell_order and only some of the tile sizes are set.
* Fix typos in tiledb.writer documentation for the aggressive filter profile.