### PR TITLE
Add `filters.expressionstats` and `pdal info --breakout` option

### DIFF
--- a/doc/stages/filters.expressionstats.rst
+++ b/doc/stages/filters.expressionstats.rst
@@ -1,0 +1,107 @@
+.. _filters.expressionstats:
+
+filters.expressionstats
+===============================================================================
+
+The :ref:`filters.expressionstats` stage computes counting summary for a single
+dimension for a given set of expressions. This is useful for summarizing dimensions
+that are conveniently countable.
+
+.. embed::
+
+.. streamable::
+
+.. warning::
+
+    The ``dimension`` selected should be an integer, not floating point dimension.
+    Additionally, a dimension with lots of unique values is likely to generate a
+    many entries in the map. This may not be what you want.
+
+Example
+................................................................................
+
+.. code-block:: json
+
+    {
+        "pipeline": [{
+            "bounds": "([-10190065.06156413, -10189065.06156413], [5109498.61041016, 5110498.61041016])",
+            "filename": "https://s3-us-west-2.amazonaws.com/usgs-lidar-public/IA_Eastern_1_2019/ept.json",
+            "requests": "16",
+            "type": "readers.ept"
+        },
+        {
+            "type": "filters.stats"
+        },
+        {
+            "type": "filters.expressionstats",
+            "dimension":"Classification",
+            "expressions":["Withheld == 1", "Keypoint == 1", "Overlap == 1", "Synthetic == 1"]
+        },
+        {
+            "filename": "hobu-office.laz",
+            "type": "writers.copc"
+        }]
+    }
+
+
+Output
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: json
+
+    {
+      "dimension": "Classification",
+      "statistic":
+      [
+        {
+          "expression": "(Keypoint==1.000000)",
+          "position": 0
+        },
+        {
+          "expression": "(Overlap==1.000000)",
+          "position": 1
+        },
+        {
+          "bins":
+          [
+            {
+              "count": 154,
+              "value": 1
+            }
+          ],
+          "expression": "(Synthetic==1.000000)",
+          "position": 2
+        },
+        {
+          "bins":
+          [
+            {
+              "count": 313615,
+              "value": 1
+            },
+            {
+              "count": 6847,
+              "value": 7
+            },
+            {
+              "count": 4425,
+              "value": 18
+            }
+          ],
+          "expression": "(Withheld==1.000000)",
+          "position": 3
+        }
+      ]
+    }
+
+Options
+-------
+
+dimension
+  The dimension on which to apply the expressions.
+
+expressions
+  An array of expressions to apply.
+
+.. include:: filter_opts.rst
+

--- a/doc/stages/filters.rst
+++ b/doc/stages/filters.rst
@@ -601,6 +601,7 @@ invalidate an existing KD-tree.
    filters.hexbin
    filters.info
    filters.stats
+   filters.expressionstats
 
 :ref:`filters.hexbin`
     Tessellate XY domain and determine point density and/or point boundary.
@@ -611,6 +612,9 @@ invalidate an existing KD-tree.
 
 :ref:`filters.stats`
     Compute statistics about each dimension (mean, min, max, etc.).
+
+:ref:`filters.expressionstats`
+    Apply expressions for a given dimension and summarize counts
 
 
 Mesh

--- a/filters/ExpressionStatsFilter.cpp
+++ b/filters/ExpressionStatsFilter.cpp
@@ -1,5 +1,5 @@
 /******************************************************************************
- * Copyright (c) 2023, Howard Butler (info@hobu.co)
+ * Copyright (c) 2024, Howard Butler (info@hobu.co)
  *
  * All rights reserved.
  *

--- a/filters/ExpressionStatsFilter.cpp
+++ b/filters/ExpressionStatsFilter.cpp
@@ -1,0 +1,181 @@
+/******************************************************************************
+ * Copyright (c) 2023, Howard Butler (info@hobu.co)
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of Hobu, Inc. or Flaxen Geo Consulting nor the
+ *       names of its contributors may be used to endorse or promote
+ *       products derived from this software without specific prior
+ *       written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ ****************************************************************************/
+
+#include "ExpressionStatsFilter.hpp"
+
+#include <pdal/util/ProgramArgs.hpp>
+#include <pdal/util/Utils.hpp>
+#include "./private/expr/ConditionalExpression.hpp"
+
+
+
+#include <cctype>
+#include <limits>
+#include <map>
+#include <string>
+#include <vector>
+
+namespace pdal
+{
+
+static StaticPluginInfo const s_info
+{
+    "filters.expressionstats",
+    "Accumulate count statistics for a given dimension for an array of expressions",
+    "http://pdal.io/stages/filters.expressionstats.html"
+};
+
+CREATE_STATIC_STAGE(ExpressionStatsFilter, s_info)
+
+std::string ExpressionStatsFilter::getName() const
+{
+    return s_info.name;
+}
+
+struct ExpressionStatsFilter::Args
+{
+    std::vector<expr::ConditionalExpression> m_expressions;
+    std::string m_dimName;
+    Arg *m_whereArg;
+};
+
+
+ExpressionStatsFilter::ExpressionStatsFilter() : m_args(new Args)
+{}
+
+
+ExpressionStatsFilter::~ExpressionStatsFilter()
+{}
+
+
+void ExpressionStatsFilter::addArgs(ProgramArgs& args)
+{
+    m_args->m_whereArg = &args.add("expressions",
+        "Conditional expressions describing points to be passed to this filter",
+        m_args->m_expressions).setPositional();
+    args.add("dimension", "Dimension on which apply expression to calculate statistics",
+        m_dimName).setPositional();
+
+}
+
+
+void ExpressionStatsFilter::prepared(PointTableRef table)
+{
+    const PointLayoutPtr layout(table.layout());
+
+    m_dimId = layout->findDim(m_dimName);
+    if (m_dimId == Dimension::Id::Unknown)
+        throwError("Invalid dimension name in 'dimension' option: '" + m_dimName + "'.");
+
+    for (auto& expression: m_args->m_expressions)
+    {
+        if (!expression.valid())
+        {
+            std::stringstream oss;
+            oss << "The expression '" <<  expression
+                << "' is invalid";
+            throwError(oss.str());
+        }
+
+        auto status = expression.prepare(table.layout());
+        if (!status)
+            throwError("Invalid 'where': " + status.what());
+    }
+}
+
+
+bool ExpressionStatsFilter::processOne(PointRef& point)
+{
+    double value = point.getFieldAs<double>(m_dimId);
+
+    for(const auto& expr: m_args->m_expressions)
+    {
+        bool status = expr.eval(point);
+        auto& stat = m_stats[expr.print()];
+        if (status)
+            stat[value]++;
+    }
+    return true;
+}
+
+
+void ExpressionStatsFilter::filter(PointView& view)
+{
+    PointRef point(view, 0);
+    for (PointId id = 0; id < view.size(); ++id)
+    {
+        point.setPointId(id);
+        processOne(point);
+    }
+}
+
+void ExpressionStatsFilter::done(PointTableRef table)
+{
+    extractMetadata(table);
+}
+
+void ExpressionStatsFilter::extractMetadata(PointTableRef table)
+{
+    uint32_t position(0);
+
+
+    MetadataNode c = m_metadata.add("dimension", table.layout()->dimName(m_dimId));
+    for (auto& stat: m_stats)
+    {
+        auto& expression_str = stat.first;
+        auto& bin_map = stat.second;
+
+        MetadataNode t = m_metadata.addList("statistic");
+        t.add("expression", expression_str);
+        t.add("position", position);
+
+        for (auto& bin: bin_map)
+        {
+
+            auto& value = bin.first;
+            auto& count = bin.second;
+
+            MetadataNode n = t.addList("bins");
+            n.add("count", count);
+            n.add("value", value);
+        }
+
+        position++;
+    }
+
+}
+
+
+
+} // namespace pdal

--- a/filters/ExpressionStatsFilter.hpp
+++ b/filters/ExpressionStatsFilter.hpp
@@ -1,0 +1,77 @@
+/******************************************************************************
+ * Copyright (c) 2024, Howard Butler (info@hobu.co)
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of Hobu, Inc. or Flaxen Geo Consulting nor the
+ *       names of its contributors may be used to endorse or promote
+ *       products derived from this software without specific prior
+ *       written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ ****************************************************************************/
+
+#pragma once
+
+#include <pdal/Filter.hpp>
+#include <pdal/Streamable.hpp>
+
+#include <memory>
+#include <map>
+#include <string>
+
+namespace pdal
+{
+
+class PDAL_DLL ExpressionStatsFilter : public Filter,  public Streamable
+{
+public:
+    ExpressionStatsFilter();
+    ~ExpressionStatsFilter();
+
+    struct Args;
+
+    std::string getName() const;
+
+private:
+    std::unique_ptr<Args> m_args;
+
+    virtual void addArgs(ProgramArgs& args);
+    virtual void prepared(PointTableRef table);
+    virtual bool processOne(PointRef& point);
+    virtual void filter(PointView& view);
+    virtual void done(PointTableRef table);
+
+    Dimension::Id m_dimId;
+    std::string m_dimName;
+    std::map<std::string, std::map<double, point_count_t>> m_stats;
+
+//     std::unordered_map<std::string, point_count_t> m_stats;
+
+    void extractMetadata(PointTableRef table);
+    ExpressionStatsFilter& operator=(const ExpressionStatsFilter&) = delete;
+    ExpressionStatsFilter(const ExpressionStatsFilter&) = delete;
+};
+
+} // namespace pdal

--- a/kernels/InfoKernel.cpp
+++ b/kernels/InfoKernel.cpp
@@ -87,6 +87,7 @@ void InfoKernel::validateSwitches(ProgramArgs& args)
         m_showSchema = true;
         m_boundary = true;
         m_stac = true;
+        m_breakout = true;
     }
 
 

--- a/kernels/InfoKernel.hpp
+++ b/kernels/InfoKernel.hpp
@@ -79,6 +79,7 @@ private:
     bool m_showMetadata;
     bool m_boundary;
     bool m_stac;
+    bool m_breakout;
     std::string m_pointIndexes;
     std::string m_dimensions;
     std::string m_enumerate;
@@ -90,6 +91,7 @@ private:
     bool m_usestdin;
 
     Stage *m_statsStage;
+    Stage *m_expressionStatsStage;
     Stage *m_hexbinStage;
     Stage *m_infoStage;
     Stage *m_reader;

--- a/kernels/TIndexKernel.cpp
+++ b/kernels/TIndexKernel.cpp
@@ -575,7 +575,7 @@ bool TIndexKernel::createLayer(std::string const& layername)
            "creation" << std::endl;
 
     m_layer = OGR_DS_CreateLayer(m_dataset, m_layerName.c_str(),
-        srs.get(), wkbPolygon, NULL);
+        srs.get(), wkbMultiPolygon, NULL);
 
     if (m_layer)
         createFields();

--- a/kernels/TIndexKernel.cpp
+++ b/kernels/TIndexKernel.cpp
@@ -575,7 +575,7 @@ bool TIndexKernel::createLayer(std::string const& layername)
            "creation" << std::endl;
 
     m_layer = OGR_DS_CreateLayer(m_dataset, m_layerName.c_str(),
-        srs.get(), wkbMultiPolygon, NULL);
+        srs.get(), wkbPolygon, NULL);
 
     if (m_layer)
         createFields();


### PR DESCRIPTION
`filters.expressionstats` allows you to applying a list of expressions to summarize a dimension (typically `Classification` but could be other integer ones like `PointSourceId`).

```
    "filters.expressionstats":
    {
      "dimension": "Classification",
      "statistic":
      [
        {
          "expression": "(Keypoint==1.000000)",
          "position": 0
        },
        {
          "expression": "(Overlap==1.000000)",
          "position": 1
        },
        {
          "bins":
          [
            {
              "count": 154,
              "value": 1
            }
          ],
          "expression": "(Synthetic==1.000000)",
          "position": 2
        },
        {
          "bins":
          [
            {
              "count": 313615,
              "value": 1
            },
            {
              "count": 6847,
              "value": 7
            },
            {
              "count": 4425,
              "value": 18
            }
          ],
          "expression": "(Withheld==1.000000)",
          "position": 3
        }
      ]
    }
```