### PR TITLE
Fixes the run-time "Missing value for positional argument 'filename' error in reading-streamer example

### DIFF
--- a/examples/reading-streamer/reading_streamer.cpp
+++ b/examples/reading-streamer/reading_streamer.cpp
@@ -14,7 +14,7 @@ namespace pdal
 // but this can be replaced with any other processing. See the LasWriter
 // class for a more detailed example.
  
-class PDAL_EXPORT StreamProcessor: public Writer, public Streamable
+class PDAL_EXPORT StreamProcessor: public NoFilenameWriter, public Streamable
 {
 
 public:


### PR DESCRIPTION
Resolves https://github.com/PDAL/PDAL/issues/4648

Due to PDAL API changes the `reading-streamer` example crashed at run-time.  This change fixes that.