### PR TITLE
Emit warnings for `pdal tindex` hexbin boundary failures

### DIFF
--- a/kernels/TIndexKernel.cpp
+++ b/kernels/TIndexKernel.cpp
@@ -618,12 +618,6 @@ void TIndexKernel::fastBoundary(Stage& reader, FileInfo& fileInfo)
 }
 
 
-void TIndexKernel::slowBoundary(PipelineManager& manager)
-{
-    manager.execute(ExecMode::PreferStream);
-}
-
-
 void TIndexKernel::getFileInfo(FileInfo& fileInfo)
 {
     PipelineManager manager;
@@ -649,7 +643,7 @@ void TIndexKernel::getFileInfo(FileInfo& fileInfo)
         manager.addStage(&hexer);
         try
         {
-            slowBoundary(manager);
+            manager.execute(ExecMode::PreferStream);
 
             fileInfo.m_boundary = hexer.toWKT();
             fileInfo.m_srs = hexer.getSpatialReference().getWKT();

--- a/kernels/TIndexKernel.hpp
+++ b/kernels/TIndexKernel.hpp
@@ -106,7 +106,6 @@ private:
     void createFields();
     void setStringField(OGRFeatureH hFeature, int idx, const char* value);
     void fastBoundary(Stage& reader, FileInfo& fileInfo);
-    void slowBoundary(PipelineManager& manager);
     std::string makeMultiPolygon(const std::string& wkt);
 
     bool isFileIndexed( const FieldIndexes& indexes, const FileInfo& fileInfo);

--- a/test/unit/apps/TIndexTest.cpp
+++ b/test/unit/apps/TIndexTest.cpp
@@ -51,7 +51,7 @@ TEST(TIndex, test1)
     std::string outPoints(Support::temppath("points.txt"));
 
     std::string cmd = Support::binpath("pdal") + " tindex create " +
-        outSpec + " \"" + inSpec + "\" -f GeoJSON";
+        outSpec + " \"" + inSpec + "\" -f GeoJSON --log=stdout";
 
     FileUtils::deleteFile(outSpec);
 
@@ -126,7 +126,7 @@ TEST(TIndex, test3)
 
     std::string cmd = "find " + Support::datapath("tindex") +
         " -name \"*.txt\" | " + Support::binpath("pdal") +
-        " tindex create --stdin " + outSpec + " -f GeoJSON";
+        " tindex create --stdin " + outSpec + " -f GeoJSON --log=stdout";
 
     std::string output;
     Utils::run_shell_command(cmd, output);
@@ -244,5 +244,25 @@ TEST(TIndex, test5)
     pos = output.find("supports a maximum of 254");
     EXPECT_NE(pos, std::string::npos);
     FileUtils::deleteDirectory(outSpec);
+}
+
+// testing warnings from failed boundary creation
+TEST(TIndex, test6)
+{
+    std::string inSpec(Support::datapath("tindex/*.txt"));
+    std::string outSpec(Support::temppath("tindex.json"));
+
+    std::string cmd = Support::binpath("pdal") + " tindex create " +
+        outSpec + " \"" + inSpec + "\" -f GeoJSON --log=stdout " +
+        "--filters.hexbin.smooth=false";
+
+    FileUtils::deleteFile(outSpec);
+    std::string output;
+    Utils::run_shell_command(cmd, output);
+
+    std::string::size_type pos = output.find("Argument references invalid/unused stage");
+    EXPECT_NE(pos, std::string::npos);
+
+    FileUtils::deleteFile(outSpec);
 }
 


### PR DESCRIPTION
Closes #4825. Made the hexbin boundary creation in `TindexKernel.cpp` emit a warning when it fails. Also changed to only catch errors during the boundary creation pipeline's execution. Added a test.

Since the slow boundary creation can be expected to fail sometimes during normal operation, this will output a lot of warnings. A `LogLevel::Debug` message could be better. If we want to be more strict about invalid stage options in particular, I could put `PipelineManager::validateStageOptions()` before the try/catch and it would throw an error.