### PR TITLE
Added threading functionality to filters.overlay

### DIFF
--- a/doc/stages/filters.overlay.rst
+++ b/doc/stages/filters.overlay.rst
@@ -101,5 +101,8 @@ _`query`
 layer
   The data source's layer to use. [Default: first layer]
 
+threads
+  The number of threads to use. Only valid in :ref:`standard mode <processing_modes>`. [Default: 1]
+
 .. include:: filter_opts.rst
 

--- a/filters/OverlayFilter.cpp
+++ b/filters/OverlayFilter.cpp
@@ -187,7 +187,7 @@ bool OverlayFilter::processOne(PointRef& point)
 void OverlayFilter::filter(PointView& view)
 {
     point_count_t npoints = view.size();
-    unsigned int chunk_size = npoints / m_threads;
+    point_count_t chunk_size = npoints / m_threads;
     if (npoints % m_threads) chunk_size++;
     std::vector<std::thread> threadList(m_threads);
 

--- a/filters/OverlayFilter.cpp
+++ b/filters/OverlayFilter.cpp
@@ -193,7 +193,7 @@ void OverlayFilter::filter(PointView& view)
 
     for (int t = 0; t < m_threads; t++)
     {
-        threadList[t] = std::thread(std::bind(
+        threadList[t] = std::thread(
             [&](const PointId start, const PointId end) {
                 PointRef point(view, start);
 
@@ -204,7 +204,7 @@ void OverlayFilter::filter(PointView& view)
                 }
             },
             t * chunk_size,
-            (t + 1) == m_threads ? npoints : (t + 1) * chunk_size));
+            (t + 1) == m_threads ? npoints : (t + 1) * chunk_size);
     }
 
     for (auto& t : threadList)

--- a/filters/OverlayFilter.hpp
+++ b/filters/OverlayFilter.hpp
@@ -96,6 +96,7 @@ private:
     Dimension::Id m_dim;
     std::vector<PolyVal> m_polygons;
     BOX2D m_bounds;
+    int m_threads;
 
 };
 

--- a/pdal/Polygon.cpp
+++ b/pdal/Polygon.cpp
@@ -96,6 +96,11 @@ void Polygon::init()
             "because OGR geometry is not Polygon or MultiPolygon.");
     }
 }
+void Polygon::initGrids() const
+{
+    for (const Polygon& p : polygons())
+        m_pd->m_grids.emplace_back(p.exteriorRing(), p.interiorRings());
+}
 
 
 Polygon::Polygon(const std::string& wkt_or_json, SpatialReference ref) :
@@ -298,8 +303,7 @@ bool Polygon::intersects(const Polygon& p) const
 bool Polygon::contains(double x, double y) const
 {
     if (m_pd->m_grids.empty())
-        for (const Polygon& p : polygons())
-            m_pd->m_grids.emplace_back(p.exteriorRing(), p.interiorRings());
+        initGrids();
     for (auto& g : m_pd->m_grids)
         if (g.inside(x, y))
             return true;

--- a/pdal/Polygon.hpp
+++ b/pdal/Polygon.hpp
@@ -82,6 +82,7 @@ public:
     bool crosses(const Polygon& p) const;
     Ring exteriorRing() const;
     std::vector<Ring> interiorRings() const;
+    void initGrids() const;
 
 private:
     void init();


### PR DESCRIPTION
There is still one issue which would require some attention. The function `Polygon::contains()` does some initialisation when it is first called. This can be seen here:

https://github.com/PDAL/PDAL/blob/98207ec4fa664f056295f6b5efa28c668f0e426a/pdal/Polygon.cpp#L300-L302

If threading is used, this will lead to a race condition. I have resolved this by first doing mock calls to the `Polygon::contains()` function to make sure the `m_pd->m_grids` is initialised prior to the threads making use of it. I feel this is not a very elegant solution, and I feel there should be a better solution. Any ideas?