### PR TITLE
[Backport 2.9-maintenance] Bump actions/upload-artifact from 4 to 5

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -72,7 +72,7 @@ jobs:
       run: |
           source ./scripts/ci/conda/examples.sh
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v5
       with:
         name: ${{ matrix.platform }}-conda-package
         path: ./libpdal-feedstock/packages/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
          done
       working-directory: ./build
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v5
       name: Gather source distribution artifact
       with:
         name: source-package-ubuntu-latest


### PR DESCRIPTION
Backport #4847
 **Authored by:** @dependabot[bot]