### PR TITLE
Make --dims in translate and pipeline kernels work in streaming mode

### DIFF
--- a/kernels/PipelineKernel.cpp
+++ b/kernels/PipelineKernel.cpp
@@ -149,7 +149,7 @@ int PipelineKernel::execute()
     m_manager.readPipeline(m_inputFile);
     if (!m_manager.hasReader())
         throw pdal_error("Pipeline does not start with a reader.");
-    m_manager.pointTable().layout()->setAllowedDims(m_dimNames);
+    m_manager.setAllowedDims(m_dimNames);
     if (m_manager.execute(m_mode).m_mode == ExecMode::None)
         throw pdal_error("Couldn't run pipeline in requested execution mode.");
 

--- a/kernels/TranslateKernel.cpp
+++ b/kernels/TranslateKernel.cpp
@@ -228,7 +228,7 @@ int TranslateKernel::execute()
         return 0;
     }
 
-    m_manager.pointTable().layout()->setAllowedDims(m_dimNames);
+    m_manager.setAllowedDims(m_dimNames);
     if (m_manager.execute(m_mode).m_mode == ExecMode::None)
         throw pdal_error("Couldn't run translation pipeline in requested "
             "execution mode.");


### PR DESCRIPTION
This command would ignore the list of dimensions and output would get all dimensions anyway:
```
pdal translate --dims=Red,Green,Blue input.copc.laz output.geoparquet
```

It would only work when forcing standard mode with `--nostream`