### PR TITLE
filters.decimation: support non-integer step

### DIFF
--- a/doc/stages/filters.decimation.rst
+++ b/doc/stages/filters.decimation.rst
@@ -35,7 +35,8 @@ Options
 step
   Number of points to skip between each sample point.  A step of 1 will skip
   no points.  A step of 2 will skip every other point.  A step of 100 will
-  reduce the input by ~99%. [Default: 1]
+  reduce the input by ~99%. A step of 1.6 will retain ``100 / 1.6 = 62.5%`` of
+  the points. [Default: 1.0]
 
 offset
   Point index to start sampling.  Point indexes start at 0.  [Default: 0]

--- a/filters/DecimationFilter.hpp
+++ b/filters/DecimationFilter.hpp
@@ -50,12 +50,14 @@ public:
     std::string getName() const;
 
 private:
-    uint32_t m_step;
-    uint32_t m_offset;
+    double m_step;
+    point_count_t m_offset;
     point_count_t m_limit;
-    PointId m_index;
+    PointId m_index = 0;
+    point_count_t m_kept = 0;
 
     virtual void addArgs(ProgramArgs& args);
+    virtual void initialize();
     void ready(PointTableRef table)
         { m_index = 0; }
     bool processOne(PointRef& point);


### PR DESCRIPTION
Currently the [decimation filter](https://pdal.io/en/2.6.3/stages/filters.decimation.html) accepts integer steps only, which restricts it to keeping 100%/50%/33%/25%/20%/16%/... of the input points.

Add the ability to use a decimal step values for more flexibility. eg: a step value of 1.6 will keep (100 / 1.6) = 62.5% of the input. A keep-percentage might be a cleaner greenfield approach, but this is backwards compatible.

Other changes:
* Add fixed and streaming tests for decimal step values.
* Restrict step values to >=1.
* Replace the 32bit offset in the filter with a 64bit one.

Quick and dirty performance check:
```sh
$ time build/bin/pdal translate -i a.copc.laz -o STDOUT \
    -w writers.text --writers.text.format=csv --writers.text.write_header=false \
    -f filters.decimation --filters.decimation.step=10 | wc -l

# 3.2M points -> 320K
# macOS arm64, release build type
# Before: 3.24s
# After:  3.23s
```