### PR TITLE
PG COPY mode support for pgpointcloud plugin

### DIFF
--- a/doc/stages/writers.pgpointcloud.rst
+++ b/doc/stages/writers.pgpointcloud.rst
@@ -44,7 +44,8 @@ Example
           "connection":"host='localhost' dbname='lidar' user='pramsey'",
           "table":"example",
           "compression":"dimensional",
-          "srid":"26916"
+          "srid":"26916",
+          "pg_use_copy": true
       }
   ]
 
@@ -104,6 +105,10 @@ scale_x, scale_y, scale_z / offset_x, offset_y, offset_z
 output_dims
   If specified, limits the dimensions written for each point.  Dimensions
   are listed by name and separated by commas.
+
+pg_use_copy
+  Set to true to use PostgreSQL COPY mode for inserting data,
+  false to use SQL INSERT (default to false)
 
 .. include:: writer_opts.rst
 

--- a/plugins/pgpointcloud/io/PgWriter.cpp
+++ b/plugins/pgpointcloud/io/PgWriter.cpp
@@ -56,7 +56,6 @@ CREATE_SHARED_STAGE(PgWriter, s_info)
 std::string PgWriter::getName() const { return s_info.name; }
 
 // TO DO:
-// - change INSERT into COPY
 //
 // - PCID / Schema consistency. If a PCID is specified,
 // must it be consistent with the buffer schema? Or should

--- a/plugins/pgpointcloud/io/PgWriter.cpp
+++ b/plugins/pgpointcloud/io/PgWriter.cpp
@@ -497,7 +497,7 @@ void PgWriter::writeTile(const PointViewPtr view)
 }
 
 // brute force copy of writeTile function: todo: factorize pg patch creation
-// copy from with libpqxx can be done with (from doc: https://www.postgresql.org/docs/16/libpq-copy.html):
+// copy from with libpq can be done with (from doc: https://www.postgresql.org/docs/16/libpq-copy.html):
 // PQputCopyData; PQputCopyEnd
 void PgWriter::copyTile(const PointViewPtr view)
 {

--- a/plugins/pgpointcloud/io/PgWriter.hpp
+++ b/plugins/pgpointcloud/io/PgWriter.hpp
@@ -60,6 +60,8 @@ private:
 
     void writeInit();
     void writeTile(const PointViewPtr view);
+    // new copy mode
+    void copyTile(const PointViewPtr view);
 
     bool CheckTableExists(std::string const& name);
     bool CheckPointCloudExists();
@@ -96,6 +98,11 @@ private:
     Orientation m_orientation;
     std::string m_pre_sql;
     std::string m_post_sql;
+    // new: copy mode management
+    bool m_pg_use_copy;
+    bool m_in_copy_mode; // copy management between copyTile invocations, to control when to send data or not
+    std::string m_copy;
+    std::string m_copy_data;
 
     // lose this
     bool m_schema_is_initialized;

--- a/plugins/pgpointcloud/test/PgpointcloudTest.cpp
+++ b/plugins/pgpointcloud/test/PgpointcloudTest.cpp
@@ -84,6 +84,9 @@ Options getDbOptions()
     options.add(Option("connection", getTestDBTempConn()));
     options.add(Option("table", "4dal-\"test\"-table")); // intentional quotes
     options.add(Option("column", "p\"a")); // intentional quotes
+    // fake filename to avoid missing arg exception.
+    // todo: ticket for pdal, as it also occurs on current version with pdal pipeline cmd
+    options.add(Option("filename", "nullfilename"));
 
     return options;
 }
@@ -194,6 +197,7 @@ void optionsWrite(const Options& writerOps)
     reader->setOptions(options);
 
     Stage* writer(f.createStage("writers.pgpointcloud"));
+    const std::string fakeFname = "null";
     writer->setOptions(writerOps);
     writer->setInput(*reader);
 
@@ -219,6 +223,17 @@ TEST_F(PgpointcloudWriterTest, write)
     }
 
     optionsWrite(getDbOptions());
+}
+
+TEST_F(PgpointcloudWriterTest, writeCopy)
+{
+    if (shouldSkipTests())
+    {
+        return;
+    }
+    Options ops = getDbOptions();
+    ops.add("pg_use_copy", true);
+    optionsWrite(ops);
 }
 
 TEST_F(PgpointcloudWriterTest, writeScaled)

--- a/plugins/pgpointcloud/test/PgpointcloudTest.cpp
+++ b/plugins/pgpointcloud/test/PgpointcloudTest.cpp
@@ -197,7 +197,7 @@ void optionsWrite(const Options& writerOps)
     reader->setOptions(options);
 
     Stage* writer(f.createStage("writers.pgpointcloud"));
-    const std::string fakeFname = "null";
+    const std::string fakeFname = "nullfn";
     writer->setOptions(writerOps);
     writer->setInput(*reader);
 


### PR DESCRIPTION
Allows `writers.pgpointcloud` to use PostgreSQL COPY mode, by adding a new config parameter named `pg_use_copy`.
COPY is significantly faster than INSERT.

Set `pg_use_copy` to `true` to use copy instead of INSERT statements (default to `false`, keeping original INSERT mode).

(a new method was added to `PgWriter` class to avoid messing-up too much with the code. A factorisation should be done between `writeTile` and `copyTile` (the new method))