### PR TITLE
[Backport 2.10-maintenance] readers.mbio: fix initialization + zero-point read with MB-System >= 5.7.6 (#3791)

### DIFF
--- a/plugins/mbio/io/MbError.cpp
+++ b/plugins/mbio/io/MbError.cpp
@@ -66,6 +66,7 @@ std::map<int, std::string> errors =
     { 14, "Bad system." },
     { 15, "Bad data." },
     { 16, "Missing data." },
+    { 17, "Bad time value." },
     { -1, "Time gap." },
     { -2, "Position out of bounds." },
     { -3, "Time out of bounds." },

--- a/plugins/mbio/io/MbReader.cpp
+++ b/plugins/mbio/io/MbReader.cpp
@@ -96,8 +96,8 @@ void MbReader::ready(PointTableRef table)
     int pings = 0;  // Perhaps an argument for this?
     int lonflip = 0; // Longitude -180 -> 180
     double bounds[4] { -180, 180, -90, 90 };
-    int btime_i[7] { 0, 0, 0, 0, 0, 0, 0 };
-    int etime_i[7] { (std::numeric_limits<int>::max)(), 0, 0, 0, 0, 0 };
+    int btime_i[7] { 1962, 2, 21, 10, 30, 0, 0 };
+    int etime_i[7] { 2062, 2, 21, 10, 30, 0, 0 };
     char *mbio_ptr;
     double btime_d;
     double etime_d;
@@ -168,14 +168,14 @@ bool MbReader::loadData()
         // years and one month.
         double gpsTime = pingTimeT;
 
-        if (status == 0)
+        if (error > 0)
         {
-            if (error > 0 && error != MB_ERROR_EOF)
+            if (error != MB_ERROR_EOF)
                 throwError("Error reading data: " + MbError::text(error));
             return false;
         }
 
-        if (kind == 1)
+        if (status == MB_SUCCESS && kind == 1)
         {
             bool ok(false);
             if (m_dataType == DataType::Multibeam)


### PR DESCRIPTION
Backport #5056
 **Authored by:** @epifanio