### PR TITLE
floor values before cast when creating grid in `filters.voxelcentroidnearestneighbor`

### DIFF
--- a/filters/VoxelCentroidNearestNeighborFilter.cpp
+++ b/filters/VoxelCentroidNearestNeighborFilter.cpp
@@ -81,9 +81,9 @@ PointViewSet VoxelCentroidNearestNeighborFilter::run(PointViewPtr view)
         double y = view->getFieldAs<double>(Dimension::Id::Y, id);
         double x = view->getFieldAs<double>(Dimension::Id::X, id);
         double z = view->getFieldAs<double>(Dimension::Id::Z, id);
-        ssize_t r = static_cast<ssize_t>((y - y0) / m_cell);
-        ssize_t c = static_cast<ssize_t>((x - x0) / m_cell);
-        ssize_t d = static_cast<ssize_t>((z - z0) / m_cell);
+        ssize_t r = static_cast<ssize_t>(std::floor((y - y0) / m_cell));
+        ssize_t c = static_cast<ssize_t>(std::floor((x - x0) / m_cell));
+        ssize_t d = static_cast<ssize_t>(std::floor((z - z0) / m_cell));
         populated_voxel_ids[std::make_tuple(r, c, d)].push_back(id);
     }
 

--- a/pdal/PointView.hpp
+++ b/pdal/PointView.hpp
@@ -66,7 +66,7 @@ typedef std::set<PointViewPtr, PointViewLess> PointViewSet;
 
 class PDAL_EXPORT PointView
 {
-    FRIEND_TEST(VoxelTest, center);
+    FRIEND_TEST(VoxelCenterNearestNeighborFilterTest, center);
     friend class Stage;
     friend class PointRef;
     friend class PointViewIter;

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -448,7 +448,8 @@ target_compile_definitions(pdal_filters_hexbin_test
         H3_PREFIX=PDALH3
 )
 
-PDAL_ADD_TEST(pdal_filters_voxel_test FILES filters/VoxelTest.cpp)
+PDAL_ADD_TEST(pdal_filters_voxel_center_nearest_neighbor_test FILES filters/VoxelCenterNearestNeighborFilterTest.cpp)
+PDAL_ADD_TEST(pdal_filters_voxel_centroid_nearest_neighbor_test FILES filters/VoxelCentroidNearestNeighborFilterTest.cpp)
 PDAL_ADD_TEST(pdal_filters_voxel_downsize_test FILES filters/VoxelDownsizeFilterTest.cpp)
 
 PDAL_ADD_TEST(pdal_app_test FILES apps/AppTest.cpp)

--- a/test/unit/filters/VoxelCenterNearestNeighborFilterTest.cpp
+++ b/test/unit/filters/VoxelCenterNearestNeighborFilterTest.cpp
@@ -41,7 +41,7 @@
 namespace pdal
 {
 
-TEST(VoxelTest, center)
+TEST(VoxelCenterNearestNeighborFilterTest, center)
 {
     StageFactory fac;
 
@@ -83,7 +83,7 @@ TEST(VoxelTest, center)
     EXPECT_EQ(sums[iter], sum);
 }
 
-TEST(VoxelTest, center_value)
+TEST(VoxelCenterNearestNeighborFilterTest, center_value)
 {
     StageFactory fac;
 

--- a/test/unit/filters/VoxelCentroidNearestNeighborFilterTest.cpp
+++ b/test/unit/filters/VoxelCentroidNearestNeighborFilterTest.cpp
@@ -1,0 +1,132 @@
+/******************************************************************************
+* Copyright (c) 2018, Hobu Inc. (info@hobu.co)
+*
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following
+* conditions are met:
+*
+*     * Redistributions of source code must retain the above copyright
+*       notice, this list of conditions and the following disclaimer.
+*     * Redistributions in binary form must reproduce the above copyright
+*       notice, this list of conditions and the following disclaimer in
+*       the documentation and/or other materials provided
+*       with the distribution.
+*     * Neither the name of Hobu, Inc. or Flaxen Geo Consulting nor the
+*       names of its contributors may be used to endorse or promote
+*       products derived from this software without specific prior
+*       written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+* FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+* COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+* BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+* OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+* AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+* OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+* OF SUCH DAMAGE.
+****************************************************************************/
+
+#include <pdal/pdal_test_main.hpp>
+
+#include "io/BufferReader.hpp"
+#include "filters/VoxelCentroidNearestNeighborFilter.hpp"
+
+namespace pdal
+{
+
+    // Helper function to check if a given point is present in a PointView.
+    bool pointFoundInOutput(PointViewPtr view, const std::array<double, 3>& pt, double eps = 1e-6)
+    {
+        for (PointId i = 0; i < view->size(); ++i)
+        {
+            PointRef p(*view, i);
+            double x = p.getFieldAs<double>(Dimension::Id::X);
+            double y = p.getFieldAs<double>(Dimension::Id::Y);
+            double z = p.getFieldAs<double>(Dimension::Id::Z);
+            if (std::fabs(x - pt[0]) < eps &&
+                std::fabs(y - pt[1]) < eps &&
+                std::fabs(z - pt[2]) < eps)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    TEST(VoxelCentroidNearestNeighborFilterTest, SyntheticCloudKnownOutput)
+    {
+        // Set up the point table and register dimensions.
+        PointTable table;
+        table.layout()->registerDims({Dimension::Id::X, Dimension::Id::Y, Dimension::Id::Z});
+        PointViewPtr inputView(new PointView(table));
+
+        // We use (5,5,5) as the first point which defines the grid origin.
+        // Points are chosen such that when downsampled with cell=10:
+        //   - Points (5,5,5) & (11,11,11) fall in one voxel, with the candidate expected to be (11,11,11)
+        //   - Points (0,0,0) & (1,1,1) (which fall to the left/below the origin) fall in the negative voxel,
+        //     with the candidate expected to be (0,0,0) (i.e. closer to the voxel center).
+        //   - (21,21,21) falls in another voxel and is kept.
+        std::vector<std::array<double, 3>> inputPoints = {
+            {5, 5, 5},       // First point, defines origin.
+            {0, 0, 0},       // Negative side.
+            {1, 1, 1},       // Same voxel as above.
+            {11, 11, 11},    // Same voxel as (5,5,5) but closer to its voxel center.
+            {21, 21, 21}     // Different voxel.
+        };
+
+        PointId id = 0;
+        for (const auto &pt : inputPoints)
+        {
+            inputView->setField(Dimension::Id::X, id, pt[0]);
+            inputView->setField(Dimension::Id::Y, id, pt[1]);
+            inputView->setField(Dimension::Id::Z, id, pt[2]);
+            ++id;
+        }
+
+        // Create a BufferReader and add our synthetic view.
+        BufferReader reader;
+        reader.addView(inputView);
+
+        // Set up the filter. With a cell size of 10, the voxel grid is built relative to (5,5,5).
+        VoxelCentroidNearestNeighborFilter filter;
+        Options opts;
+        opts.add("cell", 10);
+        filter.setOptions(opts);
+        filter.setInput(reader);
+
+        filter.prepare(table);
+        PointViewSet outputViews = filter.execute(table);
+
+        // We expect one output view.
+        ASSERT_EQ(outputViews.size(), 1u);
+        PointViewPtr outputView = *outputViews.begin();
+
+        // Expected output:
+        //   * For the voxel containing (5,5,5) and (11,11,11) the candidate is (11,11,11)
+        //   * For the voxel containing (0,0,0) and (1,1,1) the candidate is (0,0,0)
+        //   * For the voxel containing (21,21,21) the candidate is (21,21,21)
+        std::vector<std::array<double, 3>> expected = {
+            {11, 11, 11},
+            {0,  0,   0},
+            {21, 21, 21}
+        };
+
+        // Ensure that the number of points in the output matches the expected count.
+        EXPECT_EQ(outputView->size(), expected.size());
+
+        // Verify that each expected point exists in the output.
+        for (const auto& expPt : expected)
+        {
+            EXPECT_TRUE(pointFoundInOutput(outputView, expPt))
+                << "Expected point (" << expPt[0] << ", " << expPt[1]
+                << ", " << expPt[2] << ") not found in the output.";
+        }
+    }
+
+} // namespace pdal


### PR DESCRIPTION
Closes #4678

I dug into the issue and found the cause. The problem seems to be that negative values were being cast to 0—this inadvertently causes a “centerline” to form, stemming from the point at index 0. In other words, when a coordinate falls into a negative voxel based on its position, the plain cast was pushing it into the voxel at 0.

Using std::floor ensures that values on the negative side are correctly mapped to their respective negative voxel rather than being rounded up to 0. This change removes the symmetric pattern observed near the point at index 0.


### Visual Comparison

Before (Symmetric Pattern):
![image](https://github.com/user-attachments/assets/205e0d9d-d2f9-42d3-ab9b-13f1d26a4532)

After (Corrected Mapping):
![image](https://github.com/user-attachments/assets/9c320431-d7b8-4c1a-bc86-54572d2d368c)

As seen in the images above, with the floor function, points that should belong to the negative voxel are now assigned properly, thereby eliminating the symmetric “+” effect that we were observing.
