### PR TITLE
allow override/set of --breakout dimension

### DIFF
--- a/filters/ExpressionStatsFilter.cpp
+++ b/filters/ExpressionStatsFilter.cpp
@@ -110,7 +110,7 @@ void ExpressionStatsFilter::prepared(PointTableRef table)
 
         auto status = expression.prepare(table.layout());
         if (!status)
-            throwError("Invalid 'where': " + status.what());
+            throwError("Invalid expression: " + status.what());
     }
 }
 

--- a/filters/ExpressionStatsFilter.hpp
+++ b/filters/ExpressionStatsFilter.hpp
@@ -67,8 +67,6 @@ private:
     std::string m_dimName;
     std::map<std::string, std::map<double, point_count_t>> m_stats;
 
-//     std::unordered_map<std::string, point_count_t> m_stats;
-
     void extractMetadata(PointTableRef table);
     ExpressionStatsFilter& operator=(const ExpressionStatsFilter&) = delete;
     ExpressionStatsFilter(const ExpressionStatsFilter&) = delete;

--- a/kernels/InfoKernel.cpp
+++ b/kernels/InfoKernel.cpp
@@ -87,7 +87,6 @@ void InfoKernel::validateSwitches(ProgramArgs& args)
         m_showSchema = true;
         m_boundary = true;
         m_stac = true;
-        m_breakout = true;
     }
 
 
@@ -158,8 +157,8 @@ void InfoKernel::addSwitches(ProgramArgs& args)
          m_queryPoint);
     args.add("stats", "Dump stats on all points (reads entire dataset)",
         m_showStats);
-    args.add("breakout", "Breakout Classification by typical flags",
-        m_breakout, false);
+    args.add("breakout", "Breakout dimension by typical flags",
+        m_breakoutDimension );
     args.add("boundary", "Compute a hexagonal hull/boundary of dataset",
         m_boundary);
     args.add("dimensions", "Dimensions on which to compute statistics",
@@ -245,10 +244,10 @@ void InfoKernel::makePipeline()
         stage = m_statsStage =
             &m_manager.makeFilter("filters.stats", *stage, filterOptions);
 
-        if (m_breakout)
+        if (m_breakoutDimension.size())
         {
             Options expressionStatsFilterOptions;
-            expressionStatsFilterOptions.add("dimension", "Classification");
+            expressionStatsFilterOptions.add("dimension", m_breakoutDimension);
             expressionStatsFilterOptions.add("expressions", "Withheld == 1");
             expressionStatsFilterOptions.add("expressions", "Keypoint == 1");
             expressionStatsFilterOptions.add("expressions", "Overlap == 1");

--- a/kernels/InfoKernel.cpp
+++ b/kernels/InfoKernel.cpp
@@ -364,7 +364,7 @@ void InfoKernel::dump(MetadataNode& root)
     if (m_showStats)
     {
         MetadataNode stats = root.add(m_statsStage->getMetadata().clone("stats"));
-        if (m_breakout)
+        if (m_breakoutDimension.size())
             stats.add(m_expressionStatsStage->getMetadata().clone("breakout"));
     }
 

--- a/kernels/InfoKernel.hpp
+++ b/kernels/InfoKernel.hpp
@@ -79,7 +79,7 @@ private:
     bool m_showMetadata;
     bool m_boundary;
     bool m_stac;
-    bool m_breakout;
+    std::string m_breakoutDimension;
     std::string m_pointIndexes;
     std::string m_dimensions;
     std::string m_enumerate;


### PR DESCRIPTION
This also removes it from `--all` usage because not all point clouds have `Classification` or the `Withheld/Synthetic/Overlap/Keypoint` dimensions.