### PR TITLE
groupby multiple dimensions

### DIFF
--- a/doc/stages/filters.groupby.md
+++ b/doc/stages/filters.groupby.md
@@ -34,7 +34,7 @@ By default the groups are ordered according to the order of first occurance with
 
 dimension
 
-: The dimension containing data to be grouped.
+: A list of 1 or more dimensions by which to group points.
 
 ```{include} filter_opts.md
 ```

--- a/doc/stages/filters.groupby.md
+++ b/doc/stages/filters.groupby.md
@@ -3,7 +3,7 @@
 # filters.groupby
 
 The **Groupby Filter** takes a single `PointView` as its input and
-creates a `PointView` for each category in the named [dimension] as
+creates a `PointView` for each category in the named {ref}`dimensions` as
 its output.
 
 ```{eval-rst}

--- a/doc/stages/filters.groupby.md
+++ b/doc/stages/filters.groupby.md
@@ -26,8 +26,21 @@ only points of a single `Classification`.
 ]
 ```
 
-```{note}
-By default the groups are ordered according to the order of first occurance within the input. To change this, use `filters.sort` first to order the points according to `dimension`.
+By default the groups are ordered according to the order of first occurrence within the input. To control the order of output groups, use {ref}`filters.sort` first to order the points according to `dimension`. For example, the pipeline below will create a file for each PointSourceId-Classification combination in `input.las`. The first output will contain the minimum source and class, and the final output will contain the maximum source and class.
+
+```json
+[
+    "input.las",
+    {
+        "type": "filters.sort",
+        "dimension": "PointSourceId,Classification"
+    },
+    {
+        "type": "filters.groupby",
+        "dimension": "PointSourceId,Classification"
+    },
+    "output_#.las"
+]
 ```
 
 ## Options

--- a/filters/GroupByFilter.cpp
+++ b/filters/GroupByFilter.cpp
@@ -34,6 +34,8 @@
 
 #include "GroupByFilter.hpp"
 
+#include <functional>
+
 #include <pdal/util/ProgramArgs.hpp>
 
 namespace pdal
@@ -82,15 +84,30 @@ void GroupByFilter::prepared(PointTableRef table)
     }
 }
 
+/**
+    Accumulates successive hashes of `value` into a single 64-bit buffer.
+    Taken from boost, etc.
+    https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2017/p0814r0.pdf
+
+    \param hash  The accumulated 64-bit hash. An inital value of 0 is fine.
+    \param value A type that std::hash can operate on.
+*/
+template <typename Hashable>
+void hashCombine(uint64_t& hash, const Hashable& value)
+{
+    hash ^=
+        std::hash<Hashable>()(value) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
+}
+
 PointViewSet GroupByFilter::run(PointViewPtr inView)
 {
     for (PointId idx = 0; idx < inView->size(); idx++)
     {
-        std::vector<int64_t> key(m_dimIds.size()); // could hash int values
+        uint64_t key = 0;
         for (const auto& dimId : m_dimIds)
         {
             int64_t val = inView->getFieldAs<int64_t>(dimId, idx);
-            key.push_back(val);
+            hashCombine(key, val);
         }
 
         PointViewPtr& groupView = m_viewMap[key];

--- a/filters/GroupByFilter.cpp
+++ b/filters/GroupByFilter.cpp
@@ -59,11 +59,26 @@ void GroupByFilter::addArgs(ProgramArgs& args)
 
 void GroupByFilter::prepared(PointTableRef table)
 {
+    StringList badNames;
     PointLayoutPtr layout(table.layout());
-    m_dimId = layout->findDim(m_dimName);
-    if (m_dimId == Dimension::Id::Unknown)
-        throwError("Invalid dimension name '" + m_dimName + "'.");
-    // also need to check that we have a dimension with discrete values
+
+    for (const auto& name : m_dimNames)
+    {
+        auto id = layout->findDim(name);
+        if (id == Dimension::Id::Unknown)
+            badNames.push_back(name);
+        else
+            m_dimIds.push_back(id);
+
+        // TODO also check that dimensions are discrete valued (ints?)
+    }
+    if (!badNames.empty())
+    {
+        std::stringstream showBad;
+        for (const auto& name : badNames)
+            showBad << name << " ";
+        throwError("Invalid dimension name(s): " + showBad.str() + ".");
+    }
 }
 
 PointViewSet GroupByFilter::run(PointViewPtr inView)

--- a/filters/GroupByFilter.cpp
+++ b/filters/GroupByFilter.cpp
@@ -94,10 +94,10 @@ PointViewSet GroupByFilter::run(PointViewPtr inView)
             key.push_back(val);
         }
 
-        PointViewPtr& outView = m_viewMap[key];
-        if (!outView)
-            outView = inView->makeNew();
-        outView->appendPoint(*inView.get(), idx);
+        PointViewPtr& groupView = m_viewMap[key];
+        if (!groupView)
+            groupView = inView->makeNew();
+        groupView->appendPoint(*inView.get(), idx);
     }
 
     // Pull the buffers out of the map and stick them in the standard

--- a/filters/GroupByFilter.cpp
+++ b/filters/GroupByFilter.cpp
@@ -39,16 +39,12 @@
 namespace pdal
 {
 
-static StaticPluginInfo const s_info
-{
-    "filters.groupby",
-    "Split data categorically by dimension.",
-    "https://pdal.org/stages/filters.groupby.html"
-};
+static StaticPluginInfo const s_info{
+    "filters.groupby", "Split data categorically by dimension.",
+    "https://pdal.org/stages/filters.groupby.html"};
 CREATE_STATIC_STAGE(GroupByFilter, s_info)
 
-GroupByFilter::GroupByFilter() : m_viewMap()
-{}
+GroupByFilter::GroupByFilter() : m_viewMap() {}
 
 std::string GroupByFilter::getName() const
 {
@@ -89,4 +85,4 @@ PointViewSet GroupByFilter::run(PointViewPtr inView)
     return viewSet;
 }
 
-} // pdal
+} // namespace pdal

--- a/filters/GroupByFilter.cpp
+++ b/filters/GroupByFilter.cpp
@@ -53,7 +53,8 @@ std::string GroupByFilter::getName() const
 
 void GroupByFilter::addArgs(ProgramArgs& args)
 {
-    args.add("dimension", "Dimension containing data to be grouped", m_dimName);
+    args.add("dimension", "Dimension containing data to be grouped",
+             m_dimNames);
 }
 
 void GroupByFilter::prepared(PointTableRef table)
@@ -71,7 +72,7 @@ PointViewSet GroupByFilter::run(PointViewPtr inView)
 
     for (PointId idx = 0; idx < inView->size(); idx++)
     {
-        int64_t val = inView->getFieldAs<int64_t>(m_dimId, idx);
+        int64_t val = inView->getFieldAs<int64_t>(m_dimIds, idx);
         PointViewPtr& outView = m_viewMap[val];
         if (!outView)
             outView = inView->makeNew();

--- a/filters/GroupByFilter.cpp
+++ b/filters/GroupByFilter.cpp
@@ -78,7 +78,7 @@ void GroupByFilter::prepared(PointTableRef table)
         std::stringstream showBad;
         for (const auto& name : badNames)
             showBad << name << " ";
-        throwError("Invalid dimension name(s): " + showBad.str() + ".");
+        throwError("Invalid dimension name(s): " + showBad.str());
     }
 }
 

--- a/filters/GroupByFilter.cpp
+++ b/filters/GroupByFilter.cpp
@@ -83,8 +83,6 @@ void GroupByFilter::prepared(PointTableRef table)
 
 PointViewSet GroupByFilter::run(PointViewPtr inView)
 {
-    PointViewSet viewSet;
-
     for (PointId idx = 0; idx < inView->size(); idx++)
     {
         std::vector<int64_t> key(m_dimIds.size()); // could hash int values
@@ -100,11 +98,12 @@ PointViewSet GroupByFilter::run(PointViewPtr inView)
         groupView->appendPoint(*inView.get(), idx);
     }
 
-    // Pull the buffers out of the map and stick them in the standard
-    // output set.
-    for (auto bi = m_viewMap.begin(); bi != m_viewMap.end(); ++bi)
-        viewSet.insert(bi->second);
-    return viewSet;
+    // Transfer grouped pointviews to output set.
+    PointViewSet groupedViewSet;
+    for (const auto& groupKV : m_viewMap)
+        groupedViewSet.insert(groupKV.second);
+
+    return groupedViewSet;
 }
 
 } // namespace pdal

--- a/filters/GroupByFilter.cpp
+++ b/filters/GroupByFilter.cpp
@@ -53,7 +53,7 @@ std::string GroupByFilter::getName() const
 
 void GroupByFilter::addArgs(ProgramArgs& args)
 {
-    args.add("dimension", "Dimension containing data to be grouped",
+    args.add("dimension", "1 or more dimensions by which to group data",
              m_dimNames);
 }
 
@@ -72,6 +72,7 @@ void GroupByFilter::prepared(PointTableRef table)
 
         // TODO also check that dimensions are discrete valued (ints?)
     }
+
     if (!badNames.empty())
     {
         std::stringstream showBad;

--- a/filters/GroupByFilter.cpp
+++ b/filters/GroupByFilter.cpp
@@ -34,9 +34,8 @@
 
 #include "GroupByFilter.hpp"
 
-#include <functional>
-
 #include <pdal/util/ProgramArgs.hpp>
+#include <pdal/util/Utils.hpp>
 
 namespace pdal
 {
@@ -84,30 +83,16 @@ void GroupByFilter::prepared(PointTableRef table)
     }
 }
 
-/**
-    Accumulates successive hashes of `value` into a single 64-bit buffer.
-    Taken from boost, etc.
-    https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2017/p0814r0.pdf
-
-    \param hash  The accumulated 64-bit hash. An inital value of 0 is fine.
-    \param value A type that std::hash can operate on.
-*/
-template <typename Hashable>
-void hashCombine(uint64_t& hash, const Hashable& value)
-{
-    hash ^=
-        std::hash<Hashable>()(value) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
-}
-
 PointViewSet GroupByFilter::run(PointViewPtr inView)
 {
+    // create groups by hashing dimension values into a key
     for (PointId idx = 0; idx < inView->size(); idx++)
     {
-        uint64_t key = 0;
+        size_t key = 0;
         for (const auto& dimId : m_dimIds)
         {
             int64_t val = inView->getFieldAs<int64_t>(dimId, idx);
-            hashCombine(key, val);
+            Utils::hashCombine(key, val);
         }
 
         PointViewPtr& groupView = m_viewMap[key];

--- a/filters/GroupByFilter.cpp
+++ b/filters/GroupByFilter.cpp
@@ -87,8 +87,14 @@ PointViewSet GroupByFilter::run(PointViewPtr inView)
 
     for (PointId idx = 0; idx < inView->size(); idx++)
     {
-        int64_t val = inView->getFieldAs<int64_t>(m_dimIds, idx);
-        PointViewPtr& outView = m_viewMap[val];
+        std::vector<int64_t> key(m_dimIds.size()); // could hash int values
+        for (const auto& dimId : m_dimIds)
+        {
+            int64_t val = inView->getFieldAs<int64_t>(dimId, idx);
+            key.push_back(val);
+        }
+
+        PointViewPtr& outView = m_viewMap[key];
         if (!outView)
             outView = inView->makeNew();
         outView->appendPoint(*inView.get(), idx);

--- a/filters/GroupByFilter.cpp
+++ b/filters/GroupByFilter.cpp
@@ -88,6 +88,10 @@ void GroupByFilter::prepared(PointTableRef table)
 
 PointViewSet GroupByFilter::run(PointViewPtr inView)
 {
+    // note that the order of output viewsets is determined by the sorted order
+    // of their m_id. this comes from a global counter. thus the first view
+    // created from the first-encountered group has the lowest m_id.
+
     // create groups by hashing dimension values into a key
     for (PointId idx = 0; idx < inView->size(); idx++)
     {

--- a/filters/GroupByFilter.cpp
+++ b/filters/GroupByFilter.cpp
@@ -41,8 +41,11 @@ namespace pdal
 {
 
 static StaticPluginInfo const s_info{
-    "filters.groupby", "Split data categorically by dimension.",
-    "https://pdal.org/stages/filters.groupby.html"};
+    "filters.groupby",
+    "Split data categorically by dimension.",
+    "https://pdal.org/stages/filters.groupby.html",
+};
+
 CREATE_STATIC_STAGE(GroupByFilter, s_info)
 
 GroupByFilter::GroupByFilter() : m_viewMap() {}

--- a/filters/GroupByFilter.hpp
+++ b/filters/GroupByFilter.hpp
@@ -54,8 +54,8 @@ public:
 
 private:
     std::map<uint64_t, PointViewPtr> m_viewMap;
-    std::string m_dimName;
-    Dimension::Id m_dimId;
+    StringList m_dimNames;
+    Dimension::IdList m_dimIds;
 
     virtual void addArgs(ProgramArgs& args);
     virtual void prepared(PointTableRef table);

--- a/filters/GroupByFilter.hpp
+++ b/filters/GroupByFilter.hpp
@@ -53,7 +53,7 @@ public:
     std::string getName() const;
 
 private:
-    std::map<std::vector<int64_t>, PointViewPtr> m_viewMap;
+    std::map<uint64_t, PointViewPtr> m_viewMap;
     StringList m_dimNames;
     Dimension::IdList m_dimIds;
 

--- a/filters/GroupByFilter.hpp
+++ b/filters/GroupByFilter.hpp
@@ -62,7 +62,7 @@ private:
     virtual PointViewSet run(PointViewPtr view);
 
     GroupByFilter& operator=(const GroupByFilter&); // not implemented
-    GroupByFilter(const GroupByFilter&); // not implemented
+    GroupByFilter(const GroupByFilter&);            // not implemented
 };
 
 } // namespace pdal

--- a/filters/GroupByFilter.hpp
+++ b/filters/GroupByFilter.hpp
@@ -53,7 +53,7 @@ public:
     std::string getName() const;
 
 private:
-    std::map<uint64_t, PointViewPtr> m_viewMap;
+    std::map<std::vector<int64_t>, PointViewPtr> m_viewMap;
     StringList m_dimNames;
     Dimension::IdList m_dimIds;
 

--- a/filters/GroupByFilter.hpp
+++ b/filters/GroupByFilter.hpp
@@ -53,7 +53,7 @@ public:
     std::string getName() const;
 
 private:
-    std::map<uint64_t, PointViewPtr> m_viewMap;
+    std::map<size_t, PointViewPtr> m_viewMap;
     StringList m_dimNames;
     Dimension::IdList m_dimIds;
 

--- a/pdal/util/Utils.hpp
+++ b/pdal/util/Utils.hpp
@@ -41,6 +41,7 @@
 #include <cstdint>
 #include <cstring>
 #include <fstream>
+#include <functional>
 #include <iomanip>
 #include <istream>
 #include <limits>
@@ -254,6 +255,40 @@ namespace Utils
         while (size--)
             i += *buf++;
         return i;
+    }
+
+    /**
+      Accumulates successive hashes of `value` into a single `size_t` buffer.
+
+      Taken from boost, etc.
+      https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2017/p0814r0.pdf
+      https://www.boost.org/doc/libs/latest/libs/container_hash/doc/html/hash.html#ref_hash_combine
+
+      \param hash  The accumulated hash. An inital value of 0 is fine.
+      \param value A type that std::hash can operate on.
+    */
+    template <typename H = size_t, typename Hashable>
+    PDAL_EXPORT inline void hashCombine(H& hash, const Hashable& value)
+    {
+        hash ^= std::hash<Hashable>()(value) + 0x9e3779b9 + (hash << 6) +
+                (hash >> 2);
+    }
+
+    /**
+      Create a hash from all `values`.
+
+      See hashCombine() for references.
+
+      \param values One or more values compatible with std::hash.
+      \return The computed hash.
+     */
+    template <typename H = size_t, typename... Hashable>
+    PDAL_EXPORT H hashAll(const Hashable&... values)
+    {
+        H hash = 0;
+        for (const auto& v : values)
+            hashCombine(hash, v);
+        return hash;
     }
 
     /**

--- a/pdal/util/Utils.hpp
+++ b/pdal/util/Utils.hpp
@@ -267,28 +267,11 @@ namespace Utils
       \param hash  The accumulated hash. An inital value of 0 is fine.
       \param value A type that std::hash can operate on.
     */
-    template <typename H = size_t, typename Hashable>
+    template <typename Hashable, typename H = size_t>
     PDAL_EXPORT inline void hashCombine(H& hash, const Hashable& value)
     {
         hash ^= std::hash<Hashable>()(value) + 0x9e3779b9 + (hash << 6) +
                 (hash >> 2);
-    }
-
-    /**
-      Create a hash from all `values`.
-
-      See hashCombine() for references.
-
-      \param values One or more values compatible with std::hash.
-      \return The computed hash.
-     */
-    template <typename H = size_t, typename... Hashable>
-    PDAL_EXPORT H hashAll(const Hashable&... values)
-    {
-        H hash = 0;
-        for (const auto& v : values)
-            hashCombine(hash, v);
-        return hash;
     }
 
     /**

--- a/test/unit/filters/GroupByFilterTest.cpp
+++ b/test/unit/filters/GroupByFilterTest.cpp
@@ -1,42 +1,42 @@
 /******************************************************************************
-* Copyright (c) 2016, Bradley J Chambers (brad.chambers@gmail.com)
-*
-* All rights reserved.
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following
-* conditions are met:
-*
-*     * Redistributions of source code must retain the above copyright
-*       notice, this list of conditions and the following disclaimer.
-*     * Redistributions in binary form must reproduce the above copyright
-*       notice, this list of conditions and the following disclaimer in
-*       the documentation and/or other materials provided
-*       with the distribution.
-*     * Neither the name of Hobu, Inc. or Flaxen Geo Consulting nor the
-*       names of its contributors may be used to endorse or promote
-*       products derived from this software without specific prior
-*       written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-* FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-* COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-* BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
-* OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
-* AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
-* OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
-* OF SUCH DAMAGE.
-****************************************************************************/
+ * Copyright (c) 2016, Bradley J Chambers (brad.chambers@gmail.com)
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of Hobu, Inc. or Flaxen Geo Consulting nor the
+ *       names of its contributors may be used to endorse or promote
+ *       products derived from this software without specific prior
+ *       written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ ****************************************************************************/
 
 #include <pdal/pdal_test_main.hpp>
 
-#include <io/LasReader.hpp>
-#include <filters/GroupByFilter.hpp>
 #include "Support.hpp"
+#include <filters/GroupByFilter.hpp>
+#include <io/LasReader.hpp>
 
 using namespace pdal;
 
@@ -67,4 +67,61 @@ TEST(GroupByTest, basic_test)
 
     EXPECT_EQ(789u, views[0]->size());
     EXPECT_EQ(276u, views[1]->size());
+}
+
+TEST(GroupByTest, multiple_groups)
+{
+    // 1.2-with-color.las has classes 1-2 and returns 1-4,
+    // for a combined 8 class-return groups.
+    // clang-format off
+    auto expectedGroups = std::set{
+        std::pair{1, 1},
+        std::pair{1, 2},
+        std::pair{1, 3},
+        std::pair{1, 4},
+        std::pair{2, 1},
+        std::pair{2, 2},
+        std::pair{2, 3},
+        std::pair{2, 4},
+    };
+    // clang-format on
+
+    Options ro;
+    ro.add("filename", Support::datapath("las/1.2-with-color.las"));
+    LasReader r;
+    r.setOptions(ro);
+
+    Options fo;
+    fo.add("dimension", "Classification,NumberOfReturns");
+
+    GroupByFilter s;
+    s.setOptions(fo);
+    s.setInput(r);
+
+    PointTable table;
+    PointViewPtr view(new PointView(table));
+    s.prepare(table);
+    PointViewSet viewSet = s.execute(table);
+
+    EXPECT_EQ(8u, viewSet.size());
+
+    std::vector<PointViewPtr> views;
+    for (auto it = viewSet.begin(); it != viewSet.end(); ++it)
+        views.push_back(*it);
+
+    size_t totalPoints = 0;
+    std::set<std::pair<int, int>> foundGroups;
+    for (const auto& view : views)
+    {
+        totalPoints += view->size();
+
+        for (point_count_t i = 0; i < view->size(); ++i)
+            foundGroups.insert({
+                view->getFieldAs<int>(Dimension::Id::Classification, i),
+                view->getFieldAs<int>(Dimension::Id::NumberOfReturns, i),
+            });
+    }
+
+    EXPECT_EQ(1065u, totalPoints);
+    EXPECT_EQ(expectedGroups, foundGroups);
 }


### PR DESCRIPTION
### Summary
It would be useful to be able to create unique groups from multiple dimensions using `filters.groupby`. This adds that functionality and an addition unit test to support it.

### Detail
For example, imagine you overlay zones and want to extract each flightline into a PointView. This was more difficult before and required a more complex pipeline. With the proposed modification, this is all that would be required (assuming you overlay values into ClusterID):
```json
{
        "type": "filters.groupby",
        "dimension": "ClusterID,PointSourceId"
}
```

These modifications should be **backwards compatible** with existing pipelines where only a single groupby dimension was supported.

In addition to the filter modification, I have added 1 utility hashing function to `pdal/Utils/Utils.hpp`. The hash function was taken from [boost](https://www.boost.org/doc/libs/latest/libs/container_hash/doc/html/hash.html#ref_hash_combine) and a document written by [Nicolai Josuttis (nico@josuttis.de)](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2017/p0814r0.pdf). Fundamentally it uses `std::hash` and a mixing function. I have added it to PDAL utils as an exported function because it may very well be useful in user-created plugins. No such functionality is available in the cpp stdlib.

An alternative approach to hashing, as seen in the commits, is using a `std::vector<int64_t>` of the dimension values as keys. In my testing I saw no human perceptible differences in performance, though I strongly suspect the hashing approach to be more performant. I did not perform official benchmarking, however.

### Other
I have tried to follow formatting and other conventions observed in the existing codebase, and have formatted using the project .clang-format where appropriate.

I will gladly update the documentation on pdal.org if the PR is accepted.