### PR TITLE
Revert WIN32 in plugin macros

### DIFF
--- a/cmake/macros.cmake
+++ b/cmake/macros.cmake
@@ -131,7 +131,7 @@ macro(PDAL_ADD_PLUGIN _name _type _shortname)
     set(multiValueArgs FILES LINK_WITH INCLUDES SYSTEM_INCLUDES)
     cmake_parse_arguments(PDAL_ADD_PLUGIN "${options}" "${oneValueArgs}"
         "${multiValueArgs}" ${ARGN})
-    if(WIN32)
+    if(MSVC)
         set(${_name} "libpdal_plugin_${_type}_${_shortname}")
     else()
         set(${_name} "pdal_plugin_${_type}_${_shortname}")

--- a/cmake/pluginmacros.cmake
+++ b/cmake/pluginmacros.cmake
@@ -17,7 +17,7 @@ macro(PDAL_CREATE_PLUGIN)
     endif()
     set(PROJECT_NAME ${NAME}_${TYPE})
 
-    if(WIN32)
+    if(MSVC)
         set(TARGET "libpdal_plugin_${TYPE}_${NAME}")
     else()
         set(TARGET "pdal_plugin_${TYPE}_${NAME}")


### PR DESCRIPTION
Reverts PDAL_ADD_PLUGIN and PDAL_CREATE_PLUGIN back to switching on MSVC.

See [comment](https://github.com/PDAL/PDAL/pull/5039#issuecomment-4712060073) in #5039 .