### PR TITLE
[Backport 2.9-maintenance] Alias PDAL_DLL => PDAL_EXPORT and warn users to upgrade if it is defined

### DIFF
--- a/pdal/util/pdal_util_export.hpp
+++ b/pdal/util/pdal_util_export.hpp
@@ -37,13 +37,10 @@
 
 #pragma once
 
-#ifdef PDAL_DLL
-#warning "PDAL_DLL has been deprecated in favor of PDAL_EXPORT. Please update your code"
-#   define PDAL_DLL     PDAL_EXPORT
-#endif
 
 #ifdef _WIN32
 #   define PDAL_EXPORT   __declspec(dllexport)
+#   define PDAL_DLL     PDAL_EXPORT
 #   define PDAL_LOCAL
 #   define PDAL_EXPORT_UNIX
 #ifdef __GNUC__
@@ -55,6 +52,7 @@
 #   define PDAL_EXPORT     __attribute__ ((visibility("default")))
 // Keep the PDAL_DLL name around so any external plugins that still might have that defined
 // can still compile and be used
+#   define PDAL_DLL     PDAL_EXPORT
 #   define PDAL_LOCAL   __attribute__((visibility("hidden")))
 #   define PDAL_EXPORT_UNIX   __attribute__ ((visibility("default")))
 #   define PDAL_EXPORT_DEPRECATED   __attribute__((deprecated))


### PR DESCRIPTION
Backport #4811
 **Authored by:** @hobu