### PR TITLE
Fix time tile check for missing tile warning

### DIFF
--- a/plugins/tiledb/io/TileDBWriter.cpp
+++ b/plugins/tiledb/io/TileDBWriter.cpp
@@ -285,7 +285,7 @@ void TileDBWriter::ready(pdal::BasePointTable& table)
         if (!hasValidTiles &&
             ((m_args->m_x_tile_size > 0) || (m_args->m_y_tile_size > 0) ||
              (m_args->m_z_tile_size > 0) ||
-             (!m_args->m_use_time || m_args->m_time_tile_size > 0)))
+             (m_args->m_use_time && m_args->m_time_tile_size > 0)))
             std::cerr << "WARNING: Not all tile sizes are valid. Ignoring tile "
                          "sizes.";
 


### PR DESCRIPTION
Warning was mistakenly being written when not setting tiles and not using time as a dimension.