### PR TITLE
move `readers.copc` thread pool init to initialize

### DIFF
--- a/io/CopcReader.cpp
+++ b/io/CopcReader.cpp
@@ -385,6 +385,10 @@ void CopcReader::initialize(PointTableRef table)
 
     if (m_args->resolution)
         log()->get(LogLevel::Debug) << "Maximum depth: " << m_p->depthEnd << std::endl;
+
+    // Initialize our threadpool
+    m_p->pool.reset(new ThreadPool(m_args->threads));
+
 }
 
 
@@ -641,7 +645,6 @@ void CopcReader::addDimensions(PointLayoutPtr layout)
 
 void CopcReader::ready(PointTableRef table)
 {
-    m_p->pool.reset(new ThreadPool(m_args->threads));
     // Determine all overlapping data files we'll need to fetch.
     try
     {

--- a/test/unit/io/CopcReaderTest.cpp
+++ b/test/unit/io/CopcReaderTest.cpp
@@ -677,4 +677,25 @@ TEST(CopcReaderTest, ogrCrop)
     EXPECT_LE(v->size(), 90u);
 }
 
+
+TEST(CopcReaderTest, boundedpreview)
+{
+
+
+    BOX2D bounds(515380, 4918350, 515400, 4918370);
+
+    CopcReader reader;
+    {
+        Options options;
+        options.add("filename", copcPath);
+        options.add("bounds", bounds);
+        reader.setOptions(options);
+    }
+
+    pdal::QuickInfo qi(reader.preview());
+    pdal::BOX3D bounds3d = qi.m_bounds;
+
+    EXPECT_EQ(pdal::Bounds(bounds).to2d(), pdal::Bounds(bounds3d).to2d());
+}
+
 } // namespace pdal


### PR DESCRIPTION
The thread pool initialization was in `ready()`, not `initialize()`, which meant that operations like `preview()` didn't have the pool ready.

This fixes #4715