### PR TITLE
[Backport 2.8-maintenance] adapt standard gitignore for CMake files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,25 +11,32 @@ plugins/pgpointcloud/Pgtest-Support.hpp
 #
 # cmake stuff
 #
+# standard ones from
+# https://github.com/github/gitignore/blob/main/CMake.gitignore
+CMakeLists.txt.user
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Testing
+Makefile
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+_deps
+CMakeUserPresets.json
+
+
+# PDAL custom CMake ignores
 PDALConfig.cmake
 PDALConfigVersion.cmake
 PDALTargets.cmake
-CMakeCache.txt
-CMakeFiles/
-CPackConfig.cmake
-CPackSourceConfig.cmake
-cmake_install.cmake
-CTestTestfile.cmake
 Testing/
 test/temp/
 apps/pdal-config
 apps/pdal-config.bat
 apps/pdal.pc
-src/CMakeScripts/
-apps/CMakeScripts/
-CMakeScripts/
 _CPack_Packages/
-install_manifest.txt
 
 #
 # visual studio cruft


### PR DESCRIPTION
Backport #4596
 **Authored by:** @hobu