### PR TITLE
use FileSpec to pass header and query to remote readers

### DIFF
--- a/io/EptReader.cpp
+++ b/io/EptReader.cpp
@@ -158,9 +158,6 @@ public:
     double m_resolution = 0;
     std::vector<Polygon> m_polys;
     NL::json m_addons;
-
-    NL::json m_query;
-    NL::json m_headers;
     OGRSpec m_ogr;
     bool m_ignoreUnreadable = false;
 };
@@ -202,36 +199,11 @@ void EptReader::addArgs(ProgramArgs& args)
     args.add("polygon", "Bounding polygon(s) to crop requests",
         m_args->m_polys).setErrorText("Invalid polygon specification. "
             "Must be valid GeoJSON/WKT");
-    args.add("header", "Header fields to forward with HTTP requests", m_args->m_headers);
-    args.add("query", "Query parameters to forward with HTTP requests", m_args->m_query);
     args.add("ogr", "OGR filter geometries", m_args->m_ogr);
     args.add("ignore_unreadable", "Ignore errors for missing point data nodes",
         m_args->m_ignoreUnreadable);
 }
 
-
-void EptReader::setForwards(StringMap& headers, StringMap& query)
-{
-    try
-    {
-        if (!m_args->m_headers.is_null())
-            headers = m_args->m_headers.get<StringMap>();
-    }
-    catch (const std::exception& err)
-    {
-        throwError(std::string("Error parsing 'headers': ") + err.what());
-    }
-
-    try
-    {
-        if (!m_args->m_query.is_null())
-            query = m_args->m_query.get<StringMap>();
-    }
-    catch (const std::exception& err)
-    {
-        throwError(std::string("Error parsing 'query': ") + err.what());
-    }
-}
 
 void EptReader::initialize()
 {
@@ -243,10 +215,8 @@ void EptReader::initialize()
             threads << " threads" << std::endl;
     m_p->pool.reset(new ThreadPool(threads));
 
-    StringMap headers;
-    StringMap query;
-    setForwards(headers, query);
-    m_p->connector.reset(new connector::Connector(headers, query));
+
+    m_p->connector.reset(new connector::Connector(m_filespec));
 
     try
     {

--- a/io/EptReader.hpp
+++ b/io/EptReader.hpp
@@ -88,7 +88,6 @@ private:
     // bounds to the bounds of the specified origin and set m_queryOriginId to
     // the selected OriginId value.  If the selected origin is not found, throw.
     void handleOriginQuery();
-    void setForwards(StringMap& headers, StringMap& query);
 
     // Aggregate all EPT keys overlapping our query bounds and their number of
     // points from a walk through the hierarchy.  Each of these keys will be


### PR DESCRIPTION
Closes #4523 
Closes https://github.com/PDAL/PDAL/issues/4451

Rework of PR https://github.com/PDAL/PDAL/pull/4524 

- [ ] Test with local las
- [ ] Test with remote las with key (no query no header just classic downloadable link)
- [ ] Test with remote las with header
- [ ] Test with local ept
- [ ] Test with remote ept (no query no header)
- [ ] Test with remote las with header
- [ ] Apply strategy to all readers
- [ ] Add example doc to close this issue as well https://github.com/PDAL/PDAL/issues/4451
- [ ] Update Doc where ever necessary