### PR TITLE
filters: fix UB in DimRange sort comparator

### DIFF
--- a/filters/private/DimRange.cpp
+++ b/filters/private/DimRange.cpp
@@ -170,22 +170,11 @@ void DimRange::parse(const std::string& r)
         throw error("Invalid characters following valid range.");
 }
 
-
+// Dim ranges sort so that all ranges of a dimension are contiguous.
+// Beyond that we don't care. (See pointPasses)
 bool operator < (const DimRange& r1, const DimRange& r2)
 {
-    return std::tie(
-        r1.m_name,
-        r1.m_lower_bound,
-        r1.m_upper_bound,
-        r1.m_inclusive_lower_bound,
-        r1.m_inclusive_upper_bound,
-        r1.m_negate) < std::tie(
-        r2.m_name,
-        r2.m_lower_bound,
-        r2.m_upper_bound,
-        r2.m_inclusive_lower_bound,
-        r2.m_inclusive_upper_bound,
-        r2.m_negate);
+    return r1.name < r2.name;
 }
 
 

--- a/filters/private/DimRange.cpp
+++ b/filters/private/DimRange.cpp
@@ -173,9 +173,19 @@ void DimRange::parse(const std::string& r)
 
 bool operator < (const DimRange& r1, const DimRange& r2)
 {
-    return (r1.m_name < r2.m_name ? true :
-        r1.m_name > r2.m_name ? false :
-        &r1 < &r2);
+    return std::tie(
+        r1.m_name,
+        r1.m_lower_bound,
+        r1.m_upper_bound,
+        r1.m_inclusive_lower_bound,
+        r1.m_inclusive_upper_bound,
+        r1.m_negate) < std::tie(
+        r2.m_name,
+        r2.m_lower_bound,
+        r2.m_upper_bound,
+        r2.m_inclusive_lower_bound,
+        r2.m_inclusive_upper_bound,
+        r2.m_negate);
 }
 
 
@@ -202,4 +212,3 @@ std::ostream& operator<<(std::ostream& out, const DimRange& r)
 }
 
 } // namespace pdal
-


### PR DESCRIPTION
Using element addresses as a tie-breaker does not provide a valid strict weak ordering for std::sort once the elements are being reordered. Replace it with a deterministic field-based comparison so sorting the range list no longer relies on undefined behavior.

This fixes a segfault observed on Alpine Linux riscv64:

```
99% tests passed, 1 tests failed out of 144

Total Test time (real) = 127.50 sec

The following tests FAILED:
	  9 - pdal_io_arrow_writer_test (SEGFAULT)
Errors while running CTest
```