### PR TITLE
[Backport 2.10-maintenance] Bump docker/login-action from 4.5.2 to 4.6.0

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -53,7 +53,7 @@ jobs:
           version: latest
       - if: ${{ env.PUSH_PACKAGES == 'true' }}
         name: Login to GitHub Container Registry
-        uses: docker/login-action@v4.5.2
+        uses: docker/login-action@v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -62,7 +62,7 @@ jobs:
       # https://github.com/docker/metadata-action
       - if: ${{ env.PUSH_PACKAGES == 'true' }}
         name: Login to Docker Hub
-        uses: docker/login-action@v4.5.2
+        uses: docker/login-action@v4.6.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -149,7 +149,7 @@ jobs:
     needs: build_individual_images
     steps:
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4.5.2
+        uses: docker/login-action@v4.6.0
         if: env.PUSH_PACKAGES == 'true'
         with:
           registry: ghcr.io
@@ -157,7 +157,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v4.5.2
+        uses: docker/login-action@v4.6.0
         if: env.PUSH_PACKAGES == 'true'
         with:
           username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
Backport #5093
 **Authored by:** @dependabot[bot]