### PR TITLE
[readers.rxp] Add UnambiguousRange and ShotTimestamp dimensions, export empty shots

### DIFF
--- a/pdal/Dimension.json
+++ b/pdal/Dimension.json
@@ -682,16 +682,6 @@
     "description": "Precise timestamp of laser shot in seconds (GpsTime or InternalTime depending on sync_to_pps)."
     },
     {
-    "name": "Segment",
-    "type": "uint16",
-    "description": "The current segment, usually some partitioning of the angle range covered by the scanner mirror."
-    },
-    {
-    "name": "Facet",
-    "type": "uint16",
-    "description": "The current facet of the polygonal mirror."
-    },
-    {
     "name": "UnambiguousRange",
     "type": "double",
     "description": "MTA zone width (unambiguous range) in meters. Required for zone correction calculation."

--- a/plugins/rxp/io/RxpPointcloud.hpp
+++ b/plugins/rxp/io/RxpPointcloud.hpp
@@ -68,8 +68,6 @@ struct Point {
         float roll,
         float pitch,
         double shotTimestamp,
-        unsigned int facet,
-        unsigned int segment,
         double unambiguousRange);
 
     scanlib::target target;
@@ -80,8 +78,6 @@ struct Point {
     double beamDirectionX, beamDirectionY, beamDirectionZ;
     float roll, pitch;
     double shotTimestamp;
-    unsigned int facet;      // Mirror facet index
-    unsigned int segment;    // Mirror segment partition index
     double unambiguousRange;
 };
 
@@ -109,7 +105,8 @@ public:
 
 protected:
     void on_shot_end();
-    void on_gap();
+    void on_pps_synchronized();
+    void on_pps_sync_lost();
     void on_line_start_up(const scanlib::line_start_up<iterator_type> & arg);
     void on_line_start_dn(const scanlib::line_start_dn<iterator_type> & arg);
     void on_line_stop(const scanlib::line_stop<iterator_type> & arg);
@@ -121,7 +118,9 @@ private:
     void savePoints();
 
     bool m_syncToPps;
+    bool m_ppsSynced;
     bool m_reflectanceAsIntensity;
+    bool m_emitEmptyShots;
     float m_minReflectance;
     float m_maxReflectance;
     std::shared_ptr<scanlib::basic_rconnection> m_rc;
@@ -131,10 +130,6 @@ private:
     std::deque<Point> m_points;
     float m_pitch;
     float m_roll;
-    bool m_emitEmptyShots;
-    unsigned int m_lastSegment;
-    uint32_t m_rotationId;
-
 };
 
 

--- a/plugins/rxp/io/RxpReader.cpp
+++ b/plugins/rxp/io/RxpReader.cpp
@@ -84,8 +84,6 @@ Dimension::IdList getRxpDimensions(bool syncToPps, bool reflectanceAsIntensity)
     ids.push_back(Id::Roll);
     ids.push_back(Id::Pitch);
     ids.push_back(Id::ShotTimestamp);
-    ids.push_back(Id::Facet);
-    ids.push_back(Id::Segment);
     ids.push_back(Id::UnambiguousRange);
     if (reflectanceAsIntensity) {
         ids.push_back(Id::Intensity);

--- a/plugins/rxp/io/RxpReader.hpp
+++ b/plugins/rxp/io/RxpReader.hpp
@@ -56,7 +56,6 @@ namespace pdal
 const bool DEFAULT_SYNC_TO_PPS = true;
 const bool DEFAULT_IS_RDTP = false;
 const bool DEFAULT_EMPIT_EMPTY_SHOTS = false;
-const bool DEFAULT_MINIMAL = false;
 const bool DEFAULT_REFLECTANCE_AS_INTENSITY = true;
 const float DEFAULT_MIN_REFLECTANCE = -25.0;
 const float DEFAULT_MAX_REFLECTANCE = 5.0;


### PR DESCRIPTION
## Description

This PR enhances the RXP reader to properly track scanner rotations and emit complete shot metadata including empty shots (shots without echoes).

## Motivation

- Previous rotation detection relied on `EdgeOfFlightLine`, which semantically marks scan line direction changes, not full rotations
- Empty shots (laser fires with no returns) were either skipped or improperly handled
- ~Segment and Facet metadata from the scanner were not propagated to PDAL dimensions~

## Changes

### 1. New dimensions (`Dimension.json`)

- ~`Segment` (uint16): Scanner mirror segment partition index~
- ~`Facet` (uint16): Polygonal mirror facet number~
- `UnambiguousRange` (double): maximum unambiguous range (mta zone width)
- `ShotTimestamp` (double): timestamp of the laser shot

### 2. `EdgeOfFlightLine` detection (`RxpPointcloud.cpp/hpp`)

- ~Track `segment` index; when it wraps around (decreases), mark new rotation~
- ~Set `EdgeOfFlightLine` flag at rotation boundaries (repurposed for round grouping)~
- Set `EdgeOfFlightLine` on all the line callbacks


### 3. Empty shot handling

- ~Implement `on_gap()` callback (proper RiVLib pattern for shots without echoes)~ Merged with `on_shot_end()`
- Emit points with `NumberOfReturns=0` and ~NaN~ `BeamOrigin` geometry values
- Preserve valid metadata (timestamp, beam origin/direction, ~segment, facet~) for diagnostic/MTA processing
- Move from `on_echo_transformed()` to `on_shot_end()`

### 4. Metadata propagation

- Pass `unambiguous_range`, `shot_timestamp ~`facet` and `segment`~ through `Point` struct constructor
- Write to PDAL dimensions via `copyPoint()`

## Related work

Enables downstream MTA (Multiple-Time-Around) processing by providing accurate rotation grouping and complete shot inventory including gaps (empty shots). Future work to come.
