### PR TITLE
Create dimensions in filters.assign

### DIFF
--- a/doc/stages/filters.assign.rst
+++ b/doc/stages/filters.assign.rst
@@ -53,6 +53,12 @@ subtraction(`-`), multiplication(`*`) and division(`\\`).
 A :ref:`ConditionalExpression <PDAL expression>` is an optional boolean value that must
 evaluate to `true` for the ``ValueExpression`` to be applied.
 
+.. note::
+    As of PDAL 2.7.0, assignment to a dimension that does not exist will cause
+    it to be created. It will always be created with type double, however.
+
+
+
 Example 1
 =========
 

--- a/filters/AssignFilter.cpp
+++ b/filters/AssignFilter.cpp
@@ -158,8 +158,10 @@ void AssignFilter::prepared(PointTableRef table)
     for (expr::AssignStatement& expr : m_args->m_statements)
     {
         expr::IdentExpression& ident = expr.identExpr();
+        std::string dimName = ident.name();
         if (ident.eval() ==  Dimension::Id::Unknown)
         {
+            layout->registerOrAssignDim(dimName, Dimension::Type::Double);
 
         }
         auto status = expr.prepare(layout);

--- a/filters/AssignFilter.cpp
+++ b/filters/AssignFilter.cpp
@@ -157,6 +157,11 @@ void AssignFilter::prepared(PointTableRef table)
     }
     for (expr::AssignStatement& expr : m_args->m_statements)
     {
+        expr::IdentExpression& ident = expr.identExpr();
+        if (ident.eval() ==  Dimension::Id::Unknown)
+        {
+
+        }
         auto status = expr.prepare(layout);
         if (!status)
             throwError(status.what());

--- a/filters/AssignFilter.cpp
+++ b/filters/AssignFilter.cpp
@@ -162,7 +162,6 @@ void AssignFilter::prepared(PointTableRef table)
         if (ident.eval() ==  Dimension::Id::Unknown)
         {
             layout->registerOrAssignDim(dimName, Dimension::Type::Double);
-
         }
         auto status = expr.prepare(layout);
         if (!status)

--- a/filters/private/expr/Expression.hpp
+++ b/filters/private/expr/Expression.hpp
@@ -206,6 +206,7 @@ public:
     virtual Utils::StatusWithReason prepare(PointLayoutPtr l);
     virtual Result eval(PointRef& p) const;
     Dimension::Id eval() const;
+    inline std::string const& name() const { return m_name; }
 
 private:
     std::string m_name;

--- a/filters/private/expr/IdentExpression.cpp
+++ b/filters/private/expr/IdentExpression.cpp
@@ -13,6 +13,20 @@ Utils::StatusWithReason IdentExpression::prepare(PointLayoutPtr layout)
     return false;
 }
 
+
+std::string IdentExpression::name() const
+{
+    const VarNode *n = dynamic_cast<const VarNode *>(topNode());
+
+    n->name();
+    if (n)
+        return n->name();
+    else
+        return std::string("");
+
+}
+
+
 Dimension::Id IdentExpression::eval() const
 {
     const VarNode *n = dynamic_cast<const VarNode *>(topNode());

--- a/filters/private/expr/IdentExpression.cpp
+++ b/filters/private/expr/IdentExpression.cpp
@@ -18,7 +18,6 @@ std::string IdentExpression::name() const
 {
     const VarNode *n = dynamic_cast<const VarNode *>(topNode());
 
-    n->name();
     if (n)
         return n->name();
     else

--- a/filters/private/expr/IdentExpression.hpp
+++ b/filters/private/expr/IdentExpression.hpp
@@ -12,6 +12,7 @@ class IdentExpression : public Expression
 public:
     Utils::StatusWithReason prepare(PointLayoutPtr layout);
     Dimension::Id eval() const;
+    std::string name() const;
 };
 
 } // namespace expr

--- a/test/unit/filters/AssignFilterTest.cpp
+++ b/test/unit/filters/AssignFilterTest.cpp
@@ -262,8 +262,6 @@ TEST(AssignFilterTest, test_creation)
     PointLayoutPtr l = v->layout();
     Dimension::Id xiDimensionId = l->findDim("xi");
 
-    int ielse = 0;
-    int i6 = 0;
     for (PointId i = 0; i < v->size(); ++i)
     {
         int xi = v->getFieldAs<int>(xiDimensionId, i);


### PR DESCRIPTION
We previously had to use a `filters.ferry` to create a dimension that didn't exist before a `filters.assign`. This removes that hack by allowing `filters.assign` to create dimensions with their expressions.