### PR TITLE
Default writers.las to LAS 1.4

### DIFF
--- a/io/LasWriter.cpp
+++ b/io/LasWriter.cpp
@@ -148,7 +148,7 @@ void LasWriter::addArgs(ProgramArgs& args)
     args.add("major_version", "LAS major version", d->opts.majorVersion,
         decltype(d->opts.majorVersion)(1));
     args.add("minor_version", "LAS minor version", d->opts.minorVersion,
-        decltype(d->opts.minorVersion)(2));
+        decltype(d->opts.minorVersion)(4));
     args.add("dataformat_id", "Point format", d->opts.dataformatId,
         decltype(d->opts.dataformatId)(3));
     args.add("format", "Point format", d->opts.dataformatId,

--- a/test/unit/io/LasWriterTest.cpp
+++ b/test/unit/io/LasWriterTest.cpp
@@ -478,6 +478,7 @@ TEST(LasWriterTest, extra_dims)
 
     Options writerOps;
     writerOps.add("extra_dims", "Red=int32, Blue = int16, Green = int32_t");
+    writerOps.add("minor_version", "2");
     writerOps.add("filename", Support::temppath("simple.las"));
     LasWriter writer;
     writer.setInput(reader);
@@ -1766,6 +1767,7 @@ TEST(LasWriterTest, oversize_vlr)
     Options o;
 
     o.add("filename", "out.las");
+    o.add("minor_version", "2");
     w.addOptions(o);
 
     PointTable t;


### PR DESCRIPTION
We've talked about this for a few years. It's time to move on. Time to get going. LAS 1.4 is 14 years old. We can default to using it.