### PR TITLE
CI: conda.yml: change macos-latest to macos-13

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -23,7 +23,9 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        platform: ['windows-latest','macos-latest','macos-14','ubuntu-latest']
+        # macos-13: Intel
+        # macos-14: arm64
+        platform: ['ubuntu-latest','windows-latest','macos-13','macos-14']
 
     env:
       PDAL_PLATFORM: ${{ matrix.platform }}


### PR DESCRIPTION
GHA has changed the macos-latest alias to macos-14 (arm64), hence to get Intel Mac one now needs to explicitly select macos-13 Cf https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories