### PR TITLE
[Backport 2.9-maintenance] Fix multi-line comment warning

### DIFF
--- a/filters/private/hexer/H3grid.cpp
+++ b/filters/private/hexer/H3grid.cpp
@@ -78,7 +78,7 @@ HexId H3Grid::edgeHex(HexId hex, int edge) const
     //               (+ I)
     //                __0_
     // (+ I, + J)  5 /    \ 1  (- J)
-    //              /      \
+    //              /      \ 
     //              \      /
     //      (+ J)  4 \____/ 2   (- I, - J)
     //                  3


### PR DESCRIPTION
Backport #4744
 **Authored by:** @dg0yt