### PR TITLE
[Backport 2.10-maintenance] Fix COPC writer UTF-8 output paths on Windows

### DIFF
--- a/io/private/copcwriter/Common.hpp
+++ b/io/private/copcwriter/Common.hpp
@@ -36,7 +36,6 @@
 
 #include <stdint.h>
 #include <array>
-#include <filesystem>
 #include <map>
 #include <set>
 #include <string>
@@ -74,19 +73,6 @@ enum class Index
 
 namespace copcwriter
 {
-
-// std::fstream's narrow-string overload uses the active Windows code page.
-// PDAL filenames are UTF-8, so use the filesystem path overload on Windows to
-// preserve non-ASCII characters.  Other platforms retain their byte-path
-// behavior.
-inline std::filesystem::path nativePath(const std::string& filename)
-{
-#ifdef _WIN32
-    return std::filesystem::u8path(filename);
-#else
-    return std::filesystem::path(filename);
-#endif
-}
 
 // These are hopes, not absolutes.
 const int MaxPointsPerNode = 100000;

--- a/io/private/copcwriter/Common.hpp
+++ b/io/private/copcwriter/Common.hpp
@@ -36,6 +36,7 @@
 
 #include <stdint.h>
 #include <array>
+#include <filesystem>
 #include <map>
 #include <set>
 #include <string>
@@ -73,6 +74,19 @@ enum class Index
 
 namespace copcwriter
 {
+
+// std::fstream's narrow-string overload uses the active Windows code page.
+// PDAL filenames are UTF-8, so use the filesystem path overload on Windows to
+// preserve non-ASCII characters.  Other platforms retain their byte-path
+// behavior.
+inline std::filesystem::path nativePath(const std::string& filename)
+{
+#ifdef _WIN32
+    return std::filesystem::u8path(filename);
+#else
+    return std::filesystem::path(filename);
+#endif
+}
 
 // These are hopes, not absolutes.
 const int MaxPointsPerNode = 100000;

--- a/io/private/copcwriter/Output.cpp
+++ b/io/private/copcwriter/Output.cpp
@@ -40,6 +40,7 @@
 #include <pdal/util/Algorithm.hpp>
 #include <pdal/util/OStream.hpp>
 #include <pdal/util/Extractor.hpp>
+#include <pdal/util/FileUtils.hpp>
 
 #include <lazperf/filestream.hpp>
 
@@ -109,7 +110,7 @@ Output::Output(const BaseInfo& b) : b(b)
     // as points are written.
     m_pointPos = m_chunkOffsetPos + sizeof(uint64_t);
 
-    m_f.open(nativePath(b.filename), std::ios::out | std::ios::binary);
+    m_f.open(FileUtils::toNative(b.filename), std::ios::out | std::ios::binary);
 }
 
 // For this to work properly, the VLRs can't change size.

--- a/io/private/copcwriter/Output.cpp
+++ b/io/private/copcwriter/Output.cpp
@@ -109,7 +109,7 @@ Output::Output(const BaseInfo& b) : b(b)
     // as points are written.
     m_pointPos = m_chunkOffsetPos + sizeof(uint64_t);
 
-    m_f.open(b.filename, std::ios::out | std::ios::binary);
+    m_f.open(nativePath(b.filename), std::ios::out | std::ios::binary);
 }
 
 // For this to work properly, the VLRs can't change size.

--- a/io/private/copcwriter/Processor.cpp
+++ b/io/private/copcwriter/Processor.cpp
@@ -189,7 +189,8 @@ void Processor::writeCompressed(VoxelKey k, PointViewPtr v)
     std::vector<unsigned char> chunk = compressor.done();
     uint64_t location = m_manager.newChunk(k, (uint32_t)chunk.size(), (uint32_t)v->size());
 
-    std::ofstream out(b.filename, std::ios::out | std::ios::in | std::ios::binary);
+    std::ofstream out(nativePath(b.filename),
+        std::ios::out | std::ios::in | std::ios::binary);
     out.seekp(std::ofstream::pos_type(location));
     out.write(reinterpret_cast<const char *>(chunk.data()), chunk.size());
     out.close();

--- a/io/private/copcwriter/Processor.cpp
+++ b/io/private/copcwriter/Processor.cpp
@@ -37,6 +37,7 @@
 #include <random>
 
 #include <pdal/StageFactory.hpp>
+#include <pdal/util/FileUtils.hpp>
 #include <io/BufferReader.hpp>
 
 #include <lazperf/writers.hpp>
@@ -189,7 +190,7 @@ void Processor::writeCompressed(VoxelKey k, PointViewPtr v)
     std::vector<unsigned char> chunk = compressor.done();
     uint64_t location = m_manager.newChunk(k, (uint32_t)chunk.size(), (uint32_t)v->size());
 
-    std::ofstream out(nativePath(b.filename),
+    std::ofstream out(FileUtils::toNative(b.filename),
         std::ios::out | std::ios::in | std::ios::binary);
     out.seekp(std::ofstream::pos_type(location));
     out.write(reinterpret_cast<const char *>(chunk.data()), chunk.size());

--- a/test/unit/io/CopcWriterTest.cpp
+++ b/test/unit/io/CopcWriterTest.cpp
@@ -261,6 +261,10 @@ TEST(CopcWriterTest, scaling)
 
 TEST(CopcWriterTest, unicodeFilename)
 {
+#ifndef _WIN32
+    GTEST_SKIP() << "This regression covers Windows native-path conversion.";
+#endif
+
     // Use escaped UTF-8 bytes so this source stays independent of the compiler
     // source-file encoding.
     const std::string filename = Support::temppath(

--- a/test/unit/io/CopcWriterTest.cpp
+++ b/test/unit/io/CopcWriterTest.cpp
@@ -259,6 +259,43 @@ TEST(CopcWriterTest, scaling)
     FileUtils::deleteFile(filename);
 }
 
+TEST(CopcWriterTest, unicodeFilename)
+{
+    // Use escaped UTF-8 bytes so this source stays independent of the compiler
+    // source-file encoding. autzen_trim.las has enough points to exercise both
+    // the initial output stream and the random-access chunk writes.
+    const std::string filename = Support::temppath(
+        "copc-\xE8\xB7\xAF\xE5\xBE\x84.laz");
+    constexpr PointId pointCount = 110000;
+
+    Options readerOps;
+    readerOps.add("filename", Support::datapath("las/autzen_trim.las"));
+    LasReader input;
+    input.setOptions(readerOps);
+
+    Options writerOps;
+    writerOps.add("filename", filename);
+    CopcWriter writer;
+    writer.setOptions(writerOps);
+    writer.setInput(input);
+
+    PointTable table;
+    writer.prepare(table);
+    writer.execute(table);
+
+    Options outputReaderOps;
+    outputReaderOps.add("filename", filename);
+    CopcReader reader;
+    reader.setOptions(outputReaderOps);
+
+    PointTable readTable;
+    reader.prepare(readTable);
+    const PointViewSet views = reader.execute(readTable);
+    ASSERT_EQ(views.size(), 1u);
+    EXPECT_EQ((*views.begin())->size(), pointCount);
+    FileUtils::deleteFile(filename);
+}
+
 TEST(CopcWriterTest, extradim)
 {
     std::string filename(Support::datapath("las/1.2-with-color.las"));

--- a/test/unit/io/CopcWriterTest.cpp
+++ b/test/unit/io/CopcWriterTest.cpp
@@ -262,14 +262,12 @@ TEST(CopcWriterTest, scaling)
 TEST(CopcWriterTest, unicodeFilename)
 {
     // Use escaped UTF-8 bytes so this source stays independent of the compiler
-    // source-file encoding. autzen_trim.las has enough points to exercise both
-    // the initial output stream and the random-access chunk writes.
+    // source-file encoding.
     const std::string filename = Support::temppath(
         "copc-\xE8\xB7\xAF\xE5\xBE\x84.laz");
-    constexpr PointId pointCount = 110000;
 
     Options readerOps;
-    readerOps.add("filename", Support::datapath("las/autzen_trim.las"));
+    readerOps.add("filename", Support::datapath("las/1.2-with-color.las"));
     LasReader input;
     input.setOptions(readerOps);
 
@@ -283,16 +281,8 @@ TEST(CopcWriterTest, unicodeFilename)
     writer.prepare(table);
     writer.execute(table);
 
-    Options outputReaderOps;
-    outputReaderOps.add("filename", filename);
-    CopcReader reader;
-    reader.setOptions(outputReaderOps);
-
-    PointTable readTable;
-    reader.prepare(readTable);
-    const PointViewSet views = reader.execute(readTable);
-    ASSERT_EQ(views.size(), 1u);
-    EXPECT_EQ((*views.begin())->size(), pointCount);
+    EXPECT_TRUE(FileUtils::fileExists(filename));
+    EXPECT_GT(FileUtils::fileSize(filename), 0u);
     FileUtils::deleteFile(filename);
 }
 


### PR DESCRIPTION
Backport #5076
 **Authored by:** @AsterZ99