### PR TITLE
Add GDAL include dir to compile lasdump

### DIFF
--- a/tools/lasdump/CMakeLists.txt
+++ b/tools/lasdump/CMakeLists.txt
@@ -19,6 +19,7 @@ target_include_directories(lasdump PRIVATE
     ${PDAL_INCLUDE_DIR}
     ${NLOHMANN_INCLUDE_DIR}
     ${UTFCPP_INCLUDE_DIR}
+    ${GDAL_INCLUDE_DIR}
 )
 
 #


### PR DESCRIPTION
Fixes compilation error on Debian:
"fatal error: cpl_vsi.h: No such file or directory"