### PR TITLE
Update ArrowWriter.cpp to work with Arrow 21.0.0

### DIFF
--- a/plugins/arrow/io/ArrowWriter.cpp
+++ b/plugins/arrow/io/ArrowWriter.cpp
@@ -523,7 +523,7 @@ void ArrowWriter::flushBatch()
 
     if (m_formatType == arrowsupport::Parquet)
     {
-        auto result = m_parquetFileWriter->NewRowGroup(m_batchSize);
+        auto result = m_parquetFileWriter->NewRowGroup();
         if (!result.ok())
             throwError("Unable to make NewRowGroup: " + result.ToString());
 

--- a/plugins/arrow/io/ArrowWriter.cpp
+++ b/plugins/arrow/io/ArrowWriter.cpp
@@ -523,7 +523,11 @@ void ArrowWriter::flushBatch()
 
     if (m_formatType == arrowsupport::Parquet)
     {
+#if ARROW_VERSION_MAJOR >= 20
         auto result = m_parquetFileWriter->NewRowGroup();
+#else
+        auto result = m_parquetFileWriter->NewRowGroup(m_batchSize);
+#endif
         if (!result.ok())
             throwError("Unable to make NewRowGroup: " + result.ToString());
 


### PR DESCRIPTION
This call to NewRowGroup was deprecated in Arrow 19.0.0 because the implementation wasn't using it,

https://github.com/apache/arrow/issues/45048

The deprecated variant of NewRowGroup was removed in Arrow 21.0.0:

https://github.com/apache/arrow/issues/46132

so this change will make PDAL compile cleanly against Arrow 21.0.0.

See https://github.com/Homebrew/homebrew-core/pull/230431.