### PR TITLE
Allow forcing VLR creation as EVLR 

### DIFF
--- a/doc/stages/writers.las.rst
+++ b/doc/stages/writers.las.rst
@@ -43,9 +43,10 @@ as shown:
               "filename": "path-to-my-file.input"
               },
               {
-              "description": "A description under 32 bytes",
+              "description": "Write metadata as EVLR",
               "record_id": 44,
               "user_id": "hobu",
+              "evlr': true,
               "metadata": "metadata_keyname"
               }],
           "filename":"outputfile.las"

--- a/doc/stages/writers.las.rst
+++ b/doc/stages/writers.las.rst
@@ -46,7 +46,7 @@ as shown:
               "description": "Write metadata as EVLR",
               "record_id": 44,
               "user_id": "hobu",
-              "evlr': true,
+              "evlr": true,
               "metadata": "metadata_keyname"
               }],
           "filename":"outputfile.las"

--- a/io/LasWriter.cpp
+++ b/io/LasWriter.cpp
@@ -629,7 +629,7 @@ void LasWriter::addVlr(const std::string& userId, uint16_t recordId,
 /// \param  evlr  VLR to add.
 void LasWriter::addVlr(const las::Evlr& evlr)
 {
-    if (evlr.dataSize() > las::Vlr::MaxDataSize || evlr.writeAsEVLR)
+    if (evlr.dataSize() > las::Vlr::MaxDataSize)
     {
         if (d->header.versionAtLeast(1, 4))
             m_evlrs.push_back(std::move(evlr));
@@ -637,6 +637,12 @@ void LasWriter::addVlr(const las::Evlr& evlr)
             throwError("Can't write VLR with user ID/record ID = " +
                 evlr.userId + "/" + std::to_string(evlr.recordId) +
                 ".  The data size exceeds the maximum supported.");
+    } else if (evlr.writeAsEVLR)
+    {
+        if (d->header.versionAtLeast(1, 4))
+            m_evlrs.push_back(std::move(evlr));
+        else
+            throwError("User specified writing as EVLR but the file is not a 1.4+ file!");
     }
     else
         m_vlrs.push_back(std::move(evlr));

--- a/io/LasWriter.cpp
+++ b/io/LasWriter.cpp
@@ -629,7 +629,7 @@ void LasWriter::addVlr(const std::string& userId, uint16_t recordId,
 /// \param  evlr  VLR to add.
 void LasWriter::addVlr(const las::Evlr& evlr)
 {
-    if (evlr.dataSize() > las::Vlr::MaxDataSize)
+    if (evlr.dataSize() > las::Vlr::MaxDataSize || evlr.writeAsEVLR)
     {
         if (d->header.versionAtLeast(1, 4))
             m_evlrs.push_back(std::move(evlr));

--- a/io/private/las/Vlr.cpp
+++ b/io/private/las/Vlr.cpp
@@ -323,9 +323,8 @@ std::istream& operator>>(std::istream& in, las::Evlr& v)
         else if (el.key() == "evlr")
         {
             if (!el.value().is_boolean())
-                throw pdal_error("LAS VLR metadata key must be specified as a string.");
-            bool doEVLR = el.value().get<bool>();
-            v.writeAsEVLR = doEVLR;
+                throw pdal_error("LAS VLR  key must be specified as a boolean.");
+            v.writeAsEVLR = el.value().get<bool>();
         }
         else
             throw pdal_error("Invalid key '" + el.key() + "' in VLR specification.");

--- a/io/private/las/Vlr.cpp
+++ b/io/private/las/Vlr.cpp
@@ -320,6 +320,13 @@ std::istream& operator>>(std::istream& in, las::Evlr& v)
 
             v.dataFunc = MetadataFunc(metadataId);
         }
+        else if (el.key() == "evlr")
+        {
+            if (!el.value().is_boolean())
+                throw pdal_error("LAS VLR metadata key must be specified as a string.");
+            bool doEVLR = el.value().get<bool>();
+            v.writeAsEVLR = doEVLR;
+        }
         else
             throw pdal_error("Invalid key '" + el.key() + "' in VLR specification.");
     }

--- a/io/private/las/Vlr.hpp
+++ b/io/private/las/Vlr.hpp
@@ -85,10 +85,10 @@ public:
 
     Vlr() = default;
     Vlr(const std::string& userId, uint16_t recordId, const std::string& description) :
-        userId(userId), recordId(recordId), description(description)
+        userId(userId), recordId(recordId), description(description), writeAsEVLR(false)
     {}
     Vlr(const std::string& userId, uint16_t recordId) :
-        userId(userId), recordId(recordId)
+        userId(userId), recordId(recordId), writeAsEVLR(false)
     {}
     virtual ~Vlr() = default;
 
@@ -111,6 +111,9 @@ public:
     std::string description;
     std::vector<char> dataVec;
     std::string metadataId;
+
+    // User specified we want to write this at the back of the file
+    bool writeAsEVLR;
 };
 
 inline bool operator==(const Vlr& v1, const Vlr& v2)

--- a/io/private/las/Vlr.hpp
+++ b/io/private/las/Vlr.hpp
@@ -113,7 +113,7 @@ public:
     std::string metadataId;
 
     // User specified we want to write this at the back of the file
-    bool writeAsEVLR;
+    bool writeAsEVLR = false;
 };
 
 inline bool operator==(const Vlr& v1, const Vlr& v2)

--- a/io/private/las/Vlr.hpp
+++ b/io/private/las/Vlr.hpp
@@ -130,11 +130,11 @@ struct Evlr : public Vlr
     Evlr(const std::string& userId, uint16_t recordId,
             const std::string& description, const std::vector<char>& data) :
         Vlr(userId, recordId, description)
-    { dataVec = data; }
+    { dataVec = data; writeAsEVLR = false;}
     Evlr(const std::string& userId, uint16_t recordId,
             const std::string& description, std::vector<char>&& data) :
         Vlr(userId, recordId, description)
-    { dataVec = data; }
+    { dataVec = data; writeAsEVLR = false;}
 
     virtual void fillHeader(const char *buf) override;
     virtual std::vector<char> headerData() const override;

--- a/test/unit/io/LasWriterTest.cpp
+++ b/test/unit/io/LasWriterTest.cpp
@@ -1262,10 +1262,21 @@ TEST(LasWriterTest, pdal_add_vlr)
           "metadata": "software_id"
           })"
     );
+    std::string vlr4(
+      R"({
+          "description": "An explicit EVLR",
+          "record_id": 45,
+          "user_id": "hobu",
+          "evlr": true,
+          "metadata": "software_id"
+          })"
+    );
     Options writerOpts;
     writerOpts.add("vlrs", vlr1);
     writerOpts.add("vlrs", vlr2);
     writerOpts.add("vlrs", vlr3);
+    writerOpts.add("vlrs", vlr4);
+    writerOpts.add("minor_version", 4);
     writerOpts.add("filename", outfile);
 
     LasReader reader;
@@ -1287,7 +1298,7 @@ TEST(LasWriterTest, pdal_add_vlr)
     reader2.execute(t2);
 
     const VlrList& vlrs = reader2.header().vlrs();
-    EXPECT_EQ(vlrs.size(), 3u);
+    EXPECT_EQ(vlrs.size(), 4u);
 
     const LasVLR& v0 = vlrs[0];
     std::string s0(v0.data(), v0.data() + v0.dataLen());
@@ -1300,6 +1311,10 @@ TEST(LasWriterTest, pdal_add_vlr)
     const LasVLR& v2 = vlrs[2];
     std::string s2(v2.data(), v2.data() + v2.dataLen());
     EXPECT_EQ(s2, "TerraScan");
+
+    const LasVLR& v3 = vlrs[3];
+    std::string s3(v3.data(), v3.data() + v3.dataLen());
+    EXPECT_EQ(s3, "TerraScan");
 }
 
 TEST(LasWriterTest, pdal_wkt2_vlr)


### PR DESCRIPTION
Implements #4442 to allow the user to force the writing of a VLR as an EVLR if they specify it.