### PR TITLE
Optional stable sort for filters.sort

### DIFF
--- a/filters/SortFilter.cpp
+++ b/filters/SortFilter.cpp
@@ -50,11 +50,9 @@ std::string SortFilter::getName() const { return s_info.name; }
 
 void SortFilter::addArgs(ProgramArgs& args)
 {
-    args.add("dimension", "Dimension on which to sort", m_dimName).
-        setPositional();
-    args.add("order", "Sort order ASC(ending) or DESC(ending)", m_order,
-        SortOrder::ASC);
-    args.add("stable", "Use stable sorting", m_stable);
+    args.add("dimension", "Dimension on which to sort", m_dimName).setPositional();
+    args.add("order", "Sort order ASC(ending) or DESC(ending)", m_order, SortOrder::ASC);
+    args.add("algorithm", "NORMAL (default) or STABLE", m_algorithm, SortAlgorithm::Normal);
 }
 
 void SortFilter::prepared(PointTableRef table)
@@ -73,13 +71,10 @@ void SortFilter::filter(PointView& view)
         return p2.compare(m_dim, p1);
     };
 
-    /**
-    if (m_stable)
+    if (m_algorithm == SortAlgorithm::Stable)
         std::stable_sort(view.begin(), view.end(), cmp);
-    else
+    else if (m_algorithm == SortAlgorithm::Normal)
         std::sort(view.begin(), view.end(), cmp);
-        **/
-        std::stable_sort(view.begin(), view.end(), cmp);
 }
 
 std::istream& operator >> (std::istream& in, SortOrder& order)
@@ -105,6 +100,33 @@ std::ostream& operator<<(std::ostream& out, const SortOrder& order)
         out << "ASC";
     case SortOrder::DESC:
         out << "DESC";
+    }
+    return out;
+}
+
+std::istream& operator >> (std::istream& in, SortAlgorithm& order)
+{
+    std::string s;
+
+    in >> s;
+    s = Utils::toupper(s);
+    if (s == "NORMAL")
+        order = SortAlgorithm::Normal;
+    else if (s == "STABLE")
+        order = SortAlgorithm::Stable;
+    else
+        in.setstate(std::ios::failbit);
+    return in;
+}
+
+std::ostream& operator<<(std::ostream& out, const SortAlgorithm& order)
+{
+    switch (order)
+    {
+    case SortAlgorithm::Normal:
+        out << "NORMAL";
+    case SortAlgorithm::Stable:
+        out << "STABLE";
     }
     return out;
 }

--- a/filters/SortFilter.cpp
+++ b/filters/SortFilter.cpp
@@ -54,6 +54,7 @@ void SortFilter::addArgs(ProgramArgs& args)
         setPositional();
     args.add("order", "Sort order ASC(ending) or DESC(ending)", m_order,
         SortOrder::ASC);
+    args.add("stable", "Use stable sorting", m_stable);
 }
 
 void SortFilter::prepared(PointTableRef table)
@@ -72,7 +73,13 @@ void SortFilter::filter(PointView& view)
         return p2.compare(m_dim, p1);
     };
 
-    std::sort(view.begin(), view.end(), cmp);
+    /**
+    if (m_stable)
+        std::stable_sort(view.begin(), view.end(), cmp);
+    else
+        std::sort(view.begin(), view.end(), cmp);
+        **/
+        std::stable_sort(view.begin(), view.end(), cmp);
 }
 
 std::istream& operator >> (std::istream& in, SortOrder& order)

--- a/filters/SortFilter.hpp
+++ b/filters/SortFilter.hpp
@@ -49,6 +49,15 @@ enum class SortOrder
 std::istream& operator >> (std::istream& in, SortOrder& order);
 std::ostream& operator << (std::ostream& in, const SortOrder& order);
 
+enum class SortAlgorithm
+{
+    Normal,
+    Stable
+};
+
+std::istream& operator >> (std::istream& in, SortAlgorithm& order);
+std::ostream& operator << (std::ostream& in, const SortAlgorithm& order);
+
 
 class PDAL_DLL SortFilter : public Filter
 {
@@ -66,7 +75,7 @@ private:
 
     // Sort order.
     SortOrder m_order;
-    bool m_stable;
+    SortAlgorithm m_algorithm;
 
     virtual void addArgs(ProgramArgs& args);
     virtual void prepared(PointTableRef table);

--- a/filters/SortFilter.hpp
+++ b/filters/SortFilter.hpp
@@ -66,6 +66,7 @@ private:
 
     // Sort order.
     SortOrder m_order;
+    bool m_stable;
 
     virtual void addArgs(ProgramArgs& args);
     virtual void prepared(PointTableRef table);

--- a/pdal/PointRef.cpp
+++ b/pdal/PointRef.cpp
@@ -5,14 +5,14 @@ namespace pdal
 {
 
 PointRef::PointRef(PointView& v, PointId idx) : m_table(&v.table()),
-    m_idx(v.tableId(idx)), m_view(&v), m_viewIdx(idx)
+    m_idx(v.tableId(idx)), m_view(&v), m_viewIdx(idx), m_orig(true)
 {}
 
 PointRef& PointRef::operator=(const PointRef& r)
 {
     assert(m_table == r.m_table);
 
-    if (m_view)
+    if (m_orig)
         m_view->setTableId(m_viewIdx, r.m_idx);
     m_idx = r.m_idx;
     m_viewIdx = r.m_viewIdx;

--- a/pdal/PointRef.hpp
+++ b/pdal/PointRef.hpp
@@ -309,7 +309,7 @@ private:
     PointId m_idx;
     PointView *m_view;
     PointId m_viewIdx;
-    bool m_orig;
+    bool m_orig;  // Marks non-temporary PointRefs (true). Not copied.
 
     void setFieldInternal(Dimension::Id dim, void *val);
 };

--- a/pdal/PointRef.hpp
+++ b/pdal/PointRef.hpp
@@ -51,17 +51,17 @@ private:
     }
 
 public:
-    PointRef() : m_table(nullptr), m_idx(0), m_view(nullptr), m_viewIdx(0)
+    PointRef() : m_table(nullptr), m_idx(0), m_view(nullptr), m_viewIdx(0), m_orig(false)
     {}
 
     PointRef(PointView& v, PointId idx = 0);
 
     PointRef(PointTableRef t, PointId idx = 0) : m_table(&t), m_idx(idx),
-        m_view(nullptr), m_viewIdx(0)
+        m_view(nullptr), m_viewIdx(0), m_orig(false)
     {}
 
     PointRef(const PointRef& r) : m_table(r.m_table), m_idx(r.m_idx),
-        m_view(nullptr), m_viewIdx(0)
+        m_view(r.m_view), m_viewIdx(r.m_viewIdx), m_orig(false)
     {}
 
     PointRef& operator=(const PointRef& r);
@@ -309,6 +309,7 @@ private:
     PointId m_idx;
     PointView *m_view;
     PointId m_viewIdx;
+    bool m_orig;
 
     void setFieldInternal(Dimension::Id dim, void *val);
 };


### PR DESCRIPTION
This seems to fix the sorting issue by creating a boolean that never gets moved that indicates an original (non-temporary) PointRef.