### PR TITLE
Tile Index creation: add multithreaded support, where query support, new options

### DIFF
--- a/doc/apps/tindex.md
+++ b/doc/apps/tindex.md
@@ -23,10 +23,9 @@ $ pdal tindex create <tindex> <filespec>
 --lyr_name             OGR layer name to write into datasource
 --tindex_name          Tile index column name
 --ogrdriver, -f        OGR driver name to use
---absolute_path        Convert the tile index filename to absolute path when 
-                       creating a new file with OGR
 --t_srs                Target SRS of tile index
 --a_srs                Assign SRS of tile with no SRS to this value
+--write_absolute_path  Write absolute rather than relative file paths
 --stdin, -s            Read filespec pattern from standard input
 --threads              Number of threads to use for file boundary creation
 --simplify             Simplify the file's exact boundary

--- a/doc/apps/tindex.md
+++ b/doc/apps/tindex.md
@@ -23,10 +23,20 @@ $ pdal tindex create <tindex> <filespec>
 --lyr_name             OGR layer name to write into datasource
 --tindex_name          Tile index column name
 --ogrdriver, -f        OGR driver name to use
+--absolute_path        Convert the tile index filename to absolute path when 
+                       creating a new file with OGR
 --t_srs                Target SRS of tile index
 --a_srs                Assign SRS of tile with no SRS to this value
---write_absolute_path  Write absolute rather than relative file paths
 --stdin, -s            Read filespec pattern from standard input
+--threads              Number of threads to use for file boundary creation
+--simplify             Simplify the file's exact boundary
+--threshold            Number of points a cell must contain to be declared 
+                       positive space, when creating exact boundaries
+--resolution           Cell edge length to be used when creating exact boundaries
+--sample_size          Sample size for auto-edge length calculation in internal
+                       hexbin filter (exact boundary)
+--where                Expression describing points to be processed for exact
+                       boundary creation
 ```
 
 This command will index the files referred to by `filespec` and place the
@@ -41,6 +51,14 @@ Shapefile".  Any filetype that can be handled by
 In vector file-speak, each file specified by `filespec` is stored as a
 feature in a layer in the index file. The `filespec` is a [glob pattern](http://man7.org/linux/man-pages/man7/glob.7.html).  and normally needs to be
 quoted to prevent shell expansion of wildcard characters.
+
+Exact file boundaries (used when `--fast_boundary` is not set to `true`)
+are created with a grid of tessellated hexagons, in a modified version of
+{ref}`filters.hexbin`. This is controlled with the `simplify`, `threshold`,
+`resolution` and `sample_size` options.
+
+Creation mode also supports parallel file processing by specifying the `threads`
+option.
 
 ## tindex Merge Mode
 

--- a/kernels/TIndexKernel.cpp
+++ b/kernels/TIndexKernel.cpp
@@ -41,10 +41,10 @@
 
 #include <pdal/PDALUtils.hpp>
 #include <pdal/Polygon.hpp>
-#include <pdal/StageFactory.hpp>
 #include <pdal/util/FileUtils.hpp>
 #include <pdal/private/gdal/GDALUtils.hpp>
 #include <pdal/private/gdal/SpatialRef.hpp>
+#include <filters/private/hexer/HexGrid.hpp>
 
 #include "../io/LasWriter.hpp"
 
@@ -66,6 +66,78 @@ void setDate(OGRFeatureH feature, const tm& tyme, int fieldNumber)
 
 namespace pdal
 {
+
+class TindexBoundary : public Filter, public Streamable
+{
+public:
+    TindexBoundary(int32_t density, double edgeLength, uint32_t sampleSize)
+        : m_density(density), m_edgeLength(edgeLength),
+        m_sampleSize(sampleSize)
+    {}
+    ~TindexBoundary()
+    {}
+
+    std::string getName() const
+    { return "tindex-boundary"; }
+    double height()
+    { return m_grid->height(); }
+    std::string toWKT()
+    {
+        std::ostringstream out;
+        out.setf(std::ios_base::fixed, std::ios_base::floatfield);
+        out.precision(10);
+        m_grid->toWKT(out);
+        return out.str();
+    }
+private:
+    std::unique_ptr<hexer::HexGrid> m_grid;
+    int32_t m_density;
+    double m_edgeLength;
+    uint32_t m_sampleSize;
+
+    virtual void ready(PointTableRef table)
+    {
+        if (m_edgeLength == 0.0)
+        {
+            m_grid.reset(new hexer::HexGrid(m_density));
+            m_grid->setSampleSize(m_sampleSize);
+        }
+        else
+            m_grid.reset(new hexer::HexGrid(m_edgeLength * sqrt(3), m_density));
+    }
+    virtual void filter(PointView& view)
+    {
+        PointRef p(view, 0);
+
+        for (PointId idx = 0; idx < view.size(); ++idx)
+        {
+            p.setPointId(idx);
+            processOne(p);
+        }
+    }
+    virtual bool processOne(PointRef& point)
+    {
+        double x = point.getFieldAs<double>(Dimension::Id::X);
+        double y = point.getFieldAs<double>(Dimension::Id::Y);
+        m_grid->addXY(x, y);
+        return true;
+    }
+    virtual void spatialReferenceChanged(const SpatialReference& srs)
+    { setSpatialReference(srs); }
+    virtual void done(PointTableRef table)
+    {
+        try
+        {
+            m_grid->findShapes();
+            m_grid->findParentPaths();
+        }
+        catch (hexer::hexer_error& e)
+        {
+            throwError(e.what());
+            m_grid.reset(new hexer::HexGrid(m_density));
+        }
+    }
+};
 
 static StaticPluginInfo const s_info
 {
@@ -110,14 +182,32 @@ void TIndexKernel::addSubSwitches(ProgramArgs& args,
             "location");
         args.add("ogrdriver,f", "OGR driver name to use ", m_driverName,
             "ESRI Shapefile");
+        args.add("absolute_path", "Convert the tile index filename to "
+            "absolute path when creating a new file with OGR", m_absPath, true);
         args.add("t_srs", "Target SRS of tile index", m_tgtSrsString,
             "EPSG:4326");
         args.add("a_srs", "Assign SRS of tile with no SRS to this value",
             m_assignSrsString, "EPSG:4326");
-        args.add("write_absolute_path",
-            "Write absolute rather than relative file paths", m_absPath);
         args.add("stdin,s", "Read filespec pattern from standard input",
             m_usestdin);
+        args.add("path_prefix", "Prefix to be added to file paths when writing "
+            "output", m_prefix);
+        args.add("threads", "Number of threads to use for file boundary creation",
+            m_threads, 1);
+        args.addSynonym("threads", "requests");
+        args.add("simplify", "Simplify the file's exact boundary", m_doSmooth,
+            true);
+        args.addSynonym("simplify", "smooth");
+        args.add("threshold", "Number of points a cell must contain to be "
+            "declared positive space, when creating exact boundaries", m_density,
+            15);
+        args.add("resolution", "cell edge length to be used when creating exact "
+            "boundaries", m_edgeLength);
+        args.addSynonym("resolution", "edge_length");
+        args.add("sample_size", "Sample size for auto-edge length calculation in "
+            "internal hexbin filter (exact boundary)", m_sampleSize, 5000U);
+        args.add("where", "Expression describing points to be processed for exact "
+            "boundary creation", m_boundaryExpr);
     }
     else if (subcommand == "merge")
     {
@@ -235,10 +325,6 @@ void TIndexKernel::createFile()
     else
         m_files = readSTDIN();
 
-    if (m_absPath)
-        for (auto& s : m_files)
-            s = FileUtils::toAbsolutePath(s);
-
     if (m_files.empty())
     {
         std::ostringstream out;
@@ -271,35 +357,36 @@ void TIndexKernel::createFile()
             throw pdal_error(out.str());
         }
 
-    FieldIndexes indexes = getFields();
-
-    size_t filecount(0);
-    StageFactory factory(false);
+    std::vector<FileInfo> infos;
     for (auto f : m_files)
     {
-        const std::chrono::time_point<std::chrono::steady_clock> start =
-            std::chrono::steady_clock::now();
-        //ABELL - Not sure why we need to get absolute path here.
-        f = FileUtils::toAbsolutePath(f);
         FileInfo info;
-        if (getFileInfo(factory, f, info))
-        {
-            filecount++;
-            if (!isFileIndexed(indexes, info))
-            {
-                if (createFeature(indexes, info))
-                    m_log->get(LogLevel::Info) << "Indexed file " << f <<
-                    std::endl;
-                else
-                    m_log->get(LogLevel::Error) << "Failed to create feature "
-                        "for file '" << f << "'" << std::endl;
-            }
-        }
-        const std::chrono::time_point<std::chrono::steady_clock> end =
-            std::chrono::steady_clock::now();
-        std::cout << "file processing took " << std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count() << " milliseconds\n";
+        info.m_filename = f;
+        FileUtils::fileTimes(info.m_filename, &info.m_ctime, &info.m_mtime);
+        infos.push_back(info);
     }
-    if (!filecount)
+
+    ThreadPool pool(m_threads);
+
+    for (auto &info : infos)
+    {
+        pool.add([this, &info]()
+        {
+            getFileInfo(info);
+        });
+    }
+    pool.await();
+
+    bool indexedFile(false);
+    FieldIndexes indexes = getFields();
+    for (auto &info : infos)
+    {
+        if (m_prefix.size())
+            info.m_filename = m_prefix + FileUtils::getFilename(info.m_filename);
+        if (!info.m_boundary.empty() && !isFileIndexed(indexes, info))
+            indexedFile |= createFeature(indexes, info);
+    }
+    if (!indexedFile)
         throw pdal_error("Couldn't index any files.");
     OGR_DS_Destroy(m_dataset);
     m_dataset = nullptr;
@@ -458,55 +545,45 @@ bool TIndexKernel::createFeature(const FieldIndexes& indexes,
 
     const bool bRet = (OGR_L_CreateFeature(m_layer, hFeature) == OGRERR_NONE);
     OGR_F_Destroy(hFeature);
+
+    if (bRet)
+        m_log->get(LogLevel::Info) << "Indexed file " << fileInfo.m_filename <<
+            std::endl;
+    else
+        m_log->get(LogLevel::Error) << "Failed to create feature "
+            "for file '" << fileInfo.m_filename << "'" << std::endl;
+
     return bRet;
 }
 
 
-bool TIndexKernel::fastBoundary(Stage& reader, FileInfo& fileInfo)
+void TIndexKernel::fastBoundary(Stage& reader, FileInfo& fileInfo)
 {
     QuickInfo qi = reader.preview();
     if (!qi.valid())
-        return false;
+        return;
 
-    fileInfo.m_boundary = qi.m_bounds.to2d().toWKT();
+    fileInfo.m_boundary = makeMultiPolygon(qi.m_bounds.to2d().toWKT());
     if (!qi.m_srs.empty())
         fileInfo.m_srs = qi.m_srs.getWKT();
-    return true;
+    fileInfo.m_gridHeight = 0.0;
 }
 
 
-bool TIndexKernel::slowBoundary(PipelineManager& manager, FileInfo& fileInfo)
+void TIndexKernel::slowBoundary(PipelineManager& manager)
 {
-    std::cout << "running slow bounds\n";
-    manager.prepare();
-    manager.execute(ExecMode::Stream);
-    PointViewSet set = manager.views();
-    MetadataNode root = manager.getMetadata();
-
-    // If we had an error set, bail out
-    MetadataNode e = root.findChild("filters.hexbin:error");
-    if (e.valid())
-        return false;
-
-    MetadataNode m = root.findChild("filters.hexbin:boundary");
-    fileInfo.m_boundary = m.value();
-
-    PointViewPtr v = *set.begin();
-    if (!v->spatialReference().empty())
-        fileInfo.m_srs = v->spatialReference().getWKT();
-    return true;
+    manager.execute(ExecMode::PreferStream);
 }
 
 
-bool TIndexKernel::getFileInfo(StageFactory& factory,
-    const std::string& filename, FileInfo& fileInfo)
+void TIndexKernel::getFileInfo(FileInfo& fileInfo)
 {
     PipelineManager manager;
     manager.commonOptions() = m_manager.commonOptions();
     manager.stageOptions() = m_manager.stageOptions();
 
     // Need to make sure options get set.
-    Stage& reader = manager.makeReader(filename, "");
+    Stage& reader = manager.makeReader(fileInfo.m_filename, "");
 
     // If we aren't able to make a hexbin filter, we
     // will just do a simple fast_boundary.
@@ -515,24 +592,28 @@ bool TIndexKernel::getFileInfo(StageFactory& factory,
     {
         if (!fast)
         {
-            Stage& hexer = manager.makeFilter("filters.hexbin", reader);
-            fast = !slowBoundary(manager, fileInfo);
+            TindexBoundary hexer{m_density, m_edgeLength, m_sampleSize};
+            if (m_boundaryExpr.size())
+            {
+                Options opts;
+                opts.add("where", m_boundaryExpr);
+                hexer.addOptions(opts);
+            }
+            hexer.setInput(reader);
+            manager.addStage(&hexer);
+            slowBoundary(manager);
+
+            fileInfo.m_boundary = hexer.toWKT();
+            fileInfo.m_srs = hexer.getSpatialReference().getWKT();
+            fileInfo.m_gridHeight = hexer.height();
         }
     }
     catch (pdal_error&)
     {
         fast = true;
     }
-    if (fast && !fastBoundary(reader, fileInfo))
-    {
-        m_log->get(LogLevel::Error) << "Skipping file '" << filename <<
-            "': can't compute boundary." << std::endl;
-        return false;
-    }
-    FileUtils::fileTimes(filename, &fileInfo.m_ctime, &fileInfo.m_mtime);
-    fileInfo.m_filename = filename;
-
-    return true;
+    if (fast)
+        fastBoundary(reader, fileInfo);
 }
 
 
@@ -555,8 +636,12 @@ bool TIndexKernel::createDataset(const std::string& filename)
         throw pdal_error(oss.str());
     }
 
-    std::string dsname = FileUtils::toAbsolutePath(filename);
-    m_dataset = OGR_Dr_CreateDataSource(hDriver, dsname.c_str(), NULL);
+    if (m_absPath) {
+        std::string dsname = FileUtils::toAbsolutePath(filename);
+        m_dataset = OGR_Dr_CreateDataSource(hDriver, dsname.c_str(), NULL);
+    }
+    else
+       m_dataset = OGR_Dr_CreateDataSource(hDriver, filename.c_str(), NULL); 
     return (bool)m_dataset;
 }
 
@@ -580,7 +665,7 @@ bool TIndexKernel::createLayer(std::string const& layername)
            "creation" << std::endl;
 
     m_layer = OGR_DS_CreateLayer(m_dataset, m_layerName.c_str(),
-        srs.get(), wkbPolygon, NULL);
+        srs.get(), wkbMultiPolygon, NULL);
 
     if (m_layer)
         createFields();
@@ -654,12 +739,33 @@ pdal::Polygon TIndexKernel::prepareGeometry(const FileInfo& fileInfo)
     using namespace gdal;
 
     Polygon g(fileInfo.m_boundary, fileInfo.m_srs);
+    if (fileInfo.m_gridHeight && m_doSmooth)
+    {
+        double tolerance = 1.1 * fileInfo.m_gridHeight / 2;
+        double cull = (6 * tolerance * tolerance);
+        g.simplify(tolerance, cull);
+        if (g.wkt()[0] == 'P')
+        {
+            std::string multi = makeMultiPolygon(g.wkt());
+            g = Polygon(multi, fileInfo.m_srs);
+        }
+    }
     if (m_tgtSrsString.size())
     {
         SpatialReference out(m_tgtSrsString);
         g.transform(out);
     }
+
     return g;
+}
+
+
+std::string TIndexKernel::makeMultiPolygon(const std::string& wkt)
+{
+    std::string multi = wkt + ')';
+    multi.insert(8, "(");
+    multi.insert(0, "MULTI");
+    return multi;
 }
 
 } // namespace pdal

--- a/kernels/TIndexKernel.hpp
+++ b/kernels/TIndexKernel.hpp
@@ -34,6 +34,8 @@
 
 #pragma once
 
+#include <pdal/Filter.hpp>
+#include <pdal/Streamable.hpp>
 #include <pdal/Stage.hpp>
 #include <pdal/SubcommandKernel.hpp>
 #include <pdal/util/FileUtils.hpp>
@@ -47,8 +49,6 @@ namespace gdal
     class SpatialRef;
 }
 
-class StageFactory;
-
 class PDAL_DLL TIndexKernel : public SubcommandKernel
 {
     struct FileInfo
@@ -56,6 +56,7 @@ class PDAL_DLL TIndexKernel : public SubcommandKernel
         std::string m_filename;
         std::string m_srs;
         std::string m_boundary;
+        double m_gridHeight;
         struct tm m_ctime;
         struct tm m_mtime;
     };
@@ -86,13 +87,13 @@ private:
     bool openLayer(const std::string& layerName);
     bool createLayer(const std::string& layerName);
     FieldIndexes getFields();
-    bool getFileInfo(StageFactory& factory, const std::string& filename,
-        FileInfo& info);
+    void getFileInfo(FileInfo& info);
     bool createFeature(const FieldIndexes& indexes, FileInfo& info);
     pdal::Polygon prepareGeometry(const FileInfo& fileInfo);
     void createFields();
-    bool fastBoundary(Stage& reader, FileInfo& fileInfo);
-    bool slowBoundary(PipelineManager& manager, FileInfo& fileInfo);
+    void fastBoundary(Stage& reader, FileInfo& fileInfo);
+    void slowBoundary(PipelineManager& manager);
+    std::string makeMultiPolygon(const std::string& wkt);
 
     bool isFileIndexed( const FieldIndexes& indexes, const FileInfo& fileInfo);
 
@@ -105,7 +106,15 @@ private:
     std::string m_srsColumnName;
     std::string m_wkt;
     BOX2D m_bounds;
+    bool m_tindexAbsPath;
     bool m_absPath;
+    std::string m_prefix;
+    int m_threads;
+    bool m_doSmooth;
+    int32_t m_density;
+    double m_edgeLength;
+    uint32_t m_sampleSize;
+    std::string m_boundaryExpr;
 
     void *m_dataset;
     void *m_layer;

--- a/pdal/PipelineManager.cpp
+++ b/pdal/PipelineManager.cpp
@@ -538,6 +538,11 @@ void PipelineManager::destroyStage(Stage *s)
         m_factory.reset(new StageFactory());
 }
 
+void PipelineManager::addStage(Stage *s)
+{
+    m_stages.push_back(s);
+}
+
 
 // Set allowed dimensions on both tables since we don't know which one we're going to use.
 void PipelineManager::setAllowedDims(const StringList& dimNames)

--- a/pdal/PipelineManager.hpp
+++ b/pdal/PipelineManager.hpp
@@ -152,6 +152,7 @@ public:
     const std::vector<Stage *> stages() const
         { return m_stages; }
     void destroyStage(Stage *s = nullptr);
+    void addStage(Stage *s);
     void setAllowedDims(const StringList& dimNames);
 
 private:

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -435,7 +435,11 @@ PDAL_ADD_TEST(pdal_app_plugin_test FILES apps/AppPluginTest.cpp)
 PDAL_ADD_TEST(pdal_info_test FILES apps/InfoTest.cpp)
 PDAL_ADD_TEST(pdal_tile_test FILES apps/TileTest.cpp)
 
-PDAL_ADD_TEST(pdal_tindex_test FILES apps/TIndexTest.cpp)
+PDAL_ADD_TEST(pdal_tindex_test
+    FILES 
+        apps/TIndexTest.cpp
+    INCLUDES
+        ${NLOHMANN_INCLUDE_DIR})
 PDAL_ADD_TEST(pdal_merge_test FILES apps/MergeTest.cpp)
 PDAL_ADD_TEST(pc2pc_test FILES apps/pc2pcTest.cpp)
 

--- a/test/unit/apps/TIndexTest.cpp
+++ b/test/unit/apps/TIndexTest.cpp
@@ -35,8 +35,10 @@
 #include <string>
 
 #include <pdal/pdal_test_main.hpp>
-
 #include <pdal/util/FileUtils.hpp>
+#include <pdal/Polygon.hpp>
+
+#include <nlohmann/json.hpp>
 
 #include "Support.hpp"
 
@@ -145,5 +147,53 @@ TEST(TIndex, test3)
     pos = output.find("Merge filecount: 1");
     EXPECT_NE(pos, std::string::npos);
 #endif
+}
+
+std::string getGeometry(std::string& json)
+{
+    NL::basic_json<> a = nlohmann::json::parse(json);
+    auto tree = a.find("features");
+
+    std::ostringstream oss;
+    for (size_t i = 0; i < tree->size(); ++i)
+    {
+        NL::json& node = tree->at(i);
+        auto geom = node.find("geometry");
+        oss << geom->dump();
+    }
+    return oss.str();
+}
+
+// testing the internal filter
+TEST(TIndex, test4)
+{   std::string inSpec(Support::datapath("tindex/t1.txt"));
+
+    // specifying some hexbin boundary options
+    std::string cmd = Support::binpath("pdal") + " tindex create " +
+        "--tindex=\"/vsistdout/\" -f GeoJSON --absolute_path=\"false\" --threshold=1 " +
+        "--resolution=1.0 --simplify=\"false\" --filespec=\"" + inSpec + "\"";
+    std::string output;
+    Utils::run_shell_command(cmd, output);
+
+    pdal::Polygon p(getGeometry(output));
+    EXPECT_NEAR(7.79423, p.area(), 0.001);
+
+    // simplify = true
+    cmd = Support::binpath("pdal") + " tindex create --tindex=\"/vsistdout/\"" +
+        " -f \"GeoJSON\" --absolute_path=\"false\" --threshold=1 --resolution=1.0" + 
+        " --filespec=\"" + inSpec + "\"";
+    Utils::run_shell_command(cmd, output);
+
+    p = getGeometry(output);
+    EXPECT_NEAR(6.49519, p.area(), 0.001);
+
+    // where expression
+    cmd = Support::binpath("pdal") + " tindex create --tindex=\"/vsistdout/\""+ 
+        " -f \"GeoJSON\"  --absolute_path=\"false\" --threshold=1 --resolution=1.0" + 
+        " --where=\"X>1\" --simplify=\"false\" --filespec=\"" + inSpec + "\"";
+    Utils::run_shell_command(cmd, output);
+
+    p = getGeometry(output);
+    EXPECT_NEAR(2.59808, p.area(), 0.001);
 }
 

--- a/test/unit/apps/TIndexTest.cpp
+++ b/test/unit/apps/TIndexTest.cpp
@@ -103,6 +103,13 @@ TEST(TIndex, test2)
     Utils::run_shell_command(cmd, output);
     pos = output.find("Can't specify both");
     EXPECT_NE(pos, std::string::npos);
+
+    cmd = Support::binpath("pdal") + " tindex create " + outSpec + 
+        " --path_prefix=\"a\" --write_absolute_path=true " +
+        "--filespec=\"" + inSpec + "\" 2>&1";
+    Utils::run_shell_command(cmd, output);
+    pos = output.find("Can't specify both");
+    EXPECT_NE(pos, std::string::npos);
 }
 
 // Indentical to test1, but filespec input comes from find command.
@@ -170,7 +177,7 @@ TEST(TIndex, test4)
 
     // specifying some hexbin boundary options
     std::string cmd = Support::binpath("pdal") + " tindex create " +
-        "--tindex=\"/vsistdout/\" -f GeoJSON --absolute_path=\"false\" --threshold=1 " +
+        "--tindex=\"/vsistdout/\" -f GeoJSON --threshold=1 " +
         "--resolution=1.0 --simplify=\"false\" --filespec=\"" + inSpec + "\"";
     std::string output;
     Utils::run_shell_command(cmd, output);
@@ -180,7 +187,7 @@ TEST(TIndex, test4)
 
     // simplify = true
     cmd = Support::binpath("pdal") + " tindex create --tindex=\"/vsistdout/\"" +
-        " -f \"GeoJSON\" --absolute_path=\"false\" --threshold=1 --resolution=1.0" + 
+        " -f \"GeoJSON\" --threshold=1 --resolution=1.0" + 
         " --filespec=\"" + inSpec + "\"";
     Utils::run_shell_command(cmd, output);
 
@@ -189,7 +196,7 @@ TEST(TIndex, test4)
 
     // where expression
     cmd = Support::binpath("pdal") + " tindex create --tindex=\"/vsistdout/\""+ 
-        " -f \"GeoJSON\"  --absolute_path=\"false\" --threshold=1 --resolution=1.0" + 
+        " -f \"GeoJSON\" --threshold=1 --resolution=1.0" + 
         " --where=\"X>1\" --simplify=\"false\" --filespec=\"" + inSpec + "\"";
     Utils::run_shell_command(cmd, output);
 


### PR DESCRIPTION
Added new options for creating a tile index with the _pdal tindex create_ command:
- _threads_/_requests_ option: specify the number of CPU threads used to create point cloud boundaries in a new tile index; default 1
- _where_ option: PDAL where expression to run on the points being indexed
- _simplify_, _threshold_, _resolution_ and _sample_size_ options: settings for creating point cloud boundaries are now handled by an internal filter in TIndexKernel, rather than being passed as filters.hexbin options. These options are equivalent to their counterparts in filters.hexbin.

Also created new tests for the internal boundary filter in TIndexTest.cpp.