### PR TITLE
Support sorting multiple dimensions at once in `filters.sort`

### DIFF
--- a/doc/stages/filters.sort.rst
+++ b/doc/stages/filters.sort.rst
@@ -28,8 +28,8 @@ Example
 Options
 -------
 
-_`dimension`
-  The dimension on which to sort the points. [Required]
+_`dimensions`
+  A list of dimensions in the order on which to sort the points. [Required]
 
 _`order`
   The order in which to sort, ASC or DESC [Default: "ASC"]

--- a/doc/stages/filters.sort.rst
+++ b/doc/stages/filters.sort.rst
@@ -28,10 +28,10 @@ Example
 Options
 -------
 
-_`dimensions`
+dimensions
   A list of dimensions in the order on which to sort the points. [Required]
 
-_`order`
+order
   The order in which to sort, ASC or DESC [Default: "ASC"]
 
 .. include:: filter_opts.rst

--- a/doc/stages/filters.sort.rst
+++ b/doc/stages/filters.sort.rst
@@ -3,8 +3,8 @@
 filters.sort
 ============
 
-The sort filter orders a point view based on the values of a dimension_. The
-sorting can be done in increasing (ascending) or decreasing (descending) order_.
+The sort filter orders a point view based on the values of a :ref:`dimensions`. The
+sorting can be done in increasing (ascending) or decreasing (descending) order.
 
 .. embed::
 
@@ -24,6 +24,10 @@ Example
       "sorted.las"
   ]
 
+.. note::
+
+    See :ref:`filters.label_duplicates` for an example of using :ref:`filters.sort` to
+    sort multiple dimensions at once.
 
 Options
 -------

--- a/filters/LabelDuplicatesFilter.cpp
+++ b/filters/LabelDuplicatesFilter.cpp
@@ -82,7 +82,7 @@ void LabelDuplicatesFilter::prepared(PointTableRef table)
         Dimension::Id dimId = layout->findDim(dimName);
         if (dimId == Dimension::Id::Unknown)
             throwError("Dimension '" + dimName + "' specified in "
-                "'sort_dims' option not found.");
+                "'dimensions' option not found in layout.");
         m_dims.push_back(dimId);
     }
 }

--- a/filters/SortFilter.cpp
+++ b/filters/SortFilter.cpp
@@ -100,9 +100,9 @@ void SortFilter::filter(PointView& view)
             // If we have multiple dimensions, stable_sort the first one
             // and then sort the rest
             if (i == 0)
-                std::stable_sort(view.begin(), view.end(), cmp);
-            else
                 std::sort(view.begin(), view.end(), cmp);
+            else
+                std::stable_sort(view.begin(), view.end(), cmp);
         } else
         {
             if (m_algorithm == SortAlgorithm::Stable)

--- a/filters/SortFilter.cpp
+++ b/filters/SortFilter.cpp
@@ -97,8 +97,8 @@ void SortFilter::filter(PointView& view)
 
         if (m_dims.size() > 1)
         {
-            // If we have multiple dimensions, stable_sort the first one
-            // and then sort the rest
+            // If we have multiple dimensions, sort the first one
+            // and then stable_sort the rest
             if (i == 0)
                 std::sort(view.begin(), view.end(), cmp);
             else

--- a/filters/SortFilter.hpp
+++ b/filters/SortFilter.hpp
@@ -71,6 +71,7 @@ private:
 
     StringList m_dimNames;
     Dimension::IdList m_dims;
+    Dimension::Id* m_activeDim;
 
     // Sort order.
     SortOrder m_order;

--- a/filters/SortFilter.hpp
+++ b/filters/SortFilter.hpp
@@ -59,10 +59,9 @@ public:
     std::string getName() const;
 
 private:
-    // Dimension on which to sort.
-    Dimension::Id m_dim;
-    // Dimension name.
-    std::string m_dimName;
+
+    StringList m_dimNames;
+    Dimension::IdList m_dims;
 
     // Sort order.
     SortOrder m_order;

--- a/test/unit/filters/LabelDuplicatesFilterTest.cpp
+++ b/test/unit/filters/LabelDuplicatesFilterTest.cpp
@@ -53,31 +53,21 @@ void testDimensions(std::string const& data, std::string const& dimensions)
     textOptions.add("filename", Support::datapath(data));
     t.setOptions(textOptions);
 
-
     PointTable table;
+    SortFilter sortFilter;
+    Options filterOpts;
+    filterOpts.add("dimensions", dimensions);
+    sortFilter.setOptions(filterOpts);
+    sortFilter.setInput(t);
 
-    StringList splitDimension = Utils::split2(dimensions, ',');
+    Options labelOpts;
+    labelOpts.add("dimensions", dimensions);
+    LabelDuplicatesFilter labelFilter;
+    labelFilter.setOptions(labelOpts);
+    labelFilter.setInput(sortFilter);
 
-    Stage* prev = &t;
-    for (auto dimension: splitDimension)
-    {
-        SortFilter* filter = new SortFilter();
-        Options opts;
-        opts.add("dimension", dimension);
-        opts.add("algorithm", "STABLE");
-        filter->setOptions(opts);
-        prev->setInput(*filter);
-    }
-
-    Options opts;
-    opts.add("dimensions", dimensions);
-    LabelDuplicatesFilter filter;
-    filter.setOptions(opts);
-    prev->setInput(filter);
-
-
-    prev->prepare(table);
-    PointViewSet views = filter.execute(table);
+    labelFilter.prepare(table);
+    PointViewSet views = labelFilter.execute(table);
     PointViewPtr view = *views.begin();
 
     for (PointId i = dimensions.size(); i < view->size(); ++i) {


### PR DESCRIPTION
This PR implements `dimensions` option on `filters.sort` to allow the user to do multiple sorts at one time. If multiple dimensions are requested, the first dimension is `std::stable_sort` and the rest of the dimensions are `std::sort`. If only a single dimension is requested, the `algorithm` option is respected.