### PR TITLE
consolidate dumpSummary of QuickInfo into a method

### DIFF
--- a/kernels/InfoKernel.cpp
+++ b/kernels/InfoKernel.cpp
@@ -177,42 +177,6 @@ void InfoKernel::addSwitches(ProgramArgs& args)
 }
 
 
-// Note that the same information can come from the info filter, but
-// this avoids point reads.
-MetadataNode InfoKernel::dumpSummary(const QuickInfo& qi)
-{
-    MetadataNode summary;
-    summary.add("num_points", qi.m_pointCount);
-    if (qi.m_srs.valid())
-    {
-        MetadataNode srs = qi.m_srs.toMetadata();
-        summary.add(srs);
-    }
-    if (qi.m_bounds.valid())
-    {
-        MetadataNode bounds = Utils::toMetadata(qi.m_bounds);
-        summary.add(bounds.clone("bounds"));
-    }
-
-    std::string dims;
-    auto di = qi.m_dimNames.begin();
-    while (di != qi.m_dimNames.end())
-    {
-        dims += *di;
-        ++di;
-        if (di != qi.m_dimNames.end())
-           dims += ", ";
-    }
-    if (dims.size())
-        summary.add("dimensions", dims);
-
-    if (!qi.m_metadata.empty() && qi.m_metadata.valid())
-    {
-        summary.add(qi.m_metadata.clone("metadata"));
-    }
-
-    return summary;
-}
 
 void InfoKernel::makeReader(const std::string& filename)
 {
@@ -309,7 +273,7 @@ MetadataNode InfoKernel::run(const std::string& filename)
             m_reader->getMetadata().addOrUpdate("count", pointCountOverride);
             qi.m_pointCount = pointCountOverride;
         }
-        root.add(dumpSummary(qi).clone("summary"));
+        root.add(qi.dumpSummary().clone("summary"));
     }
     else
     {

--- a/kernels/InfoKernel.hpp
+++ b/kernels/InfoKernel.hpp
@@ -70,7 +70,6 @@ private:
     void makeReader(const std::string& filename);
     void makePipeline();
     void dump(MetadataNode& root);
-    MetadataNode dumpSummary(const QuickInfo& qi);
 
     std::string m_inputFile;
     bool m_showStats;

--- a/pdal/QuickInfo.hpp
+++ b/pdal/QuickInfo.hpp
@@ -37,6 +37,7 @@
 #include <vector>
 
 #include <pdal/util/Bounds.hpp>
+#include <pdal/Metadata.hpp>
 #include <pdal/SpatialReference.hpp>
 
 namespace pdal
@@ -58,6 +59,41 @@ public:
 
     bool valid() const
         { return m_valid; }
+
+    MetadataNode dumpSummary() const
+    {
+        MetadataNode summary;
+        summary.add("num_points", this->m_pointCount);
+        if (this->m_srs.valid())
+        {
+            MetadataNode srs = this->m_srs.toMetadata();
+            summary.add(srs);
+        }
+        if (this->m_bounds.valid())
+        {
+            MetadataNode bounds = Utils::toMetadata(this->m_bounds);
+            summary.add(bounds.clone("bounds"));
+        }
+
+        std::string dims;
+        auto di = this->m_dimNames.begin();
+        while (di != this->m_dimNames.end())
+        {
+            dims += *di;
+            ++di;
+            if (di != this->m_dimNames.end())
+               dims += ", ";
+        }
+        if (dims.size())
+            summary.add("dimensions", dims);
+
+        if (!this->m_metadata.empty() && this->m_metadata.valid())
+        {
+            summary.add(this->m_metadata.clone("metadata"));
+        }
+
+        return summary;
+    }
 };
 
 } // namespace pdal


### PR DESCRIPTION
@kylemann16 points out that `.quickinfo` in Python is different than from `pdal info`. This is due to the fact that we have duplicate code. This PR consolidates it into a method that can be used for both.

https://github.com/PDAL/python/issues/193