### PR TITLE
[Backport 2.8-maintenance] Define destructor in source file for CSFilter.

### DIFF
--- a/filters/CSFilter.cpp
+++ b/filters/CSFilter.cpp
@@ -88,6 +88,9 @@ CSFilter::CSFilter() : m_args(new CSArgs)
 {
 }
 
+CSFilter::~CSFilter()
+{}
+
 std::string CSFilter::getName() const
 {
     return s_info.name;

--- a/filters/CSFilter.hpp
+++ b/filters/CSFilter.hpp
@@ -45,6 +45,7 @@ class PDAL_DLL CSFilter : public Filter
 {
 public:
     CSFilter();
+    ~CSFilter();
 
     CSFilter& operator=(const CSFilter&) = delete;
     CSFilter(const CSFilter&) = delete;


### PR DESCRIPTION
Backport #4620
 **Authored by:** @abellgithub