### PR TITLE
Added tiledb metadata fields to easily tag array type

### DIFF
--- a/plugins/tiledb/io/TileDBWriter.cpp
+++ b/plugins/tiledb/io/TileDBWriter.cpp
@@ -574,6 +574,9 @@ void TileDBWriter::done(PointTableRef table)
             std::string m = pdal::Utils::toJSON(node);
             m_array->put_metadata("_pdal", TILEDB_UINT8, m.length() + 1,
                                   m.c_str());
+            // add tiledb pointcloud tag
+            std::string datasetType = "pointcloud";
+            m_array->put_metadata("dataset_type", TILEDB_STRING_UTF8, datasetType.size(), datasetType.data());
         }
         m_array->close();
     }

--- a/plugins/tiledb/test/TileDBReaderTest.cpp
+++ b/plugins/tiledb/test/TileDBReaderTest.cpp
@@ -198,6 +198,11 @@ TEST_F(TileDBReaderTest, read)
     options.add("array_name", data_path);
 
     tiledb::Array array(ctx, data_path, TILEDB_READ);
+
+    tiledb_datatype_t v_type = (tiledb_datatype_t)std::numeric_limits<int32_t>::max();
+    EXPECT_TRUE(array.has_metadata("dataset_type", &v_type));
+    EXPECT_EQ(v_type, TILEDB_STRING_UTF8);
+
     tiledb::Query q(ctx, array, TILEDB_READ);
 
     std::vector<double> xs(count);


### PR DESCRIPTION
TileDB is a multi-modal array database with applications outside of geospatial, this PR adds tagging to the array so that the array can be easily recognized by other TileDB client libraries. Currently `raster`, `geometry` and `pointcloud` are used for geospatial array tags.

Related: https://github.com/OSGeo/gdal/pull/9034