### PR TITLE
Enabled VSI for FileSpec connector

### DIFF
--- a/io/private/connector/Connector.cpp
+++ b/io/private/connector/Connector.cpp
@@ -140,6 +140,10 @@ std::vector<char> Connector::getBinary(const std::string& path) const
 
 arbiter::LocalHandle Connector::getLocalHandle(const std::string& path) const
 {
+    if (Utils::startsWith(Utils::toupper(path), "/VSI"))
+        // workaround so that arbiter path is not used to read/write with VSI
+        return arbiter::LocalHandle(path, false);
+
     if (m_arbiter->isLocal(path))
         return m_arbiter->getLocalHandle(path);
     else

--- a/test/unit/io/LasReaderTest.cpp
+++ b/test/unit/io/LasReaderTest.cpp
@@ -40,6 +40,7 @@
 #include <pdal/StageFactory.hpp>
 #include <pdal/Streamable.hpp>
 #include <pdal/util/FileUtils.hpp>
+#include <pdal/util/Utils.hpp>
 #include <io/HeaderVal.hpp>
 #include <io/LasHeader.hpp>
 #include <io/LasReader.hpp>
@@ -830,10 +831,8 @@ TEST(LasReaderTest, remote_vsi)
         }
         catch(const pdal_error& e)
         {
-            auto errMsg = "Unable to open stream for "
-                          "'/vsicurl/http://localhost/simple.laz' "
-                          "with error 'Connection refused'";
-            EXPECT_STREQ(errMsg, e.what());
+            EXPECT_TRUE(Utils::startsWith(e.what(),
+                "Unable to open stream for"));
             throw;
         }
     }, pdal_error);

--- a/test/unit/io/LasReaderTest.cpp
+++ b/test/unit/io/LasReaderTest.cpp
@@ -811,3 +811,30 @@ TEST(LasReaderTest, Laz_with_severals_extra_byte_with_wrong_options_name)
     ASSERT_TRUE(view->hasDim( layout->findDim("confidence") ));
     ASSERT_TRUE(view->hasDim( layout->findDim("Bad_Name") ));
 }
+
+TEST(LasReaderTest, remote_vsi)
+{
+    Options ops1;
+    ops1.add("filename", "/vsicurl/http://localhost/simple.laz");
+
+    LasReader reader;
+    reader.setOptions(ops1);
+
+    PointTable table;
+
+    // check we get past looking up the arbiter driver
+    EXPECT_THROW({
+        try
+        {
+            reader.prepare(table);
+        }
+        catch(const pdal_error& e)
+        {
+            auto errMsg = "Unable to open stream for "
+                          "'/vsicurl/http://localhost/simple.laz' "
+                          "with error 'Connection refused'";
+            EXPECT_STREQ(errMsg, e.what());
+            throw;
+        }
+    }, pdal_error);
+}


### PR DESCRIPTION
The original VSI PR was not rebased on master (by me) before merge and hence did not have the `FileSpec` changes in the branch. 

https://github.com/PDAL/PDAL/blob/master/io/LasReader.cpp#L248

Hence the connector logic needed to be updated as reported by @hobu 

This PR bypasses arbiter for VSI paths with the connector.

Arbiter ignores `/vsimem` and others because `://` is used as the key for detecting remote (and also in other places `Utils::isRemote` performs a simpler check). 

@oleg-alexandrov reported this in https://github.com/PDAL/PDAL/pull/4647



