### PR TITLE
[Backport 2.9-maintenance] Bump actions/upload-artifact from 5 to 6

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -72,7 +72,7 @@ jobs:
       run: |
           source ./scripts/ci/conda/examples.sh
 
-    - uses: actions/upload-artifact@v5
+    - uses: actions/upload-artifact@v6
       with:
         name: ${{ matrix.platform }}-conda-package
         path: ./libpdal-feedstock/packages/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
          done
       working-directory: ./build
 
-    - uses: actions/upload-artifact@v5
+    - uses: actions/upload-artifact@v6
       name: Gather source distribution artifact
       with:
         name: source-package-ubuntu-latest


### PR DESCRIPTION
Backport #4896
 **Authored by:** @dependabot[bot]