### PR TITLE
Bump versions used in dockerfile construction

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -129,7 +129,7 @@ jobs:
             org.opencontainers.image.created=${{ steps.prep.outputs.BUILD_DATE }}
       
       - name: Generate artifact attestation
-        if: ${{ vars.PUSH_PACKAGES == 'true' }}
+        if: ${{ env.PUSH_PACKAGES == 'true' }}
         uses: actions/attest-build-provenance@v3
         with:
           subject-name: ghcr.io/pdal/pdal

--- a/scripts/docker/ubuntu/Dockerfile
+++ b/scripts/docker/ubuntu/Dockerfile
@@ -54,7 +54,7 @@ RUN cd pdal/build  && \
     ninja install
 
 RUN git clone https://github.com/PDAL/python-plugins.git pdal-python-plugins && \
-    cd pdal-python-plugins && git checkout 1.6.5  && \
+    cd pdal-python-plugins && git checkout 1.6.6  && \
     python -m pip install \
     -Cbuild-dir=build \
     . \
@@ -64,7 +64,7 @@ RUN git clone https://github.com/PDAL/python-plugins.git pdal-python-plugins && 
     --no-build-isolation
 
 RUN git clone https://github.com/PDAL/python.git pdal-python && \
-    cd pdal-python && git checkout 3.5.0  && \
+    cd pdal-python && git checkout 3.5.3  && \
     python -m pip install \
     -Cbuild-dir=build \
     . \


### PR DESCRIPTION
Bump versions of pdal-python-plugins and pdal-python used in the construction of docker images.

Also fix incorrect usage of `vars` in the docker CI workflow.