### PR TITLE
Correct PDAL_CREATE_PLUGIN target name (take 2)

### DIFF
--- a/cmake/macros.cmake
+++ b/cmake/macros.cmake
@@ -126,7 +126,7 @@ macro(PDAL_ADD_PLUGIN _name _type _shortname)
     set(multiValueArgs FILES LINK_WITH INCLUDES SYSTEM_INCLUDES)
     cmake_parse_arguments(PDAL_ADD_PLUGIN "${options}" "${oneValueArgs}"
         "${multiValueArgs}" ${ARGN})
-    if(MSVC)
+    if(WIN32)
         set(${_name} "libpdal_plugin_${_type}_${_shortname}")
     else()
         set(${_name} "pdal_plugin_${_type}_${_shortname}")

--- a/cmake/pluginmacros.cmake
+++ b/cmake/pluginmacros.cmake
@@ -18,9 +18,9 @@ macro(PDAL_CREATE_PLUGIN)
     set(PROJECT_NAME ${NAME}_${TYPE})
 
     if(MSVC)
-        set(${_name} "libpdal_plugin_${TYPE}_${NAME}")
+        set(TARGET "libpdal_plugin_${TYPE}_${NAME}")
     else()
-        set(${_name} "pdal_plugin_${TYPE}_${NAME}")
+        set(TARGET "pdal_plugin_${TYPE}_${NAME}")
     endif()
 
     project(${PROJECT_NAME} VERSION ${VERSION} LANGUAGES CXX)

--- a/cmake/pluginmacros.cmake
+++ b/cmake/pluginmacros.cmake
@@ -17,7 +17,7 @@ macro(PDAL_CREATE_PLUGIN)
     endif()
     set(PROJECT_NAME ${NAME}_${TYPE})
 
-    if(MSVC)
+    if(WIN32)
         set(TARGET "libpdal_plugin_${TYPE}_${NAME}")
     else()
         set(TARGET "pdal_plugin_${TYPE}_${NAME}")

--- a/cmake/pluginmacros.cmake
+++ b/cmake/pluginmacros.cmake
@@ -16,7 +16,12 @@ macro(PDAL_CREATE_PLUGIN)
         message(FATAL_ERROR "Invalid plugin type '${TYPE}'. Must be 'reader', 'writer', 'filter' or 'kernel'.")
     endif()
     set(PROJECT_NAME ${NAME}_${TYPE})
-    set(TARGET libpdal_plugin_${TYPE}_${NAME})
+
+    if(MSVC)
+        set(${_name} "libpdal_plugin_${TYPE}_${NAME}")
+    else()
+        set(${_name} "pdal_plugin_${TYPE}_${NAME}")
+    endif()
 
     project(${PROJECT_NAME} VERSION ${VERSION} LANGUAGES CXX)
 

--- a/cmake/pluginmacros.cmake
+++ b/cmake/pluginmacros.cmake
@@ -16,7 +16,7 @@ macro(PDAL_CREATE_PLUGIN)
         message(FATAL_ERROR "Invalid plugin type '${TYPE}'. Must be 'reader', 'writer', 'filter' or 'kernel'.")
     endif()
     set(PROJECT_NAME ${NAME}_${TYPE})
-    set(TARGET pdal_plugin_${TYPE}_${NAME})
+    set(TARGET libpdal_plugin_${TYPE}_${NAME})
 
     project(${PROJECT_NAME} VERSION ${VERSION} LANGUAGES CXX)
 


### PR DESCRIPTION
See #5037

Prepends "lib" to plugin target name, as expected by pdal.

This is a resubmitted clone of #5038  as requested by @hobu 