### PR TITLE
Merge handling of `reader_args` for `readers.tindex` and `readers.stac`

### DIFF
--- a/doc/stages/reader_args.md
+++ b/doc/stages/reader_args.md
@@ -1,0 +1,19 @@
+reader_args
+
+: A list of JSON objects with keys of reader options and the values to pass through.
+  These will be in the exact same form as a Pipeline Stage object, minus the filename.
+
+  Exmaple:
+
+```bash
+--readers.stac.reader_args \
+'[{"type": "readers.ept", "resolution": 100}, {"type": "readers.las", "nosrs": true}]'
+```
+
+  HTTP headers & queries can be forwarded to the reader using a partial {ref}`filespec`
+  JSON object, omitting the `path` component:
+
+```bash
+--readers.stac.reader_args \
+'{"type": "readers.copc", "filename": {"headers": {"your_header_key": "header_val"}, "query": {"your_query_key": "query_val"}}}'
+```

--- a/doc/stages/readers.stac.md
+++ b/doc/stages/readers.stac.md
@@ -102,24 +102,7 @@ properties
   In this example, a Feature must have a `pc:type` key with values of either
   `lidar` or `sonar`, and a `pc:encoding` key with a value of `ept`.
 
-reader_args
-
-: A list of JSON objects with keys of reader options and the values to pass through.
-  These will be in the exact same form as a Pipeline Stage object minus the filename.
-
-  Exmaple:
-
-```bash
---readers.stac.reader_args \
-'[{"type": "readers.ept", "resolution": 100}, {"type": "readers.las", "nosrs": true}]'
-```
-
-  HTTP headers & queries can be forwarded to the reader using a partial {ref}`filespec`
-  JSON object, omitting the `path` component:
-
-```bash
---readers.stac.reader_args \
-'{"type": "readers.copc", "filename": {"headers": {"your_header_key": "header_val"}, "query": {"your_query_key": "query_val"}}}'
+```{include} reader_args.md
 ```
 
 catalog_schema_url

--- a/doc/stages/readers.tindex.md
+++ b/doc/stages/readers.tindex.md
@@ -59,24 +59,7 @@ lyr_name
 : The OGR layer name for the data source to use to
   fetch the tile index information.
 
-reader_args
-
-: A list of JSON objects with keys of reader options and the values to pass through.
-  These will be in the exact same form as a Pipeline Stage object minus the filename.
-
-  Exmaple:
-
-```bash
---readers.tindex.reader_args \
-'[{"type": "readers.ept", "resolution": 100}, {"type": "readers.las", "nosrs": true}]'
-```
-
-  HTTP headers & queries can be forwarded to the reader using a partial {ref}`filespec`
-  JSON object, omitting the `path` component:
-
-```bash
---readers.tindex.reader_args \
-'{"type": "readers.copc", "filename": {"headers": {"your_header_key": "header_val"}, "query": {"your_query_key": "query_val"}}}'
+```{include} reader_args.md
 ```
 
 srs_column

--- a/io/StacReader.cpp
+++ b/io/StacReader.cpp
@@ -466,7 +466,7 @@ void StacReader::initialize()
 
     NL::json stacJson = m_p->m_connector->getJson(m_filename);
 
-    std::string stacType = StacUtils::jsonValue<std::string>(stacJson, "type");
+    std::string stacType = Utils::jsonValue<std::string>(stacJson, "type");
     if (stacType == "Feature")
         m_p->handleItem(stacJson, m_filename);
     else if (stacType == "Catalog")

--- a/io/TIndexReader.cpp
+++ b/io/TIndexReader.cpp
@@ -41,6 +41,7 @@
 #include <pdal/util/ProgramArgs.hpp>
 #include <pdal/private/gdal/GDALUtils.hpp>
 #include <pdal/private/gdal/SpatialRef.hpp>
+#include <pdal/util/private/JsonSupport.hpp>
 #include <pdal/StageWrapper.hpp>
 
 #include <nlohmann/json.hpp>
@@ -78,112 +79,6 @@ struct TIndexReader::Args
     std::vector<NL::json> m_rawReaderArgs;
     NL::json m_readerArgs;
 };
-
-namespace
-{
-
-NL::json handleReaderArgs(NL::json rawReaderArgs)
-{
-    if (rawReaderArgs.is_object())
-    {
-        NL::json array_args = NL::json::array();
-        array_args.push_back(rawReaderArgs);
-        rawReaderArgs = array_args;
-    }
-    for (auto& opts: rawReaderArgs)
-        if (!opts.is_object())
-            throw pdal_error("Reader Args for each reader must be a valid JSON object");
-
-    NL::json readerArgs;
-    for (NL::json& readerPipeline: rawReaderArgs)
-    {
-
-        if (!readerPipeline.contains("type"))
-            throw pdal_error("No \"type\" key found in supplied reader arguments.");
-
-        std::string driver = readerPipeline.at("type").get<std::string>();
-        if (rawReaderArgs.contains(driver))
-            throw pdal_error("Multiple instances of the same driver in supplied reader arguments.");
-        readerArgs[driver] = { };
-
-        for (auto& arg: readerPipeline.items())
-        {
-            if (arg.key() == "type")
-                continue;
-
-            std::string key = arg.key();
-            readerArgs[driver][key] = { };
-            readerArgs[driver][key] = arg.value();
-        }
-    }
-    return readerArgs;
-}
-
-Options setReaderOptions(const NL::json& readerArgs, const std::string& driver,
-    const std::string& filename)
-{
-    Options readerOptions;
-    bool filenameSet = false;
-    if (readerArgs.contains(driver)) {
-        NL::json args = readerArgs.at(driver).get<NL::json>();
-        for (auto& arg : args.items()) {
-            if (arg.key() == "filename")
-            {
-                NL::json filespecArg = arg.value().get<NL::json>();
-                if (!filespecArg.is_object())
-                    throw pdal_error("Value for " + driver + " 'filename' argument " +
-                        "expected to be a 'FileSpec' JSON object.");
-                if (filespecArg.contains("path"))
-                    filespecArg.erase("path");
-                filespecArg += {"path", filename};
-
-                // This doesn't check if the driver supports headers/queries: if not,
-                // the reader will only use the filename
-                readerOptions.add("filename", filespecArg.dump());
-                filenameSet = true;
-                continue;
-            }
-
-            NL::detail::value_t type = readerArgs.at(driver).at(arg.key()).type();
-            switch(type)
-            {
-                case NL::detail::value_t::string:
-                {
-                    std::string val = arg.value().get<std::string>();
-                    readerOptions.add(arg.key(), arg.value().get<std::string>());
-                    break;
-                }
-                case NL::detail::value_t::number_float:
-                {
-                    readerOptions.add(arg.key(), arg.value().get<float>());
-                    break;
-                }
-                case NL::detail::value_t::number_integer:
-                {
-                    readerOptions.add(arg.key(), arg.value().get<int>());
-                    break;
-                }
-                case NL::detail::value_t::boolean:
-                {
-                    readerOptions.add(arg.key(), arg.value().get<bool>());
-                    break;
-                }
-                default:
-                {
-                    readerOptions.add(arg.key(), arg.value());
-                    break;
-                }
-            }
-        }
-    }
-    if (!filenameSet)
-        readerOptions.add("filename", filename);
-
-
-    return readerOptions;
-}
-
-} // unnamed namespace
 
 TIndexReader::TIndexReader() :
     m_args(new TIndexReader::Args),
@@ -363,7 +258,7 @@ void TIndexReader::initialize()
 
 
     if (m_args->m_rawReaderArgs.size())
-        m_args->m_readerArgs = handleReaderArgs(m_args->m_rawReaderArgs);
+        m_args->m_readerArgs = Utils::handleReaderArgs(m_args->m_rawReaderArgs);
 
     for (auto f : getFiles())
     {
@@ -377,7 +272,7 @@ void TIndexReader::initialize()
                 "'.");
         reader->setLog(log());
 
-        Options readerOptions = setReaderOptions(m_args->m_readerArgs, driver, f.m_filename);
+        Options readerOptions = Utils::setReaderOptions(m_args->m_readerArgs, driver, f.m_filename);
 
         reader->setOptions(readerOptions);
         Stage *premerge = reader;

--- a/io/private/stac/Utils.cpp
+++ b/io/private/stac/Utils.cpp
@@ -127,12 +127,12 @@ std::string icSelfPath(const NL::json& json)
 {
     try
     {
-        NL::json links = jsonValue(json, "links");
+        NL::json links = Utils::jsonValue(json, "links");
         for (const NL::json& link: links)
         {
-            std::string target = jsonValue<std::string>(link, "rel");
+            std::string target = Utils::jsonValue<std::string>(link, "rel");
             if (target == "self")
-                return jsonValue<std::string>(link, "href");
+                return Utils::jsonValue<std::string>(link, "href");
         }
     }
     catch(std::runtime_error& )

--- a/io/private/stac/Utils.hpp
+++ b/io/private/stac/Utils.hpp
@@ -74,23 +74,6 @@ namespace StacUtils
     std::string stacType(const NL::json& stac);
     std::string icSelfPath(const NL::json& json);
 
-    template <class T = NL::json>
-    inline T jsonValue(const NL::json& json, std::string key = "")
-    {
-        try
-        {
-            if (key.empty())
-                return json.get<T>();
-            return json.at(key).get<T>();
-        }
-        catch (NL::detail::exception& e)
-        {
-            std::stringstream msg;
-            msg << "Error: " << e.what() << ", for object " << json.dump();
-            throw pdal_error(msg.str());
-        }
-    }
-
     template <class U = NL::json>
     inline U stacValue(const NL::json& stac, std::string key = "",
         const NL::json& rootJson = {})

--- a/io/private/stac/Utils.hpp
+++ b/io/private/stac/Utils.hpp
@@ -38,6 +38,7 @@
 #include <arbiter/arbiter.hpp>
 #include <pdal/util/FileUtils.hpp>
 #include <pdal/pdal_types.hpp>
+#include <pdal/util/private/JsonSupport.hpp>
 
 namespace pdal
 {

--- a/pdal/util/private/JsonSupport.hpp
+++ b/pdal/util/private/JsonSupport.hpp
@@ -37,6 +37,7 @@
 #include <string>
 
 #include <nlohmann/json.hpp>
+#include <pdal/Options.hpp>
 
 namespace pdal
 {
@@ -60,6 +61,106 @@ inline StatusWithReason parseJson(const std::string& s, NL::json& json)
         return { -1, s };
     }
     return true;
+}
+
+template <class T = NL::json>
+inline T jsonValue(const NL::json& json, std::string key = "")
+{
+    try
+    {
+        if (key.empty())
+            return json.get<T>();
+        return json.at(key).get<T>();
+    }
+    catch (NL::detail::exception& e)
+    {
+        std::stringstream msg;
+        msg << "Error: " << e.what() << ", for object " << json.dump();
+        throw pdal_error(msg.str());
+    }
+}
+
+// Functions for parsing StacReader & TindexReader reader args
+
+NL::json handleReaderArgs(NL::json rawReaderArgs)
+{
+    if (rawReaderArgs.is_object())
+    {
+        NL::json array_args = NL::json::array();
+        array_args.push_back(rawReaderArgs);
+        rawReaderArgs = array_args;
+    }
+    for (auto& opts: rawReaderArgs)
+        if (!opts.is_object())
+            throw pdal_error("Reader Args for each reader must be a valid JSON object");
+
+    NL::json readerArgs;
+    for (const NL::json& readerPipeline: rawReaderArgs)
+    {
+        if (!readerPipeline.contains("type"))
+            throw pdal_error("No \"type\" key found in supplied reader arguments.");
+
+        std::string driver = readerPipeline.at("type").get<std::string>();
+        if (rawReaderArgs.contains(driver))
+            throw pdal_error("Multiple instances of the same driver in supplied reader arguments.");
+        readerArgs[driver] = { };
+
+        for (auto& arg: readerPipeline.items())
+        {
+            if (arg.key() == "type")
+                continue;
+
+            std::string key = arg.key();
+            readerArgs[driver][key] = { };
+            readerArgs[driver][key] = arg.value();
+        }
+    }
+    return readerArgs;
+}
+
+Options setReaderOptions(const NL::json& readerArgs,
+    const std::string& driver, const std::string& filename)
+{
+    Options readerOptions;
+    bool filenameSet = false;
+    if (readerArgs.contains(driver)) {
+        NL::json args = jsonValue(readerArgs, driver);
+        for (auto& arg : args.items())
+        {
+            std::string key = arg.key();
+            NL::json val = arg.value();
+            NL::detail::value_t type = val.type();
+            // We treat a partial FileSpec as a special case
+            if (key == "filename")
+            {
+                if (!val.is_object())
+                    throw pdal_error("value for " + driver + "'filename' argument " +
+                        " must be a valid JSON object.");
+                if (val.contains("path"))
+                    val.erase("path");
+                val += {"path", filename};
+
+                // This doesn't check if the driver supports headers/queries: if not,
+                // the reader will only use the filename
+                readerOptions.replace("filename", val.dump());
+                filenameSet = true;
+                continue;
+            }
+
+            // if value is of type string, dump() returns string with
+            // escaped string inside and kills pdal program args
+            std::string v;
+            if (type == NL::detail::value_t::string)
+                v = jsonValue<std::string>(val);
+            else
+                v = arg.value().dump();
+            readerOptions.add(key, v);
+        }
+    }
+    if (!filenameSet)
+        readerOptions.add("filename", filename);
+
+    return readerOptions;
 }
 
 } // namespace Utils

--- a/pdal/util/private/JsonSupport.hpp
+++ b/pdal/util/private/JsonSupport.hpp
@@ -82,7 +82,7 @@ inline T jsonValue(const NL::json& json, std::string key = "")
 
 // Functions for parsing StacReader & TindexReader reader args
 
-NL::json handleReaderArgs(NL::json rawReaderArgs)
+inline NL::json handleReaderArgs(NL::json rawReaderArgs)
 {
     if (rawReaderArgs.is_object())
     {
@@ -100,7 +100,7 @@ NL::json handleReaderArgs(NL::json rawReaderArgs)
         if (!readerPipeline.contains("type"))
             throw pdal_error("No \"type\" key found in supplied reader arguments.");
 
-        std::string driver = readerPipeline.at("type").get<std::string>();
+        std::string driver = jsonValue<std::string>(readerPipeline, "type");
         if (rawReaderArgs.contains(driver))
             throw pdal_error("Multiple instances of the same driver in supplied reader arguments.");
         readerArgs[driver] = { };
@@ -118,7 +118,7 @@ NL::json handleReaderArgs(NL::json rawReaderArgs)
     return readerArgs;
 }
 
-Options setReaderOptions(const NL::json& readerArgs,
+inline Options setReaderOptions(const NL::json& readerArgs,
     const std::string& driver, const std::string& filename)
 {
     Options readerOptions;
@@ -134,8 +134,8 @@ Options setReaderOptions(const NL::json& readerArgs,
             if (key == "filename")
             {
                 if (!val.is_object())
-                    throw pdal_error("value for " + driver + "'filename' argument " +
-                        " must be a valid JSON object.");
+                    throw pdal_error("value for " + driver + " 'filename' argument " +
+                        "must be a valid JSON object.");
                 if (val.contains("path"))
                     val.erase("path");
                 val += {"path", filename};


### PR DESCRIPTION
Removed duplicate code for the handling of JSON `reader_args` in `readers.tindex` & `readers.stac`; moved to `JsonSupport.hpp`. Consolidated the docs for it. 

Also moved `JsonValue()` out of StacUtils, which catches Nlohmann parse errors and throws `pdal_error` -- this could probably replace most uses of `json::get<T>()` in the codebase, but I need to check more to see where it's appropriate.