### PR TITLE
Convert day seconds

### DIFF
--- a/doc/stages/filters.gpstimeconvert.md
+++ b/doc/stages/filters.gpstimeconvert.md
@@ -92,13 +92,19 @@ Convert from wrapped GPS week seconds to GPS time.
 
 ## Options
 
+conversion (deprecated)
+
+: The time conversion. Must follow the pattern: "{in_time}2{out_time}". Can't be used with "in_time" and "out_time" \[Required\]
+
 in_time
 
-: The input time standard ("gt","gst","gws" or "gds"). \[Required\]
+: The input time standard ("gt","gst","gws" or "gds"). Must be used with
+ "out_time". Can't be used with "conversion" \[Required\]
 
 out_time
 
-: The output time standard ("gt","gst","gws" or "gds"). \[Required\]
+: The output time standard ("gt","gst","gws" or "gds"). Must be used with 
+"in_time". Can't be used with "conversion" \[Required\]
 
 start_date
 

--- a/doc/stages/filters.gpstimeconvert.md
+++ b/doc/stages/filters.gpstimeconvert.md
@@ -8,9 +8,10 @@ lidar data:
 1. GPS time (gt)
 2. GPS standard time (gst), also known as GPS adjusted time
 3. GPS week seconds (gws)
+4. GPS day seconds (gds)
 
 Since GPS week seconds are ambiguous (they reset to 0 at the start of each new
-GPS week), care must be taken when they are the source or destination of a
+GPS week or each day), care must be taken when they are the source or destination of a
 conversion:
 
 - When converting from GPS week seconds, the GPS week number must be known. This
@@ -23,6 +24,10 @@ conversion:
   unwrapped week seconds are allowed to exceed 604800 (60x60x24x7) seconds.
 - When converting to GPS week seconds, the week second wrapping preference
   should be specified with the [wrap] option.
+- When converting from GPS day seconds and the times span a new day, the [wrapped] option
+  reset to 0 and midnight or are allowed to exceed 86400 (60x60x24) seconds.
+- When converting to GPS day seconds, the day second wrapping preference should
+  also be specified with the [wrap] option.
 
 ```{note}
 The filter assumes points are ordered by ascending time, which can be
@@ -60,7 +65,8 @@ Convert from GPS standard time to unwrapped GPS week seconds.
     },
     {
         "type":"filters.gpstimeconvert",
-        "conversion":"gst2gws",
+        "in_time":"gst",
+        "out_time": "gws",
         "wrap":false
     }
 ]
@@ -75,7 +81,8 @@ Convert from wrapped GPS week seconds to GPS time.
     "input.las",
     {
         "type":"filters.gpstimeconvert",
-        "conversion":"gws2gt",
+        "in_time":"gws",
+        "out_time": "gt",
         "start_date":"2020-12-12",
         "wrapped":true
     },
@@ -85,10 +92,13 @@ Convert from wrapped GPS week seconds to GPS time.
 
 ## Options
 
-conversion
+in_time
 
-: The time conversion. Must be one of the following: "gst2gt", "gst2gws",
-  "gt2gst", "gt2gws", "gws2gst", or "gws2gt". \[Required\]
+: The input time standard ("gt","gst","gws" or "gds"). \[Required\]
+
+out_time
+
+: The output time standard ("gt","gst","gws" or "gds"). \[Required\]
 
 start_date
 
@@ -98,10 +108,10 @@ start_date
 
 wrap
 
-: Whether to output wrapped (true) or unwrapped (false) GPS week seconds.
+: Whether to output wrapped (true) or unwrapped (false) GPS week\day seconds.
   \[Default: false\]
 
 wrapped
 
-: Specifies whether input GPS week seconds are wrapped (true) or unwrapped
+: Specifies whether input GPS week\day seconds are wrapped (true) or unwrapped
   (false). \[Default: false\]

--- a/filters/GpsTimeConvert.cpp
+++ b/filters/GpsTimeConvert.cpp
@@ -343,7 +343,7 @@ void GpsTimeConvert::gpsTime2DaySeconds(PointView& view)
 
     // wrap week seconds
     if (m_wrap)
-        wrapWeekSeconds(view);
+        wrapDaySeconds(view);
 }
 
 

--- a/filters/GpsTimeConvert.cpp
+++ b/filters/GpsTimeConvert.cpp
@@ -88,7 +88,7 @@ void GpsTimeConvert::initialize()
     if (!m_conversion.empty() && (m_inTime.empty()) && (m_outTime.empty()))
     {
         m_conversion = Utils::tolower(m_conversion);
-        s = Utils::split(m_conversion,'2');
+        std::vector<std::string> s = Utils::split(m_conversion,'2');
         m_inTime = s[0];
         m_outTime = s[1];
     }

--- a/filters/GpsTimeConvert.cpp
+++ b/filters/GpsTimeConvert.cpp
@@ -54,6 +54,8 @@ std::string GpsTimeConvert::getName() const
 
 void GpsTimeConvert::addArgs(ProgramArgs& args)
 {
+    args.add("conversion", "conversion (deprecated)",
+             m_conversion);
     args.add("in_time", "input time type",
              m_inTime).setPositional();
     args.add("out_time", "output time type",
@@ -83,6 +85,23 @@ void GpsTimeConvert::testTimeType(std::string& type)
 
 void GpsTimeConvert::initialize()
 {
+    if (!m_conversion.empty() && (m_inTime.empty()) && (m_outTime.empty()))
+    {
+        m_conversion = Utils::tolower(m_conversion);
+        s = Utils::split(m_conversion,'2');
+        m_inTime = s[0];
+        m_outTime = s[1];
+    }
+    else if (m_conversion.empty() && (!m_inTime.empty()) && (!m_outTime.empty()))
+    {
+        m_inTime = Utils::tolower(m_inTime);
+        m_outTime = Utils::tolower(m_outTime);
+    }
+    else
+    {
+        Stage::throwError("Use 'conversion' or 'in_time' and 'out_time'.");
+    }
+    
     testTimeType(m_inTime);
     testTimeType(m_outTime);
 

--- a/filters/GpsTimeConvert.cpp
+++ b/filters/GpsTimeConvert.cpp
@@ -368,14 +368,20 @@ void GpsTimeConvert::filter(PointView& view)
         if (m_outTime == "gst" || m_outTime == "gt")
             weekSeconds2GpsTime(view);
         else if (m_outTime == "gds")
-            weekSeconds2DaySeconds(view);
+        {
+            weekSeconds2GpsTime(view);
+            gpsTime2DaySeconds(view);
+        }
     }
     else if (m_inTime == "gds")
     {
         if (m_outTime == "gst" || m_outTime == "gt")
             daySeconds2GpsTime(view);
         if (m_outTime == "gws")
-            daySeconds2WeekSeconds(view);
+        {
+            daySeconds2GpsTime(view);
+            gpsTime2WeekSeconds(view);
+        }
 
     }
     else if (m_inTime == "gst" || m_inTime == "gt")

--- a/filters/GpsTimeConvert.hpp
+++ b/filters/GpsTimeConvert.hpp
@@ -47,6 +47,7 @@ public:
     std::string getName() const;
 
 private:
+    std::string m_conversion;
     std::string m_inTime;
     std::string m_outTime;
     std::string m_strDate;

--- a/filters/GpsTimeConvert.hpp
+++ b/filters/GpsTimeConvert.hpp
@@ -55,13 +55,23 @@ private:
     bool m_wrapped;
 
     void weekSeconds2GpsTime(PointView& view);
+    void daySeconds2GpsTime(PointView& view);
+
     void gpsTime2WeekSeconds(PointView& view);
+    void gpsTime2DaySeconds(PointView& view);
+
     void gpsTime2GpsTime(PointView& view);
 
     std::tm gpsTime2Date(int seconds);
+
     int weekStartGpsSeconds(std::tm date);
+    int dayStartGpsSeconds(std::tm date);
+
     void unwrapWeekSeconds(PointView& view);
     void wrapWeekSeconds(PointView& view);
+    
+    void unwrapDaySeconds(PointView& view);
+    void wrapDaySeconds(PointView& view);
 
     void testTimeType(std::string& type);
 

--- a/filters/GpsTimeConvert.hpp
+++ b/filters/GpsTimeConvert.hpp
@@ -47,7 +47,8 @@ public:
     std::string getName() const;
 
 private:
-    std::string m_conversion;
+    std::string m_inTime;
+    std::string m_outTime;
     std::string m_strDate;
     std::tm m_tmDate;
     bool m_wrap;
@@ -61,6 +62,8 @@ private:
     int weekStartGpsSeconds(std::tm date);
     void unwrapWeekSeconds(PointView& view);
     void wrapWeekSeconds(PointView& view);
+
+    void testTimeType(std::string& type);
 
     virtual void addArgs(ProgramArgs& args);
     virtual void initialize();

--- a/test/unit/filters/GpsTimeConvertTest.cpp
+++ b/test/unit/filters/GpsTimeConvertTest.cpp
@@ -78,6 +78,38 @@ TEST(gws2gtTest, HandlesWrappedWeekSeconds)
     checkTime(outView, 1, 1291852800.5);
 }
 
+TEST(gds2gtTest, HandlesWrappedWeekSeconds)
+{
+    using namespace Dimension;
+
+    PointTable table;
+    table.layout()->registerDims({Id::GpsTime});
+
+    PointViewPtr inView(new PointView(table));
+    inView->setField(Id::GpsTime, 0, 86399.5);
+    inView->setField(Id::GpsTime, 1, 0.5);
+
+    BufferReader reader;
+    reader.addView(inView);
+
+    Options options;
+    options.add("in_time", "gds");
+    options.add("out_time","gt");
+    options.add("start_date", "2020-12-12");
+    options.add("wrapped", true);
+
+    GpsTimeConvert filter;
+    filter.setOptions(options);
+    filter.setInput(reader);
+    filter.prepare(table);
+
+    PointViewSet viewSet = filter.execute(table);
+    PointViewPtr outView = *viewSet.begin();
+
+    checkTime(outView, 0, 1291852799.5);
+    checkTime(outView, 1, 1291852800.5);
+}
+
 TEST(gws2gtTest, HandlesUnwrappedWeekSeconds)
 {
     using namespace Dimension;
@@ -94,6 +126,38 @@ TEST(gws2gtTest, HandlesUnwrappedWeekSeconds)
 
     Options options;
     options.add("in_time", "gws");
+    options.add("out_time", "gt");
+    options.add("start_date", "2020-12-12");
+    options.add("wrapped", false);
+
+    GpsTimeConvert filter;
+    filter.setOptions(options);
+    filter.setInput(reader);
+    filter.prepare(table);
+
+    PointViewSet viewSet = filter.execute(table);
+    PointViewPtr outView = *viewSet.begin();
+
+    checkTime(outView, 0, 1291852799.5);
+    checkTime(outView, 1, 1291852800.5);
+}
+
+TEST(gds2gtTest, HandlesUnwrappedDaySeconds)
+{
+    using namespace Dimension;
+
+    PointTable table;
+    table.layout()->registerDims({Id::GpsTime});
+
+    PointViewPtr view(new PointView(table));
+    view->setField(Id::GpsTime, 0, 86399.5);
+    view->setField(Id::GpsTime, 1, 86400.5);
+
+    BufferReader reader;
+    reader.addView(view);
+
+    Options options;
+    options.add("in_time", "gds");
     options.add("out_time", "gt");
     options.add("start_date", "2020-12-12");
     options.add("wrapped", false);
@@ -142,6 +206,39 @@ TEST(gws2gstTest, HandlesWrappedWeekSeconds)
     checkTime(outView, 1, 291852800.5);
 }
 
+TEST(gds2gstTest, HandlesWrappedDaySeconds)
+{
+    using namespace Dimension;
+
+    PointTable table;
+    table.layout()->registerDims({Id::GpsTime});
+
+    PointViewPtr inView(new PointView(table));
+    inView->setField(Id::GpsTime, 0, 86399.5);
+    inView->setField(Id::GpsTime, 1, 0.5);
+
+    BufferReader reader;
+    reader.addView(inView);
+
+    Options options;
+    options.add("in_time", "gds");
+    options.add("out_time", "gst");
+    options.add("start_date", "2020-12-12");
+    options.add("wrapped", true);
+
+    GpsTimeConvert filter;
+    filter.setOptions(options);
+    filter.setInput(reader);
+    filter.prepare(table);
+
+    PointViewSet viewSet = filter.execute(table);
+    PointViewPtr outView = *viewSet.begin();
+
+    checkTime(outView, 0, 291852799.5);
+    checkTime(outView, 1, 291852800.5);
+}
+
+
 TEST(gws2gstTest, HandlesUnwrappedWeekSeconds)
 {
     using namespace Dimension;
@@ -158,6 +255,38 @@ TEST(gws2gstTest, HandlesUnwrappedWeekSeconds)
 
     Options options;
     options.add("in_time", "gws");
+    options.add("out_time", "gst");
+    options.add("start_date", "2020-12-12");
+    options.add("wrapped", false);
+
+    GpsTimeConvert filter;
+    filter.setOptions(options);
+    filter.setInput(reader);
+    filter.prepare(table);
+
+    PointViewSet viewSet = filter.execute(table);
+    PointViewPtr outView = *viewSet.begin();
+
+    checkTime(outView, 0, 291852799.5);
+    checkTime(outView, 1, 291852800.5);
+}
+
+TEST(gds2gstTest, HandlesUnwrappedDaySeconds)
+{
+    using namespace Dimension;
+
+    PointTable table;
+    table.layout()->registerDims({Id::GpsTime});
+
+    PointViewPtr view(new PointView(table));
+    view->setField(Id::GpsTime, 0, 86399.5);
+    view->setField(Id::GpsTime, 1, 86400.5);
+
+    BufferReader reader;
+    reader.addView(view);
+
+    Options options;
+    options.add("in_time", "gds");
     options.add("out_time", "gst");
     options.add("start_date", "2020-12-12");
     options.add("wrapped", false);
@@ -205,6 +334,37 @@ TEST(gt2gwsTest, WrapsWeekSeconds)
     checkTime(outView, 1, 0.5);
 }
 
+TEST(gt2gdsTest, WrapsWeekSeconds)
+{
+    using namespace Dimension;
+
+    PointTable table;
+    table.layout()->registerDims({Id::GpsTime});
+
+    PointViewPtr view(new PointView(table));
+    view->setField(Id::GpsTime, 0, 1291852799.5);
+    view->setField(Id::GpsTime, 1, 1291852800.5);
+
+    BufferReader reader;
+    reader.addView(view);
+
+    Options options;
+    options.add("in_time", "gt");
+    options.add("out_time", "gds");
+    options.add("wrap", true);
+
+    GpsTimeConvert filter;
+    filter.setOptions(options);
+    filter.setInput(reader);
+    filter.prepare(table);
+
+    PointViewSet viewSet = filter.execute(table);
+    PointViewPtr outView = *viewSet.begin();
+
+    checkTime(outView, 0, 86399.5);
+    checkTime(outView, 1, 0.5);
+}
+
 TEST(gt2gwsTest, DoesNotWrapWeekSeconds)
 {
     using namespace Dimension;
@@ -234,6 +394,37 @@ TEST(gt2gwsTest, DoesNotWrapWeekSeconds)
 
     checkTime(outView, 0, 604799.5);
     checkTime(outView, 1, 604800.5);
+}
+
+TEST(gt2gdsTest, DoesNotWrapWeekSeconds)
+{
+    using namespace Dimension;
+
+    PointTable table;
+    table.layout()->registerDims({Id::GpsTime});
+
+    PointViewPtr view(new PointView(table));
+    view->setField(Id::GpsTime, 0, 1291852799.5);
+    view->setField(Id::GpsTime, 1, 1291852800.5);
+
+    BufferReader reader;
+    reader.addView(view);
+
+    Options options;
+    options.add("in_time", "gt");
+    options.add("out_time", "gds");
+    options.add("wrap", false);
+
+    GpsTimeConvert filter;
+    filter.setOptions(options);
+    filter.setInput(reader);
+    filter.prepare(table);
+
+    PointViewSet viewSet = filter.execute(table);
+    PointViewPtr outView = *viewSet.begin();
+
+    checkTime(outView, 0, 86399.5);
+    checkTime(outView, 1, 86400.5);
 }
 
 TEST(gst2gwsTest, WrapsWeekSeconds)

--- a/test/unit/filters/GpsTimeConvertTest.cpp
+++ b/test/unit/filters/GpsTimeConvertTest.cpp
@@ -61,7 +61,8 @@ TEST(gws2gtTest, HandlesWrappedWeekSeconds)
     reader.addView(inView);
 
     Options options;
-    options.add("conversion", "gws2gt");
+    options.add("in_time", "gws");
+    options.add("out_time","gt");
     options.add("start_date", "2020-12-12");
     options.add("wrapped", true);
 
@@ -92,7 +93,8 @@ TEST(gws2gtTest, HandlesUnwrappedWeekSeconds)
     reader.addView(view);
 
     Options options;
-    options.add("conversion", "gws2gt");
+    options.add("in_time", "gws");
+    options.add("out_time", "2gt");
     options.add("start_date", "2020-12-12");
     options.add("wrapped", false);
 
@@ -123,7 +125,8 @@ TEST(gws2gstTest, HandlesWrappedWeekSeconds)
     reader.addView(inView);
 
     Options options;
-    options.add("conversion", "gws2gst");
+    options.add("in_time", "gws");
+    options.add("out_time", "2gst");
     options.add("start_date", "2020-12-12");
     options.add("wrapped", true);
 
@@ -154,7 +157,8 @@ TEST(gws2gstTest, HandlesUnwrappedWeekSeconds)
     reader.addView(view);
 
     Options options;
-    options.add("conversion", "gws2gst");
+    options.add("in_time", "gws");
+    options.add("out_time", "gst");
     options.add("start_date", "2020-12-12");
     options.add("wrapped", false);
 
@@ -185,7 +189,8 @@ TEST(gt2gwsTest, WrapsWeekSeconds)
     reader.addView(view);
 
     Options options;
-    options.add("conversion", "gt2gws");
+    options.add("in_time", "gt");
+    options.add("out_time", "gws");
     options.add("wrap", true);
 
     GpsTimeConvert filter;
@@ -215,7 +220,8 @@ TEST(gt2gwsTest, DoesNotWrapWeekSeconds)
     reader.addView(view);
 
     Options options;
-    options.add("conversion", "gt2gws");
+    options.add("in_time", "gt");
+    options.add("out_time", "gws");
     options.add("wrap", false);
 
     GpsTimeConvert filter;
@@ -245,7 +251,8 @@ TEST(gst2gwsTest, WrapsWeekSeconds)
     reader.addView(view);
 
     Options options;
-    options.add("conversion", "gst2gws");
+    options.add("in_time", "gst");
+    options.add("out_time", "gws");
     options.add("wrap", true);
 
     GpsTimeConvert filter;
@@ -275,7 +282,8 @@ TEST(gst2gwsTest, DoesNotWrapWeekSeconds)
     reader.addView(view);
 
     Options options;
-    options.add("conversion", "gst2gws");
+    options.add("in_time", "gst");
+    options.add("out_time", "gws");
     options.add("wrap", false);
 
     GpsTimeConvert filter;
@@ -305,7 +313,8 @@ TEST(gt2gstTest, ToGpsStandardTime)
     reader.addView(view);
 
     Options options;
-    options.add("conversion", "gt2gst");
+    options.add("in_time", "gt");
+    options.add("out_time", "gst");
 
     GpsTimeConvert filter;
     filter.setOptions(options);
@@ -334,7 +343,8 @@ TEST(gst2gtTest, FromGpsStandardTime)
     reader.addView(view);
 
     Options options;
-    options.add("conversion", "gst2gt");
+    options.add("in_time", "gst");
+    options.add("out_time", "gt");
 
     GpsTimeConvert filter;
     filter.setOptions(options);

--- a/test/unit/filters/GpsTimeConvertTest.cpp
+++ b/test/unit/filters/GpsTimeConvertTest.cpp
@@ -94,7 +94,7 @@ TEST(gws2gtTest, HandlesUnwrappedWeekSeconds)
 
     Options options;
     options.add("in_time", "gws");
-    options.add("out_time", "2gt");
+    options.add("out_time", "gt");
     options.add("start_date", "2020-12-12");
     options.add("wrapped", false);
 
@@ -126,7 +126,7 @@ TEST(gws2gstTest, HandlesWrappedWeekSeconds)
 
     Options options;
     options.add("in_time", "gws");
-    options.add("out_time", "2gst");
+    options.add("out_time", "gst");
     options.add("start_date", "2020-12-12");
     options.add("wrapped", true);
 


### PR DESCRIPTION
## Extend `filters.gpstimeconvert` to handle day seconds.

In some formats (like `rxp`), `GpsTime` is in day seconds. I extended `filters.gpstimeconvert` to be able to handle that time representation.

* Added `GPS day seconds (gds)` format definition
* Mark `conversion` parameter as deprecated. Introduice `in_time` and `out_time` as new arguments.
*  Update documentation
*  Added tests