### PR TITLE
[Backport 2.9-maintenance] Make sure to Flush() in VSIStreamBuffer::sync()

### DIFF
--- a/pdal/util/VSIIO.cpp
+++ b/pdal/util/VSIIO.cpp
@@ -207,6 +207,7 @@ int VSIStreamBuffer::sync()
             nBufferStart += nWritten;
             setp(buffer.data(), buffer.data() + nBufferSize);
         }
+        fp->Flush();
     }
     else
     {


### PR DESCRIPTION
Backport #4806
 **Authored by:** @hobu