### PR TITLE
Make DbWriters not need a filename.

### DIFF
--- a/pdal/DbWriter.hpp
+++ b/pdal/DbWriter.hpp
@@ -46,7 +46,7 @@ namespace pdal
 class PgWriter;
 class OciWriter;
 
-class PDAL_DLL DbWriter : public Writer
+class PDAL_DLL DbWriter : public NoFilenameWriter
 {
 protected:
     DbWriter()


### PR DESCRIPTION
Db writers should not require a filename.