### PR TITLE
Align `readers.tindex` & `readers.stac` with normal FileSpec

### DIFF
--- a/doc/stages/readers.stac.md
+++ b/doc/stages/readers.stac.md
@@ -119,7 +119,7 @@ reader_args
 
 ```bash
 --readers.stac.reader_args \
-'{"type": "readers.copc", "filespec": {"headers": {"your_header_key": "header_val"}, "query": {"your_query_key": "query_val"}}}'
+'{"type": "readers.copc", "filename": {"headers": {"your_header_key": "header_val"}, "query": {"your_query_key": "query_val"}}}'
 ```
 
 catalog_schema_url

--- a/doc/stages/readers.tindex.md
+++ b/doc/stages/readers.tindex.md
@@ -76,7 +76,7 @@ reader_args
 
 ```bash
 --readers.tindex.reader_args \
-'{"type": "readers.copc", "filespec": {"headers": {"your_header_key": "header_val"}, "query": {"your_query_key": "query_val"}}}'
+'{"type": "readers.copc", "filename": {"headers": {"your_header_key": "header_val"}, "query": {"your_query_key": "query_val"}}}'
 ```
 
 srs_column


### PR DESCRIPTION
Changed "file_spec" reader arg to use "filename" instead, per [this comment](https://github.com/PDAL/PDAL/commit/560cc7851d51fa651df17c032456a7f163ef11da#r160308164)