### PR TITLE
Use standard CMake installation locations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,19 +46,26 @@ set(PDAL_TEST_SUPPORT_OBJS pdal_test_support)
 
 set(CMAKE_INCLUDE_DIRECTORIES_PROJECT_BEFORE ON)
 
-set(PDAL_OUTPUT_LIB_DIR "${PDAL_BINARY_DIR}/${PDAL_LIB_INSTALL_DIR}")
-set(PDAL_OUTPUT_BIN_DIR "${PDAL_BINARY_DIR}/${PDAL_BIN_INSTALL_DIR}")
+set(PDAL_OUTPUT_LIB_DIR "${PROJECT_BINARY_DIR}/lib")
+set(PDAL_OUTPUT_BIN_DIR "${PROJECT_BINARY_DIR}/bin")
+
+
+if (NOT CMAKE_LIBRARY_OUTPUT_DIRECTORY)
+  set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${PDAL_OUTPUT_LIB_DIR}")
+endif()
+
+if (NOT CMAKE_RUNTIME_OUTPUT_DIRECTORY)
+  set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${PDAL_OUTPUT_BIN_DIR}")
+endif()
 
 # allow override of PDAL_PLUGIN_INSTALL_PATH path
 if (NOT PDAL_PLUGIN_INSTALL_PATH)
     if (WIN32)
-        set(PDAL_PLUGIN_INSTALL_PATH "${CMAKE_INSTALL_PREFIX}/${PDAL_BIN_INSTALL_DIR}" CACHE PATH "PDAL Plugin install location")
+        set(PDAL_PLUGIN_INSTALL_PATH "${CMAKE_INSTALL_BINDIR}" CACHE PATH "PDAL Plugin install location")
     else()
-        set(PDAL_PLUGIN_INSTALL_PATH "${CMAKE_INSTALL_PREFIX}/${PDAL_LIB_INSTALL_DIR}" CACHE PATH "PDAL Plugin install location")
+        set(PDAL_PLUGIN_INSTALL_PATH "${CMAKE_INSTALL_LIBDIR}" CACHE PATH "PDAL Plugin install location")
     endif()
 endif()
-file(MAKE_DIRECTORY "${PDAL_OUTPUT_LIB_DIR}")
-file(MAKE_DIRECTORY "${PDAL_OUTPUT_BIN_DIR}")
 
 include(${PDAL_CMAKE_DIR}/rpath.cmake)
 
@@ -76,13 +83,6 @@ if(WIN32)
   set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_${CMAKE_BUILD_TYPE} "${PDAL_OUTPUT_BIN_DIR}" )
 endif(WIN32)
 
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${PDAL_OUTPUT_LIB_DIR}")
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${PDAL_OUTPUT_BIN_DIR}")
-if(WIN32)
-  set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${PDAL_OUTPUT_BIN_DIR}")
-else()
-  set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${PDAL_OUTPUT_LIB_DIR}")
-endif()
 
 # Choose package components
 
@@ -254,6 +254,22 @@ target_link_libraries(${PDAL_LIB_NAME}
         ${PDAL_LIBDIR}
         ${WINSOCK_LIBRARY}
 )
+
+#
+# Allow downstream cmake projects to find PDAL header files without
+# being explicit.
+#
+target_include_directories(${PDAL_LIB_NAME}
+    INTERFACE
+        $<INSTALL_INTERFACE:include>)
+
+if(WIN32)
+    target_compile_definitions(${PDAL_LIB_NAME}
+        PUBLIC
+            PDAL_DLL_EXPORT=1
+    )
+endif(WIN32)
+
 set_target_properties(${PDAL_LIB_NAME} PROPERTIES
     VERSION ${PDAL_BUILD_VERSION}
     SOVERSION ${PDAL_API_VERSION}
@@ -362,13 +378,7 @@ install(
         "${CMAKE_INSTALL_LIBDIR}/cmake/PDAL")
 include(${PDAL_CMAKE_DIR}/config.cmake)
 
-#
-# Allow downstream cmake projects to find PDAL header files without
-# being explicit.
-#
-target_include_directories(${PDAL_LIB_NAME}
-    INTERFACE
-        $<INSTALL_INTERFACE:include>)
+
 
 feature_summary(WHAT ALL INCLUDE_QUIET_PACKAGES)
 

--- a/cmake/macros.cmake
+++ b/cmake/macros.cmake
@@ -228,9 +228,9 @@ macro(PDAL_ADD_TEST _name)
     # https://github.com/PDAL/PDAL/issues/840
     if (WIN32)
         set_property(TEST ${_name} PROPERTY ENVIRONMENT
-            "PDAL_DRIVER_PATH=$CMAKE_RUNTIME_OUTPUT_DIRECTORY")
+            "PDAL_DRIVER_PATH=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
     else()
         set_property(TEST ${_name} PROPERTY ENVIRONMENT
-            "PDAL_DRIVER_PATH=$CMAKE_LIBRARY_OUTPUT_DIRECTORY")
+            "PDAL_DRIVER_PATH=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
     endif()
 endmacro(PDAL_ADD_TEST)

--- a/cmake/macros.cmake
+++ b/cmake/macros.cmake
@@ -228,9 +228,9 @@ macro(PDAL_ADD_TEST _name)
     # https://github.com/PDAL/PDAL/issues/840
     if (WIN32)
         set_property(TEST ${_name} PROPERTY ENVIRONMENT
-            "PDAL_DRIVER_PATH=${PROJECT_BINARY_DIR}/bin")
+            "PDAL_DRIVER_PATH=$CMAKE_RUNTIME_OUTPUT_DIRECTORY")
     else()
         set_property(TEST ${_name} PROPERTY ENVIRONMENT
-            "PDAL_DRIVER_PATH=${PROJECT_BINARY_DIR}/lib")
+            "PDAL_DRIVER_PATH=$CMAKE_LIBRARY_OUTPUT_DIRECTORY")
     endif()
 endmacro(PDAL_ADD_TEST)

--- a/plugins/icebridge/CMakeLists.txt
+++ b/plugins/icebridge/CMakeLists.txt
@@ -33,7 +33,7 @@ else()
     )
 
     if (WITH_TESTS)
-        PDAL_ADD_TEST(icetest
+        PDAL_ADD_TEST(pdal_io_icebridge_reader_test
             FILES test/IcebridgeReaderTest.cpp
             LINK_WITH ${libname})
     endif()

--- a/scripts/ci/linux/examples.sh
+++ b/scripts/ci/linux/examples.sh
@@ -7,5 +7,5 @@ do
     cd $BASE/examples/$EXAMPLE
     mkdir -p _build || exit 1
     cd _build || exit 1
-    cmake -G "Ninja" .. -DPDAL_DIR=$CONDA_PREFIX/lib/cmake/PDAL -DCMAKE_VERBOSE_MAKEFILE=ON --debug-find && cmake --build . -v
+    cmake -G "Ninja" .. -DPDAL_DIR=$CONDA_PREFIX/lib/cmake/PDAL && cmake --build . -v
 done

--- a/scripts/conda/osx.sh
+++ b/scripts/conda/osx.sh
@@ -2,9 +2,14 @@
 BUILDDIR=conda-build
 
 CONFIG="Debug"
+INSTALL_PREFIX="$CONDA_PREFIX"
 
 if ! [ -z "$1" ]; then
     CONFIG="$1"
+fi
+
+if ! [ -z "$2" ]; then
+    INSTALL_PREFIX="$2"
 fi
 
 
@@ -17,7 +22,16 @@ CFLAGS= CXXFLAGS="-Werror=strict-aliasing" CC=/usr/bin/cc CXX=/usr/bin/c++ cmake
         -DCMAKE_FIND_FRAMEWORK="NEVER" \
         -DCMAKE_BUILD_TYPE=$CONFIG \
         -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
-        -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} \
+        -DCMAKE_INSTALL_PREFIX="$INSTALL_PREFIX" \
+        -DCMAKE_INSTALL_BINDIR="$INSTALL_PREFIX/bin" \
+        -DCMAKE_INSTALL_LIBEXECDIR="$INSTALL_PREFIX/libexec" \
+        -DCMAKE_INSTALL_LOCALEDIR="$INSTALL_PREFIX/locale" \
+        -DCMAKE_INSTALL_LIBDIR="$INSTALL_PREFIX/lib" \
+        -DCMAKE_INSTALL_DOCDIR="$INSTALL_PREFIX/man" \
+        -DCMAKE_INSTALL_INCLUDEDIR="$INSTALL_PREFIX/include" \
+        -DCMAKE_INSTALL_NAME_DIR="$INSTALL_PREFIX/lib" \
+        -DCMAKE_INSTALL_SBINDIR="$INSTALL_PREFIX/sbin" \
+        -DCMAKE_INSTALL_OLDINCLUDEDIR="$INSTALL_PREFIX/include" \
         -DBUILD_PLUGIN_PGPOINTCLOUD=ON \
         -DBUILD_PLUGIN_NITF=ON \
         -DBUILD_PLUGIN_HDF=ON \
@@ -29,6 +43,7 @@ CFLAGS= CXXFLAGS="-Werror=strict-aliasing" CC=/usr/bin/cc CXX=/usr/bin/c++ cmake
         -DCMAKE_CXX_FLAGS="-fsanitize=address" \
         -DBUILD_PLUGIN_TILEDB=OFF \
         -DWITH_ZSTD=ON \
+        -DWITH_TESTS=ON \
         ..
 
 


### PR DESCRIPTION
PDAL's install location stuff predates standardization of many variable locations by CMake. This PR attempts to align with current CMake installation locations so that packagers can control where things go with normally provided variable overrides as needed.

