### PR TITLE
add ``readers.stac.validate_schema_schema`` option

### DIFF
--- a/doc/stages/readers.stac.md
+++ b/doc/stages/readers.stac.md
@@ -93,6 +93,13 @@ validate_schema
   it's being read using JSON schema and the publicly available STAC schemas and
   list of STAC extension schemas.
 
+validate_schema_schema
+
+: Boolean value determining if schema documents referenced by STAC schemas
+  should also be validated. Set this to false to avoid resolving remote JSON
+  Schema metaschemas such as `json-schema.org` while still validating STAC
+  objects.
+
 properties
 
 : A key value mapping (JSON) of properties and the desired values to prune

--- a/io/StacReader.cpp
+++ b/io/StacReader.cpp
@@ -186,6 +186,9 @@ void StacReader::addArgs(ProgramArgs& args)
     //Reader options
     args.add("validate_schema", "Use JSON schema to validate your STAC objects."
         " Default: false", m_p->m_args->validateSchema, false);
+    args.add("validate_schema_schema", "Validate schema documents that are "
+        "referenced by STAC schemas. Default: true",
+        m_p->m_args->schemaUrls.validateSchemaSchema, true);
     args.add("reader_args", "Map of reader arguments to their values to pass"
         " through.", m_p->m_args->rawReaderArgs);
     args.add("requests", "Number of threads for fetching JSON files, Default: 8",

--- a/io/StacReader.cpp
+++ b/io/StacReader.cpp
@@ -187,7 +187,7 @@ void StacReader::addArgs(ProgramArgs& args)
     args.add("validate_schema", "Use JSON schema to validate your STAC objects."
         " Default: false", m_p->m_args->validateSchema, false);
     args.add("validate_schema_schema", "Validate schema documents that are "
-        "referenced by STAC schemas. Default: true",
+        "referenced by STAC schemas.",
         m_p->m_args->schemaUrls.validateSchemaSchema, true);
     args.add("reader_args", "Map of reader arguments to their values to pass"
         " through.", m_p->m_args->rawReaderArgs);

--- a/io/private/stac/Catalog.cpp
+++ b/io/private/stac/Catalog.cpp
@@ -229,12 +229,14 @@ void Catalog::validate()
 {
     nlohmann::json_schema::json_validator val(
         [this](const nlohmann::json_uri& json_uri, nlohmann::json& json) {
-            json = m_connector.getJson(json_uri.url());
+            json = loadSchemaJson(m_connector, json_uri.url(),
+                m_schemaUrls.validateSchemaSchema);
         },
         [](const std::string &, const std::string &) {}
     );
 
-    NL::json schemaJson = m_connector.getJson(m_schemaUrls.catalog);
+    NL::json schemaJson = loadSchemaJson(m_connector, m_schemaUrls.catalog,
+        m_schemaUrls.validateSchemaSchema);
     val.set_root_schema(schemaJson);
     try {
         val.validate(m_json);

--- a/io/private/stac/Collection.cpp
+++ b/io/private/stac/Collection.cpp
@@ -50,13 +50,15 @@ Collection::~Collection() {}
 void Collection::validate() {
     nlohmann::json_schema::json_validator val(
         [this](const nlohmann::json_uri& json_uri, nlohmann::json& json) {
-            json = m_connector.getJson(json_uri.url());
+            json = loadSchemaJson(m_connector, json_uri.url(),
+                m_schemaUrls.validateSchemaSchema);
         },
         [](const std::string &, const std::string &) {}
     );
 
     // Validate against base Collection schema first
-    NL::json schemaJson = m_connector.getJson(m_schemaUrls.collection);
+    NL::json schemaJson = loadSchemaJson(m_connector, m_schemaUrls.collection,
+        m_schemaUrls.validateSchemaSchema);
     val.set_root_schema(schemaJson);
     try {
         val.validate(m_json);
@@ -78,7 +80,8 @@ void Collection::validate() {
                 "", m_json);
 
             try {
-                NL::json schemaJson = m_connector.getJson(url);
+                NL::json schemaJson = loadSchemaJson(m_connector, url,
+                    m_schemaUrls.validateSchemaSchema);
                 val.set_root_schema(schemaJson);
                 val.validate(m_json);
             }

--- a/io/private/stac/Item.cpp
+++ b/io/private/stac/Item.cpp
@@ -159,13 +159,15 @@ void Item::validate()
 
     nlohmann::json_schema::json_validator val(
         [this](const nlohmann::json_uri& json_uri, nlohmann::json& json) {
-            json = m_connector.getJson(json_uri.url());
+            json = loadSchemaJson(m_connector, json_uri.url(),
+                m_schemaUrls.validateSchemaSchema);
         },
         [](const std::string &, const std::string &) {}
     );
 
     // Validate against base Item schema first
-    NL::json schemaJson = m_connector.getJson(m_schemaUrls.item);
+    NL::json schemaJson = loadSchemaJson(m_connector, m_schemaUrls.item,
+        m_schemaUrls.validateSchemaSchema);
     val.set_root_schema(schemaJson);
     try {
         val.validate(m_json);
@@ -186,7 +188,8 @@ void Item::validate()
             std::string url = stacValue<std::string>(extSchemaUrl, "", m_json);
 
             try {
-                NL::json schemaJson = m_connector.getJson(url);
+                NL::json schemaJson = loadSchemaJson(m_connector, url,
+                    m_schemaUrls.validateSchemaSchema);
                 val.set_root_schema(schemaJson);
                 val.validate(m_json);
             }

--- a/io/private/stac/Item.hpp
+++ b/io/private/stac/Item.hpp
@@ -56,6 +56,7 @@ struct SchemaUrls
     std::string catalog;
     std::string collection;
     std::string item;
+    bool validateSchemaSchema = true;
 };
 
 class Item

--- a/io/private/stac/Utils.cpp
+++ b/io/private/stac/Utils.cpp
@@ -34,6 +34,8 @@
 
 #include "Utils.hpp"
 
+#include "../connector/Connector.hpp"
+
 namespace pdal
 {
 
@@ -49,6 +51,16 @@ pdal_error stac_error(std::string id, std::string stacType,
 pdal_error stac_error(std::string const& msg)
 {
     return pdal_error("STACError: " + msg);
+}
+
+NL::json loadSchemaJson(const connector::Connector& connector,
+    const std::string& url, bool validateSchemaSchema)
+{
+    if (!validateSchemaSchema &&
+        url.find("json-schema.org") != std::string::npos)
+        return true;
+
+    return connector.getJson(url);
 }
 
 namespace StacUtils

--- a/io/private/stac/Utils.cpp
+++ b/io/private/stac/Utils.cpp
@@ -56,6 +56,8 @@ pdal_error stac_error(std::string const& msg)
 NL::json loadSchemaJson(const connector::Connector& connector,
     const std::string& url, bool validateSchemaSchema)
 {
+    // Avoid intermittent failures while resolving remote JSON Schema
+    // metaschemas; STAC schemas are still fetched and used for validation.
     if (!validateSchemaSchema &&
         url.find("json-schema.org") != std::string::npos)
         return true;

--- a/io/private/stac/Utils.hpp
+++ b/io/private/stac/Utils.hpp
@@ -43,6 +43,11 @@
 namespace pdal
 {
 
+namespace connector
+{
+    class Connector;
+}
+
 namespace stac
 {
     class Item;
@@ -64,6 +69,8 @@ namespace stac
 
     pdal_error stac_error(std::string id, std::string stacType, std::string const& msg);
     pdal_error stac_error(std::string const& msg);
+    NL::json loadSchemaJson(const connector::Connector& connector,
+        const std::string& url, bool validateSchemaSchema);
 
 
 namespace StacUtils

--- a/test/unit/io/StacReaderTest.cpp
+++ b/test/unit/io/StacReaderTest.cpp
@@ -551,6 +551,7 @@ TEST(StacReaderTest, wrench_test)
     Options options;
     options.add("filename", Support::datapath("stac/wrench.vpc"));
     options.add("validate_schema", "true");
+    options.add("validate_schema_schema", "false");
 
     StageFactory f;
     Stage& reader = *f.createStage("readers.stac");
@@ -574,6 +575,7 @@ TEST(StacReaderTest, schema_validate_test)
     options.add("asset_names", "ept.json");
     options.add("asset_names", "data");
     options.add("validate_schema", "true");
+    options.add("validate_schema_schema", "false");
 
     StageFactory f;
     Stage& reader = *f.createStage("readers.stac");


### PR DESCRIPTION
json-schema.org is no longer consistently available. Let's add an option that can turn off schema validation of schemas themselves.