### PR TITLE
CI: add support for Conda osx_arm64 builds

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -68,6 +68,7 @@ jobs:
 
     - name: Install dependencies
       run: |
+          sudo apt-get update
           sudo apt-get install -y \
             ccache cmake g++ \
             libcurl4-gnutls-dev \

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        platform: ['windows-latest','macos-latest','ubuntu-latest']
+        platform: ['windows-latest','macos-latest','macos-14','ubuntu-latest']
 
     env:
       PDAL_PLATFORM: ${{ matrix.platform }}

--- a/scripts/ci/conda/compile.sh
+++ b/scripts/ci/conda/compile.sh
@@ -5,18 +5,24 @@ mkdir packages
 export CI_PLAT=""
 if grep -q "windows" <<< "$PDAL_PLATFORM"; then
     CI_PLAT="win"
+    ARCH="64"
 fi
 
 if grep -q "ubuntu" <<< "$PDAL_PLATFORM"; then
     CI_PLAT="linux"
+    ARCH="64"
 fi
 
-if grep -q "macos" <<< "$PDAL_PLATFORM"; then
+if grep -q "macos-14" <<< "$PDAL_PLATFORM"; then
     CI_PLAT="osx"
+    ARCH="arm64"
+elif grep -q "macos" <<< "$PDAL_PLATFORM"; then
+    CI_PLAT="osx"
+    ARCH="64"
 fi
 
-conda build recipe --clobber-file recipe/recipe_clobber.yaml --output-folder packages -m ".ci_support/${CI_PLAT}_64_.yaml"
-conda create -y -n test -c ./packages/$CI_PLAT-64 python pdal
+conda build recipe --clobber-file recipe/recipe_clobber.yaml --output-folder packages -m ".ci_support/${CI_PLAT}_${ARCH}_.yaml"
+conda create -y -n test -c ./packages/${CI_PLAT}-${ARCH} python pdal
 conda deactivate
 
 conda activate test


### PR DESCRIPTION
Now that https://github.com/conda-incubator/setup-miniconda/releases/tag/v3.0.2 has been released with support for them

(port similar changes from
https://github.com/OSGeo/gdal/commit/fe693c6d13ccfd3c33420961891645b274095825)