### PR TITLE
examples: Align with main project CMake minimum 3.13

### DIFF
--- a/examples/batch-streamer/CMakeLists.txt
+++ b/examples/batch-streamer/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.6)
+cmake_minimum_required(VERSION 3.13)
 project(BatchStreamer)
 
 find_package(PDAL 2.0.0 REQUIRED CONFIG)

--- a/examples/filter-streamer/CMakeLists.txt
+++ b/examples/filter-streamer/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.6)
+cmake_minimum_required(VERSION 3.13)
 project(StreamerTutorial)
 
 find_package(PDAL 2.0.0 REQUIRED CONFIG)

--- a/examples/reading-streamer/CMakeLists.txt
+++ b/examples/reading-streamer/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.6)
+cmake_minimum_required(VERSION 3.13)
 project(StreamerTutorial)
 
 find_package(PDAL 2.0.0 REQUIRED CONFIG)

--- a/examples/writing-streamer/CMakeLists.txt
+++ b/examples/writing-streamer/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.6)
+cmake_minimum_required(VERSION 3.13)
 project(StreamerTutorial)
 
 find_package(PDAL 2.0.0 REQUIRED CONFIG)

--- a/examples/writing/CMakeLists.txt
+++ b/examples/writing/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.6)
+cmake_minimum_required(VERSION 3.13)
 project(WritingTutorial)
 
 find_package(PDAL 2.0.0 REQUIRED CONFIG)


### PR DESCRIPTION
Since version 3.31, CMake warns that compatibility with CMake < 3.10 will be removed from a future version of CMake. Moreover, the project already has 3.13 baseline.

Closes: https://bugs.gentoo.org/976077