### PR TITLE
Segfault bug

### DIFF
--- a/test/unit/io/CopcReaderTest.cpp
+++ b/test/unit/io/CopcReaderTest.cpp
@@ -183,6 +183,7 @@ TEST(CopcReaderTest, resolutionLimit)
 
 TEST(CopcReaderTest, boundedRead2d)
 {
+
     BOX2D bounds(515380, 4918350, 515400, 4918370);
 
     // First we'll query the EptReader for these bounds.
@@ -195,25 +196,31 @@ TEST(CopcReaderTest, boundedRead2d)
     }
     PointTable copcTable;
     reader.prepare(copcTable);
-    const auto set(reader.execute(copcTable));
+    
+    // BUG here. With these lines commented out, the test segfaults.
+    //const auto set(reader.execute(copcTable));
+
+    pdal::QuickInfo qi(reader.preview());
+    pdal::BOX3D bounds3d = qi.m_bounds;
+    std::cout << "Bounds are: " << bounds3d << std::endl;
 
     double x, y, z;
     uint64_t o;
     uint64_t np(0);
-    for (const PointViewPtr& view : set)
-    {
-        for (point_count_t i(0); i < view->size(); ++i)
-        {
-            ++np;
-            x = view->getFieldAs<double>(Dimension::Id::X, i);
-            y = view->getFieldAs<double>(Dimension::Id::Y, i);
-            z = view->getFieldAs<double>(Dimension::Id::Z, i);
-            o = view->getFieldAs<uint64_t>(Dimension::Id::OriginId, i);
-            ASSERT_TRUE(bounds.contains(x, y)) << bounds << ": " <<
-                x << ", " << y << ", " << z << std::endl;
-            ASSERT_TRUE(o < 4);
-        }
-    }
+    // for (const PointViewPtr& view : set)
+    // {
+    //     for (point_count_t i(0); i < view->size(); ++i)
+    //     {
+    //         ++np;
+    //         x = view->getFieldAs<double>(Dimension::Id::X, i);
+    //         y = view->getFieldAs<double>(Dimension::Id::Y, i);
+    //         z = view->getFieldAs<double>(Dimension::Id::Z, i);
+    //         o = view->getFieldAs<uint64_t>(Dimension::Id::OriginId, i);
+    //         ASSERT_TRUE(bounds.contains(x, y)) << bounds << ": " <<
+    //             x << ", " << y << ", " << z << std::endl;
+    //         ASSERT_TRUE(o < 4);
+    //     }
+    // }
 
     // Now we'll check the result against a crop filter of the source file with
     // the same bounds.


### PR DESCRIPTION
I managed to get PDAL QuickInfo to segfault. Apparently this function really does not like to be called before the reader performs an "execution".

That makes sense, but then it should not crash, but rather throw an error about uninitialized reader.

How to test:

Pull and build tests. Run:

ctest -V -R copc   

It will do:

```
51: [ RUN      ] CopcReaderTest.boundedRead2d
1/2 Test #51: pdal_io_copc_reader_test .........***Exception: SegFault  0.14 sec

```

