### PR TITLE
[Backport 2.10-maintenance] Bump prefix-dev/setup-pixi from 0.10.1 to 0.10.2

### DIFF
--- a/.github/workflows/pixi.yml
+++ b/.github/workflows/pixi.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
     steps:
     - uses: actions/checkout@v7
-    - uses: prefix-dev/setup-pixi@v0.10.1
+    - uses: prefix-dev/setup-pixi@v0.10.2
       with:
         environments: >-
           dev


### PR DESCRIPTION
Backport #5118
 **Authored by:** @dependabot[bot]