### PR TITLE
Fix radius parameter in `erodeDiamond` for `SMRFilter`

### DIFF
--- a/filters/SMRFilter.cpp
+++ b/filters/SMRFilter.cpp
@@ -672,7 +672,7 @@ std::vector<int> SMRFilter::progressiveFilter(std::vector<double> const& ZImin,
     {
         // "On the first iteration, the minimum surface (ZImin) is opened using
         // a disk-shaped structuring element with a radius of one pixel."
-        math::erodeDiamond(erosion, m_rows, m_cols, 1);
+        math::erodeDiamond(erosion, m_rows, m_cols, radius);
         std::vector<double> curOpening = erosion;
         math::dilateDiamond(curOpening, m_rows, m_cols, radius);
 


### PR DESCRIPTION
I was going through the SMRF paper and the implementation in PDAL and the [original matlab implementation](https://github.com/thomaspingel/smrf-matlab/tree/master) and I think that I found a bug in the SMRFilter implementation.

The radius parameter for the `erodeDiamond` function was always `1` and didn't change with the radius like in the `dilateDiamond` function.  