### PR TITLE
Fix build with GDAL 3.11.0 debug (`GDAL_DEBUG`)

### DIFF
--- a/filters/OverlayFilter.cpp
+++ b/filters/OverlayFilter.cpp
@@ -93,7 +93,7 @@ void OverlayFilter::prepared(PointTableRef table)
 void OverlayFilter::ready(PointTableRef table)
 {
     m_ds = OGRDSPtr(OGROpen(m_datasource.c_str(), 0, 0),
-            [](void *p){ if (p) ::OGR_DS_Destroy(p); });
+            [](OGRDSPtr::element_type *p){ if (p) ::OGR_DS_Destroy(p); });
     if (!m_ds)
         throwError("Unable to open data source '" + m_datasource + "'");
 
@@ -114,7 +114,7 @@ void OverlayFilter::ready(PointTableRef table)
         OGR_L_SetSpatialFilter(m_lyr, g.getOGRHandle());
     }
 
-    auto featureDeleter = [](void *p)
+    auto featureDeleter = [](OGRFeaturePtr::element_type *p)
     {
         if (p)
             ::OGR_F_Destroy(p);

--- a/filters/OverlayFilter.hpp
+++ b/filters/OverlayFilter.hpp
@@ -42,7 +42,13 @@
 #include <memory>
 #include <string>
 
-typedef void *OGRLayerH;
+// Get GDAL's forward decls if available
+// otherwise make our own
+#if __has_include(<gdal_fwd.h>)
+#include <gdal_fwd.h>
+#else
+using OGRLayerH = void *;
+#endif
 
 namespace pdal
 {

--- a/filters/OverlayFilter.hpp
+++ b/filters/OverlayFilter.hpp
@@ -41,6 +41,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <type_traits>
 
 // Get GDAL's forward decls if available
 // otherwise make our own
@@ -58,9 +59,13 @@ namespace gdal
     class ErrorHandler;
 }
 
+#if __has_include(<gdal_fwd.h>)
+typedef std::shared_ptr<std::remove_pointer<OGRDataSourceH>::type> OGRDSPtr;
+typedef std::shared_ptr<std::remove_pointer<OGRFeatureH>::type> OGRFeaturePtr;
+#else
 typedef std::shared_ptr<void> OGRDSPtr;
 typedef std::shared_ptr<void> OGRFeaturePtr;
-typedef std::shared_ptr<void> OGRGeometryPtr;
+#endif
 
 class Arg;
 
@@ -89,8 +94,6 @@ private:
 
     OverlayFilter& operator=(const OverlayFilter&) = delete;
     OverlayFilter(const OverlayFilter&) = delete;
-
-    typedef std::shared_ptr<void> OGRDSPtr;
 
     OGRDSPtr m_ds;
     OGRLayerH m_lyr;

--- a/io/TIndexReader.cpp
+++ b/io/TIndexReader.cpp
@@ -89,7 +89,7 @@ TIndexReader::FieldIndexes TIndexReader::getFields()
 {
     FieldIndexes indexes;
 
-    void *fDefn = OGR_L_GetLayerDefn(m_layer);
+    OGRFeatureDefnH fDefn = OGR_L_GetLayerDefn(m_layer);
 
     indexes.m_filename = OGR_FD_GetFieldIndex(fDefn,
         m_args->m_tileIndexColumnName.c_str());

--- a/io/TIndexReader.hpp
+++ b/io/TIndexReader.hpp
@@ -41,6 +41,15 @@
 
 #include <pdal/JsonFwd.hpp>
 
+// Get GDAL's forward decls if available
+// otherwise make our own
+#if __has_include(<gdal_fwd.h>)
+#include <gdal_fwd.h>
+#else
+using OGRDataSourceH = void *;
+using OGRLayerH = void *;
+#endif
+
 namespace pdal
 {
 
@@ -88,8 +97,8 @@ private:
 
     std::unique_ptr<Args> m_args;
     std::unique_ptr<gdal::SpatialRef> m_out_ref;
-    void *m_dataset;
-    void *m_layer;
+    OGRDataSourceH m_dataset;
+    OGRLayerH m_layer;
 
     StageFactory m_factory;
     MergeFilter m_merge;

--- a/kernels/TIndexKernel.cpp
+++ b/kernels/TIndexKernel.cpp
@@ -723,7 +723,7 @@ TIndexKernel::FieldIndexes TIndexKernel::getFields()
 {
     FieldIndexes indexes;
 
-    void *fDefn = OGR_L_GetLayerDefn(m_layer);
+    OGRFeatureDefnH fDefn = OGR_L_GetLayerDefn(m_layer);
 
     indexes.m_filename = OGR_FD_GetFieldIndex(fDefn,
         m_tileIndexColumnName.c_str());

--- a/kernels/TIndexKernel.hpp
+++ b/kernels/TIndexKernel.hpp
@@ -40,6 +40,15 @@
 #include <pdal/SubcommandKernel.hpp>
 #include <pdal/util/FileUtils.hpp>
 
+// Get GDAL's forward decls if available
+// otherwise make our own
+#if __has_include(<gdal_fwd.h>)
+#include <gdal_fwd.h>
+#else
+using OGRDataSourceH = void *;
+using OGRLayerH = void *;
+#endif
+
 namespace pdal
 {
     class Polygon;
@@ -118,8 +127,8 @@ private:
     uint32_t m_sampleSize;
     std::string m_boundaryExpr;
 
-    void *m_dataset;
-    void *m_layer;
+    OGRDataSourceH m_dataset;
+    OGRLayerH m_layer;
     std::string m_tgtSrsString;
     std::string m_assignSrsString;
     bool m_fastBoundary;

--- a/kernels/private/density/OGR.hpp
+++ b/kernels/private/density/OGR.hpp
@@ -35,6 +35,15 @@
 
 #include <string>
 
+// Get GDAL's forward decls if available
+// otherwise make our own
+#if __has_include(<gdal_fwd.h>)
+#include <gdal_fwd.h>
+#else
+using OGRDataSourceH = void *;
+using OGRLayerH = void *;
+#endif
+
 namespace hexer
 {
     class BaseGrid;
@@ -45,9 +54,6 @@ namespace pdal
 
 class OGR
 {
-    using OGRDataSourceH = void *;
-    using OGRLayerH = void *;
-
 public:
     OGR(std::string const& filename, const std::string& srs,
         std::string driver = "ESRI Shapefile", std::string layerName ="");

--- a/pdal/Geometry.cpp
+++ b/pdal/Geometry.cpp
@@ -275,11 +275,11 @@ Geometry Geometry::getRing() const
 {
     throwNoGeos();
 
-    int count = OGR_G_GetGeometryCount(m_geom.get());
+    int count = OGR_G_GetGeometryCount(gdal::toHandle(m_geom.get()));
     if (count)
     {
 
-        OGRGeometryH ring = OGR_G_Clone(OGR_G_GetGeometryRef(m_geom.get(), 0));
+        OGRGeometryH ring = OGR_G_Clone(OGR_G_GetGeometryRef(gdal::toHandle(m_geom.get()), 0));
         OGRGeometryH linestring = OGR_G_ForceToLineString(ring);
 
         return Geometry(linestring, getSpatialReference());

--- a/pdal/SpatialReference.cpp
+++ b/pdal/SpatialReference.cpp
@@ -358,7 +358,7 @@ bool SpatialReference::equals(const SpatialReference& input) const
     if (!current || !other)
         return false;
 
-    int output = current.get()->IsSame(other.get());
+    int output = current->IsSame(other.get());
 
     return (output == 1);
 }
@@ -389,7 +389,7 @@ bool SpatialReference::isGeographic() const
     if (!current)
         return false;
 
-    bool output = current.get()->IsGeographic();
+    bool output = current->IsGeographic();
     return output;
 }
 
@@ -400,7 +400,7 @@ bool SpatialReference::isGeocentric() const
     if (!current)
         return false;
 
-    bool output = current.get()->IsGeocentric();
+    bool output = current->IsGeocentric();
     return output;
 }
 
@@ -411,7 +411,7 @@ bool SpatialReference::isProjected() const
     if (!current)
         return false;
 
-    bool output = current.get()->IsProjected();
+    bool output = current->IsProjected();
     return output;
 }
 
@@ -420,7 +420,7 @@ std::vector<int> SpatialReference::getAxisOrdering() const
     std::vector<int> output;
     OGRScopedSpatialReference current = ogrCreateSrs(m_wkt, m_epoch);
     if (current)
-        output = current.get()->GetDataAxisToSRSAxisMapping();
+        output = current->GetDataAxisToSRSAxisMapping();
     return output;
 }
 
@@ -564,7 +564,7 @@ int SpatialReference::getUTMZone() const
         throw pdal_error("Could not fetch current SRS");
 
     int north(0);
-    int zone = current.get()->GetUTMZone(&north);
+    int zone = current->GetUTMZone(&north);
     return (north ? 1 : -1) * zone;
 }
 

--- a/pdal/private/gdal/GDALUtils.cpp
+++ b/pdal/private/gdal/GDALUtils.cpp
@@ -357,7 +357,7 @@ std::vector<Polygon> getPolygons(const OGRSpecOptions& ogr)
                 throw pdal_error("Unable to execute OGR SQL query.");
 
             SpatialRef sref;
-            sref.setFromLayer(poLayer);
+            sref.setFromLayer(reinterpret_cast<OGRLayerH>(poLayer));
             ds->ReleaseResultSet(poLayer);
 
             poly.update(ogr.geometry);
@@ -380,7 +380,7 @@ std::vector<Polygon> getPolygons(const OGRSpecOptions& ogr)
     std::vector<Polygon> polys;
     while ((poFeature = poLayer->GetNextFeature()) != NULL)
     {
-        polys.emplace_back(poFeature->GetGeometryRef());
+        polys.emplace_back(reinterpret_cast<OGRGeometryH>(poFeature->GetGeometryRef()));
         OGRFeature::DestroyFeature( poFeature );
     }
 

--- a/pdal/private/gdal/SpatialRef.cpp
+++ b/pdal/private/gdal/SpatialRef.cpp
@@ -106,9 +106,9 @@ bool SpatialRef::empty() const
     return wkt().empty();
 }
 
-void SpatialRef::newRef(void *v)
+void SpatialRef::newRef(OGRSpatialReferenceH v)
 {
-    m_ref = RefPtr(v, [](void* t){ OSRDestroySpatialReference(t); } );
+    m_ref = RefPtr(v, [](OGRSpatialReferenceH t){ OSRDestroySpatialReference(t); } );
 }
 
 } // namespace gdal

--- a/pdal/private/gdal/SpatialRef.hpp
+++ b/pdal/private/gdal/SpatialRef.hpp
@@ -35,6 +35,7 @@
 #pragma once
 
 #include <memory>
+#include <type_traits>
 
 // Get GDAL's forward decls if available
 // otherwise make our own
@@ -42,6 +43,7 @@
 #include <gdal_fwd.h>
 #else
     using OGRLayerH = void *;
+    using OGRSpatialReferenceH = void *;
 #endif
 
 
@@ -53,7 +55,7 @@ namespace gdal
 
 class SpatialRef
 {
-    typedef std::shared_ptr<void> RefPtr;
+    typedef std::shared_ptr<std::remove_pointer<OGRSpatialReferenceH>::type> RefPtr;
 public:
     SpatialRef();
     SpatialRef(const std::string& srs);
@@ -65,7 +67,7 @@ public:
     bool empty() const;
 
 private:
-    void newRef(void *v);
+    void newRef(OGRSpatialReferenceH v);
 
     RefPtr m_ref;
 };


### PR DESCRIPTION
Build tested (modified for 2.8.4) locally with the vcpkg ports (and only `pdal[core]`). https://github.com/microsoft/vcpkg/pull/45153

Sharing this now as a draft.

There is a tricky mix of C and C++ API of GDAL in `pdal/private/gdal` - and there are two `reinterpret_cast` which let the compiler continue but come with smell.