### PR TITLE
Add check for unsupported field lengths in `tindex create`

### DIFF
--- a/kernels/TIndexKernel.cpp
+++ b/kernels/TIndexKernel.cpp
@@ -523,8 +523,7 @@ bool TIndexKernel::createFeature(const FieldIndexes& indexes,
 {
     using namespace gdal;
 
-    OGRFeatureDefnH hDefn = OGR_L_GetLayerDefn(m_layer);
-    OGRFeatureH hFeature = OGR_F_Create(hDefn);
+    OGRFeatureH hFeature = OGR_F_Create(OGR_L_GetLayerDefn(m_layer));
 
     // Set the creation time into the feature.
     setDate(hFeature, fileInfo.m_ctime, indexes.m_ctime);

--- a/kernels/TIndexKernel.hpp
+++ b/kernels/TIndexKernel.hpp
@@ -47,6 +47,7 @@
 #else
 using OGRDataSourceH = void *;
 using OGRLayerH = void *;
+using OGRFeatureH = void *;
 #endif
 
 namespace pdal
@@ -103,6 +104,7 @@ private:
     bool createFeature(const FieldIndexes& indexes, FileInfo& info);
     pdal::Polygon prepareGeometry(const FileInfo& fileInfo);
     void createFields();
+    void setStringField(OGRFeatureH hFeature, int idx, const char* value);
     void fastBoundary(Stage& reader, FileInfo& fileInfo);
     void slowBoundary(PipelineManager& manager);
     std::string makeMultiPolygon(const std::string& wkt);

--- a/kernels/TIndexKernel.hpp
+++ b/kernels/TIndexKernel.hpp
@@ -136,6 +136,7 @@ private:
     bool m_overrideASrs;
     bool m_skipMultiSrs;
     std::string m_originalSrs;
+    size_t m_maxFieldSize;
 };
 
 } // namespace pdal


### PR DESCRIPTION
Started checking to see if a file that's being indexed with `pdal tindex create` has a CRS WKT string that's too large to fit in the output field. After looking over the OGR docs, I'm fairly sure that Shapefiles are the only driver that has a hard limit on the size of a field.

Fixed tests by no longer writing to shapefiles (default tindex output), and made sure temp files are getting cleaned up properly. Added a test for long CRS strings.

Resolves #4696.