### PR TITLE
Update minimum TileDB version to 2.18.0

### DIFF
--- a/cmake/tiledb.cmake
+++ b/cmake/tiledb.cmake
@@ -1,7 +1,7 @@
 #
 # TileDB support
 #
-find_package(TileDB QUIET 2.3.0 REQUIRED)
+find_package(TileDB QUIET 2.18.0 REQUIRED)
 
 set_package_properties(TileDB PROPERTIES
         TYPE OPTIONAL

--- a/plugins/tiledb/io/TileDBReader.cpp
+++ b/plugins/tiledb/io/TileDBReader.cpp
@@ -125,19 +125,10 @@ void TileDBReader::initialize()
         if (m_args->m_stats)
             tiledb::Stats::enable();
 
-#if TILEDB_VERSION_MAJOR == 2 && TILEDB_VERSION_MINOR < 15
-        m_array.reset(new tiledb::Array(*m_ctx, m_filename, TILEDB_READ));
-        if (m_args->m_startTimeStamp != 0)
-            m_array->set_open_timestamp_start(m_args->m_startTimeStamp);
-        if (m_args->m_endTimeStamp != UINT64_MAX)
-            m_array->set_open_timestamp_end(m_args->m_endTimeStamp);
-        m_array->reopen();
-#else
         m_array.reset(new tiledb::Array(*m_ctx, m_filename, TILEDB_READ,
                                         {tiledb::TimestampStartEndMarker(),
                                          m_args->m_startTimeStamp,
                                          m_args->m_endTimeStamp}));
-#endif
     }
     catch (const tiledb::TileDBError& err)
     {

--- a/plugins/tiledb/io/TileDBUtils.cpp
+++ b/plugins/tiledb/io/TileDBUtils.cpp
@@ -221,12 +221,6 @@ tiledb::Filter FilterFactory::filter(const tiledb::Context& ctx,
         else if (key == "reinterpret_datatype" ||
                  key == "COMPRESSION_REINTERPRET_DATATYPE")
         {
-#if TILEDB_VERSION_MAJOR == 2 && TILEDB_VERSION_MINOR < 16
-            throw tiledb::TileDBError(
-                "Unable to set filter option '" + key +
-                "'. Requires TileDB version 2.16 or greater.");
-
-#else
             auto datatype_str = options[key].get<std::string>();
             tiledb_datatype_t output_datatype{};
             auto rc = tiledb_datatype_from_str(datatype_str.c_str(),
@@ -238,8 +232,6 @@ tiledb::Filter FilterFactory::filter(const tiledb::Context& ctx,
             uint8_t datatype_int = static_cast<uint8_t>(output_datatype);
             filter.set_option<uint8_t>(TILEDB_COMPRESSION_REINTERPRET_DATATYPE,
                                        datatype_int);
-
-#endif
         }
         else
             throw tiledb::TileDBError("Unable to set filter option '" + key +
@@ -361,15 +353,12 @@ tiledb::FilterList FilterFactory::defaultProfileFilterList(
         floatScale.set_option(TILEDB_SCALE_FLOAT_OFFSET, m_add_offset[index]);
         filterList.add_filter(floatScale);
 
-#if TILEDB_VERSION_MAJOR > 2 ||                                                \
-    (TILEDB_VERSION_MAJOR == 2 && TILEDB_VERSION_MINOR >= 16)
         // Delta filter
         tiledb::Filter delta{ctx, TILEDB_FILTER_DELTA};
         uint8_t deltaDatatype = static_cast<uint8_t>(TILEDB_INT32);
         delta.set_option<uint8_t>(TILEDB_COMPRESSION_REINTERPRET_DATATYPE,
                                   deltaDatatype);
         filterList.add_filter(delta);
-#endif
 
         if (balanced)
         {
@@ -397,15 +386,12 @@ tiledb::FilterList FilterFactory::defaultProfileFilterList(
     }
     else if (dimName == "GpsTime")
     {
-#if TILEDB_VERSION_MAJOR > 2 ||                                                \
-    (TILEDB_VERSION_MAJOR == 2 && TILEDB_VERSION_MINOR >= 16)
         // Delta filter
         tiledb::Filter delta{ctx, TILEDB_FILTER_DELTA};
         uint8_t deltaDatatype = static_cast<uint8_t>(TILEDB_INT64);
         delta.set_option<uint8_t>(TILEDB_COMPRESSION_REINTERPRET_DATATYPE,
                                   deltaDatatype);
         filterList.add_filter(delta);
-#endif
 
         // Bit width reduction
         tiledb::Filter bit_width_reduction{ctx,
@@ -429,12 +415,9 @@ tiledb::FilterList FilterFactory::defaultProfileFilterList(
     }
     else if (dimName == "Red" || dimName == "Green" || dimName == "Blue")
     {
-#if TILEDB_VERSION_MAJOR > 2 ||                                                \
-    (TILEDB_VERSION_MAJOR == 2 && TILEDB_VERSION_MINOR >= 16)
         // Delta filter
         tiledb::Filter delta{ctx, TILEDB_FILTER_DELTA};
         filterList.add_filter(delta);
-#endif
 
         // Bit width reduction
         tiledb::Filter bit_width_reduction{ctx,
@@ -459,12 +442,9 @@ tiledb::FilterList FilterFactory::defaultProfileFilterList(
     }
     else if (dimName == "Intensity")
     {
-#if TILEDB_VERSION_MAJOR > 2 ||                                                \
-    (TILEDB_VERSION_MAJOR == 2 && TILEDB_VERSION_MINOR >= 16)
         // Delta filter
         tiledb::Filter delta{ctx, TILEDB_FILTER_DELTA};
         filterList.add_filter(delta);
-#endif
 
         if (balanced)
         {

--- a/plugins/tiledb/io/TileDBWriter.cpp
+++ b/plugins/tiledb/io/TileDBWriter.cpp
@@ -495,18 +495,9 @@ void TileDBWriter::ready(pdal::BasePointTable& table)
     }
 
     // Open the array at the requested timestamp range.
-#if TILEDB_VERSION_MAJOR == 2 && TILEDB_VERSION_MINOR < 15
-    if (m_args->m_timeStamp != UINT64_MAX)
-        m_array.reset(new tiledb::Array(*m_ctx, m_args->m_arrayName,
-                                        TILEDB_WRITE, m_args->m_timeStamp));
-    else
-        m_array.reset(
-            new tiledb::Array(*m_ctx, m_args->m_arrayName, TILEDB_WRITE));
-#else
     m_array.reset(
         new tiledb::Array(*m_ctx, m_args->m_arrayName, TILEDB_WRITE,
                           {tiledb::TimeTravelMarker(), m_args->m_timeStamp}));
-#endif
     const auto& schema = m_array->schema();
 
     for (const auto& dimBuffer : m_buffers)
@@ -576,7 +567,8 @@ void TileDBWriter::done(PointTableRef table)
                                   m.c_str());
             // add tiledb pointcloud tag
             std::string datasetType = "pointcloud";
-            m_array->put_metadata("dataset_type", TILEDB_STRING_UTF8, datasetType.size(), datasetType.data());
+            m_array->put_metadata("dataset_type", TILEDB_STRING_UTF8,
+                                  datasetType.size(), datasetType.data());
         }
         m_array->close();
     }

--- a/plugins/tiledb/test/TileDBReaderTest.cpp
+++ b/plugins/tiledb/test/TileDBReaderTest.cpp
@@ -49,7 +49,6 @@
 #undef DELETE
 #endif
 
-
 #include <tiledb/tiledb>
 
 #include "Support.hpp"
@@ -199,7 +198,8 @@ TEST_F(TileDBReaderTest, read)
 
     tiledb::Array array(ctx, data_path, TILEDB_READ);
 
-    tiledb_datatype_t v_type = (tiledb_datatype_t)std::numeric_limits<int32_t>::max();
+    tiledb_datatype_t v_type =
+        (tiledb_datatype_t)std::numeric_limits<int32_t>::max();
     EXPECT_TRUE(array.has_metadata("dataset_type", &v_type));
     EXPECT_EQ(v_type, TILEDB_STRING_UTF8);
 
@@ -356,10 +356,6 @@ TEST(TileDBRoundTripTest, delta_filter_test)
         writer.setOptions(writerOptions);
         writer.setInput(bufferReader);
         writer.prepare(table);
-#if TILEDB_VERSION_MAJOR == 2 && TILEDB_VERSION_MINOR < 16
-        EXPECT_THROW(writer.execute(table), tiledb::TileDBError);
-    }
-#else
         writer.execute(table);
     }
 
@@ -411,6 +407,5 @@ TEST(TileDBRoundTripTest, delta_filter_test)
                 gpsTimeValues[index]);
         }
     }
-#endif
 }
 }; // namespace pdal

--- a/plugins/tiledb/test/TileDBUtilsTest.cpp
+++ b/plugins/tiledb/test/TileDBUtilsTest.cpp
@@ -275,9 +275,6 @@ TEST(FilterFactory, user_set_delta)
                           {{1.0, 1.0, 1.0}}, "zstd",     7};
 
     tiledb::Context ctx{};
-#if TILEDB_VERSION_MAJOR == 2 && TILEDB_VERSION_MINOR < 16
-    EXPECT_THROW(factory.filterList(ctx, "GpsTime"), tiledb::TileDBError);
-#else
     auto filterList = factory.filterList(ctx, "GpsTime");
     auto nfilters = filterList.nfilters();
     EXPECT_EQ(nfilters, 1);
@@ -291,7 +288,6 @@ TEST(FilterFactory, user_set_delta)
                           &output_type);
         EXPECT_EQ(output_type, TILEDB_UINT64);
     }
-#endif
 }
 
 TEST(FilterFactory, user_set_bzip2)

--- a/plugins/tiledb/test/TileDBWriterTest.cpp
+++ b/plugins/tiledb/test/TileDBWriterTest.cpp
@@ -361,11 +361,7 @@ TEST_F(TileDBWriterTest, default_options)
 
     tiledb::FilterList fl =
         array.schema().domain().dimension("X").filter_list();
-#if TILEDB_VERSION_MAJOR == 2 && TILEDB_VERSION_MINOR < 16
-    EXPECT_EQ(fl.nfilters(), 3U);
-#else
     EXPECT_EQ(fl.nfilters(), 4U);
-#endif
 
     tiledb::Filter f1 = fl.filter(0);
     EXPECT_EQ(f1.filter_type(), TILEDB_FILTER_SCALE_FLOAT);


### PR DESCRIPTION
* Update CMake to require TileDB 2.18.0 or more recent.
* Remove preprocessor if/else needed for earlier version of TileDB.