### PR TITLE
[Backport 2.10-maintenance] Bump prefix-dev/setup-pixi from 0.9.4 to 0.9.5

### DIFF
--- a/.github/workflows/pixi.yml
+++ b/.github/workflows/pixi.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
     steps:
     - uses: actions/checkout@v6
-    - uses: prefix-dev/setup-pixi@v0.9.4
+    - uses: prefix-dev/setup-pixi@v0.9.5
       with:
         environments: >-
           dev


### PR DESCRIPTION
Backport #4999
 **Authored by:** @dependabot[bot]