### PR TITLE
Optional HEAD request

### DIFF
--- a/pdal/PDALUtils.cpp
+++ b/pdal/PDALUtils.cpp
@@ -248,7 +248,9 @@ public:
 uintmax_t fileSize(const std::string& path)
 {
     uintmax_t size = 0;
-    if (isRemote(path))
+    std::string disabled;
+    int set = Utils::getenv("PDAL_NO_HEAD", disabled);
+    if (isRemote(path) and set != -1)
     {
         std::unique_ptr<std::size_t> pSize = arbiter::Arbiter().tryGetSize(path);
         if (pSize)


### PR DESCRIPTION
Some API might not implement the HEAD verb to get file info.

For streaming reader such as `readers.ept` this means a lot of failed requests.

Similar to `gdal` option `CPL_VSIL_CURL_USE_HEAD` there can be a `PDAL_NO_HEAD` env variable that, if set, would disable

```cpp
std::unique_ptr<std::size_t> pSize = arbiter::Arbiter().tryGetSize(path);
```

for remote files.

There might be better ways to implement that, maybe in `Arbiter` directly ?

```cpp
std::unique_ptr<std::size_t> Http::tryGetSize(const std::string path) const
{
    return getDriver(path)->tryGetSize(stripProtocol(path));
    // return std::unique_ptr<std::size_t>(); if ARBITER_NO_HEAD ?
}
```