### PR TITLE
Do not run on git-push from dependabot

### DIFF
--- a/.github/workflows/alpine.yml
+++ b/.github/workflows/alpine.yml
@@ -4,6 +4,7 @@ on:
     push:
         paths-ignore:
             - 'doc/**'
+        branches-ignore: ["dependabot/**"]
     pull_request:
         paths-ignore:
             - 'doc/**'

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -4,6 +4,7 @@ on:
     push:
         paths-ignore:
             - 'doc/**'
+        branches-ignore: ["dependabot/**"]
     pull_request:
         paths-ignore:
             - 'doc/**'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,11 +3,12 @@ name: Docker
 
 on:
   push:
-      paths-ignore:
-          - 'doc/**'
+    paths-ignore:
+      - 'doc/**'
+    branches-ignore: ["dependabot/**"]
   pull_request:
-      paths-ignore:
-          - 'doc/**'
+    paths-ignore:
+      - 'doc/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -4,6 +4,7 @@ on:
     push:
         paths-ignore:
             - 'doc/**'
+        branches-ignore: ["dependabot/**"]
     pull_request:
         paths-ignore:
             - 'doc/**'

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -4,6 +4,7 @@ on:
     push:
         paths-ignore:
             - 'doc/**'
+        branches-ignore: ["dependabot/**"]
     pull_request:
         paths-ignore:
             - 'doc/**'

--- a/.github/workflows/pixi.yml
+++ b/.github/workflows/pixi.yml
@@ -4,6 +4,7 @@ on:
     push:
         paths-ignore:
             - 'doc/**'
+        branches-ignore: ["dependabot/**"]
     pull_request:
         paths-ignore:
             - 'doc/**'

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -4,6 +4,7 @@ on:
     push:
         paths-ignore:
             - 'doc/**'
+        branches-ignore: ["dependabot/**"]
     pull_request:
         paths-ignore:
             - 'doc/**'


### PR DESCRIPTION
The CI will run on dependabot submitted PRs, but no need to run on dependabot push events.