### PR TITLE
`readers.ept`: add `ept.json` metadata items to reader metadata

### DIFF
--- a/io/EptReader.cpp
+++ b/io/EptReader.cpp
@@ -299,7 +299,7 @@ void EptReader::initialize()
     }
 
     // Adding point count info from ept.json to metadata
-    m_metadata.add<point_count_t>("points", m_p->info->pointCount(),
+    m_metadata.add<point_count_t>("points", m_p->info->points(),
         "The total number of points indexed into this EPT dataset");
 
     // Figure out our max depth.

--- a/io/EptReader.cpp
+++ b/io/EptReader.cpp
@@ -298,8 +298,9 @@ void EptReader::initialize()
         throwError(e.what());
     }
 
-    // Adding total point count to the metadata
-    m_metadata.add("points", m_p->info->pointCount());
+    // Adding point count info from ept.json to metadata
+    m_metadata.add<point_count_t>("points", m_p->info->pointCount(),
+        "The total number of points indexed into this EPT dataset");
 
     // Figure out our max depth.
     const double queryResolution(m_args->m_resolution);

--- a/io/EptReader.cpp
+++ b/io/EptReader.cpp
@@ -298,9 +298,17 @@ void EptReader::initialize()
         throwError(e.what());
     }
 
-    // Adding point count info from ept.json to metadata
-    m_metadata.add<point_count_t>("points", m_p->info->points(),
+    // Adding info from ept.json to metadata
+    MetadataNode m = getMetadata();
+    MetadataNode eptMeta = m.add("ept_info");
+
+    eptMeta.add<point_count_t>("points", m_p->info->points(),
         "The total number of points indexed into this EPT dataset");
+    eptMeta.add<uint64_t>("span", m_p->info->span(),
+        "The span of voxels in each spatial dimension defining the "
+        "grid size used for the octree");
+    eptMeta.add("version", m_p->info->version(),
+        "The version number of the EPT file");
 
     // Figure out our max depth.
     const double queryResolution(m_args->m_resolution);

--- a/io/EptReader.cpp
+++ b/io/EptReader.cpp
@@ -298,6 +298,9 @@ void EptReader::initialize()
         throwError(e.what());
     }
 
+    // Adding total point count to the metadata
+    m_metadata.add("points", m_p->info->pointCount());
+
     // Figure out our max depth.
     const double queryResolution(m_args->m_resolution);
     //reseting depthEnd if initialize() has been called before

--- a/io/EptReader.cpp
+++ b/io/EptReader.cpp
@@ -299,11 +299,39 @@ void EptReader::initialize()
     }
 
     // Adding info from ept.json to metadata
+    // Not added: hierarchyType
     MetadataNode m = getMetadata();
     MetadataNode eptMeta = m.add("ept_info");
 
+    eptMeta.add("bounds", m_p->info->bounds(),
+        "The cubic bounds of the octree indexing structure");
+    eptMeta.add("boundsConforming", m_p->info->boundsConforming(),
+        "The narrowest bounds conforming to the maximal extents of the data");
+
+    std::string dataType;
+    if (m_p->info->dataType() == ept::EptInfo::DataType::Binary)
+        dataType = "binary";
+    else if (m_p->info->dataType() == ept::EptInfo::DataType::Zstandard)
+        dataType = "zstandard";
+    else if (m_p->info->dataType() == ept::EptInfo::DataType::Laszip)
+        dataType = "laszip";
+    eptMeta.add("dataType", dataType,
+        "The binary encoding of the tiled point cloud data");
     eptMeta.add<point_count_t>("points", m_p->info->points(),
         "The total number of points indexed into this EPT dataset");
+    for (auto& [name, type] : m_p->info->dims())
+    {
+        MetadataNode schema("schema");
+        schema.add("name", name);
+        schema.add("type", Dimension::toName(Dimension::base(type.m_type)));
+        schema.add("size", Dimension::size(type.m_type));
+        if (name == "X" || name == "Y" || name == "Z")
+        {
+            schema.add<double>("scale", type.m_xform.m_scale.m_val);
+            schema.add<double>("offset", type.m_xform.m_offset.m_val);
+        }
+        eptMeta.addList(schema);
+    }
     eptMeta.add<uint64_t>("span", m_p->info->span(),
         "The span of voxels in each spatial dimension defining the "
         "grid size used for the octree");


### PR DESCRIPTION
Added the point count and other items from an EPT dataset's `ept.json` to the reader's metadata. This is helpful in #5007 where I need to read point count based on reader metadata. `hierarchyType` is not added currently.