### PR TITLE
Fix READTHEDOCS_CANONICAL_URL

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,6 +16,7 @@ build:
       # Generate on-the-fly Sphinx configuration from Jupyter Book's _config.yml
       - "jupyter-book config sphinx doc/"
       - sed -i "1i\import os, sys; sys.path.append(os.path.abspath(\"./_ext\"))" doc/conf.py
+      - sed -i "\$ahtml_baseurl = os.environ.get(\"READTHEDOCS_CANONICAL_URL\", \"\")" doc/conf.py
 
   apt_packages:
     - graphviz


### PR DESCRIPTION
We weren't properly setting `READTHEDOCS_CANONICAL_URL` after the migration to JupyterBook. This means our google indexing isn't pointing at the right location and the google juice gets messed up. Only thing I can think of is to stick the html_baseurl in the Sphinx conf.py like we do for the `_ext`. JupyterBook doesn't seem to have a way to configure or pass things through via environment variables.