### PR TITLE
Fix doc message in crop filter

### DIFF
--- a/filters/CropFilter.cpp
+++ b/filters/CropFilter.cpp
@@ -96,7 +96,7 @@ void CropFilter::addArgs(ProgramArgs& args)
     args.add("point", "Center of circular/spherical crop region.  Use with "
         "'distance'.", m_args->m_centers).
         setErrorText("Invalid point specification.  Must be valid "
-            "GeoJSON/WKT. Ex: \"(1.00, 1.00)\" or \"(1.00, 1.00, 1.00)\"");
+            "GeoJSON/WKT. Ex: \"POINT (1 1)\" or \"POINT (1 1 1)\"");
     args.add("distance", "Crop with this distance from 2D or 3D 'point'",
         m_args->m_distance);
     args.add("polygon", "Bounding polying for cropped points", m_args->m_polys).


### PR DESCRIPTION
A minor fix for an error message in the crop filter. The suggested format `(1.00, 1.00)` is not valid.

This better matches the docs online. https://pdal.io/en/2.7.1/stages/filters.crop.html