### PR TITLE
Hexbin filter OGR - write spatial reference

### DIFF
--- a/filters/HexBinFilter.cpp
+++ b/filters/HexBinFilter.cpp
@@ -235,13 +235,13 @@ void HexBin::done(PointTableRef table)
     // density and boundary writing with OGR does not support polygon smoothing
     if (m_DensityOutput.size())
     {
-        OGR writer(m_DensityOutput, getSpatialReference().getWKT(), m_grid->isH3(),
+        OGR writer(m_DensityOutput, m_srs.getWKT(), m_grid->isH3(),
             m_driver, "hexbins");
         writer.writeDensity(*m_grid);
     }
     if (m_boundaryOutput.size())
     {
-        OGR writer(m_boundaryOutput, getSpatialReference().getWKT(), m_grid->isH3(),
+        OGR writer(m_boundaryOutput, m_srs.getWKT(), m_grid->isH3(),
             m_driver, "hexbins");
         writer.writeBoundary(*m_grid); 
     }


### PR DESCRIPTION
getSpatialReference() in the filters.hexbin _done_ stage was empty, and files written with OGR didn't have a spatial reference. Fixed by using the SRS variable assigned during the _spatialReferenceChanged_ stage instead.