### PR TITLE
`filters.m3c2` docs: clarifcations & typo fix

### DIFF
--- a/doc/stages/filters.m3c2.md
+++ b/doc/stages/filters.m3c2.md
@@ -4,15 +4,18 @@
 
 The **M3C2 filter** uses the Multiscale Model to Model Cloud Comparison (M3C2)
 algorithm, introduced in {cite:p}`lague2013`, to find the 3D distance between two 
-point clouds. The filter takes three inputs; the first is the 'reference' cloud,
-and the second is the 'compared' cloud whose change is being calculated. The third input
-is a set of "core points", generally a subset of the reference cloud, for which distance 
-metrics are calculated. For example, these could be spaced in a regular grid created by 
-{ref}`filters.voxelcenternearestneighbor` to allow for easier rasterization.
+point clouds. The filter takes three inputs in the following order:
+
+- Input 1: the reference point cloud
+- Input 2: the comparison cloud whose change is being calculated
+- Input 3: a set of "core points", generally a subset of the reference cloud, for which distance 
+  metrics and statistics are calculated. For example, these could be spaced in
+  a regular grid created by {ref}`filters.voxelcenternearestneighbor` to allow
+  for easier rasterization.
 
 M3C2 creates seven new dimensions: `m3c2_distance`, `m3c2_uncertainty`, `m3c2_significant`, 
 `m3c2_std_dev1`, `m3c2_std_dev2`, `m3c2_count1` & `m3c2_count2`. The filter always returns 
-a single PointView containg core points.
+a single PointView containing only the core points.
 
 ```{note}
 For best results, the input point sets can be aligned using a registration algorithm like 
@@ -62,7 +65,7 @@ For best results, the input point sets can be aligned using a registration algor
             "Sampled"
         ]
     },
-        "output.las"
+    "output.las"
 ]
 ```
 

--- a/doc/stages/filters.md
+++ b/doc/stages/filters.md
@@ -235,7 +235,7 @@ filters.griddecimation
 
 {ref}`filters.m3c2`
 
-; Compute the 3D distance between two sets of points based on the M3C2 algorithm.
+: Compute the 3D distance between two sets of points based on the M3C2 algorithm.
 
 {ref}`filters.miniball`
 


### PR DESCRIPTION
Clarified the input ordering for `filters.m3c2` and fixed a typo on the filters page