### PR TITLE
Remove `jupyter-book build` in ReadTheDocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,24 +12,6 @@ build:
   jobs:
     pre_build:
       - ./doc/rtd-prebuild.sh
-    build:
-      html:
-        - jupyter-book build doc/
-        - mkdir -p $READTHEDOCS_OUTPUT/html/
-        - cp -R doc/_build/html/* $READTHEDOCS_OUTPUT/html/
-      # not sure how this compares to --builder=latex + latexmk (rtd default)
-      pdf:
-        - jupyter-book build --builder pdflatex doc/
-        - mkdir -p $READTHEDOCS_OUTPUT/pdf/
-        - cp -R doc/_build/latex/* $READTHEDOCS_OUTPUT/pdf/
-      htmlzip:
-        - jupyter-book build --builder singlehtml doc/
-        - mkdir -p $READTHEDOCS_OUTPUT/htmlzip/
-        - cp -R doc/_build/singlehtml/* $READTHEDOCS_OUTPUT/htmlzip/
-      epub:
-        - jupyter-book build --builder custom --custom-builder epub doc/
-        - mkdir -p $READTHEDOCS_OUTPUT/epub/
-        - cp -R doc/_build/epub/* $READTHEDOCS_OUTPUT/epub/
   apt_packages:
     - graphviz
 

--- a/cmake/docs.cmake
+++ b/cmake/docs.cmake
@@ -8,6 +8,13 @@ if (NOT JUPYTERBOOK)
     )
 endif()
 
+# Find sed command for jupter-book config - only really necessary for readthedocs
+if(UNIX AND NOT CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    find_program(SED_EXECUTABLE gsed)
+else()
+    find_program(SED_EXECUTABLE sed)
+endif()
+
 find_package(Doxygen)
 if (NOT DOXYGEN_FOUND)
     message("Could not find Doxygen. API documentation will not be built.")

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -55,18 +55,28 @@ if (DOXYGEN_FOUND)
 endif()
 
 ###
-### Jupyterbook config - unused
+### Jupyterbook config
 ###
 
-set(JB_CONF_FILE "${PDAL_DOC_DIR}/conf.py")
+if(SED_EXECUTABLE)
+    set(JB_CONF_FILE "${PDAL_DOC_DIR}/conf.py")
 
-# If we aren't using the sphinx-build command, we don't need to configure
-# Jupyter Book -- everything will be created from _config.yml.
-add_custom_target(jupyterbook_config
-    WORKING_DIRECTORY ${ROOT_DIR}
-    BYPRODUCTS ${JB_CONF_FILE}
-    COMMAND ${JUPYTERBOOK} config sphinx doc/
-    COMMENT "Configuring Jupyter Book for Sphinx")
+    # If we aren't using the sphinx-build command, we don't need to configure
+    # Jupyter Book -- everything will be created from _config.yml.
+    add_custom_command(
+        WORKING_DIRECTORY ${ROOT_DIR}
+        OUTPUT ${JB_CONF_FILE}
+        COMMAND ${JUPYTERBOOK} config sphinx doc/
+        )
+
+    set(PREPEND_STRING [==[1i\import os, sys; sys.path.append(os.path.abspath(\"./_ext\"))]==])
+
+    add_custom_target(jupyterbook_config
+        WORKING_DIRECTORY ${ROOT_DIR}
+        DEPENDS ${JB_CONF_FILE}
+        COMMAND ${SED_EXECUTABLE} -i \"${PREPEND_STRING}\" ${JB_CONF_FILE}
+        COMMENT "Configuring Jupyter Book for Sphinx")
+endif()
 
 ###
 ### Final targets

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -69,7 +69,7 @@ if(SED_EXECUTABLE)
         COMMAND ${JUPYTERBOOK} config sphinx doc/
         )
 
-    set(PREPEND_STRING [==[1i\import os, sys; sys.path.append(os.path.abspath(\"./_ext\"))]==])
+    set(PREPEND_STRING [==[1i\import os, sys\; sys.path.append(os.path.abspath(\"./_ext\"))]==])
 
     add_custom_target(jupyterbook_config
         WORKING_DIRECTORY ${ROOT_DIR}

--- a/doc/rtd-prebuild.sh
+++ b/doc/rtd-prebuild.sh
@@ -13,5 +13,3 @@ cmake \
 cmake --build . --target doxygen
 # Target creates conf.py
 cmake --build . --target jupyterbook_config
-# Makes sphinx extensions available
-sed -i "1i\import os, sys; sys.path.append(os.path.abspath(\"./_ext\"))" ../conf.py

--- a/doc/rtd-prebuild.sh
+++ b/doc/rtd-prebuild.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-# Assuming readthedocs is running this from pdal root directory
-
 # Making a build directory for cmake - if we name it _build it will also be
 # the output location for jupyterbook. This can be customizable if we want
 mkdir -p doc/_build
@@ -10,5 +8,10 @@ cd doc/_build
 cmake \
 	-DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} \
 	..
+
 # Target makes dimension-table.csv, runs doxygen
 cmake --build . --target doxygen
+# Target creates conf.py
+cmake --build . --target jupyterbook_config
+# Makes sphinx extensions available
+sed -i "1i\import os, sys; sys.path.append(os.path.abspath(\"./_ext\"))" ../conf.py


### PR DESCRIPTION
Changed back to the default readthedocs build steps, using `sphinx-build` instead of `jupyter-book build`. Added the `sed` command back in that finds our sphinx extensions, so the canonical URL and is still being set correctly. Creating `conf.py` should only be necessary for ReadTheDocs.