### PR TITLE
Make EptInfo header self-contained

### DIFF
--- a/io/private/ept/EptInfo.hpp
+++ b/io/private/ept/EptInfo.hpp
@@ -38,6 +38,8 @@
 #include <pdal/SpatialReference.hpp>
 #include <pdal/util/Bounds.hpp>
 
+#include <nlohmann/json.hpp>
+
 #include "FixedPointLayout.hpp"
 
 namespace pdal


### PR DESCRIPTION
## Summary

The formatting pass exposed a latent include-order dependency: `io/private/ept/EptInfo.hpp` stores `NL::json` by value but relied on a transitive include for the complete `nlohmann/json.hpp` definition. Include it directly to make the header self-contained.

This is kept separate from the formatting changes so the review stays focused.

## Validation

- Compiled a standalone translation unit that includes `io/private/ept/EptInfo.hpp` with the configured build include roots
- Ran `git diff --check`