### PR TITLE
readers.mbio: fix initialization + zero-point read with MB-System >= 5.7.6 (#3791)

### DIFF
--- a/plugins/mbio/io/MbError.cpp
+++ b/plugins/mbio/io/MbError.cpp
@@ -66,6 +66,7 @@ std::map<int, std::string> errors =
     { 14, "Bad system." },
     { 15, "Bad data." },
     { 16, "Missing data." },
+    { 17, "Bad time value." },
     { -1, "Time gap." },
     { -2, "Position out of bounds." },
     { -3, "Time out of bounds." },

--- a/plugins/mbio/io/MbReader.cpp
+++ b/plugins/mbio/io/MbReader.cpp
@@ -96,8 +96,8 @@ void MbReader::ready(PointTableRef table)
     int pings = 0;  // Perhaps an argument for this?
     int lonflip = 0; // Longitude -180 -> 180
     double bounds[4] { -180, 180, -90, 90 };
-    int btime_i[7] { 0, 0, 0, 0, 0, 0, 0 };
-    int etime_i[7] { (std::numeric_limits<int>::max)(), 0, 0, 0, 0, 0 };
+    int btime_i[7] { 1962, 2, 21, 10, 30, 0, 0 };
+    int etime_i[7] { 2062, 2, 21, 10, 30, 0, 0 };
     char *mbio_ptr;
     double btime_d;
     double etime_d;
@@ -251,14 +251,14 @@ bool MbReader::loadData()
 
         double gpsTime = timeconvert(pingTime);
 
-        if (status == 0)
+        if (error > 0)
         {
-            if (error > 0 && error != MB_ERROR_EOF)
+            if (error != MB_ERROR_EOF)
                 throwError("Error reading data: " + MbError::text(error));
             return false;
         }
 
-        if (kind == 1)
+        if (status == MB_SUCCESS && kind == 1)
         {
             bool ok(false);
             if (m_dataType == DataType::Multibeam)


### PR DESCRIPTION
## Summary

`readers.mbio` fails against **MB-System >= 5.7.6** (and current 5.8.x). This fixes the regression reported in #3791.

MB-System 5.7.6 added strict date validation in `mb_get_time()`, which `mb_read_init()` now applies to the begin/end times. The plugin passes **invalid hardcoded dates** (year 0 / `INT_MAX`, month 0, day 0), so:

1. **Initialization aborts** with the new `MB_ERROR_BAD_TIME` (17). That code is missing from `MbError`'s table, so the message renders **blank**: `Can't initialize mb-system reader:` (the empty text after the colon is the tell).
2. Even past init, the read loop treats any `mb_read()` `status == 0` as end-of-data and **bails on the first non-fatal record** (the comment/header records that precede survey data) → **zero points read**.

## Fix (3 small changes, `plugins/mbio/io/`)

- **`MbReader.cpp::ready()`** — use MB-System's canonical default epoch (`1962/2/21 .. 2062/2/21`) for `btime_i`/`etime_i`. It spans any real survey and passes the new validation.
- **`MbError.cpp`** — add code `17` (`"Bad time value."`) so the diagnostic is no longer blank.
- **`MbReader.cpp::loadData()`** — stop only on a **fatal** error (`error > 0`, incl. EOF); skip non-fatal records; extract only successful survey pings (`status == MB_SUCCESS && kind == MB_DATA_DATA`).

```diff
-    int btime_i[7] { 0, 0, 0, 0, 0, 0, 0 };
-    int etime_i[7] { (std::numeric_limits<int>::max)(), 0, 0, 0, 0, 0 };
+    int btime_i[7] { 1962, 2, 21, 10, 30, 0, 0 };
+    int etime_i[7] { 2062, 2, 21, 10, 30, 0, 0 };
...
-        if (status == 0)
+        if (error > 0)
         {
-            if (error > 0 && error != MB_ERROR_EOF)
+            if (error != MB_ERROR_EOF)
                 throwError("Error reading data: " + MbError::text(error));
             return false;
         }
-        if (kind == 1)
+        if (status == MB_SUCCESS && kind == 1)
```

## Testing

Verified on Ubuntu 24.04 with MB-System `master` and PDAL: `readers.mbio` reads bathymetry from MB-System's bundled `mb24`/`mb43` test files (58 points) and from real **Reson 7k** (`.s7k`, format 89) survey data. Before: init aborted with the blank error; after fixing only init: 0 points; after all three fixes: full data.

## Notes / possible follow-ups

- On modern glibc, building the plugin also needs `<rpc/rpc.h>` from **libtirpc** (MB-System's installed `mb_define.h` includes it under `CMAKE_BUILD_SYSTEM`); that's a build-environment concern handled outside this source change.
- Separate, smaller bugs observed in the same plugin (not part of #3791): a hand-rolled `timeconvert()` that skews `GpsTime`, a stray all-zero point emitted on empty reads, and `MB_SIDESCAN_NULL` padding in `datatype=sidescan`. Happy to send these as follow-up PRs if welcome.