### PR TITLE
Fixed logic for adding srs to bounds filtering

### DIFF
--- a/io/StacReader.cpp
+++ b/io/StacReader.cpp
@@ -181,6 +181,7 @@ void StacReader::addArgs(ProgramArgs& args)
 
 void StacReader::addItem(Item& item)
 {
+    log()->get(LogLevel::Debug) << "Selected Item: " << item.id() << std::endl;
     std::string driver = item.driver();
 
     Stage *stage = m_factory.createStage(driver);
@@ -213,7 +214,10 @@ void StacReader::handleItem(NL::json stacJson, std::string itemPath)
     Item item(stacJson, m_filename, *m_p->m_connector,
         m_args->validateSchema);
     if (item.init(*m_p->m_itemFilters, m_args->rawReaderArgs, m_args->schemaUrls))
+    {
+
         addItem(item);
+    }
 }
 
 void StacReader::printErrors(Catalog& c)

--- a/io/StacReader.cpp
+++ b/io/StacReader.cpp
@@ -403,7 +403,7 @@ void StacReader::initializeArgs()
             m_p->m_itemFilters->bounds = m_args->bounds.to3d();
         }
 
-        if (!userSrs.valid())
+        if (userSrs.valid())
             m_p->m_itemFilters->srs = m_args->bounds.spatialReference();
     }
 

--- a/io/StacReader.cpp
+++ b/io/StacReader.cpp
@@ -392,23 +392,7 @@ void StacReader::initializeArgs()
             throw pdal_error("Supplied bounds are not valid.");
         log()->get(LogLevel::Debug) << "Bounds: " << m_args->bounds << std::endl;
 
-        SpatialReference stacSrs("EPSG:4326");
-        SpatialReference userSrs = m_args->bounds.spatialReference();
-        if (m_args->bounds.is2d())
-        {
-            m_p->m_itemFilters->bounds = BOX3D(m_args->bounds.to2d());
-            m_p->m_itemFilters->bounds.minz =
-                (std::numeric_limits<double>::lowest)();
-            m_p->m_itemFilters->bounds.maxz =
-                (std::numeric_limits<double>::max)();
-        }
-        else
-        {
-            m_p->m_itemFilters->bounds = m_args->bounds.to3d();
-        }
-
-        if (userSrs.valid())
-            m_p->m_itemFilters->srs = m_args->bounds.spatialReference();
+        m_p->m_itemFilters->bounds = m_args->bounds;
     }
 
     if (!m_args->assetNames.empty())

--- a/io/private/stac/Item.cpp
+++ b/io/private/stac/Item.cpp
@@ -412,10 +412,10 @@ bool Item::filterBounds(BOX3D bounds, SpatialReference srs)
 
         NL::json props = stacValue(m_json, "properties");
         SpatialReference ref = extractSRS(props);
-        userPolygon.setSpatialReference(srs);
+        userPolygon.setSpatialReference(ref);
 
         const SpatialReference srs(userPolygon.getSpatialReference());
-        if (srs != stacPolygon.getSpatialReference())
+        if (ref != stacPolygon.getSpatialReference())
             stacPolygon.transform(srs);
     }
 

--- a/io/private/stac/Item.cpp
+++ b/io/private/stac/Item.cpp
@@ -395,7 +395,6 @@ bool Item::filterBounds(BOX3D bounds, SpatialReference srs)
         {
             try
             {
-                std::cout << e.what() << std::endl;
                 NL::json projjson = jsonValue(props, "proj:projjson");
                 const SpatialReference srs(projjson.dump());
                 userPolygon.setSpatialReference(srs);
@@ -407,7 +406,6 @@ bool Item::filterBounds(BOX3D bounds, SpatialReference srs)
             }
             catch (const std::exception& e)
             {
-                std::cout << e.what() << std::endl;
                 userPolygon.setSpatialReference("EPSG:4326");
             }
         }

--- a/io/private/stac/Item.cpp
+++ b/io/private/stac/Item.cpp
@@ -382,8 +382,8 @@ bool Item::filterBounds(BOX3D bounds, SpatialReference srs)
         NL::json props = stacValue(m_json, "properties");
         try
         {
-            int projepsg = jsonValue(props, "proj:epsg");
-            const SpatialReference srs("EPSG:" + std::to_string(projepsg));
+            std::string wkt = jsonValue(props, "proj:wkt2");
+            const SpatialReference srs(wkt);
             userPolygon.setSpatialReference(srs);
         }
         catch (const std::exception& e)
@@ -398,8 +398,8 @@ bool Item::filterBounds(BOX3D bounds, SpatialReference srs)
             {
                 try
                 {
-                    std::string wkt = jsonValue(props, "proj:wkt2");
-                    const SpatialReference srs(wkt);
+                    int projepsg = jsonValue(props, "proj:epsg");
+                    const SpatialReference srs("EPSG:" + std::to_string(projepsg));
                     userPolygon.setSpatialReference(srs);
                 }
                 catch(const std::exception& e)

--- a/io/private/stac/Item.hpp
+++ b/io/private/stac/Item.hpp
@@ -71,7 +71,7 @@ public:
 
     struct Filters {
         std::vector<RegEx> ids;
-        BOX3D bounds;
+        SrsBounds bounds;
         SpatialReference srs;
         NL::json properties;
         DatePairs datePairs;
@@ -113,7 +113,7 @@ private:
     bool filterCol(std::vector<RegEx> ids);
     bool filterDates(DatePairs dates);
     bool filterProperties(const NL::json& filterProps);
-    bool filterBounds(BOX3D bounds, SpatialReference srs);
+    bool filterBounds(SrsBounds bounds);
 
 
 };

--- a/test/unit/io/StacReaderTest.cpp
+++ b/test/unit/io/StacReaderTest.cpp
@@ -436,7 +436,7 @@ TEST(StacReaderTest, date_prune_reject_test)
 TEST(StacReaderTest, bounds_prune_accept_test)
 {
     Options options;
-    std::string bounds = "([-79.0,-74.0],[38.0,39.0])";
+    std::string bounds = "([-79.0,-74.0],[38.0,39.0]) / EPSG:4326";
 
     options.add("filename", Support::datapath("stac/MD_GoldenBeach_2012.json"));
     options.add("asset_names", "ept.json");


### PR DESCRIPTION
Bounds filtering was not working correctly. The sample pipeline:
```
{
    "pipeline":
    [
      {
        "asset_names": "ept.json",
        "bounds": "{\"minx\": -8699874.3, \"miny\": 4907333.9, \"maxx\": -8698420.4, \"maxy\": 4908135.7}",
        "filename": "https://usgs-lidar-stac.s3-us-west-2.amazonaws.com/ept/item_collection.json",
        "reader_args": [
            {"resolution":1000,"type":"readers.ept"}
        ],
        "tag": "readers_stac1",
        "type": "readers.stac"
      },
      {
        "filename": "stac-filter.copc.laz",
        "type": "writers.copc"
      }
    ]
}
```
Was producing no results. First because no srs was being applied to the bounds in the properties in STAC Reader, but also because STAC reader wasn't defaulting to the srs supplied by STAC items in `proj:epsg`, `proj:projjson`, or `proj:wkt2` keys, which are highly encouraged keys for any STAC item using the projection extension.