### PR TITLE
Add `readers.stac` OGR option

### DIFF
--- a/io/StacReader.cpp
+++ b/io/StacReader.cpp
@@ -38,6 +38,8 @@
 #include <pdal/SrsBounds.hpp>
 #include <pdal/PipelineManager.hpp>
 #include <pdal/private/SrsTransform.hpp>
+#include <pdal/private/OGRSpec.hpp>
+#include <pdal/Polygon.hpp>
 
 #include <arbiter/arbiter.hpp>
 #include <nlohmann/json.hpp>
@@ -98,6 +100,7 @@ struct StacReader::Args
 
     NL::json::array_t dates;
     SrsBounds bounds;
+    OGRSpec ogr;
     std::vector<std::string> assetNames;
 
     SchemaUrls schemaUrls;
@@ -139,6 +142,8 @@ void StacReader::addArgs(ProgramArgs& args)
         , m_args->dates);
     args.add("bounds", "Bounding box to select stac items by. This will "
         "propogate down through all readers being used.", m_args->bounds);
+    args.add("ogr", "OGR filter geometriesmto select stac items by.",
+        m_args->ogr);
     args.add("properties", "Map of STAC property names to regular expression "
         "values. ie. {\"pc:type\": \"(lidar|sonar)\"}. Selected items will "
         "match all properties.", m_args->properties);
@@ -400,8 +405,16 @@ void StacReader::initializeArgs()
             throw pdal_error("Supplied bounds are not valid.");
         log()->get(LogLevel::Debug) << "Bounds: " << m_args->bounds << std::endl;
 
-        m_p->m_itemFilters->bounds = m_args->bounds;
+        Polygon boundsPoly(m_args->bounds.to2d());
+        if (!m_args->bounds.spatialReference().empty())
+            boundsPoly.setSpatialReference(m_args->bounds.spatialReference());
+        m_p->m_itemFilters->bounds = boundsPoly;
     }
+    else if (m_args->ogr.size())
+    {
+        m_p->m_itemFilters->bounds = m_args->ogr.getPolygons()[0];
+    }
+
     if (!m_args->assetNames.empty())
     {
         std::stringstream s;

--- a/io/StacReader.cpp
+++ b/io/StacReader.cpp
@@ -142,7 +142,7 @@ void StacReader::addArgs(ProgramArgs& args)
         , m_args->dates);
     args.add("bounds", "Bounding box to select stac items by. This will "
         "propogate down through all readers being used.", m_args->bounds);
-    args.add("ogr", "OGR filter geometriesmto select stac items by.",
+    args.add("ogr", "OGR filter geometries to select stac items by.",
         m_args->ogr);
     args.add("properties", "Map of STAC property names to regular expression "
         "values. ie. {\"pc:type\": \"(lidar|sonar)\"}. Selected items will "
@@ -398,6 +398,7 @@ void StacReader::initializeArgs()
         m_p->m_itemFilters->properties = m_args->properties;
     }
 
+    // There should be a check if both are specified
     if (!m_args->bounds.empty())
     {
 

--- a/io/private/stac/Item.cpp
+++ b/io/private/stac/Item.cpp
@@ -410,8 +410,7 @@ bool Item::filterBounds(Polygon bounds)
             "Polygon created from STAC 'geometry' key is invalid");
 
     // If the user didn't provide an SRS via option, we can only filter
-    // assuming it is 4326. Otherwise, we'll set or polygon's srs to
-    // the bounds as well.
+    // assuming it is 4326.
 
     if (!bounds.srsValid())
     {
@@ -427,6 +426,7 @@ bool Item::filterBounds(Polygon bounds)
         stacPolygon.transform(ref);
     }
 
+    // Could change the option to multiple polygons and loop thru them here
     if (!stacPolygon.disjoint(bounds))
         return true;
 

--- a/io/private/stac/Item.hpp
+++ b/io/private/stac/Item.hpp
@@ -38,7 +38,7 @@
 #include <pdal/Reader.hpp>
 #include <pdal/StageFactory.hpp>
 #include <pdal/PointView.hpp>
-#include <pdal/SrsBounds.hpp>
+#include <pdal/Polygon.hpp>
 #include <pdal/Log.hpp>
 
 #include "Utils.hpp"
@@ -78,7 +78,7 @@ public:
 
     struct Filters {
         std::vector<RegEx> ids;
-        SrsBounds bounds;
+        Polygon bounds;
         SpatialReference srs;
         NL::json properties;
         DatePairs datePairs;
@@ -121,7 +121,7 @@ private:
     bool filterCol(std::vector<RegEx> ids);
     bool filterDates(DatePairs dates);
     bool filterProperties(const NL::json& filterProps);
-    bool filterBounds(SrsBounds bounds);
+    bool filterBounds(Polygon bounds);
 
 
 };


### PR DESCRIPTION
Closes #4601. Added new `ogr` option in `readers.stac` for OGR-specified polygons to select STAC items by. Using polygons instead of `SrsBounds` to filter stac items.

Some things to fix:

- Throw errors w/ invalid polygons in `Item::filterBounds`, instead of just skipping them
- Specify multiple polygons in StacReader?
- Add WKT option?