### PR TITLE
Threading rework

### DIFF
--- a/doc/stages/filters.covariancefeatures.rst
+++ b/doc/stages/filters.covariancefeatures.rst
@@ -88,7 +88,7 @@ knn
   [Default: 10]
 
 threads
-  The number of threads used for computing the feature descriptors. [Default: 1]
+  The number of threads to use. Only valid in :ref:`standard mode <processing_modes>`. [Default: 1]
 
 feature_set
   A comma-separated list of individual features or feature presets (e.g.,

--- a/doc/stages/filters.miniball.rst
+++ b/doc/stages/filters.miniball.rst
@@ -51,5 +51,8 @@ Options
 knn
   The number of k nearest neighbors. [Default: 8]
 
+threads
+  The number of threads to use. Only valid in :ref:`standard mode <processing_modes>`. [Default: 1]
+
 .. include:: filter_opts.rst
 

--- a/doc/stages/filters.planefit.rst
+++ b/doc/stages/filters.planefit.rst
@@ -54,7 +54,7 @@ knn
   The number of k nearest neighbors. [Default: 8]
 
 threads
-  The number of threads used for computing the plane fit criterion. [Default: 1]
+  The number of threads to use. Only valid in :ref:`standard mode <processing_modes>`. [Default: 1]
 
 .. include:: filter_opts.rst
 

--- a/doc/stages/filters.reciprocity.rst
+++ b/doc/stages/filters.reciprocity.rst
@@ -53,5 +53,8 @@ Options
 knn
   The number of k nearest neighbors. [Default: 8]
 
+threads
+  The number of threads to use. Only valid in :ref:`standard mode <processing_modes>`. [Default: 1]
+
 .. include:: filter_opts.rst
 

--- a/filters/MiniballFilter.cpp
+++ b/filters/MiniballFilter.cpp
@@ -82,18 +82,23 @@ void MiniballFilter::addDimensions(PointLayoutPtr layout)
 
 void MiniballFilter::filter(PointView& view)
 {
-    point_count_t nloops = view.size();
+    point_count_t npoints = view.size();
+    point_count_t chunk_size = npoints / m_threads;
+    if (npoints % m_threads) chunk_size++;
     std::vector<std::thread> threadList(m_threads);
+
     for (int t = 0; t < m_threads; t++)
     {
-        threadList[t] = std::thread(std::bind(
+        threadList[t] = std::thread(
             [&](const PointId start, const PointId end) {
                 for (PointId i = start; i < end; i++)
                     setMiniball(view, i);
             },
-            t * nloops / m_threads,
-            (t + 1) == m_threads ? nloops : (t + 1) * nloops / m_threads));
+            t * chunk_size,
+            (t + 1) == m_threads ? npoints : (t + 1) * chunk_size
+        );
     }
+
     for (auto& t : threadList)
         t.join();
 }

--- a/filters/OverlayFilter.cpp
+++ b/filters/OverlayFilter.cpp
@@ -204,7 +204,8 @@ void OverlayFilter::filter(PointView& view)
                 }
             },
             t * chunk_size,
-            (t + 1) == m_threads ? npoints : (t + 1) * chunk_size);
+            (t + 1) == m_threads ? npoints : (t + 1) * chunk_size
+        );
     }
 
     for (auto& t : threadList)

--- a/filters/PlaneFitFilter.cpp
+++ b/filters/PlaneFitFilter.cpp
@@ -83,18 +83,23 @@ void PlaneFitFilter::addDimensions(PointLayoutPtr layout)
 
 void PlaneFitFilter::filter(PointView& view)
 {
-    point_count_t nloops = view.size();
+    point_count_t npoints = view.size();
+    point_count_t chunk_size = npoints / m_threads;
+    if (npoints % m_threads) chunk_size++;
     std::vector<std::thread> threadList(m_threads);
+
     for (int t = 0; t < m_threads; t++)
     {
-        threadList[t] = std::thread(std::bind(
+        threadList[t] = std::thread(
             [&](const PointId start, const PointId end) {
                 for (PointId i = start; i < end; i++)
                     setPlaneFit(view, i);
             },
-            t * nloops / m_threads,
-            (t + 1) == m_threads ? nloops : (t + 1) * nloops / m_threads));
+            t * chunk_size,
+            (t + 1) == m_threads ? npoints : (t + 1) * chunk_size
+        );
     }
+
     for (auto& t : threadList)
         t.join();
 }

--- a/filters/ReciprocityFilter.cpp
+++ b/filters/ReciprocityFilter.cpp
@@ -80,18 +80,23 @@ void ReciprocityFilter::addDimensions(PointLayoutPtr layout)
 
 void ReciprocityFilter::filter(PointView& view)
 {
-    point_count_t nloops = view.size();
+    point_count_t npoints = view.size();
+    point_count_t chunk_size = npoints / m_threads;
+    if (npoints % m_threads) chunk_size++;
     std::vector<std::thread> threadList(m_threads);
+
     for (int t = 0; t < m_threads; t++)
     {
-        threadList[t] = std::thread(std::bind(
+        threadList[t] = std::thread(
             [&](const PointId start, const PointId end) {
                 for (PointId i = start; i < end; i++)
                     setReciprocity(view, i);
             },
-            t * nloops / m_threads,
-            (t + 1) == m_threads ? nloops : (t + 1) * nloops / m_threads));
+            t * chunk_size,
+            (t + 1) == m_threads ? npoints : (t + 1) * chunk_size
+        );
     }
+
     for (auto& t : threadList)
         t.join();
 }


### PR DESCRIPTION
### Documentation
Added missing threads parameter to the documentation of `filters.miniball` and `filters.reciprocity`. Also mention explicitly that threading is only supported in `standard mode` processing

### Threading
Based on feedback from #4307, the unnecessary `std::bind` has been removed. And iteration of the points is now based on chunks. 