### PR TITLE
Fix ref to readers.arrow in readers.rst

### DIFF
--- a/doc/stages/readers.rst
+++ b/doc/stages/readers.rst
@@ -54,7 +54,7 @@ like :ref:`readers.pgpointcloud`, or a network service like :ref:`readers.ept`.
    readers.tiledb
    readers.tindex
 
-:ref: `readers.arrow`
+:ref:`readers.arrow`
     Read GeoArrow/GeoParquet formatted data.
 
 :ref:`readers.bpf`


### PR DESCRIPTION
This should fix the bad formatting in the docs:

![image](https://github.com/PDAL/PDAL/assets/193367/d180aa4a-95e8-418b-8044-b67156e4199f)
