### PR TITLE
Fix building on OpenBSD

### DIFF
--- a/test/unit/ProgramArgsTest.cpp
+++ b/test/unit/ProgramArgsTest.cpp
@@ -37,7 +37,7 @@
 #include <nlohmann/json.hpp>
 
 // No wordexp() on windows and I don't feel like doing something special.
-#ifndef _WIN32
+#if !defined(_WIN32) && !defined(__OpenBSD__)
 
 #include <wordexp.h>
 #include <pdal/pdal_internal.hpp>

--- a/vendor/kazhdan/MyTime.h
+++ b/vendor/kazhdan/MyTime.h
@@ -30,7 +30,9 @@ DAMAGE.
 #define MY_TIME_INCLUDED
 
 #include <string.h>
+#ifndef __OpenBSD__
 #include <sys/timeb.h>
+#endif
 #ifndef WIN32
 #include <sys/time.h>
 #endif // WIN32


### PR DESCRIPTION
OpenBSD does not have a sys/timeb.h header.
OpenBSD does not have wordexp(3).