### PR TITLE
Update minimum GDAL version

### DIFF
--- a/cmake/gdal.cmake
+++ b/cmake/gdal.cmake
@@ -12,7 +12,7 @@ function(gdal_find_version _version)
     set(${_version} ${MAJOR}.${MINOR}.${REV} PARENT_SCOPE)
 endfunction(gdal_find_version)
 
-find_package(GDAL 3.4 REQUIRED)
+find_package(GDAL 3.8 REQUIRED)
 set_package_properties(GDAL PROPERTIES TYPE REQUIRED
     PURPOSE "Provides general purpose raster, vector, and reference system support")
 if (GDAL_FOUND)
@@ -20,9 +20,9 @@ if (GDAL_FOUND)
     #
     # Older versions of FindGDAL.cmake don't properly set GDAL_VERSION
     #
-    if (GDAL_VERSION VERSION_LESS 3.4.0)
+    if (GDAL_VERSION VERSION_LESS 3.8.0)
         message(FATAL_ERROR
-            "Found GDAL version ${GDAL_VERSION}.  Version 3.4+ is required")
+            "Found GDAL version ${GDAL_VERSION}.  Version 3.8+ is required")
     endif()
     mark_as_advanced(CLEAR GDAL_INCLUDE_DIR)
     mark_as_advanced(CLEAR GDAL_LIBRARY)

--- a/doc/development/compilation/dependencies.md
+++ b/doc/development/compilation/dependencies.md
@@ -16,7 +16,7 @@ on your system.
 
 ## Required Dependencies
 
-### GDAL (3.0+)
+### GDAL (3.8+)
 
 PDAL uses GDAL for spatial reference system description manipulation, and image
 reading supporting for the NITF driver. In


### PR DESCRIPTION
In the documentation, the minimum GDAL version listed is 3.0+ while in the cmake file, it is 3.4+

I failed to compile PDAL with GDAL 3.4.1 due to the following error:

```
[205/643] Building CXX object CMakeFiles/pdalcpp.dir/pdal/util/VSIIO.cpp.o
FAILED: CMakeFiles/pdalcpp.dir/pdal/util/VSIIO.cpp.o 
/usr/bin/c++ -DH3_PREFIX=PDALH3 -DUNIX -Dpdalcpp_EXPORTS -I/home/kasparas/PDAL/vendor/gtest/include -I/home/kasparas/PDAL/vendor/gtest -I/home/kasparas/PDAL -I/home/kasparas/PDAL/build/include -I/home/kasparas/PDAL/vendor -I/home/kasparas/PDAL/vendor/nlohmann -I/home/kasparas/PDAL/vendor/utfcpp/source -I/usr/include/geotiff -isystem /home/kasparas/PDAL/vendor/eigen -isystem /home/kasparas/PDAL/vendor/kazhdan -isystem /home/kasparas/PDAL/vendor/h3/include -isystem /usr/include/gdal -isystem /usr/include/libxml2 -fPIC -Wno-noexcept-type -Wno-class-memaccess -Wno-psabi -Wno-implicit-fallthrough -Wno-int-in-bool-context -Wno-dangling-else -Wall -Wextra -Wpointer-arith -Wcast-align -Wcast-qual -Wno-error=parentheses -Wno-error=cast-qual -Wredundant-decls -Wno-unused-parameter -Wno-unused-variable -Wno-long-long -Wno-unknown-pragmas -Wno-deprecated-declarations -fvisibility-inlines-hidden -fvisibility=hidden -std=c++17 -MD -MT CMakeFiles/pdalcpp.dir/pdal/util/VSIIO.cpp.o -MF CMakeFiles/pdalcpp.dir/pdal/util/VSIIO.cpp.o.d -o CMakeFiles/pdalcpp.dir/pdal/util/VSIIO.cpp.o -c /home/kasparas/PDAL/pdal/util/VSIIO.cpp
/home/kasparas/PDAL/pdal/util/VSIIO.cpp: In constructor ‘pdal::VSI::VSIStreamBuffer::VSIStreamBuffer(std::string, std::ios_base::openmode, std::size_t)’:
/home/kasparas/PDAL/pdal/util/VSIIO.cpp:143:42: error: no matching function for call to ‘VSICreateBufferedReaderHandle(VSILFILE*)’
  143 |             VSICreateBufferedReaderHandle(VSIFOpenL(filename.c_str(), fm.c_str()))));
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /home/kasparas/PDAL/pdal/util/VSIIO.cpp:40:
/usr/include/gdal/cpl_vsi_virtual.h:273:27: note: candidate: ‘VSIVirtualHandle* VSICreateBufferedReaderHandle(VSIVirtualHandle*)’
  273 | VSIVirtualHandle CPL_DLL *VSICreateBufferedReaderHandle(VSIVirtualHandle* poBaseHandle);
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/gdal/cpl_vsi_virtual.h:273:75: note:   no known conversion for argument 1 from ‘VSILFILE*’ {aka ‘FILE*’} to ‘VSIVirtualHandle*’
  273 | VSIVirtualHandle CPL_DLL *VSICreateBufferedReaderHandle(VSIVirtualHandle* poBaseHandle);
      |                                                         ~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
/usr/include/gdal/cpl_vsi_virtual.h:274:19: note: candidate: ‘VSIVirtualHandle* VSICreateBufferedReaderHandle(VSIVirtualHandle*, const GByte*, vsi_l_offset)’
  274 | VSIVirtualHandle* VSICreateBufferedReaderHandle(VSIVirtualHandle* poBaseHandle,
      |                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/gdal/cpl_vsi_virtual.h:274:19: note:   candidate expects 3 arguments, 1 provided
```

Compilation succeeds after I upgarde my GDAL to 3.8.4 although an even older version (such as 3.6) may be compatible, as I did not trace back at which exact version the API for `VSICreateBufferedReaderHandle` has changed.

If necessary, I may investigate further by trying to compile with different GDAL versions and update this PR, but as it stands now 3.8 seems like a safe choice.