### PR TITLE
Expose ICP iteration count in metadata

### DIFF
--- a/filters/IterativeClosestPoint.cpp
+++ b/filters/IterativeClosestPoint.cpp
@@ -155,7 +155,7 @@ PointViewPtr IterativeClosestPoint::icp(PointViewPtr fixed,
     int iterations(0);
     for (int iter = 0; iter < m_max_iters; ++iter)
     {
-        iterations = iter + 1
+        iterations = iter + 1;
         // At the beginning of each iteration, transform our centered, moving
         // PointView by the current final_transformation.
         PointViewPtr tempMovingTransformed =
@@ -335,7 +335,7 @@ PointViewPtr IterativeClosestPoint::icp(PointViewPtr fixed,
     root.add("centroid", ss.str());
     root.add("converged", converged);
     root.add("fitness", mse);
-    root.add("iterations", iterations)
+    root.add("iterations", iterations);
 
     return moving;
 }

--- a/filters/IterativeClosestPoint.cpp
+++ b/filters/IterativeClosestPoint.cpp
@@ -152,8 +152,10 @@ PointViewPtr IterativeClosestPoint::icp(PointViewPtr fixed,
     bool converged(false);
     double prev_mse(0.0);
     int num_similar(0);
+    int iterations(0);
     for (int iter = 0; iter < m_max_iters; ++iter)
     {
+        iterations = iter + 1
         // At the beginning of each iteration, transform our centered, moving
         // PointView by the current final_transformation.
         PointViewPtr tempMovingTransformed =
@@ -333,6 +335,7 @@ PointViewPtr IterativeClosestPoint::icp(PointViewPtr fixed,
     root.add("centroid", ss.str());
     root.add("converged", converged);
     root.add("fitness", mse);
+    root.add("iterations", iterations)
 
     return moving;
 }


### PR DESCRIPTION
This PR adds an iterations field to the metadata produced by filters.icp, reporting the number of iterations executed before convergence or reaching the configured maximum. This is intended as an additional diagnostic metric and does not change the filter's behavior.