### PR TITLE
Update include directives for LasReader and LasHeader in transition from libLAS to PDAL guide

### DIFF
--- a/doc/api/transition/index.md
+++ b/doc/api/transition/index.md
@@ -21,8 +21,8 @@ which will be useful later:
 #include <memory>
 #include <pdal/PointTable.hpp>
 #include <pdal/PointView.hpp>
-#include <pdal/LasReader.hpp>
-#include <pdal/LasHeader.hpp>
+#include <pdal/io/LasReader.hpp>
+#include <pdal/io/LasHeader.hpp>
 #include <pdal/Options.hpp>
 ```
 


### PR DESCRIPTION
The transition from libLAS to PDAL docs are currently outdated, showing incorrect include directives for LasReader and LasHeader. This document is referenced by people looking for a minimal working solution for reading las data with PDAL and so it would help many new users to keep it updated.