### PR TITLE
Build docker image also for Apple Silicon (arm64) architecture

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -65,7 +65,7 @@ jobs:
           builder: ${{ steps.buildx.outputs.name }}
           file: "./scripts/docker/ubuntu/Dockerfile"
           context: .
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
 
           # We need to pass in the SHA to the Dockerfile so it can checkout
           # our code. It is a different active SHA depending on whether it is a


### PR DESCRIPTION
Right now only Docker image for amd64 architecture is built. That results in poor performance on Apple Silicon macs. This change should build Docker image also for Apple Silicon (arm64) architecture. 