### PR TITLE
Fix CPD compilation of tests when building filters.cpd in non-standalone builds

### DIFF
--- a/plugins/cpd/CMakeLists.txt
+++ b/plugins/cpd/CMakeLists.txt
@@ -31,6 +31,7 @@ if(${WITH_TESTS})
         FILES
             test/CpdFilterTest.cpp
         LINK_WITH
+            ${filter_libname}
             Cpd::Library-C++
         INCLUDES
             "${include_dirs}"


### PR DESCRIPTION
This should fix the issue brought up at https://github.com/PDAL/PDAL/pull/4396#issuecomment-2214091102