### PR TITLE
Correct PDAL_CREATE_PLUGIN target name

### DIFF
--- a/cmake/pluginmacros.cmake
+++ b/cmake/pluginmacros.cmake
@@ -16,7 +16,7 @@ macro(PDAL_CREATE_PLUGIN)
         message(FATAL_ERROR "Invalid plugin type '${TYPE}'. Must be 'reader', 'writer', 'filter' or 'kernel'.")
     endif()
     set(PROJECT_NAME ${NAME}_${TYPE})
-    set(TARGET pdal_plugin_${TYPE}_${NAME})
+    set(TARGET libpdal_plugin_${TYPE}_${NAME})
 
     project(${PROJECT_NAME} VERSION ${VERSION} LANGUAGES CXX)
 


### PR DESCRIPTION
See #5037 

Prepends "lib" to plugin target name, as expected by pdal.