### PR TITLE
Add float-encoded RGB and Alpha as built-in dimensions

### DIFF
--- a/pdal/Dimension.json
+++ b/pdal/Dimension.json
@@ -675,5 +675,29 @@
     "name": "Duplicate",
     "type": "uint8",
     "description": "Indicator of whether or not a point is a labeled duplicate"
+    },
+    {
+    "name": "RedF",
+    "alt_names": "f_dc_0",
+    "type": "float",
+    "description": "Red channel represented as 0-1 decimal value"
+    },
+    {
+    "name": "GreenF",
+    "alt_names": "f_dc_1",
+    "type": "float",
+    "description": "Green channel represented as 0-1 decimal value"
+    },
+    {
+    "name": "BlueF",
+    "alt_names": "f_dc_2",
+    "type": "float",
+    "description": "Blue channel represented as 0-1 decimal value"
+    },
+    {
+    "name": "AlphaF",
+    "alt_names": "opacity",
+    "type": "float",
+    "description": "Alpha represented as 0-1 decimal value"
     }
 ] }

--- a/pdal/Dimension.json
+++ b/pdal/Dimension.json
@@ -677,27 +677,69 @@
     "description": "Indicator of whether or not a point is a labeled duplicate"
     },
     {
-    "name": "RedF",
+    "name": "RedD",
     "alt_names": "f_dc_0",
-    "type": "float",
+    "type": "float32",
     "description": "Red channel represented as 0-1 decimal value"
     },
     {
-    "name": "GreenF",
+    "name": "GreenD",
     "alt_names": "f_dc_1",
-    "type": "float",
+    "type": "float32",
     "description": "Green channel represented as 0-1 decimal value"
     },
     {
-    "name": "BlueF",
+    "name": "BlueD",
     "alt_names": "f_dc_2",
-    "type": "float",
+    "type": "float32",
     "description": "Blue channel represented as 0-1 decimal value"
     },
     {
-    "name": "AlphaF",
+    "name": "AlphaD",
     "alt_names": "opacity",
-    "type": "float",
+    "type": "float32",
     "description": "Alpha represented as 0-1 decimal value"
+    },
+    {
+    "name": "RotationW",
+    "alt_names": "rot_0",
+    "type": "float32",
+    "description": "W component of rotation quaternion for this point"
+    },
+    {
+    "name": "RotationX",
+    "alt_names": "rot_1",
+    "type": "float32",
+    "description": "X component of rotation quaternion for this point"
+    },
+    {
+    "name": "RotationY",
+    "alt_names": "rot_2",
+    "type": "float32",
+    "description": "Y component of rotation quaternion for this point"
+    },
+    {
+    "name": "RotationZ",
+    "alt_names": "rot_3",
+    "type": "float32",
+    "description": "Z component of rotation quaternion for this point"
+    },
+    {
+    "name": "ScaleX",
+    "alt_names": "scale_0",
+    "type": "float32",
+    "description": "X component of scale for gaussians"
+    },
+    {
+    "name": "ScaleY",
+    "alt_names": "scale_1",
+    "type": "float32",
+    "description": "Y component of scale for gaussians"
+    },
+    {
+    "name": "scaleZ",
+    "alt_names": "scale_2",
+    "type": "float32",
+    "description": "Z component of scale for gaussians"
     }
 ] }


### PR DESCRIPTION
Adding new built-in dimensions that support R/G/B/Alpha as 0-1 floats (`RedF`, `GreenF`, `BlueF`, `AlphaF`). The alternate names are the standard for their equivalent .ply vertex attributes (at least for 3DGS data).