### PR TITLE
[Bugfix] `CopcReader` maybe has memory leaks

### DIFF
--- a/io/CopcReader.cpp
+++ b/io/CopcReader.cpp
@@ -264,7 +264,16 @@ CopcReader::CopcReader() : m_args(new CopcReader::Args), m_p(new CopcReader::Pri
 
 
 CopcReader::~CopcReader()
-{}
+{
+    if (m_p)
+    {
+        if (m_p->pool)
+        {
+            m_p->pool->stop();
+        }
+        m_p->connector.reset();
+    }
+}
 
 
 std::string CopcReader::getName() const
@@ -638,6 +647,7 @@ QuickInfo CopcReader::inspect()
             qi.m_bounds.clip(b);
     }
     qi.m_valid = true;
+    done(t);
 
     return qi;
 }


### PR DESCRIPTION
- `CopcReader::inspect()`, initializes `PointTable t` with `initialize(t)` but does not ever call `done(t)`. This seems to be a memory leak and is caught by ASan
- Also added a safer destructor for the threadpools, so that there is no accidental leak.

PS: I'm not sure if this is the best way to do this, or if any other implementation is preferred?  