### PR TITLE
CMake: Add WITH_OPENSSL CMake-option

### DIFF
--- a/cmake/openssl.cmake
+++ b/cmake/openssl.cmake
@@ -1,7 +1,14 @@
-find_package(OpenSSL 1.1)
-if (OPENSSL_FOUND)
-    set(ARBITER_OPENSSL TRUE)
-else ()
-    message("OpenSSL NOT found - `export OPENSSL_ROOT_DIR=___`")
-    message("Google storage IO will not be available")
+#
+# OpenSSL support
+#
+option(WITH_OPENSSL
+    "Build with OpenSSL for Google storage IO support" TRUE)
+if (WITH_OPENSSL)
+    find_package(OpenSSL 1.1)
+    if (OPENSSL_FOUND)
+        set(ARBITER_OPENSSL TRUE)
+    else ()
+        message("OpenSSL NOT found - `export OPENSSL_ROOT_DIR=___`")
+        message("Google storage IO will not be available")
+    endif ()
 endif ()


### PR DESCRIPTION
Linking against OpenSSL is optional and not necessary if Google storage IO support is not required (or desired). However, until now there was now way of disabling linking against OpenSSL in CMake.

The added WITH_OPENSSL CMake-option is set to TRUE to keep the current default behavior.