### PR TITLE
Handle relative paths to STAC assets correctly

### DIFF
--- a/io/private/stac/Utils.cpp
+++ b/io/private/stac/Utils.cpp
@@ -58,13 +58,15 @@ std::string handleRelativePath(std::string srcPath, std::string linkPath)
 {
     //Make absolute path of current item's directory, then create relative path from that
 
+    //If the filepath is already absolute we don't need to bother.
+    if (FileUtils::isAbsolutePath(linkPath))
+        return linkPath;
+
     //If src item isn't an absolute path, we need to convert it to one for getDirectory to work
     if (!FileUtils::isAbsolutePath(srcPath))
         srcPath = FileUtils::toAbsolutePath(srcPath);
     //Get driectory of src item
     const std::string baseDir = FileUtils::getDirectory(srcPath);
-    if (FileUtils::isAbsolutePath(linkPath))
-        return linkPath;
     //Create absolute path from src item filepath, if it's not already
     // and join relative path to src item's dir path
     return FileUtils::toAbsolutePath(linkPath, baseDir);

--- a/io/private/stac/Utils.cpp
+++ b/io/private/stac/Utils.cpp
@@ -58,6 +58,9 @@ std::string handleRelativePath(std::string srcPath, std::string linkPath)
 {
     //Make absolute path of current item's directory, then create relative path from that
 
+    //If src item isn't an absolute path, we need to convert it to one for getDirectory to work
+    if (!FileUtils::isAbsolutePath(srcPath))
+        srcPath = FileUtils::toAbsolutePath(srcPath);
     //Get driectory of src item
     const std::string baseDir = FileUtils::getDirectory(srcPath);
     if (FileUtils::isAbsolutePath(linkPath))


### PR DESCRIPTION
Resolves #4594. If a path to the input Stac file was provided as `test.vpc` rather than `./test.vpc`, StacUtils was unable to expand relative paths to the Stac item's assets. `FileUtils::getDirectory()` was returning `/` as the base directory, which got stuck on the front of the asset's relative path. Made sure `HandleRelativePath()` always feeds absolute paths to `getDirectory()`.