### PR TITLE
[Backport 2.9-maintenance] Bump prefix-dev/setup-pixi from 0.8.10 to 0.8.11

### DIFF
--- a/.github/workflows/pixi.yml
+++ b/.github/workflows/pixi.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
     steps:
     - uses: actions/checkout@v4
-    - uses: prefix-dev/setup-pixi@v0.8.10
+    - uses: prefix-dev/setup-pixi@v0.8.11
       with:
         environments: >-
           dev


### PR DESCRIPTION
Backport #4762
 **Authored by:** @dependabot[bot]