### PR TITLE
[Backport 2.8-maintenance] Fix compilation issue when using raster filter without stage runner

### DIFF
--- a/filters/FaceRasterFilter.cpp
+++ b/filters/FaceRasterFilter.cpp
@@ -59,6 +59,8 @@ std::string FaceRasterFilter::getName() const
 FaceRasterFilter::FaceRasterFilter() : m_limits(new RasterLimits)
 {}
 
+FaceRasterFilter::~FaceRasterFilter() 
+{}
 
 void FaceRasterFilter::addArgs(ProgramArgs& args)
 {

--- a/filters/FaceRasterFilter.hpp
+++ b/filters/FaceRasterFilter.hpp
@@ -48,6 +48,7 @@ class PDAL_DLL FaceRasterFilter : public pdal::Filter
 {
 public:
     FaceRasterFilter();
+    ~FaceRasterFilter();
     FaceRasterFilter& operator=(const FaceRasterFilter&) = delete;
     FaceRasterFilter(const FaceRasterFilter&) = delete;
 


### PR DESCRIPTION
Backport #4646
 **Authored by:** @blenderfan