### PR TITLE
rotation matrix example corrected

### DIFF
--- a/doc/stages/filters.transformation.rst
+++ b/doc/stages/filters.transformation.rst
@@ -150,7 +150,7 @@ shown below.
   [
       {
           "type":"filters.transformation",
-          "matrix":"0  0  -1  0  1  0  0  0  0  0  1  0  0  0  0  1"
+          "matrix":"0  -1  0  0  1  0  0  0  0  0  1  0  0  0  0  1"
       }
   ]
 


### PR DESCRIPTION
The correct matrix for a 90-degree counterclockwise rotation about the Z-axis is as follows:

| 0  -1  0  0 |
| 1   0  0  0 |
| 0   0  1  0 |
| 0   0  0  1 |

But on the example json file it was showing this:
"matrix":"0  0  -1  0  1  0  0  0  0  0  1  0  0  0  0  1"

Correct matrix would be:
"matrix": "0  -1  0  0  1  0  0  0  0  0  1  0  0  0  0  1"