### PR TITLE
fix(ci): publish versioned Docker images on release again

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,6 +6,8 @@ on:
     paths-ignore:
       - 'doc/**'
     branches-ignore: ["dependabot/**"]
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+"
   pull_request:
     paths-ignore:
       - 'doc/**'
@@ -116,9 +118,9 @@ jobs:
             GITHUB_REPOSITORY=${{ github.event.pull_request.head.repo.full_name != '' && github.event.pull_request.head.repo.full_name || github.repository }}
           tags: |
             docker.io/pdal/pdal:${{ steps.prep.outputs.VERSION }}-${{ steps.prep.outputs.ARCH }}
-            docker.io/pdal/pdal:latest-${{ steps.prep.outputs.ARCH }}
             ghcr.io/pdal/pdal:${{ steps.prep.outputs.VERSION }}-${{ steps.prep.outputs.ARCH }}
-            ghcr.io/pdal/pdal:latest-${{ steps.prep.outputs.ARCH }}
+            ${{ github.ref == 'refs/heads/master' && format('docker.io/pdal/pdal:latest-{0}', steps.prep.outputs.ARCH) || '' }}
+            ${{ github.ref == 'refs/heads/master' && format('ghcr.io/pdal/pdal:latest-{0}', steps.prep.outputs.ARCH) || '' }}
           labels: |
             org.opencontainers.image.title=${{ github.event.repository.name }}
             org.opencontainers.image.description=${{ github.event.repository.description }}
@@ -165,13 +167,29 @@ jobs:
 
       - name: Create and push multi-platform manifest
         if: env.PUSH_PACKAGES == 'true'
+        env:
+          VERSION: ${{ github.ref_name }}
         run: |
-          docker buildx imagetools create \
-          -t ghcr.io/pdal/pdal:latest \
-          ghcr.io/pdal/pdal:latest-amd64 \
-          ghcr.io/pdal/pdal:latest-arm64
+          if [[ $GITHUB_REF == refs/heads/master ]]; then
+            docker buildx imagetools create \
+            -t ghcr.io/pdal/pdal:latest \
+            ghcr.io/pdal/pdal:latest-amd64 \
+            ghcr.io/pdal/pdal:latest-arm64
 
-          docker buildx imagetools create \
-          -t pdal/pdal:latest \
-          pdal/pdal:latest-amd64 \
-          pdal/pdal:latest-arm64
+            docker buildx imagetools create \
+            -t pdal/pdal:latest \
+            pdal/pdal:latest-amd64 \
+            pdal/pdal:latest-arm64
+          fi
+
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
+            docker buildx imagetools create \
+            -t "ghcr.io/pdal/pdal:${VERSION}" \
+            "ghcr.io/pdal/pdal:${VERSION}-amd64" \
+            "ghcr.io/pdal/pdal:${VERSION}-arm64"
+
+            docker buildx imagetools create \
+            -t "pdal/pdal:${VERSION}" \
+            "pdal/pdal:${VERSION}-amd64" \
+            "pdal/pdal:${VERSION}-arm64"
+          fi

--- a/HOWTORELEASE.md
+++ b/HOWTORELEASE.md
@@ -61,7 +61,12 @@ This document describes the process for releasing a new version of PDAL.
     and a starting point. If you find issues after making the release branch,
     add them to the release notes.
 
-7) Update Conda package
+7) Confirm the Docker workflow published `pdal/pdal:x.x.x` and
+   `ghcr.io/pdal/pdal:x.x.x` for both amd64 and arm64.
+
+   >     docker buildx imagetools inspect pdal/pdal:2.9.0
+
+8) Update Conda package
 
    - For PDAL releases that bump minor version number, but do not change
      dependencies or build configurations, the
@@ -81,7 +86,7 @@ This document describes the process for releasing a new version of PDAL.
      <https://github.com/conda-forge/libpdal-feedstock> repository. In
      these cases, the build number should be incremented.
 
-8) \[Optional\] Update Alpine package
+9) \[Optional\] Update Alpine package
 
    - The PDAL Alpine package lives at
      <https://github.com/alpinelinux/aports/blob/master/testing/pdal/APKBUILD>.


### PR DESCRIPTION
Fixes #5121.

No versioned `pdal/pdal` image has been [published](https://hub.docker.com/r/pdal/pdal/tags) since 2.9.2. This restores it (for both architectures) and re-pins `latest` to `master`.

### Changes

**1. Run on release tags again.** #4816 added `branches-ignore` to `on.push`; a push trigger with branch filters and no tag filters [does not run on tag pushes](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#onpushbranchestagsbranches-ignoretags-ignore), so the `refs/tags/` branch of `Prepare` has been dead code since. 
The filter matches the one `release.yml` already uses.

**2. Assemble the version index.** #4810 split the build across two single-architecture runners and suffixed every tag with `-${ARCH}`, but `create-manifest` only joined these for `latest`. It now does the same for `${VERSION}`.

**3. Pin `latest` to master.** Without this, (2) would make things worse: 2.10.1 and 2.10.2 were tagged off `2.10-maintenance`, so a release would silently re-point `latest` at a maintenance build. This also fixes the existing behaviour where a push to *any* branch (except `dependabot/**`) re-points `latest`, contradicting `doc/project/docker.md`.

**4.** Insert a release-step in `HOWTORELEASE.md` to confirm the images published.

### Result

| Ref | Joined tags |
|---|---|
| `master` | `latest` |
| `2.10-maintenance` | none |
| `refs/tags/2.10.3` | `2.10.3` |

### Verification

_Has **not** been run end to end as that requires a real tag push._

- `create-manifest` (with docker stubbed out) produces tags as per above.
- `actionlint` (with shellcheck) shows no new findings.
- The cherry-pick onto 2.10-maintenance applies cleanly.


### Notes

- **Could this please get the `backport 2.10-maintenance` label?**
Releases are tagged off that branch, so a master-only fix will not fix the next 2.10.x.
`2.9-maintenance` also still runs the pre-#4810 single-architecture workflow and would need more than a cherry-pick to backport.
- `paths-ignore` is not evaluated for tag pushes, so a release-prep commit touching only `doc/` still builds when the tag is pushed.
- A follow-up branch deduplicates the tag derivation and wires up the `metadata-action` step (which currently produces output that is unused). 
Happy to open it once this lands: https://github.com/schmidtnz/PDAL/tree/refactor/docker-tagging