### PR TITLE
New argument to process OGR JSON blocks

### DIFF
--- a/doc/stages/filters.crop.md
+++ b/doc/stages/filters.crop.md
@@ -84,6 +84,17 @@ polygon
   eg: `"POLYGON((0 0, 5000 10000, 10000 0, 0 0))"`.  This option can be
   specified more than once by placing values in an array.
 
+ogr
+
+: A JSON object representing an OGR query to fetch polygons to use for filtering. The polygons
+  fetched from the query are treated exactly like those specified in the `polygon` option.
+  The JSON object is specified as follows:
+
+```{include} ogr_json.md
+```
+
+
+
 outside
 
 : Invert the cropping logic and only take points outside the cropping

--- a/doc/stages/ogr_json.md
+++ b/doc/stages/ogr_json.md
@@ -1,0 +1,16 @@
+
+```json
+{
+    "type":"ogr",
+    "datasource": "File path to OGR-readable geometry",
+    "drivers": ["OGR driver to use", "and OGR KEY=VALUE driver options"],
+    "openoptions": ["Options to pass to the OGR open function [optional]"],
+    "layer": "OGR layer from which to fetch polygons [optional]",
+    "sql": "SQL query to use to filter the polygons in the layer [optional]",
+    "options":
+    {
+        "geometry": "WKT or GeoJSON geomtry used to filter query [optional]",
+        "dialect": "SQL dialect to use (default: OGR SQL) [optional]"
+    }
+}
+```

--- a/doc/stages/readers.copc.md
+++ b/doc/stages/readers.copc.md
@@ -91,18 +91,8 @@ ogr
   fetched from the query are treated exactly like those specified in the `polygon` option.
   The JSON object is specified as follows:
 
-  ```json
-  {
-      "drivers": "OGR drivers to use",
-      "openoptions": "Options to pass to the OGR open function [optional]",
-      "layer": "OGR layer from which to fetch polygons [optional]",
-      "sql": "SQL query to use to filter the polygons in the layer [optional]",
-      "options":
-      {
-          "geometry", "WKT or GeoJSON geomtry used to filter query [optional]"
-      }
-  }
-  ```
+```{include} ogr_json.md
+```
 
 requests
 

--- a/doc/stages/readers.ept.md
+++ b/doc/stages/readers.ept.md
@@ -155,18 +155,8 @@ ogr
   fetched from the query are treated exactly like those specified in the `polygon` option.
   The JSON object is specified as follows:
 
-  ```json
-  {
-      "drivers": "OGR drivers to use",
-      "openoptions": "Options to pass to the OGR open function [optional]",
-      "layer": "OGR layer from which to fetch polygons [optional]",
-      "sql": "SQL query to use to filter the polygons in the layer [optional]",
-      "options":
-      {
-          "geometry", "WKT or GeoJSON geomtry used to filter query [optional]"
-      }
-  }
-  ```
+```{include} ogr_json.md
+```
 
 requests
 

--- a/doc/stages/readers.tindex.md
+++ b/doc/stages/readers.tindex.md
@@ -98,6 +98,16 @@ wkt
 : A geometry to pre-filter the tile index using
   OGR.
 
+ogr
+
+: A JSON object representing an OGR query to fetch a polygon for pre-filtering
+  the tile index. This will also override any [wkt] option if set. 
+  The JSON object is specified as follows:
+
+```{include} ogr_json.md
+```
+
+
 t_srs
 
 : Reproject the layer SRS, otherwise default to the

--- a/filters/CropFilter.cpp
+++ b/filters/CropFilter.cpp
@@ -122,12 +122,10 @@ void CropFilter::initialize()
         }
     }
     // Add geometry from OGR specification
-    if (m_args->m_ogr.size())
+
+    for (const Polygon& poly : m_args->m_ogr.getPolygons())
     {
-        for (Polygon& poly : m_args->m_ogr.getPolygons())
-        {
-            m_geoms.emplace_back(poly);
-        }
+        m_geoms.push_back(poly);
     }
 
     m_boxes.clear();

--- a/filters/CropFilter.cpp
+++ b/filters/CropFilter.cpp
@@ -37,6 +37,7 @@
 #include <pdal/PointView.hpp>
 #include <pdal/StageFactory.hpp>
 #include <pdal/Polygon.hpp>
+#include <pdal/private/OGRSpec.hpp>
 #include <pdal/util/Bounds.hpp>
 #include <pdal/util/ProgramArgs.hpp>
 #include <pdal/private/gdal/GDALUtils.hpp>
@@ -67,6 +68,7 @@ struct CropArgs
     std::vector<filter::Point> m_centers;
     double m_distance;
     std::vector<Polygon> m_polys;
+    OGRSpec m_ogr;
 };
 
 CropFilter::ViewGeom::ViewGeom(const Polygon& poly) : m_poly(poly)
@@ -102,6 +104,7 @@ void CropFilter::addArgs(ProgramArgs& args)
     args.add("polygon", "Bounding polying for cropped points", m_args->m_polys).
         setErrorText("Invalid polygon specification.  "
             "Must be valid GeoJSON/WKT");
+    args.add("ogr", "OGR filter geometries", m_args->m_ogr);
 }
 
 
@@ -115,6 +118,14 @@ void CropFilter::initialize()
         {
             // Throws if invalid.
             poly.valid();
+            m_geoms.emplace_back(poly);
+        }
+    }
+    // Add geometry from OGR specification
+    if (m_args->m_ogr.size())
+    {
+        for (Polygon& poly : m_args->m_ogr.getPolygons())
+        {
             m_geoms.emplace_back(poly);
         }
     }

--- a/filters/GeomDistanceFilter.cpp
+++ b/filters/GeomDistanceFilter.cpp
@@ -39,6 +39,7 @@
 
 #include <pdal/Geometry.hpp>
 #include <pdal/Polygon.hpp>
+#include <pdal/private/OGRSpec.hpp>
 #include <pdal/util/Bounds.hpp>
 #include <pdal/util/ProgramArgs.hpp>
 #include <pdal/private/gdal/GDALUtils.hpp>
@@ -64,7 +65,7 @@ struct GeomDistanceArgs
     std::string m_dimName;
     pdal::Geometry m_geometry;
     bool m_doRingMode;
-    NL::json m_ogr;
+    OGRSpec m_ogr;
 
 };
 
@@ -116,13 +117,9 @@ void GeomDistanceFilter::prepared(PointTableRef table)
 
 void GeomDistanceFilter::ready(PointTableRef table)
 {
-    if (!m_args->m_ogr.is_null())
-    {
-        std::vector<Polygon> polys = gdal::getPolygons(m_args->m_ogr);
-        if (!polys.size())
-            throwError("No polygons were selected from 'ogr'!");
-        m_args->m_geometry = polys[0];
-    }
+    // this overwrites the "geometry" option - should throw something if both are entered
+    if (!m_args->m_ogr.empty())
+        m_args->m_geometry = m_args->m_ogr.getPolygon();
 
     if (m_args->m_doRingMode)
         m_args->m_geometry = m_args->m_geometry.getRing();

--- a/filters/GeomDistanceFilter.cpp
+++ b/filters/GeomDistanceFilter.cpp
@@ -117,9 +117,8 @@ void GeomDistanceFilter::prepared(PointTableRef table)
 
 void GeomDistanceFilter::ready(PointTableRef table)
 {
-    // this overwrites the "geometry" option - should throw something if both are entered
     if (!m_args->m_ogr.empty())
-        m_args->m_geometry = m_args->m_ogr.getPolygon();
+        m_args->m_geometry = m_args->m_ogr.getPolygons()[0];
 
     if (m_args->m_doRingMode)
         m_args->m_geometry = m_args->m_geometry.getRing();

--- a/io/CopcReader.cpp
+++ b/io/CopcReader.cpp
@@ -46,6 +46,7 @@
 #include <pdal/Polygon.hpp>
 #include <pdal/Scaling.hpp>
 #include <pdal/SrsBounds.hpp>
+#include <pdal/private/OGRSpec.hpp>
 #include <pdal/util/Charbuf.hpp>
 #include <pdal/util/ThreadPool.hpp>
 #include <pdal/private/gdal/GDALUtils.hpp>
@@ -225,7 +226,7 @@ public:
 
     NL::json query;
     NL::json headers;
-    NL::json ogr;
+    OGRSpec ogr;
 
     int keepAliveChunkCount = 10;
     SrsOrderSpec srsVlrOrder;
@@ -573,13 +574,8 @@ void CopcReader::createSpatialFilters()
         }
     }
 
-    // Read polygons from OGR and add to the polygon list.
-    if (!m_args->ogr.is_null())
-    {
-        auto& plist = m_args->polys;
-        std::vector<Polygon> ogrPolys = gdal::getPolygons(m_args->ogr);
-        plist.insert(plist.end(), ogrPolys.begin(), ogrPolys.end());
-    }
+    std::vector<Polygon> ogrPolys = m_args->ogr.getPolygons();
+    m_args->polys.insert(m_args->polys.end(), ogrPolys.begin(), ogrPolys.end());
 
     // Create transform from the point source SRS to the poly SRS.
     for (Polygon& poly : m_args->polys)

--- a/io/EptReader.cpp
+++ b/io/EptReader.cpp
@@ -40,6 +40,7 @@
 
 #include <pdal/ArtifactManager.hpp>
 #include <pdal/Polygon.hpp>
+#include <pdal/private/OGRSpec.hpp>
 #include <pdal/SrsBounds.hpp>
 #include <pdal/pdal_features.hpp>
 #include <pdal/util/ThreadPool.hpp>
@@ -160,7 +161,7 @@ public:
 
     NL::json m_query;
     NL::json m_headers;
-    NL::json m_ogr;
+    OGRSpec m_ogr;
     bool m_ignoreUnreadable = false;
 };
 
@@ -258,12 +259,8 @@ void EptReader::initialize()
         throwError(err.what());
     }
 
-    if (!m_args->m_ogr.is_null())
-    {
-        auto& plist = m_args->m_polys;
-        std::vector<Polygon> ogrPolys = gdal::getPolygons(m_args->m_ogr);
-        plist.insert(plist.end(), ogrPolys.begin(), ogrPolys.end());
-    }
+    std::vector<Polygon> ogrPolys = m_args->m_ogr.getPolygons();
+    m_args->m_polys.insert(m_args->m_polys.end(), ogrPolys.begin(), ogrPolys.end());
 
     // Create transformations from our source data to the bounds SRS.
     if (m_args->m_bounds.valid())

--- a/io/TIndexReader.cpp
+++ b/io/TIndexReader.cpp
@@ -37,6 +37,7 @@
 #include <ogr_api.h>
 
 #include <pdal/Polygon.hpp>
+#include <pdal/private/OGRSpec.hpp>
 #include <pdal/util/ProgramArgs.hpp>
 #include <pdal/private/gdal/GDALUtils.hpp>
 #include <pdal/private/gdal/SpatialRef.hpp>
@@ -67,6 +68,7 @@ struct TIndexReader::Args
     std::string m_tileIndexColumnName;
     std::string m_srsColumnName;
     std::string m_wkt;
+    OGRSpec m_ogr;
     std::string m_tgtSrsString;
     std::string m_filterSRS;
     std::string m_attributeFilter;
@@ -149,6 +151,7 @@ void TIndexReader::addArgs(ProgramArgs& args)
     args.add("polygon", "Well-known text description of bounds to limit query",
         m_args->m_wkt);
     args.addSynonym("polygon", "wkt");
+    args.add("ogr", "Specified OGR polygon to limit query", m_args->m_ogr);
     args.add("t_srs", "Transform SRS of tile index geometry", m_args->m_tgtSrsString,
         "EPSG:4326");
     args.add("filter_srs", "Transforms any wkt or boundary option to "
@@ -213,6 +216,14 @@ void TIndexReader::initialize()
     if (getSpatialReference().empty())
         setSpatialReference(SpatialReference(m_out_ref->wkt()));
 
+    // If an OGR specification was added, we overwrite the wkt polygon
+    // with it. If OGRSpec is going to contain non-polygon geometries
+    // in the future this method would need to be changed.
+    if (m_args->m_ogr.size())
+    {
+        Polygon ogrPoly = m_args->m_ogr.getPolygon();
+        m_args->m_wkt = ogrPoly.wkt();
+    }
     // If the user set either explicit 'polygon' or 'boundary' options
     // we will filter by that geometry. The user can set a 'filter_srs'
     // option to override the SRS of the input geometry and we will

--- a/io/TIndexReader.cpp
+++ b/io/TIndexReader.cpp
@@ -221,7 +221,7 @@ void TIndexReader::initialize()
     // in the future this method would need to be changed.
     if (m_args->m_ogr.size())
     {
-        Polygon ogrPoly = m_args->m_ogr.getPolygon();
+        Polygon ogrPoly = m_args->m_ogr.getPolygons()[0];
         m_args->m_wkt = ogrPoly.wkt();
     }
     // If the user set either explicit 'polygon' or 'boundary' options

--- a/pdal/private/OGRSpec.cpp
+++ b/pdal/private/OGRSpec.cpp
@@ -70,7 +70,7 @@ void OGRSpec::parse()
     else if (!(Utils::tolower(m_json.at("type").get<std::string>()) == "ogr"))
         throw error("'ogr' option must have 'type':'ogr' specified!");
 
-    // m_opts should maybe get cleared here
+    m_opts = {};
     for (auto& item : m_json.items())
     {
         std::string key = Utils::tolower(item.key());
@@ -110,7 +110,6 @@ void OGRSpec::parse()
         {           
             std::stringstream out;
             out << "unexpected field '" << key << "' in OGR JSON!";
-            // this is fatal - caught by fromString(). Should just log maybe, if that's possible
             throw error(out.str());
         }
     }

--- a/pdal/private/OGRSpec.cpp
+++ b/pdal/private/OGRSpec.cpp
@@ -1,0 +1,133 @@
+#include "OGRSpec.hpp"
+#include <pdal/private/gdal/GDALUtils.hpp>
+
+#include <nlohmann/json.hpp>
+
+namespace pdal
+{
+
+OGRSpec::OGRSpec()
+{}
+
+
+OGRSpec::OGRSpec(const std::string& ogrJsonStr)
+{
+    validateInput(ogrJsonStr); 
+    initialize();
+}
+
+OGRSpec::OGRSpec(const NL::json& ogrJson)
+{
+    validateInput(ogrJson);
+    initialize();
+}
+
+void OGRSpec::update(const std::string& ogrJsonStr)
+{
+    m_geom.clear();
+    validateInput(ogrJsonStr);
+    initialize();
+}
+
+void OGRSpec::update(const NL::json& ogrJson)
+{
+    m_geom.clear();
+    validateInput(ogrJson);
+    initialize();
+}
+
+void OGRSpec::validateInput(const std::string& ogrJsonStr)
+{
+    try
+    {
+        m_json = NL::json::parse(ogrJsonStr);
+    }
+    catch(NL::json::parse_error& e)
+    {
+        std::string s(e.what());
+        auto pos = s.find("]");
+        if (pos != std::string::npos)
+            s = s.substr(pos + 1);
+        std::stringstream msg;
+
+        msg << "Failed to parse OGR JSON with error: " << s;
+        throw error(msg.str());
+    }
+    parse();
+}
+
+void OGRSpec::validateInput(const NL::json& ogrJson)
+{
+    m_json = ogrJson;
+    parse();
+}
+
+void OGRSpec::parse()
+{
+    // "type" field name is case sensitive, value is not
+    if (!(m_json.is_object() && m_json.contains("type")))
+        throw error("'ogr' option must be a JSON object with 'type':'ogr' specified!");
+    else if (!(Utils::tolower(m_json.at("type").get<std::string>()) == "ogr"))
+        throw error("'ogr' option must have 'type':'ogr' specified!");
+
+    // m_opts should maybe get cleared here
+    for (auto& item : m_json.items())
+    {
+        std::string key = Utils::tolower(item.key());
+
+        if (item.value().is_null() || (item.value() == ""))
+        {
+            std::stringstream out;
+            out << "invalid value for field '" << key << "' in OGR JSON!";
+            throw error(out.str());
+        }
+        if (key == "datasource")
+            assignJSON(item.value(), m_opts.datasource);
+        else if (key == "drivers")
+            assignJSON(item.value(), m_opts.drivers);
+        else if (key == "openoptions")
+            assignJSON(item.value(), m_opts.openOpts);
+        else if (key == "layer")
+            assignJSON(item.value(), m_opts.layer);
+        else if (key == "sql")
+            assignJSON(item.value(), m_opts.sql);
+        else if (key == "options")
+        {
+            for (auto optItem : item.value().items())
+            {
+                std::string optKey = Utils::tolower(optItem.key());
+                if (optKey == "dialect")
+                    assignJSON(optItem.value(), m_opts.dialect);
+                else if (optKey == "geometry")
+                    assignJSON(optItem.value(), m_opts.geometry);
+                else
+                    throw error("invalid value for 'options' field in OGR JSON!");
+            }
+        }
+        else if (key == "type")
+            continue;
+        else
+        {           
+            std::stringstream out;
+            out << "unexpected field '" << key << "' in OGR JSON!";
+            // this is fatal - caught by fromString(). Should just log maybe, if that's possible
+            throw error(out.str());
+        }
+    }
+
+    if (m_opts.datasource.empty())
+        throw error("'ogr' option must contain a 'datasource' field!");
+}
+
+void OGRSpec::initialize()
+{
+    m_geom = gdal::getPolygons(m_opts);
+}
+
+std::ostream& operator << (std::ostream& out, const OGRSpec& ogr)
+{
+    out << ogr.m_json;
+    return out;
+}
+
+} // namespace pdal

--- a/pdal/private/OGRSpec.hpp
+++ b/pdal/private/OGRSpec.hpp
@@ -10,7 +10,7 @@
 namespace pdal
 {
 
-struct OGRData
+struct OGRSpecOptions
 {
     std::string datasource;
     std::string layer;
@@ -21,9 +21,9 @@ struct OGRData
     std::vector<std::string> openOpts;
 };
 
-class PDAL_EXPORT OGRSpec
+class OGRSpec
 {
-    PDAL_EXPORT friend std::ostream& operator<<(std::ostream& out,
+    friend std::ostream& operator<<(std::ostream& out,
         const OGRSpec& bounds);
 
 public:
@@ -59,7 +59,7 @@ private:
     {
         try
         {
-            to = field.get<T>();
+            field.get_to(to);
         }
         catch(const NL::json::exception& e)
         {
@@ -77,7 +77,7 @@ private:
     std::vector<Polygon> m_geom;
     // m_json mostly only exists for operator<< output
     NL::json m_json;
-    OGRData m_opts;
+    OGRSpecOptions m_opts;
 };
 
 namespace Utils

--- a/pdal/private/OGRSpec.hpp
+++ b/pdal/private/OGRSpec.hpp
@@ -1,0 +1,107 @@
+#pragma once
+
+#include <vector>
+
+#include <pdal/Polygon.hpp>
+#include <pdal/pdal_types.hpp>
+
+#include <nlohmann/json.hpp>
+
+namespace pdal
+{
+
+struct OGRData
+{
+    std::string datasource;
+    std::string layer;
+    std::string sql;
+    std::string dialect;
+    std::string geometry;
+    std::vector<std::string> drivers;
+    std::vector<std::string> openOpts;
+};
+
+class PDAL_EXPORT OGRSpec
+{
+    PDAL_EXPORT friend std::ostream& operator<<(std::ostream& out,
+        const OGRSpec& bounds);
+
+public:
+    OGRSpec(const std::string& ogrJsonStr);
+    OGRSpec(const NL::json& ogrJson);
+    OGRSpec();
+
+    bool empty()
+    { return m_geom.empty(); }
+    // test function
+    int size()
+    { return m_geom.size(); }
+    void update(const std::string& ogrJsonStr);
+    void update(const NL::json& ogrJson);
+
+    std::vector<Polygon> getPolygons()
+    { return m_geom; }
+    Polygon getPolygon()
+    { return m_geom[0]; }
+    // potential alternative for stages like CopcReader
+    void insert(std::vector<Polygon>& plist)
+    { plist.insert(plist.end(), m_geom.begin(), m_geom.end()); }
+
+    struct error : public std::runtime_error
+    {
+        error(const std::string& err) : std::runtime_error(err)
+        {}
+    };
+
+private:
+    void initialize();
+    void validateInput(const std::string& ogrJsonStr);
+    void validateInput(const NL::json& ogrJson);
+    void parse();
+
+    template <typename T>
+    void assignJSON(const NL::json& field, T& to)
+    {
+        try
+        {
+            to = field.get<T>();
+        }
+        catch(const NL::json::exception& e)
+        {
+            std::string s(e.what());
+            auto pos = s.find("]");
+            if (pos != std::string::npos)
+                s = s.substr(pos + 1);
+            std::stringstream msg;
+
+            msg << "Failed to parse JSON field with error: " << s;
+            throw error(msg.str());
+        }
+    }
+
+    std::vector<Polygon> m_geom;
+    // m_json mostly only exists for operator<< output
+    NL::json m_json;
+    OGRData m_opts;
+};
+
+namespace Utils
+{
+
+    template<>
+    inline StatusWithReason fromString(const std::string& from, OGRSpec& to)
+    {
+        try
+        {
+            to.update(from);
+        }
+        catch (OGRSpec::error& e)
+        {
+            return StatusWithReason(-1, e.what());
+        }
+        return true;
+    }
+
+} // nampespace utils
+
+} // namespace pdal

--- a/pdal/private/OGRSpec.hpp
+++ b/pdal/private/OGRSpec.hpp
@@ -31,21 +31,16 @@ public:
     OGRSpec(const NL::json& ogrJson);
     OGRSpec();
 
-    bool empty()
-    { return m_geom.empty(); }
-    // test function
-    int size()
-    { return m_geom.size(); }
     void update(const std::string& ogrJsonStr);
     void update(const NL::json& ogrJson);
 
     std::vector<Polygon> getPolygons()
     { return m_geom; }
-    Polygon getPolygon()
-    { return m_geom[0]; }
-    // potential alternative for stages like CopcReader
-    void insert(std::vector<Polygon>& plist)
-    { plist.insert(plist.end(), m_geom.begin(), m_geom.end()); }
+    bool empty()
+    { return m_geom.empty(); }
+    // test function
+    int size()
+    { return m_geom.size(); }
 
     struct error : public std::runtime_error
     {

--- a/pdal/private/gdal/GDALUtils.cpp
+++ b/pdal/private/gdal/GDALUtils.cpp
@@ -296,21 +296,13 @@ std::vector<Polygon> getPolygons(const OGRData& ogr)
     registerDrivers();
 
     char** papszDriverOptions = nullptr;
-    if (ogr.drivers.size())
-    {
-        for (const auto& s: ogr.drivers)
-            papszDriverOptions = CSLAddString(papszDriverOptions, s.c_str());
-    }
-    std::vector<const char*> openoptions{};
+    for (const auto& s: ogr.drivers)
+        papszDriverOptions = CSLAddString(papszDriverOptions, s.c_str());
 
     char** papszOpenOptions = nullptr;
-    if (ogr.openOpts.size())
-    {
-        for(const auto& s: ogr.openOpts)
-            papszOpenOptions = CSLAddString(papszOpenOptions, s.c_str());
-    }
+    for(const auto& s: ogr.openOpts)
+        papszOpenOptions = CSLAddString(papszOpenOptions, s.c_str());
 
-    //std::string dsString = ogr.datasource;
     unsigned int openFlags =
         GDAL_OF_READONLY | GDAL_OF_VECTOR | GDAL_OF_VERBOSE_ERROR;
     GDALDataset* ds;

--- a/pdal/private/gdal/GDALUtils.cpp
+++ b/pdal/private/gdal/GDALUtils.cpp
@@ -291,7 +291,7 @@ OGRGeometry *createFromGeoJson(const std::string& s, std::string& srs)
   \param ogr  JSON that specifies how to load data.
   \return  Vector of polygons read from datasource.
 */
-std::vector<Polygon> getPolygons(const OGRData& ogr)
+std::vector<Polygon> getPolygons(const OGRSpecOptions& ogr)
 {
     registerDrivers();
 

--- a/pdal/private/gdal/GDALUtils.hpp
+++ b/pdal/private/gdal/GDALUtils.hpp
@@ -46,6 +46,7 @@ typedef void *OGRGeometryH;
 namespace pdal
 {
 class Polygon;
+struct OGRData;
 
 namespace gdal
 {
@@ -63,7 +64,7 @@ PDAL_EXPORT bool reproject(double& x, double& y, double& z,
 PDAL_EXPORT std::string lastError();
 
 // Exported for test support. Not sure why the above are exported.
-PDAL_EXPORT std::vector<Polygon> getPolygons(const NL::json& ogr);
+PDAL_EXPORT std::vector<Polygon> getPolygons(const OGRData& ogr);
 
 // New signatures to support extraction of SRS from the end of geometry
 // specifications.

--- a/pdal/private/gdal/GDALUtils.hpp
+++ b/pdal/private/gdal/GDALUtils.hpp
@@ -46,7 +46,7 @@ typedef void *OGRGeometryH;
 namespace pdal
 {
 class Polygon;
-struct OGRData;
+struct OGRSpecOptions;
 
 namespace gdal
 {
@@ -64,7 +64,7 @@ PDAL_EXPORT bool reproject(double& x, double& y, double& z,
 PDAL_EXPORT std::string lastError();
 
 // Exported for test support. Not sure why the above are exported.
-PDAL_EXPORT std::vector<Polygon> getPolygons(const OGRData& ogr);
+PDAL_EXPORT std::vector<Polygon> getPolygons(const OGRSpecOptions& ogr);
 
 // New signatures to support extraction of SRS from the end of geometry
 // specifications.

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -75,11 +75,12 @@ PDAL_ADD_TEST(pdal_dimension_test
 PDAL_ADD_TEST(pdal_ogr_arg_test 
     FILES 
         OGRSpecTest.cpp
+        ${PDAL_SRC_DIR}/private/OGRSpec.cpp
     INCLUDES
         ${NLOHMANN_INCLUDE_DIR}
-        ${GDAL_INCLUDE_DIR}
     LINK_WITH
-        ${GDAL_LIBRARY})
+        ${GDAL_LIBRARY}
+)
 PDAL_ADD_TEST(pdal_pipeline_manager_test FILES PipelineManagerTest.cpp)
 PDAL_ADD_TEST(pdal_pipeline_writer_test
     FILES
@@ -158,6 +159,7 @@ PDAL_ADD_TEST(pdal_io_stac_reader_test
 PDAL_ADD_TEST(pdal_io_ept_reader_test
     FILES
         io/EptReaderTest.cpp
+        ${PDAL_SRC_DIR}/private/OGRSpec.cpp
     LINK_WITH
         ${GDAL_LIBRARY}
     INCLUDES
@@ -173,6 +175,7 @@ PDAL_ADD_TEST(pdal_io_ept_addon_writer_test
 PDAL_ADD_TEST(pdal_io_copc_reader_test
     FILES
         io/CopcReaderTest.cpp
+        ${PDAL_SRC_DIR}/private/OGRSpec.cpp
     INCLUDES
         ${NLOHMANN_INCLUDE_DIR}
 )
@@ -329,6 +332,7 @@ PDAL_ADD_TEST(pdal_filters_colorization_test
 PDAL_ADD_TEST(pdal_filters_crop_test
     FILES
         filters/CropFilterTest.cpp
+        ${PDAL_SRC_DIR}/private/OGRSpec.cpp
     INCLUDES
         ${GDAL_INCLUDE_DIR}
         ${NLOHMANN_INCLUDE_DIR}

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -72,6 +72,14 @@ PDAL_ADD_TEST(pdal_dimension_test
     INCLUDES
         ${NLOHMANN_INCLUDE_DIR}
 )
+PDAL_ADD_TEST(pdal_ogr_arg_test 
+    FILES 
+        OGRSpecTest.cpp
+    INCLUDES
+        ${NLOHMANN_INCLUDE_DIR}
+        ${GDAL_INCLUDE_DIR}
+    LINK_WITH
+        ${GDAL_LIBRARY})
 PDAL_ADD_TEST(pdal_pipeline_manager_test FILES PipelineManagerTest.cpp)
 PDAL_ADD_TEST(pdal_pipeline_writer_test
     FILES
@@ -323,6 +331,7 @@ PDAL_ADD_TEST(pdal_filters_crop_test
         filters/CropFilterTest.cpp
     INCLUDES
         ${GDAL_INCLUDE_DIR}
+        ${NLOHMANN_INCLUDE_DIR}
     LINK_WITH
         ${GDAL_LIBRARY}
 )

--- a/test/unit/OGRSpecTest.cpp
+++ b/test/unit/OGRSpecTest.cpp
@@ -1,0 +1,127 @@
+#include <pdal/pdal_test_main.hpp>
+
+#include <pdal/private/OGRSpec.hpp>
+#include <pdal/util/FileUtils.hpp>
+
+#include "Support.hpp"
+
+using namespace pdal;
+
+TEST(OGRSpecTest, createFromFile)
+{
+    NL::json json;
+    json["type"] = "ogr";
+    json["datasource"] = Support::datapath("autzen/attributes.json");
+    json["drivers"] = {"GeoJSON"};
+    json["openoptions"] = {"FLATTEN_NESTED_ATTRIBUTES=YES","NATIVE_DATA=YES"};
+    json["sql"] = "select \"_ogr_geometry_\" from attributes";
+    NL::json subJson;
+    subJson["dialect"] = "OGRSQL";
+    json["options"] = subJson;
+    OGRSpec ogr(json);
+
+    std::vector<pdal::Polygon> polys = ogr.getPolygons();
+
+    EXPECT_NEAR(polys[0].area(), 5.235e-06, 0.001);
+    EXPECT_NEAR(polys[1].area(), 1.450e-06, 0.001);
+    EXPECT_NEAR(polys[2].area(), 5.407e-07, 0.001);
+    EXPECT_NEAR(polys[3].area(), 4.516e-06, 0.001);
+    EXPECT_NEAR(polys[4].area(), 1.026e-06, 0.001);
+
+    // sql selection
+    NL::json updateJson = json;
+    updateJson["sql"] = "select \"_ogr_geometry_\" from attributes WHERE id = 1";
+    ogr.update(updateJson);
+    EXPECT_EQ(ogr.size(), 1);
+
+    // geometry filter
+    updateJson = json;
+    subJson["geometry"] = "{\"type\":\"Polygon\",\"coordinates\":[[[-123.071871740947586, 44.058426242457685],[-123.070376025800414, 44.058117017731242],[-123.07060216253906, 44.057465769662898],[-123.072144836409578, 44.057837746292243],[-123.071871740947586, 44.058426242457685]]]}";
+    updateJson["options"] = subJson;
+    OGRSpec ogrGeom(updateJson);
+    EXPECT_EQ(ogrGeom.size(), 1);
+}
+
+TEST(OGRSpecTest, parseErrors)
+{
+    NL::json json;
+    json["type"] = "ogr";
+    json["datasource"] = "no_path";
+    json["sql"] ="select \"_ogr_geometry_\" from attributes"; 
+
+    // removing datasource field
+    NL::json updateJson = json;
+    updateJson.erase("datasource");
+    try
+    {
+        OGRSpec ogr(updateJson);
+    }
+    catch(OGRSpec::error const& e)
+    {
+        EXPECT_EQ("'ogr' option must contain a 'datasource' field!",
+            std::string(e.what()));
+    }
+
+    // invalid type field
+    updateJson = json;
+    updateJson["type"] = "test";
+    try
+    {
+        OGRSpec ogr(updateJson);
+    }
+    catch(OGRSpec::error const& e)
+    {
+        EXPECT_EQ("'ogr' option must have 'type':'ogr' specified!",
+            std::string(e.what()));
+    }
+
+    // invalid field
+    updateJson = json;
+    updateJson["foo"] = "test";
+    try
+    {
+        OGRSpec ogr(updateJson);
+    }
+    catch(OGRSpec::error const& e)
+    {
+        EXPECT_EQ("unexpected field 'foo' in OGR JSON!", std::string(e.what())); 
+    }
+
+    // invalid value
+    updateJson = json;
+    updateJson["sql"] = "";
+    try
+    {
+        OGRSpec ogr(updateJson);
+    }
+    catch(OGRSpec::error const& e)
+    {
+        EXPECT_EQ("invalid value for field 'sql' in OGR JSON!", std::string(e.what()));
+    }
+
+    // input json array
+    std::stringstream dump;
+    dump << "[" << json.dump() << "]";
+    try
+    {
+        OGRSpec ogr(dump.str());
+    }
+    catch(OGRSpec::error const& e)
+    {
+        EXPECT_EQ("'ogr' option must be a JSON object with 'type':'ogr' specified!",
+            std::string(e.what()));
+    }
+
+    // initializing w/ non-json string
+    try
+    {
+        OGRSpec ogr(std::string("invalid json string"));
+    }
+    catch(OGRSpec::error const& e)
+    {
+        EXPECT_EQ("Failed to parse OGR JSON with error:  parse error "
+            "at line 1, column 1: syntax error while parsing value - "
+            "invalid literal; last read: 'i'", std::string(e.what()));
+    }
+}
+

--- a/test/unit/io/CopcReaderTest.cpp
+++ b/test/unit/io/CopcReaderTest.cpp
@@ -44,6 +44,7 @@
 #include <filters/ReprojectionFilter.hpp>
 #include <filters/SortFilter.hpp>
 #include <pdal/SrsBounds.hpp>
+#include <pdal/private/OGRSpec.hpp>
 #include <pdal/util/FileUtils.hpp>
 #include <pdal/private/gdal/GDALUtils.hpp>
 
@@ -618,10 +619,12 @@ TEST(CopcReaderTest, ogrCrop)
 {
     const std::string srs = R"(PROJCS["NAD_1983_HARN_Lambert_Conformal_Conic",GEOGCS["GCS_North_American_1983_HARN",DATUM["NAD83_High_Accuracy_Reference_Network",SPHEROID["GRS 1980",6378137,298.2572221010002,AUTHORITY["EPSG","7019"]],AUTHORITY["EPSG","6152"]],PRIMEM["Greenwich",0],UNIT["degree",0.0174532925199433]],PROJECTION["Lambert_Conformal_Conic_2SP"],PARAMETER["standard_parallel_1",43],PARAMETER["standard_parallel_2",45.5],PARAMETER["latitude_of_origin",41.75],PARAMETER["central_meridian",-120.5],PARAMETER["false_easting",1312335.958005249],PARAMETER["false_northing",0],UNIT["foot",0.3048,AUTHORITY["EPSG","9002"]]])";
 
-    NL::json ogr;
-    ogr["drivers"] = {"GeoJSON"};
-    ogr["datasource"] = Support::datapath("autzen/attributes.json");
-    ogr["sql"] = "select \"_ogr_geometry_\" from attributes";
+    NL::json json;
+    json["type"] = "ogr";
+    json["drivers"] = {"GeoJSON"};
+    json["datasource"] = Support::datapath("autzen/attributes.json");
+    json["sql"] = "select \"_ogr_geometry_\" from attributes";
+    OGRSpec ogr(json);
 
     CopcReader reader;
     {
@@ -648,7 +651,7 @@ TEST(CopcReaderTest, ogrCrop)
         source.setOptions(options);
     }
 
-    std::vector<Polygon> polys = gdal::getPolygons(ogr);
+    std::vector<Polygon> polys = ogr.getPolygons();
     for (Polygon& p : polys)
         p.transform(srs);
     PointTable sourceTable;

--- a/test/unit/io/EptReaderTest.cpp
+++ b/test/unit/io/EptReaderTest.cpp
@@ -42,6 +42,7 @@
 #include <io/LasReader.hpp>
 #include <filters/CropFilter.hpp>
 #include <filters/ReprojectionFilter.hpp>
+#include <pdal/private/OGRSpec.hpp>
 #include <pdal/SrsBounds.hpp>
 #include <pdal/Writer.hpp>
 #include <pdal/util/FileUtils.hpp>
@@ -894,10 +895,12 @@ TEST(EptReaderTest, ogrCrop)
     {
         Options options;
         options.add("filename", eptAutzenPath);
-        NL::json ogr;
-        ogr["drivers"] = {"GeoJSON"};
-        ogr["datasource"] = attributesPath;
-        ogr["sql"] = "select \"_ogr_geometry_\" from attributes";
+        NL::json json;
+        json["type"] = "ogr";
+        json["drivers"] = {"GeoJSON"};
+        json["datasource"] = attributesPath;
+        json["sql"] = "select \"_ogr_geometry_\" from attributes";
+        OGRSpec ogr(json);
 
         options.add("ogr", ogr);
 


### PR DESCRIPTION
Creating a new class that resolves #4548; the OGRSpec class processes a JSON specification for reading geometry with OGR at the time an argument is added, rather than during a stage's execution.

Right now, the class 
- takes a string argument 
- parses it
- validates it into a JSON
- gets all OGR-specified polygons as PDAL `Polygons`, stores them

This covers the needs of most stages that could potentially use an OGR datasource, like `readers.ept` and `readers.copc`. It's implemented there, as well as in `filters.geomdistance` (where it only uses a single polygon from the container we create). It still needs to be added to `filters.crop`, `readers.tindex` ~~and `filters.overlay`~~ but that should be trivial.

Right now, it could use some reworking to allow non-`Polygon` geometries to be specified. This might be nice for consistency's sake, for the few times this gets used currently (or maybe future additions, like 2.5D polygons?). I've been having some trouble designing a good solution for that, though.