### PR TITLE
Fix multi-line comment warning

### DIFF
--- a/filters/private/hexer/H3grid.cpp
+++ b/filters/private/hexer/H3grid.cpp
@@ -78,7 +78,7 @@ HexId H3Grid::edgeHex(HexId hex, int edge) const
     //               (+ I)
     //                __0_
     // (+ I, + J)  5 /    \ 1  (- J)
-    //              /      \
+    //              /      \ 
     //              \      /
     //      (+ J)  4 \____/ 2   (- I, - J)
     //                  3


### PR DESCRIPTION
Fixes
~~~
/pdal/src/2.9.0-26ec19b2d5.clean/filters/private/hexer/H3grid.cpp:81:5: warning: multi-line comment [-Wcomment]
   81 |     //              /      \
      |     ^
~~~