### PR TITLE
Fixed 'Edit on GitHub' link.

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -154,7 +154,8 @@ html_context = {
   'theme_vcs_pageview_mode': 'edit',
   'github_user': 'PDAL',
   'github_repo': 'PDAL',
-  'github_version': '/master/doc/'
+  'github_version': 'master',
+  'conf_py_path': '/doc/'
 }
 
 html_theme_options = {


### PR DESCRIPTION
The current documentation creates the following 'Edit on GitHub' url:
`https://github.com/PDAL/PDAL/edit//master/doc//doc/stages/filters.csf.rst`
This results into a 404 page not found error.

The suggested change creates the correct url:
`https://github.com/PDAL/PDAL/edit/master/doc/stages/filters.csf.rst`