### PR TITLE
[Backport 2.10-maintenance] Bump conda-incubator/setup-miniconda from 3 to 4

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -41,7 +41,7 @@ jobs:
         path: ~/conda_pkgs_dir
         key: ${{ runner.os }}-${{ steps.get-date.outputs.today }}-conda-${{ env.CACHE_NUMBER }}
 
-    - uses: conda-incubator/setup-miniconda@v3
+    - uses: conda-incubator/setup-miniconda@v4
       with:
         miniforge-variant: Miniforge3
         miniforge-version: latest


### PR DESCRIPTION
Backport #5012
 **Authored by:** @dependabot[bot]