### PR TITLE
[Backport 2.9-maintenance] Use namespace-qualified name for spz library.

### DIFF
--- a/cmake/spz.cmake
+++ b/cmake/spz.cmake
@@ -4,7 +4,6 @@
 
 # The oldest spz release that's on conda-forge is 2.0.0,
 # but they have it marked as 1.1 in their cmake file.
-#find_package(spz 1.1.0 REQUIRED CONFIG)
 find_package(spz 1.1.0 REQUIRED)
 set_package_properties(spz PROPERTIES TYPE REQUIRED
     PURPOSE "SPZ gaussian splat format support")

--- a/cmake/spz.cmake
+++ b/cmake/spz.cmake
@@ -4,7 +4,8 @@
 
 # The oldest spz release that's on conda-forge is 2.0.0,
 # but they have it marked as 1.1 in their cmake file.
-find_package(spz 1.1.0 REQUIRED CONFIG)
+#find_package(spz 1.1.0 REQUIRED CONFIG)
+find_package(spz 1.1.0 REQUIRED)
 set_package_properties(spz PROPERTIES TYPE REQUIRED
     PURPOSE "SPZ gaussian splat format support")
 if(spz_FOUND)

--- a/plugins/spz/CMakeLists.txt
+++ b/plugins/spz/CMakeLists.txt
@@ -9,13 +9,15 @@ endif(STANDALONE)
 include(${PDAL_CMAKE_DIR}/spz.cmake)
 if (NOT PDAL_HAVE_SPZ)
     message("Can't find SPZ support required by SPZ plugin.")
+else()
+    set(SPZ_LIBRARIES spz::spz)
 endif()
 
 PDAL_ADD_PLUGIN(spz_reader reader spz
     FILES
         io/SpzReader.cpp
     LINK_WITH
-        spz
+        ${SPZ_LIBRARIES}
         ${PDAL_LIBRARIES}
     INCLUDES
         ${PDAL_VENDOR_DIR}
@@ -27,7 +29,7 @@ PDAL_ADD_PLUGIN(spz_writer writer spz
     FILES
         io/SpzWriter.cpp
     LINK_WITH
-        spz
+        ${SPZ_LIBRARIES}
         ${PDAL_LIBRARIES}
     INCLUDES
         ${PDAL_VENDOR_DIR}


### PR DESCRIPTION
Backport #4783
 **Authored by:** @abellgithub