### PR TITLE
PROJ style RTD config

### DIFF
--- a/.github/workflows/auto_tag_stable.yml
+++ b/.github/workflows/auto_tag_stable.yml
@@ -1,0 +1,49 @@
+name: Update Stable Tag
+
+# taken directly from OSGeo/PROJ
+on:
+  push:
+    branches:
+      - '**'  # Matches all branches, but we later filter on the one matching the STABLE_BRANCH repository variable
+
+permissions:
+    contents: read
+
+jobs:
+  update-stable-tag:
+    runs-on: ubuntu-latest
+    if: github.repository == 'PDAL/PDAL'
+    permissions:
+        contents: write
+    steps:
+      - name: Check branch match
+        id: check_branch
+        env:
+          STABLE_BRANCH: ${{ vars.STABLE_BRANCH }} # Repository variable
+        run: |
+          echo "Push detected on branch $GITHUB_REF"
+          if [[ "${GITHUB_REF#refs/heads/}" != "${STABLE_BRANCH}" ]]; then
+            echo "This workflow only runs for branch $STABLE_BRANCH. Skipping further steps."
+            echo "run=false" >> $GITHUB_OUTPUT
+          else
+            echo "run=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Checkout code
+        if: steps.check_branch.outputs.run == 'true'
+        uses: actions/checkout@v4
+
+      - name: Tag
+        if: steps.check_branch.outputs.run == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config --global user.email "PDAL-bot@example.com"
+          git config --global user.name "PDAL-bot"
+          touch .dummy-file
+          git add .dummy-file
+          # Do that so that stable doesn't have the same git sha as the stable branch, so ReadTheDocs triggers a build
+          git commit -a -m "Add .dummy-file"
+          git checkout -b stable
+          git push -f origin stable
+

--- a/HOWTORELEASE.txt
+++ b/HOWTORELEASE.txt
@@ -24,7 +24,7 @@ Release Process
 2) Build and run the tests. Turn on all the optional bits that you have support for in
    your cmake options..
 
-    :: 
+    ::
 
         mkdir build
         cd build
@@ -50,11 +50,9 @@ Release Process
 
   - doc/download.rst point to new release
 
-  - Increment the doc build branch of .github/workflows/docs.yml:
+  - Update the ``STABLE_BRANCH`` pointer in the GitHub variables at
+    https://github.com/PDAL/PDAL/settings/variables/actions
 
-    if: github.ref == 'refs/heads/2.4-maintenance'
-
-  - Make DockerHub build entry for new release branch.
 
 5) Write the `release notes. <https://github.com/PDAL/PDAL/releases/new>`_
 
@@ -63,17 +61,7 @@ Release Process
      for a template and a starting point. If you find issues after making the release
      branch, add them to the release notes.
 
-   - Manually store a copy of the release notes in ./doc/development/release-notes/2.4.0.md
-     for future reference.
-
-   - Convert it to reStructuredText using pandoc and add the output to the
-     RELEASENOTES.txt document
-
-     ::
-
-        pandoc --from markdown --to rst --output=2.4.rst doc/development/release-notes/2.4.0.md
-
-6) Make the source distribution. If you are doing a release candidate
+6) Make the source distribution. This requires docker. If you are doing a release candidate
    add an RC tag to the invocation. The version number is automatically picked out of the PDAL
    release. The package is based on the current HEAD commit.
 


### PR DESCRIPTION
PROJ [recently adjusted](https://github.com/OSGeo/PROJ/pull/4326) how it organizes ReadTheDocs by auto-tagging the `stable` branch to whatever branch is labeled `STABLE_BRANCH` in its repository's variables. We will follow suit with PDAL, as this has been a source of manual frustration for a while. Thanks @rouault! 