### PR TITLE
TindexKernel - remove unused variable

### DIFF
--- a/kernels/TIndexKernel.hpp
+++ b/kernels/TIndexKernel.hpp
@@ -108,7 +108,6 @@ private:
     std::string m_srsColumnName;
     std::string m_wkt;
     BOX2D m_bounds;
-    bool m_tindexAbsPath;
     bool m_absPath;
     std::string m_prefix;
     int m_threads;


### PR DESCRIPTION
Deleting a dead member variable I missed in #4531