### PR TITLE
Implemented new filter separateflightline, edited docs of related filters

### DIFF
--- a/doc/stages/filters.separateflightline.md
+++ b/doc/stages/filters.separateflightline.md
@@ -17,7 +17,7 @@ be sorted by ascending `GpsTime`.
 
 ```json
 [
-    "input.text",
+    "input.las",
     {
         "type": "filters.sort",
         "dimension": "GpsTime",

--- a/doc/stages/filters.separateflightline.md
+++ b/doc/stages/filters.separateflightline.md
@@ -1,0 +1,41 @@
+(filters.separateflightline)=
+
+# filters.separateflightline
+
+The **separate flight line filter** takes a single `PointView` as its input and
+creates a new `PointView` for each pass of an aircraft based on `GpsTime`. 
+`PointView` must contain the `GpsTime` dimension. If two sequential returns are
+separated by a difference in `GpsTime` greater than the threshold `time_gap`, it
+is assumed that the returns came from different flight lines. Points must first
+be sorted by ascending `GpsTime`.
+
+```{eval-rst}
+.. embed::
+```
+
+## Example
+
+```json
+[
+    "input.text",
+    {
+        "type": "filters.sort",
+        "dimension": "GpsTime",
+        "order": "ASC"
+    },
+    {
+        "type":"filters.separateflightline",
+        "time_gap":5
+    },
+    "output_#.las"
+]
+```
+
+## Options
+
+time_gap
+
+: Minimum amount of GpsTime that separates two flight lines. \[Default : 5.0\]
+
+```{include} filter_opts.md
+```

--- a/doc/stages/filters.separatescanline.md
+++ b/doc/stages/filters.separatescanline.md
@@ -3,8 +3,11 @@
 # filters.separatescanline
 
 The **Separate scan line Filter** takes a single `PointView` as its input and
-creates a `PointView` for each scan line as its output. `PointView` must contain
-the `EdgeOfFlightLine` dimension.
+creates a `PointView` for each scan line (or group of san lines) as its output. 
+`PointView` must contain the `EdgeOfFlightLine` dimension. A scan lines is defined 
+as the set of returns between two returns marked as EdgeOfFlightLine. Scan lines are
+perpendicular to the direction of the aircraft's travel in typical ALS data collection. 
+This filter will likely produce a large number of output files if `groupby` is small.
 
 ```{eval-rst}
 .. embed::

--- a/doc/stages/filters.trajectory.md
+++ b/doc/stages/filters.trajectory.md
@@ -5,7 +5,8 @@
 The **trajectory filter** computes an estimate the the sensor location based
 on the position of multiple returns and the sensor scan angle. It is primarily
 useful for LAS input as it requires scan angle and return counts in order to
-work.
+work. Points must be sorted by `GpsTime` and should be separated by independent 
+flight lines (trajectories) before applying this filter.
 
 The method is described in detail [here]. It extends the method of {cite}`Gatziolis2019`.
 
@@ -20,9 +21,17 @@ replacing the input dataset.
 [
     "input.las",
     {
+        "type": "filters.sort",
+        "dimension": "GpsTime",
+        "order": "ASC"
+    },
+    {
+        "type": "filters.separateflightline"
+    },
+    {
         "type": "filters.trajectory"
     },
-    "trajectory.las"
+    "trajectories.las"
 ]
 ```
 

--- a/filters/SeparateFlightLineFilter.cpp
+++ b/filters/SeparateFlightLineFilter.cpp
@@ -82,7 +82,7 @@ PointViewSet SeparateFlightLineFilter::run(PointViewPtr inView)
         gpsTimeNext = inView->getFieldAs<double>(Dimension::Id::GpsTime, i+1);
         if (gpsTimeNext<gpsTime)
         throwError("View must be sorted by ascending GpsTime")
-        if (gpsTimeNext - gpsTime >= m_timeGap);
+        if (gpsTimeNext - gpsTime >= m_timeGap)
         {
             v = inView->makeNew();
             result.insert(v);

--- a/filters/SeparateFlightLineFilter.cpp
+++ b/filters/SeparateFlightLineFilter.cpp
@@ -57,7 +57,7 @@ std::string SeparateFlightLineFilter::getName() const
 
 void SeparateFlightLineFilter::addArgs(ProgramArgs& args)
 {
-    args.add("time_gap", "Minimum amount of GpsTime that separates two flight lines", m_timeGap, 5.0f);
+    args.add("time_gap", "Minimum amount of GpsTime that separates two flight lines", m_timeGap, (double) 5.0);
 }
 
 void SeparateFlightLineFilter::prepared(PointTableRef table)
@@ -81,7 +81,7 @@ PointViewSet SeparateFlightLineFilter::run(PointViewPtr inView)
         gpsTime = inView->getFieldAs<double>(Dimension::Id::GpsTime, i);
         gpsTimeNext = inView->getFieldAs<double>(Dimension::Id::GpsTime, i+1);
         if (gpsTimeNext<gpsTime)
-        throwError("View must be sorted by ascending GpsTime")
+        throwError("View must be sorted by ascending GpsTime");
         if (gpsTimeNext - gpsTime >= m_timeGap)
         {
             v = inView->makeNew();

--- a/filters/SeparateFlightLineFilter.cpp
+++ b/filters/SeparateFlightLineFilter.cpp
@@ -1,0 +1,98 @@
+/******************************************************************************
+ * Copyright (c) 2025, Johnathan Tenny (jt893@nau.edu)
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of Hobu, Inc. or Flaxen Geo Consulting nor the
+ *       names of its contributors may be used to endorse or promote
+ *       products derived from this software without specific prior
+ *       written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ ****************************************************************************/
+
+#include "SeparateFlightLineFilter.hpp"
+
+#include <pdal/util/ProgramArgs.hpp>
+
+namespace pdal
+{
+
+static StaticPluginInfo const s_info
+{
+    "filters.separateflightline",
+    "Split data by flight line based on a gap in GpsTime.",
+    "http://pdal.io/stages/filters.separateflightline.html"
+};
+CREATE_STATIC_STAGE(SeparateFlightLineFilter, s_info)
+
+SeparateFlightLineFilter::SeparateFlightLineFilter()
+{}
+
+std::string SeparateFlightLineFilter::getName() const
+{
+    return s_info.name;
+}
+
+void SeparateFlightLineFilter::addArgs(ProgramArgs& args)
+{
+    args.add("time_gap", "Minimum amount of GpsTime that separates two flight lines", m_timeGap, 5.0f);
+}
+
+void SeparateFlightLineFilter::prepared(PointTableRef table)
+{
+    PointLayoutPtr layout(table.layout());
+    if (!layout->hasDim(Dimension::Id::GpsTime))
+        throwError("Layout does not contain GpsTime dimension.");
+}
+
+PointViewSet SeparateFlightLineFilter::run(PointViewPtr inView)
+{
+    PointViewSet result;
+    PointViewPtr v(inView->makeNew());
+    result.insert(v);
+
+    float gpsTime = 0;
+    float gpsTimeNext = 0;
+    for (PointId i = 0; i < inView->size() - 1;++i)
+    {
+        v->appendPoint(*inView, i);
+        gpsTime = inView->getFieldAs<double>(Dimension::Id::GpsTime, i);
+        gpsTimeNext = inView->getFieldAs<double>(Dimension::Id::GpsTime, i+1);
+        if (gpsTimeNext<gpsTime)
+        throwError("View must be sorted by ascending GpsTime")
+        if (gpsTimeNext - gpsTime >= m_timeGap);
+        {
+            v = inView->makeNew();
+            result.insert(v);
+        }
+    }
+    //add last point to current view
+    if (inView->size() > 0)
+    v->appendPoint(*inView, inView->size() - 1);
+    
+    return result;
+}
+
+} // pdal

--- a/filters/SeparateFlightLineFilter.hpp
+++ b/filters/SeparateFlightLineFilter.hpp
@@ -1,0 +1,62 @@
+/******************************************************************************
+ * Copyright (c) 2025, Johnathan Tenny (jt893@nau.edu)
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of Hobu, Inc. or Flaxen Geo Consulting nor the
+ *       names of its contributors may be used to endorse or promote
+ *       products derived from this software without specific prior
+ *       written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ ****************************************************************************/
+
+#pragma once
+
+#include <pdal/Filter.hpp>
+
+namespace pdal
+{
+
+class PointView;
+class ProgramArgs;
+
+class PDAL_EXPORT SeparateFlightLineFilter : public Filter
+{
+public:
+    SeparateFlightLineFilter();
+    SeparateFlightLineFilter& operator=(const SeparateFlightLineFilter&) = delete;
+    SeparateFlightLineFilter(const SeparateFlightLineFilter&) = delete;
+
+    std::string getName() const;
+
+private:
+    float m_timeGap;
+
+    virtual void addArgs(ProgramArgs& args);
+    virtual void prepared(PointTableRef table);
+    virtual PointViewSet run(PointViewPtr view);
+};
+
+} // namespace pdal

--- a/filters/SeparateFlightLineFilter.hpp
+++ b/filters/SeparateFlightLineFilter.hpp
@@ -52,7 +52,7 @@ public:
     std::string getName() const;
 
 private:
-    float m_timeGap;
+    double m_timeGap;
 
     virtual void addArgs(ProgramArgs& args);
     virtual void prepared(PointTableRef table);


### PR DESCRIPTION
The purpose of this filter is to separate points by flight line before going into filters.trajectory, thus an independent trajectory can be created for each flight path over an area of interest. This filter considers each return sequentially in order of GPS time and separates points into a new view if the difference in GPS time between two time-adjacent returns is greater than threshold `time_gap`. 