### PR TITLE
`PipelineManager`: return stream mode point table

### DIFF
--- a/pdal/PipelineManager.hpp
+++ b/pdal/PipelineManager.hpp
@@ -149,7 +149,12 @@ public:
 
     // Get the point table data.
     PointTableRef pointTable() const
-        { return m_table; }
+    { 
+        if (m_streamTable.layout()->finalized())
+            return *m_streamTablePtr;
+        else
+            return m_table;
+    }
 
     MetadataNode getMetadata() const;
     Options& commonOptions()


### PR DESCRIPTION
`PipelineManager` contains two `PointTable`s for stream mode & standard mode, but only the standard point table was being returned from `PipelineManager::pointTable()`. If the manager was executed in stream mode, it now returns the stream point table instead.