### PR TITLE
Use current PDAL for workshop

### DIFF
--- a/doc/workshop/environment.yml
+++ b/doc/workshop/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.11
-  - pdal=2.5.6
+  - pdal=2.6.2
   - python-pdal
   - gdal
   - untwine


### PR DESCRIPTION
Workshop environment should use the current PDAL version.