### PR TITLE
[Backport 2.8-maintenance] Geometry.hpp: fix compatibility with GDAL master in debug mode

### DIFF
--- a/pdal/Geometry.hpp
+++ b/pdal/Geometry.hpp
@@ -74,7 +74,7 @@ public:
     virtual ~Geometry();
 
     OGRGeometryH getOGRHandle()
-    { return m_geom.get(); }
+    { return reinterpret_cast<OGRGeometryH>(m_geom.get()); }
 
     virtual void update(const std::string& wkt_or_json);
     virtual bool valid() const;


### PR DESCRIPTION
Backport #4668
 **Authored by:** @rouault