### PR TITLE
no need for PDAL_EXPORT in example code

### DIFF
--- a/examples/filter-streamer/filter_streamer.cpp
+++ b/examples/filter-streamer/filter_streamer.cpp
@@ -13,8 +13,8 @@ namespace pdal {
 // is processed in streaming mode, without loading the entire point cloud into
 // memory. Adjust appropriately the scale and offset in the header of the output
 // file.
-    
-class PDAL_EXPORT FilterStreamer : public Filter, public Streamable
+
+class FilterStreamer : public Filter, public Streamable
 {
 public:
     std::string getName() const;
@@ -25,24 +25,24 @@ private:
     virtual bool processOne(PointRef& point);
     double m_factor;
 };
-    
+
 std::string FilterStreamer::getName() const
 {
     return "filter_streamer";
 }
 
-FilterStreamer::FilterStreamer(double factor): m_factor(factor) 
+FilterStreamer::FilterStreamer(double factor): m_factor(factor)
 {
 }
 
-FilterStreamer::~FilterStreamer() 
+FilterStreamer::~FilterStreamer()
 {
 }
 
 // Apply a transform to each point
 bool FilterStreamer::processOne(PointRef& point)
 {
-    
+
     // Apply the scale factor
     double x = point.getFieldAs<double>(Dimension::Id::X) * m_factor;
     double y = point.getFieldAs<double>(Dimension::Id::Y) * m_factor;
@@ -59,21 +59,21 @@ bool FilterStreamer::processOne(PointRef& point)
 int main(int argc, char* argv[])
 {
     using namespace pdal;
-    
+
     // buf_size is the number of points that will be
-    // processed and kept in this table at the same time. 
+    // processed and kept in this table at the same time.
     // A somewhat bigger value may result in some efficiencies.
     int buf_size = 5;
     FixedPointTable t(buf_size);
-    
-    // Set the input point cloud    
+
+    // Set the input point cloud
     Options read_options;
     read_options.add("filename", "input.las");
     std::cout << "Reading: input.las\n";
     LasReader reader;
     reader.setOptions(read_options);
-    reader.prepare(t); 
-    
+    reader.prepare(t);
+
     // Get the scale and offset from the input cloud header
     // Must be run after the table is prepared
     const LasHeader & header = reader.header();
@@ -83,7 +83,7 @@ int main(int argc, char* argv[])
     // Will multiply each point by this factor
     double factor = 2.0;
     std::cout << "Applying factor: " << factor << std::endl;
-    
+
     // Set up the filter
     FilterStreamer streamer(factor);
     streamer.setInput(reader);
@@ -93,7 +93,7 @@ int main(int argc, char* argv[])
     Options write_options;
     write_options.add("filename", "output.las");
     std::cout << "Writing: output.las\n";
-    
+
     // The scale and offset for the output file will be adjusted
     // given that we multiply each point by a factor
     write_options.add("offset_x", factor * offset[0]);
@@ -102,7 +102,7 @@ int main(int argc, char* argv[])
     write_options.add("scale_x",  factor * scale[0]);
     write_options.add("scale_y",  factor * scale[1]);
     write_options.add("scale_z",  factor * scale[2]);
-    
+
     // Write the output file
     LasWriter writer;
     writer.setOptions(write_options);
@@ -110,5 +110,5 @@ int main(int argc, char* argv[])
     writer.prepare(t);
     writer.execute(t);
 
-    return 0;   
+    return 0;
 }

--- a/examples/reading-streamer/reading_streamer.cpp
+++ b/examples/reading-streamer/reading_streamer.cpp
@@ -13,8 +13,8 @@ namespace pdal
 // loading it fully in memory. The points are printed to the screen,
 // but this can be replaced with any other processing. See the LasWriter
 // class for a more detailed example.
- 
-class PDAL_EXPORT StreamProcessor: public NoFilenameWriter, public Streamable
+
+class StreamProcessor: public NoFilenameWriter, public Streamable
 {
 
 public:
@@ -52,11 +52,11 @@ void StreamProcessor::initialize()
 bool StreamProcessor::processOne(PointRef& point)
 {
    // Print the point coordinates
-   std::cout << "Process point: " 
-             << point.getFieldAs<double>(Dimension::Id::X) <<  ", " 
-             << point.getFieldAs<double>(Dimension::Id::Y) << ", " 
+   std::cout << "Process point: "
+             << point.getFieldAs<double>(Dimension::Id::X) <<  ", "
+             << point.getFieldAs<double>(Dimension::Id::Y) << ", "
              << point.getFieldAs<double>(Dimension::Id::Z) << std::endl;
-    return true;  
+    return true;
 }
 
 void StreamProcessor::done(PointTableRef table) {
@@ -71,17 +71,17 @@ void StreamProcessor::writeView(const PointViewPtr view)
 
 int main(int argc, char* argv[])
 {
- 
+
     using namespace pdal;
-    
-    // Set the input point cloud    
+
+    // Set the input point cloud
     Options read_options;
     read_options.add("filename", "input.las");
     LasReader reader;
     reader.setOptions(read_options);
 
     // buf_size is the number of points that will be
-    // processed and kept in this table at the same time. 
+    // processed and kept in this table at the same time.
     // A somewhat bigger value may result in some efficiencies.
     int buf_size = 100;
     FixedPointTable t(buf_size);
@@ -94,6 +94,6 @@ int main(int argc, char* argv[])
     writer.setInput(reader);
     writer.prepare(t);
     writer.execute(t);
-    
+
     return 0;
 }

--- a/examples/writing-filter/MyFilter.hpp
+++ b/examples/writing-filter/MyFilter.hpp
@@ -8,7 +8,7 @@
 namespace pdal
 {
 
-class PDAL_EXPORT MyFilter : public Filter
+class MyFilter : public Filter
 {
 public:
     MyFilter() : Filter()

--- a/examples/writing-kernel/MyKernel.hpp
+++ b/examples/writing-kernel/MyKernel.hpp
@@ -9,7 +9,7 @@
 namespace pdal
 {
 
-class PDAL_EXPORT MyKernel : public Kernel
+class MyKernel : public Kernel
 {
 public:
     MyKernel();

--- a/examples/writing-streamer/writing_streamer.cpp
+++ b/examples/writing-streamer/writing_streamer.cpp
@@ -8,12 +8,12 @@
 #include <vector>
 
 namespace pdal {
-    
+
 // A class to produce a point cloud point-by-point, rather than
 // having it all in memory at the same time. It will be streamed to
 // disk. See the GDALReader class for how to add more fields
 // and read from disk.
-class PDAL_EXPORT StreamedPointCloud : public Reader, public Streamable
+class StreamedPointCloud : public Reader, public Streamable
 {
 public:
     std::string getName() const;
@@ -31,7 +31,7 @@ private:
 
     point_count_t m_count, m_size;
 };
-    
+
 std::string StreamedPointCloud::getName() const
 {
     return "streamed_point_cloud";
@@ -86,7 +86,7 @@ bool StreamedPointCloud::processOne(PointRef& point)
     double x = m_count * 0.1;
     double y = m_count * 0.2;
     double z = m_count * 0.3;
-    
+
     point.setField(Dimension::Id::X, x);
     point.setField(Dimension::Id::Y, y);
     point.setField(Dimension::Id::Z, z);
@@ -104,12 +104,12 @@ void StreamedPointCloud::done(PointTableRef table)
 int main(int argc, char* argv[])
 {
     using namespace pdal;
-    
+
     // Streamed cloud structure
     StreamedPointCloud stream_cloud;
 
     // buf_size is the number of points that will be
-    // processed and kept in this table at the same time. 
+    // processed and kept in this table at the same time.
     // A somewhat bigger value may result in some efficiencies.
     int buf_size = 5;
     FixedPointTable t(buf_size);
@@ -118,7 +118,7 @@ int main(int argc, char* argv[])
     // Set the output filename
     Options write_options;
     write_options.add("filename", "output.las");
-    
+
     // StageFactory always "owns" stages it creates. They'll be destroyed with
     // the factory.
     StageFactory factory;
@@ -129,6 +129,6 @@ int main(int argc, char* argv[])
     writer->setOptions(write_options);
     writer->prepare(t);
     writer->execute(t);
- 
-    return 0;   
+
+    return 0;
 }


### PR DESCRIPTION
This should clean up the Conda builder CI. I don't know that we should show how to export in the examples anyway.