### PR TITLE
Added the height difference threshold as parameter to the CSF filter.

### DIFF
--- a/doc/stages/filters.csf.rst
+++ b/doc/stages/filters.csf.rst
@@ -45,7 +45,7 @@ threshold
   Classification threshold. [Default: **0.5**]
 
 hdiff
-  Height difference threshold. [Default: **0.5**]
+  Height difference threshold. [Default: **0.3**]
 
 smooth
   Perform slope post-processing? [Default: **true**]

--- a/doc/stages/filters.csf.rst
+++ b/doc/stages/filters.csf.rst
@@ -44,6 +44,9 @@ returns
 threshold
   Classification threshold. [Default: **0.5**]
 
+hdiff
+  Height difference threshold. [Default: **0.5**]
+
 smooth
   Perform slope post-processing? [Default: **true**]
 

--- a/filters/CSFilter.cpp
+++ b/filters/CSFilter.cpp
@@ -32,10 +32,10 @@
  * OF SUCH DAMAGE.
  ****************************************************************************/
 
-// PDAL implementation of T. J. Pingel, K. C. Clarke, and W. A. McBride, “An
-// improved simple morphological filter for the terrain classification of
-// airborne LIDAR data,” ISPRS J. Photogramm. Remote Sens., vol. 77, pp. 21–30,
-// 2013.
+// PDAL implementation of Zhang W, Qi J, Wan P, Wang H, Xie D, Wang X, Yan G,
+// "An Easy-to-Use Airborne LiDAR Data Filtering Method Based on Cloth
+// Simulation", Remote Sensing. 2016; 8(6):501.
+// https://doi.org/10.3390/rs8060501
 
 #include "CSFilter.hpp"
 
@@ -65,7 +65,7 @@ using namespace Eigen;
 
 static StaticPluginInfo const s_info{
     "filters.csf", "Cloth Simulation Filter (Zhang et al., 2016)",
-    "http://pdal.io/stages/filters.csf.html"};
+    "https://pdal.io/stages/filters.csf.html"};
 
 CREATE_STATIC_STAGE(CSFilter, s_info)
 
@@ -74,6 +74,7 @@ struct CSArgs
     bool m_smooth;
     double m_step;
     double m_threshold;
+    double m_hdiff;
     double m_resolution;
     int m_rigid;
     int m_iterations;
@@ -97,6 +98,7 @@ void CSFilter::addArgs(ProgramArgs& args)
     args.add("smooth", "Slope postprocessing?", m_args->m_smooth, true);
     args.add("step", "Time step", m_args->m_step, 0.65);
     args.add("threshold", "Classification threshold", m_args->m_threshold, 0.5);
+    args.add("hdiff", "Height difference threshold", m_args->m_hdiff, 0.3);
     args.add("resolution", "Cloth resolution", m_args->m_resolution, 1.0);
     args.add("rigidness", "Rigidness", m_args->m_rigid, 3);
     args.add("iterations", "Max iterations", m_args->m_iterations, 500);
@@ -229,6 +231,7 @@ PointViewSet CSFilter::run(PointViewPtr view)
     c.params.bSloopSmooth = m_args->m_smooth;
     c.params.time_step = m_args->m_step;
     c.params.class_threshold = m_args->m_threshold;
+    c.params.height_threshold = m_args->m_hdiff;
     c.params.cloth_resolution = m_args->m_resolution;
     c.params.rigidness = m_args->m_rigid;
     c.params.interations = m_args->m_iterations;

--- a/filters/private/csf/CSF.cpp
+++ b/filters/private/csf/CSF.cpp
@@ -31,6 +31,7 @@ CSF::CSF(int index) {
     params.bSloopSmooth     = true;
     params.time_step        = 0.65;
     params.class_threshold  = 0.5;
+    params.height_threshold  = 0.3;
     params.cloth_resolution = 1;
     params.rigidness        = 3;
     params.interations      = 500;
@@ -42,6 +43,7 @@ CSF::CSF() {
     params.bSloopSmooth     = true;
     params.time_step        = 0.65;
     params.class_threshold  = 0.5;
+    params.height_threshold  = 0.3;
     params.cloth_resolution = 1;
     params.rigidness        = 3;
     params.interations      = 500;
@@ -151,7 +153,7 @@ void CSF::do_filtering(std::vector<int>& groundIndexes,
         height_num,
         params.cloth_resolution,
         params.cloth_resolution,
-        0.3,
+        params.height_threshold,
         9999,
         params.rigidness,
         params.time_step,

--- a/filters/private/csf/CSF.h
+++ b/filters/private/csf/CSF.h
@@ -33,8 +33,8 @@
 
 
 // cloth simulation filter for airborne lidar filtering
-#ifndef _CSF_H_
-#define _CSF_H_
+#pragma once
+
 #include <vector>
 #include <string>
 #include "point_cloud.h"
@@ -47,6 +47,7 @@ struct Params {
     bool bSloopSmooth;
     double time_step;
     double class_threshold;
+    double height_threshold;
     double cloth_resolution;
     int rigidness;
     int interations;
@@ -127,5 +128,3 @@ public:
     Params params;
     int index;
 };
-
-#endif // ifndef _CSF_H_

--- a/filters/private/csf/Cloth.h
+++ b/filters/private/csf/Cloth.h
@@ -36,9 +36,7 @@
  */
 // using discrete steps (drop and pull) to approximate the physical process
 
-#ifndef _CLOTH_H_
-#define _CLOTH_H_
-
+#pragma once
 
 #ifdef _WIN32
 # include <windows.h>
@@ -164,6 +162,3 @@ public:
 
     void saveMovableToFile(string path = "");
 };
-
-
-#endif // ifndef _CLOTH_H_

--- a/filters/private/csf/Constraint.h
+++ b/filters/private/csf/Constraint.h
@@ -15,9 +15,7 @@
 // limitations under the License.
 // ======================================================================================
 
-#ifndef _CONSTRAINT_H_
-#define _CONSTRAINT_H_
-
+#pragma once
 
 #include "Vec3.h"
 #include "Particle.h"
@@ -40,6 +38,3 @@ public:
      * by Cloth.time_step() many times per frame*/
     void satisfyConstraint(int constraintTimes);
 };
-
-
-#endif // ifndef _CONSTRAINT_H_

--- a/filters/private/csf/Particle.h
+++ b/filters/private/csf/Particle.h
@@ -15,8 +15,7 @@
 // limitations under the License.
 // ======================================================================================
 
-#ifndef _PARTICLE_H_
-#define _PARTICLE_H_
+#pragma once
 
 #include "Vec3.h"
 #include <vector>
@@ -149,6 +148,3 @@ public:
     //    cout << s << ": " << this->getPos().f[0] << " movable:  " << this->movable << endl;
     //}
 };
-
-
-#endif // ifndef _PARTICLE_H_

--- a/filters/private/csf/Rasterization.h
+++ b/filters/private/csf/Rasterization.h
@@ -15,8 +15,7 @@
 // limitations under the License.
 // ======================================================================================
 
-#ifndef _KNN_H_
-#define _KNN_H_
+#pragma once
 
 #include "point_cloud.h"
 #include "Cloth.h"
@@ -40,5 +39,3 @@ public:
                                 csf::PointCloud& pc,
                                 vector<double> & heightVal);
 };
-
-#endif // ifndef _KNN_H_

--- a/filters/private/csf/Vec3.h
+++ b/filters/private/csf/Vec3.h
@@ -15,9 +15,7 @@
 // limitations under the License.
 // ======================================================================================
 
-#ifndef _VEC3_H_
-#define _VEC3_H_
-
+#pragma once
 
 #include <cmath>
 #include <string>
@@ -88,6 +86,3 @@ public:
         return f[0] * v.f[0] + f[1] * v.f[1] + f[2] * v.f[2];
     }
 };
-
-
-#endif // ifndef _VEC3_H_

--- a/filters/private/csf/XYZReader.h
+++ b/filters/private/csf/XYZReader.h
@@ -15,9 +15,7 @@
 // limitations under the License.
 // ======================================================================================
 
-#ifndef XYZ_READER_H_
-#define XYZ_READER_H_
-
+#pragma once
 
 #include <string>
 #include <vector>
@@ -27,6 +25,3 @@ using namespace std;
 #include "point_cloud.h"
 
 void read_xyz(string fname, csf::PointCloud& pointcloud);
-
-
-#endif // ifndef XYZ_READER_H_

--- a/filters/private/csf/c2cdist.h
+++ b/filters/private/csf/c2cdist.h
@@ -15,9 +15,7 @@
 // limitations under the License.
 // ======================================================================================
 
-#ifndef _C2CDIST_H_
-#define _C2CDIST_H_
-
+#pragma once
 
 #include "Cloth.h"
 #include "point_cloud.h"
@@ -39,8 +37,5 @@ public:
 
 private:
 
-    double class_treshold; //
+    double class_treshold;
 };
-
-
-#endif // ifndef _C2CDIST_H_

--- a/filters/private/csf/point_cloud.h
+++ b/filters/private/csf/point_cloud.h
@@ -31,8 +31,7 @@
 // #                                                                                     #
 // #######################################################################################
 
-#ifndef _POINT_CLOUD_H_
-#define _POINT_CLOUD_H_
+#pragma once
 
 #include <vector>
 
@@ -58,6 +57,3 @@ public:
 };
 
 }
-
-
-#endif // ifndef _POINT_CLOUD_H_


### PR DESCRIPTION
- Added the height difference threshold as parameter to the CSF filter.
- Removed the `#include` guard macros in favour of the `#pragma once` macro.
- Corrected a reference to the correct article

The original article seems to focus on aerial point clouds. This PR enables the user to try other values for the height difference threshold. This could be beneficial for point clouds captured by mobile laser scanners.