### PR TITLE
`readers.stac` & `readers.tindex`: forward HTTP headers & queries to readers

### DIFF
--- a/doc/stages/readers.stac.md
+++ b/doc/stages/readers.stac.md
@@ -114,6 +114,14 @@ reader_args
 '[{"type": "readers.ept", "resolution": 100}, {"type": "readers.las", "nosrs": true}]'
 ```
 
+  HTTP headers & queries can be forwarded to the reader using a partial {ref}`filespec`
+  JSON object, omitting the `path` component:
+
+```bash
+--readers.stac.reader_args \
+'{"type": "readers.copc", "filespec": {"headers": {"your_header_key": "header_val"}, "query": {"your_query_key": "query_val"}}}'
+```
+
 catalog_schema_url
 
 : URL of JSON schema you'd like to use for JSON schema validation of STAC Catalogs.

--- a/doc/stages/readers.tindex.md
+++ b/doc/stages/readers.tindex.md
@@ -67,8 +67,16 @@ reader_args
   Exmaple:
 
 ```bash
---readers.stac.reader_args \
+--readers.tindex.reader_args \
 '[{"type": "readers.ept", "resolution": 100}, {"type": "readers.las", "nosrs": true}]'
+```
+
+  HTTP headers & queries can be forwarded to the reader using a partial {ref}`filespec`
+  JSON object, omitting the `path` component:
+
+```bash
+--readers.tindex.reader_args \
+'{"type": "readers.copc", "filespec": {"headers": {"your_header_key": "header_val"}, "query": {"your_query_key": "query_val"}}}'
 ```
 
 srs_column

--- a/io/TIndexReader.cpp
+++ b/io/TIndexReader.cpp
@@ -119,42 +119,58 @@ NL::json handleReaderArgs(NL::json rawReaderArgs)
     return readerArgs;
 }
 
-Options setReaderOptions(const NL::json& args)
+Options setReaderOptions(const NL::json& readerArgs, const std::string& driver,
+    const std::string& filename)
 {
     Options readerOptions;
-    for (auto& arg : args.items()) {
-        std::cout << arg.key() << std::endl;
-        // We treat the FileSpec as a special case to be dealt with later
-        if (arg.key() == "file_spec" || arg.key() == "filespec")
-            continue;
-        NL::detail::value_t type = args.at(arg.key()).type();
-        switch(type)
-        {
-            case NL::detail::value_t::string:
+    readerOptions.add("filename", filename);
+    if (readerArgs.contains(driver)) {
+        NL::json args = readerArgs.at(driver).get<NL::json>();
+        for (auto& arg : args.items()) {
+            NL::detail::value_t type = readerArgs.at(driver).at(arg.key()).type();
+
+            // We treat the partial FileSpec as a special case
+            if (arg.key() == "file_spec" || arg.key() == "filespec")
             {
-                std::string val = arg.value().get<std::string>();
-                readerOptions.add(arg.key(), arg.value().get<std::string>());
-                break;
+                NL::json filespecArg = arg.value();
+                if (!filespecArg.is_object())
+                    throw pdal_error("value for " + driver + "'file_spec' argument " +
+                        " must be a valid JSON object.");
+                filespecArg += {"path", filename};
+
+                // This doesn't check if the driver supports headers/queries: if not,
+                // the reader will only use the filename
+                readerOptions.replace("filename", filespecArg.dump());
+                continue;
             }
-            case NL::detail::value_t::number_float:
+            switch(type)
             {
-                readerOptions.add(arg.key(), arg.value().get<float>());
-                break;
-            }
-            case NL::detail::value_t::number_integer:
-            {
-                readerOptions.add(arg.key(), arg.value().get<int>());
-                break;
-            }
-            case NL::detail::value_t::boolean:
-            {
-                readerOptions.add(arg.key(), arg.value().get<bool>());
-                break;
-            }
-            default:
-            {
-                readerOptions.add(arg.key(), arg.value());
-                break;
+                case NL::detail::value_t::string:
+                {
+                    std::string val = arg.value().get<std::string>();
+                    readerOptions.add(arg.key(), arg.value().get<std::string>());
+                    break;
+                }
+                case NL::detail::value_t::number_float:
+                {
+                    readerOptions.add(arg.key(), arg.value().get<float>());
+                    break;
+                }
+                case NL::detail::value_t::number_integer:
+                {
+                    readerOptions.add(arg.key(), arg.value().get<int>());
+                    break;
+                }
+                case NL::detail::value_t::boolean:
+                {
+                    readerOptions.add(arg.key(), arg.value().get<bool>());
+                    break;
+                }
+                default:
+                {
+                    readerOptions.add(arg.key(), arg.value());
+                    break;
+                }
             }
         }
     }
@@ -356,30 +372,7 @@ void TIndexReader::initialize()
                 "'.");
         reader->setLog(log());
 
-        Options readerOptions;
-        NL::json currentArgs;
-        if (m_args->m_readerArgs.contains(driver))
-        {
-            currentArgs = m_args->m_readerArgs.at(driver).get<NL::json>();
-            readerOptions = setReaderOptions(currentArgs);
-        }
-        // We need to handle partial FileSpecs here, since they aren't
-        // a valid reader option as-is
-        auto it = currentArgs.find("file_spec");
-        if (it != currentArgs.end())
-        {
-            NL::json filespecArg = currentArgs["file_spec"];
-            if (!filespecArg.is_object())
-                throwError("value for " + driver + "'file_spec' argument " +
-                    " must be a valid JSON object.");
-            filespecArg += {"path", f.m_filename};
-
-            // This doesn't check if the driver supports headers/queries: if not,
-            // the reader will only use the filename
-            readerOptions.add("filename", filespecArg.dump());
-        }
-        else
-            readerOptions.add("filename", f.m_filename);
+        Options readerOptions = setReaderOptions(m_args->m_readerArgs, driver, f.m_filename);
 
         reader->setOptions(readerOptions);
         Stage *premerge = reader;

--- a/io/private/stac/Item.hpp
+++ b/io/private/stac/Item.hpp
@@ -103,7 +103,8 @@ private:
     std::string m_id;
 
     std::string extractDriverFromItem(const NL::json& asset) const;
-    Options setReaderOptions(const NL::json& readerArgs, const std::string& driver) const;
+    Options setReaderOptions(const NL::json& readerArgs, const std::string& driver,
+        const std::string& filename) const;
 
     NL::json handleReaderArgs(NL::json rawReaderArgs);
     void validate();


### PR DESCRIPTION
Since `FileSpec` was added to replace the `header` and `query` options (specified in place of the filename), `readers.stac` and `readers.tindex` haven't been able to forward these options to their sub-readers. Allowed a partial `FileSpec` object (without the `path` field) to be specified in `reader_args` for these drivers. Consolidated all of the option setting for readers into `setReaderOptions()` so it can be aware of the filepath when iterating through the reader args. Documented it in the tindex & stac docs.

`--readers.stac.reader_args = '{"type": "readers.copc", "filespec": {"headers": {"header_key": "header_val"}, "query": {"query_key": "query_val"}}}'`

There are a couple issues with this: 

- The `filespec` reader arg that's being used isn't _actually_ sent to the reader, and would be an invalid `FileSpec` in a normal case (since it doesn't include the path)
- Since we aren't aware of whether the reader supports headers & queries, they are silently ignored if the reader can't use them

This seems like the best option to fix this without remaking `FileSpec` or messing with the base Reader class. I can add some more validation of the `filespec` in `setReaderOptions()` if it's needed.