### PR TITLE
Make the use of Ccache optional for building libE57Format

### DIFF
--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -86,8 +86,6 @@ option(BUILD_PLUGIN_E57
     "Choose if e57 support should be built" FALSE)
 add_feature_info("E57 plugin" BUILD_PLUGIN_E57
     "read/write data to and from e57 format")
-option(WITH_CCACHE_E57
-    "Build libE57Format with Ccache" OFF)
 
 option(BUILD_PLUGIN_ARROW
     "Choose if Arrow support should be built" FALSE)

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -86,6 +86,8 @@ option(BUILD_PLUGIN_E57
     "Choose if e57 support should be built" FALSE)
 add_feature_info("E57 plugin" BUILD_PLUGIN_E57
     "read/write data to and from e57 format")
+option(WITH_CCACHE_E57
+    "Build libE57Format with Ccache" OFF)
 
 option(BUILD_PLUGIN_ARROW
     "Choose if Arrow support should be built" FALSE)

--- a/plugins/e57/libE57Format/CMakeLists.txt
+++ b/plugins/e57/libE57Format/CMakeLists.txt
@@ -206,8 +206,9 @@ install(
 )
 
 # ccache
-# Turns on ccache if found
-include( ccache )
+if ( E57_WITH_CCACHE )
+    include( ccache )
+endif()
 
 # Formatting
 include( ClangFormat )

--- a/plugins/e57/libE57Format/CMakeLists.txt
+++ b/plugins/e57/libE57Format/CMakeLists.txt
@@ -205,11 +205,6 @@ install(
         E57Format-export
 )
 
-# ccache
-if ( E57_WITH_CCACHE )
-    include( ccache )
-endif()
-
 # Formatting
 include( ClangFormat )
 


### PR DESCRIPTION
Configuration of libE57Format opportunistically uses Ccache if found, without possibility to opt out.
This is a rather unfortunate decision, especially for packaging systems (see eg. [bug report for MacPorts](https://trac.macports.org/ticket/74004)).

This introduces an option for "use Ccache for libE57Format", which defaults to 'OFF'.

An alternative solution could be to hard code the `WITH_CCACHE_E57` variable to OFF  in PDAL instead of making it optional.