### PR TITLE
Add writers.copc.sort to allow user to change the dimension that chun…

### DIFF
--- a/io/CopcWriter.cpp
+++ b/io/CopcWriter.cpp
@@ -133,6 +133,7 @@ void CopcWriter::addArgs(ProgramArgs& args)
         decltype(b->opts.enhancedSrsVlrs)(false));
     args.add("extra_dims", "List of dimension names to write in addition to those of the "
         "point format or 'all' for all available dimensions", b->opts.extraDimSpec);
+    args.add("sort", "Dimension name to sort chunks", b->sortDimName, "GpsTime");
 }
 
 void CopcWriter::fillForwardList()
@@ -293,6 +294,10 @@ void CopcWriter::prepared(PointTableRef table)
             "(" << Dimension::interpretationName(dim.m_dimType.m_type) <<
             ") " << " to COPC extra bytes." << std::endl;
     }
+
+    b->sortDim = layout->findDim(b->sortDimName);
+    if (b->sortDim == Dimension::Id::Unknown)
+        throwError("Dimension '" + b->sortDimName + "' not found in layout");
 }
 
 void CopcWriter::ready(PointTableRef table)

--- a/io/CopcWriter.cpp
+++ b/io/CopcWriter.cpp
@@ -295,9 +295,21 @@ void CopcWriter::prepared(PointTableRef table)
             ") " << " to COPC extra bytes." << std::endl;
     }
 
-    b->sortDim = layout->findDim(b->sortDimName);
-    if (b->sortDim == Dimension::Id::Unknown)
-        throwError("Dimension '" + b->sortDimName + "' not found in layout");
+    // User-provided sorting dimension
+    // If we can't find our dimension but the user used the default
+    // dimension of GpsTime, we're just going to use that.
+    Dimension::Id sortDim = layout->findDim(b->sortDimName);
+    if (sortDim == Dimension::Id::Unknown)
+    {
+        if (Utils::iequals(b->sortDimName, "GPSTIME"))
+            b->sortDim = Dimension::Id::GpsTime;
+        else
+            throwError("Dimension '" + b->sortDimName + "' not found in layout");
+    } else
+    {
+        b->sortDim = sortDim;
+    }
+
 }
 
 void CopcWriter::ready(PointTableRef table)

--- a/io/private/copcwriter/Common.hpp
+++ b/io/private/copcwriter/Common.hpp
@@ -138,6 +138,8 @@ struct BaseInfo
         stats::Summary("ReturnNumber", stats::Summary::Enumerate),
     };
     std::string filename;
+    std::string sortDimName;
+    Dimension::Id sortDim = Dimension::Id::GpsTime;
 };
 
 } // namespace copcwriter

--- a/io/private/copcwriter/Processor.cpp
+++ b/io/private/copcwriter/Processor.cpp
@@ -178,9 +178,9 @@ void Processor::writeCompressed(VoxelKey k, PointViewPtr v)
     lazperf::writer::chunk_compressor compressor(b.pointFormatId, b.numExtraBytes);
 
     // Sort by GPS time - no-op if there's no GPS time.
-    v->stableSort([](const PointRef& p1, const PointRef& p2)
+    v->stableSort([this](const PointRef& p1, const PointRef& p2)
     {
-        return p1.compare(Dimension::Id::GpsTime, p2);
+        return p1.compare(b.sortDim, p2);
     });
 
     for (PointId idx = 0; idx < v->size(); ++idx)


### PR DESCRIPTION
Add `writers.copc.sort` to take in a dimension name to allow users to control what dimension the chunks are sorted upon. This defaults to `GpsTime`, which was what has always been used.

There are situations where you might want to control the sorting. For example, if you are dropping the `GpsTime` dimension from your data, the default behavior is going to be random in the chunk (and extra compute). 

## Sorting behavior INCLUDING normal existing `GpsTime` values

``writers.copc`` normally sorts the data on `GpsTime`. As you can see this is usually the right thing to do.

<img width="558" alt="image" src="https://github.com/PDAL/PDAL/assets/87751/9860001c-d162-4103-bbf4-88dfec2c9083">


## Sorting behavior after ZEROING OUT `GpsTime` values

However, if the `GpsTime` values are `0`, we probably want to sort on something else...

<img width="605" alt="image" src="https://github.com/PDAL/PDAL/assets/87751/51522ef9-9bea-42ec-a82a-1fe3efd6598b">

