### PR TITLE
Stop including <sys/timeb.h> unless on WIN32

### DIFF
--- a/vendor/kazhdan/MyTime.h
+++ b/vendor/kazhdan/MyTime.h
@@ -30,10 +30,9 @@ DAMAGE.
 #define MY_TIME_INCLUDED
 
 #include <string.h>
-#ifndef __OpenBSD__
+#ifdef WIN32
 #include <sys/timeb.h>
-#endif
-#ifndef WIN32
+#else // WIN32
 #include <sys/time.h>
 #endif // WIN32
 


### PR DESCRIPTION
The header was removed not only from OpenBSD (https://github.com/PDAL/PDAL/pull/4434) but also from Android.
`_timeb` and `_ftime` is used only in the WIN32 code.

(From vcpkg CI, tested on android, linux, osx, windows).